### PR TITLE
Add CompetitionBase: now competitions can be created in form of unit test.

### DIFF
--- a/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -37,6 +37,9 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -46,14 +49,19 @@
     <Compile Include="Benchmark.cs" />
     <Compile Include="BenchmarkCompetition.cs" />
     <Compile Include="BenchmarkCompetitionTask.cs" />
+    <Compile Include="BenchmarkMethodAttribute.cs" />
     <Compile Include="BenchmarkSettings.cs" />
     <Compile Include="BenchmarkUtils.cs" />
+    <Compile Include="CompetitionBase.cs" />
     <Compile Include="ConsoleHelper.cs" />
     <Compile Include="BenchmarkInfo.cs" />
     <Compile Include="BenchmarkRun.cs" />
     <Compile Include="BenchmarkRunList.cs" />
     <Compile Include="BenchmarkExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/BenchmarkDotNet/BenchmarkExtensions.cs
+++ b/BenchmarkDotNet/BenchmarkExtensions.cs
@@ -34,5 +34,10 @@ namespace BenchmarkDotNet
         {
             return value.ToString(BenchmarkSettings.Instance.CultureInfo);
         }
+
+        internal static string WithoutSuffix(this string str, string suffix, StringComparison stringComparison = StringComparison.CurrentCulture)
+        {
+            return str.EndsWith(suffix, stringComparison) ? str.Substring(0, str.Length - suffix.Length) : str;
+        }
     }
 }

--- a/BenchmarkDotNet/BenchmarkMethodAttribute.cs
+++ b/BenchmarkDotNet/BenchmarkMethodAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace BenchmarkDotNet
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class BenchmarkMethodAttribute: Attribute
+    {
+    }
+}

--- a/BenchmarkDotNet/CompetitionBase.cs
+++ b/BenchmarkDotNet/CompetitionBase.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using NUnit.Framework;
+
+namespace BenchmarkDotNet
+{
+    [TestFixture]
+    public abstract class CompetitionBase
+    {
+        private class TextWriterWithForcedSpaces : TextWriter
+        {
+            private readonly TextWriter textWriter;
+
+            public TextWriterWithForcedSpaces(TextWriter textWriter)
+            {
+                this.textWriter = textWriter;
+            }
+
+            public override Encoding Encoding
+            {
+                get { return textWriter.Encoding; }
+            }
+
+            public override void Write(char value)
+            {
+                switch (value)
+                {
+                    case '\r':
+                        return;
+                    case '\n':
+                        textWriter.Write("\u200b\n");
+                        return;
+                    case ' ':
+                        textWriter.Write(" \u200b");
+                        return;
+                    default:
+                        textWriter.Write(value);
+                        return;
+                }
+            }
+        }
+
+        private static void AssertBenchmarkMethodHasCorrectSignature(MethodInfo method)
+        {
+            if (method.GetParameters().Any() || method.ReturnType != typeof (Action))
+                throw new InvalidOperationException(
+                    string.Format("Benchmark method {0} has incorrect signature.\n"
+                                  + "Correct signature is: public Action BenchmarkName() {{ ... }}",
+                        method.Name));
+        }
+
+        private static bool IsBenchmarkMethod(MethodInfo method)
+        {
+            return method.GetCustomAttributes(typeof (BenchmarkMethodAttribute), false).Any();
+        }
+
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+            Console.SetOut(new TextWriterWithForcedSpaces(Console.Error)); // fix for bug in NUnit+ReSharper output
+        }
+
+        [Test]
+        public void CompetitionEntryPoint()
+        {
+            Type type = GetType();
+            string benchmarkName = type.Name.WithoutSuffix("competition", StringComparison.InvariantCultureIgnoreCase);
+
+            var competition = new BenchmarkCompetition();
+            foreach (var method in type.GetMethods())
+                if (IsBenchmarkMethod(method)) {
+                    AssertBenchmarkMethodHasCorrectSignature(method);
+                    var competitionTask = (Action) method.Invoke(this, new object[0]);
+                    competition.AddTask(benchmarkName + " - " + method.Name, competitionTask);
+                }
+
+            competition.Run();
+        }
+    }
+}

--- a/BenchmarkDotNet/packages.config
+++ b/BenchmarkDotNet/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.2" targetFramework="net35" />
+</packages>

--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -49,6 +49,7 @@
     <Compile Include="MultidimensionalArrayProgram.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReflectionVsExpressionCompetition.cs" />
     <Compile Include="ShiftVsMultiplyProgram.cs" />
     <Compile Include="ReverseSortProgram.cs" />
     <Compile Include="ArrayIterationProgram.cs" />

--- a/Benchmarks/ReflectionVsExpressionCompetition.cs
+++ b/Benchmarks/ReflectionVsExpressionCompetition.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using BenchmarkDotNet;
+
+namespace Benchmarks
+{
+    public class ReflectionVsExpressionCompetition: CompetitionBase
+    {
+        private const int IterationCount = 200000;
+
+        private struct SomeStruct
+        {
+            private int field;
+        }
+
+        [BenchmarkMethod]
+        public Action SetFieldViaReflection()
+        {
+            FieldInfo field = typeof (SomeStruct).GetField("field", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            object someClass = new SomeStruct();
+            Func<object, object, object> setMemberDelegate = (container, value) => {
+                                                                 field.SetValue(container, value);
+                                                                 return container;
+                                                             };
+
+            return () => {
+                       for (int i = 0; i < IterationCount; i++)
+                           someClass = setMemberDelegate(someClass, i);
+                   };
+        }
+
+        [BenchmarkMethod]
+        public Action SetFieldViaExpression()
+        {
+            FieldInfo field = typeof (SomeStruct).GetField("field", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            ParameterExpression xValue = Expression.Parameter(typeof (object));
+            ParameterExpression xContainer = Expression.Parameter(typeof (object));
+            ParameterExpression xTypedContainer = Expression.Parameter(typeof (SomeStruct));
+            Expression<Func<object, object, object>> xSetField = Expression
+                .Lambda<Func<object, object, object>>(
+                    Expression.Block(new[] { xTypedContainer },
+                        Expression.Assign(
+                            xTypedContainer,
+                            Expression.Convert(xContainer, typeof (SomeStruct))),
+                        Expression.Assign(
+                            Expression.Field(xTypedContainer, field),
+                            Expression.Convert(xValue, typeof (int))),
+                        Expression.Convert(xTypedContainer, typeof (object))),
+                    xContainer, xValue);
+
+            object someClass = new SomeStruct();
+            Func<object, object, object> setFieldDelegate = xSetField.Compile();
+
+            return () => {
+                       for (int i = 0; i < IterationCount; i++)
+                           someClass = setFieldDelegate(someClass, i);
+                   };
+        }
+    }
+}


### PR DESCRIPTION
As discussed in AndreyAkinshin/BenchmarkDotNet#2 I've created a integration between BenchmarkDotNet and NUnit.

Now new competition can be created as a class inherited from `CompetitionBase`, each task should be represented by one method marked with `BenchmarkMethod` and returning `Action` delegate.

Classes inherited from `CompetitionBase` are recognized as tests (with single test method) by ReSharper and NUnit and can be executed either inside VisualStudio or via external test runner.
