### PR TITLE
Improved information about job environments in summary

### DIFF
--- a/src/BenchmarkDotNet.Core/Environments/BenchmarkEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet.Core/Environments/BenchmarkEnvironmentInfo.cs
@@ -8,6 +8,7 @@ namespace BenchmarkDotNet.Environments
     public class BenchmarkEnvironmentInfo
     {
         internal const string RuntimeInfoPrefix = "Runtime=";
+        internal const string GcInfoPrefix = "GC=";
 
         public string Architecture { get; }
 
@@ -19,6 +20,8 @@ namespace BenchmarkDotNet.Environments
 
         public bool HasRyuJit { get; }
 
+        public string JitInfo { get; }
+
         public bool IsServerGC { get; }
 
         public bool IsConcurrentGC { get; }
@@ -29,6 +32,7 @@ namespace BenchmarkDotNet.Environments
             RuntimeVersion = RuntimeInformation.GetRuntimeVersion();
             Configuration = RuntimeInformation.GetConfiguration();
             HasRyuJit = RuntimeInformation.HasRyuJit();
+            JitInfo = RuntimeInformation.GetJitInfo();
             IsServerGC = GCSettings.IsServerGC;
             IsConcurrentGC = GCSettings.LatencyMode != GCLatencyMode.Batch;
         }
@@ -39,18 +43,20 @@ namespace BenchmarkDotNet.Environments
         public virtual IEnumerable<string> ToFormattedString()
         {
             yield return "Benchmark Process Environment Information:";
-            yield return $"{RuntimeInfoPrefix}{RuntimeVersion}, Arch={Architecture} {GetConfigurationFlag()}{GetDebuggerFlag()}{GetJitFlag()}";
-            yield return $"GC={GetGcConcurrentFlag()} {GetGcServerFlag()}";
+            yield return $"{RuntimeInfoPrefix}{GetRuntimeInfo()}";
+            yield return $"{GcInfoPrefix}{GetGcConcurrentFlag()} {GetGcServerFlag()}";
         }
 
-        protected string GetJitFlag() => HasRyuJit ? " [RyuJIT]" : "";
-
-        protected string GetConfigurationFlag() => Configuration == RuntimeInformation.Unknown ? "" : Configuration;
+        protected string GetConfigurationFlag() => Configuration == RuntimeInformation.Unknown || Configuration == RuntimeInformation.ReleaseConfigurationName
+            ? ""
+            : Configuration;
 
         protected string GetDebuggerFlag() => HasAttachedDebugger ? " [AttachedDebugger]" : "";
 
         protected string GetGcServerFlag() => IsServerGC ? "Server" : "Workstation";
 
         protected string GetGcConcurrentFlag() => IsConcurrentGC ? "Concurrent" : "Non-concurrent";
+
+        internal string GetRuntimeInfo() => $"{RuntimeVersion}, {Architecture} {JitInfo}{GetConfigurationFlag()}{GetDebuggerFlag()}";
     }
 }

--- a/src/BenchmarkDotNet.Core/Environments/HostEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet.Core/Environments/HostEnvironmentInfo.cs
@@ -59,7 +59,7 @@ namespace BenchmarkDotNet.Environments
             ProcessorCount = System.Environment.ProcessorCount;
             ChronometerFrequency = Chronometer.Frequency;
             HardwareTimerKind = Chronometer.HardwareTimerKind;
-            JitModules = RuntimeInformation.GetJitModules();
+            JitModules = RuntimeInformation.GetJitModulesInfo();
             DotNetCliVersion = new Lazy<string>(DotNetCliCommandExecutor.GetDotNetCliVersion);
         }
 
@@ -73,11 +73,6 @@ namespace BenchmarkDotNet.Environments
             yield return $"OS={OsVersion}";
             yield return $"Processor={ProcessorName.Value}, ProcessorCount={ProcessorCount}";
             yield return $"Frequency={ChronometerFrequency}, Resolution={GetChronometerResolution()}, Timer={HardwareTimerKind.ToString().ToUpper()}";
-            yield return $"Host Runtime={RuntimeVersion}, Arch={Architecture} {GetConfigurationFlag()}{GetDebuggerFlag()}{GetJitFlag()}";
-            yield return $"GC={GetGcConcurrentFlag()} {GetGcServerFlag()}";
-#if CLASSIC
-            yield return $"JitModules={JitModules}";
-#endif
 #if !CLASSIC
             yield return $"dotnet cli version={DotNetCliVersion.Value}";
 #endif

--- a/src/BenchmarkDotNet.Core/Environments/HostEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet.Core/Environments/HostEnvironmentInfo.cs
@@ -69,8 +69,7 @@ namespace BenchmarkDotNet.Environments
 
         public override IEnumerable<string> ToFormattedString()
         {
-            yield return $"{BenchmarkDotNetCaption}=v{BenchmarkDotNetVersion}";
-            yield return $"OS={OsVersion}";
+            yield return $"{BenchmarkDotNetCaption}=v{BenchmarkDotNetVersion}, OS={OsVersion}";
             yield return $"Processor={ProcessorName.Value}, ProcessorCount={ProcessorCount}";
             yield return $"Frequency={ChronometerFrequency}, Resolution={GetChronometerResolution()}, Timer={HardwareTimerKind.ToString().ToUpper()}";
 #if !CLASSIC

--- a/src/BenchmarkDotNet.Core/Exporters/AsciiDocExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/AsciiDocExporter.cs
@@ -23,7 +23,7 @@ namespace BenchmarkDotNet.Exporters
             {
                 logger.WriteLineInfo(infoLine);
             }
-            logger.WriteLineInfo(summary.JobRuntimes);
+            logger.WriteLineInfo(summary.AllRuntimes);
             logger.WriteLine();
 
             PrintTable(summary.Table, logger);

--- a/src/BenchmarkDotNet.Core/Exporters/HtmlExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/HtmlExporter.cs
@@ -35,7 +35,7 @@ namespace BenchmarkDotNet.Exporters
             {
                 logger.WriteLine(infoLine);
             }
-            logger.WriteLine(summary.JobRuntimes);
+            logger.WriteLine(summary.AllRuntimes);
             logger.Write("</code></pre>");
             logger.WriteLine();
 

--- a/src/BenchmarkDotNet.Core/Exporters/MarkdownExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/MarkdownExporter.cs
@@ -77,7 +77,7 @@ namespace BenchmarkDotNet.Exporters
             {
                 logger.WriteLineInfo(infoLine);
             }
-            logger.WriteLineInfo(summary.JobRuntimes);
+            logger.WriteLineInfo(summary.AllRuntimes);
             logger.WriteLine();
 
             PrintTable(summary.Table, logger);

--- a/src/BenchmarkDotNet.Core/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet.Core/Portability/RuntimeInformation.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.RegularExpressions;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Extensions;
@@ -21,15 +23,15 @@ namespace BenchmarkDotNet.Portability
     {
         private static readonly bool isMono = Type.GetType("Mono.Runtime") != null; // it allocates a lot of memory, we need to check it once in order to keep Enging non-allocating!
 
-        private const string Debug = "DEBUG";
-        private const string Release = "RELEASE";
+        private const string DebugConfigurationName = "DEBUG";
+        internal const string ReleaseConfigurationName = "RELEASE";
         internal const string Unknown = "?";
 
         internal static string ExecutableExtension => IsWindows() ? ".exe" : string.Empty;
 
         internal static string ScriptFileExtension => IsWindows() ? ".bat" : ".sh";
 
-        internal static string GetArchitecture() => IntPtr.Size == 4 ? "32-bit" : "64-bit";
+        internal static string GetArchitecture() => IntPtr.Size == 4 ? "32bit" : "64bit";
 
         internal static bool IsWindows()
         {
@@ -115,14 +117,23 @@ namespace BenchmarkDotNet.Portability
 
         public static Platform GetCurrentPlatform() => IntPtr.Size == 4 ? Platform.X86 : Platform.X64;
 
-        internal static string GetJitModules()
+        internal static IEnumerable<JitModule> GetJitModules()
         {
 #if !CORE
-            return string.Join(";",
+            return
                 Process.GetCurrentProcess().Modules
                     .OfType<ProcessModule>()
                     .Where(module => module.ModuleName.Contains("jit"))
-                    .Select(module => Path.GetFileNameWithoutExtension(module.FileName) + "-v" + module.FileVersionInfo.ProductVersion));
+                    .Select(module => new JitModule(Path.GetFileNameWithoutExtension(module.FileName), module.FileVersionInfo.ProductVersion));
+#else
+            return Enumerable.Empty<JitModule>(); // TODO: verify if it is possible to get this for CORE
+#endif
+        }
+
+        internal static string GetJitModulesInfo()
+        {
+#if !CORE
+            return string.Join(";", GetJitModules().Select(m => m.Name + "-v" + m.Version));
 #else
             return Unknown; // TODO: verify if it is possible to get this for CORE
 #endif
@@ -132,13 +143,40 @@ namespace BenchmarkDotNet.Portability
         {
             return !IsMono()
                    && IntPtr.Size == 8
-                   && GetConfiguration() != Debug
+                   && GetConfiguration() != DebugConfigurationName
                    && !new JitHelper().IsMsX64();
         }
 
         internal static Jit GetCurrentJit()
         {
             return HasRyuJit() ? Jit.RyuJit : Jit.LegacyJit;
+        }
+
+        internal static string GetJitInfo()
+        {
+            if (IsMono())
+                return ""; // There is no helpful information about JIT on Mono
+#if CORE
+            return "RyuJIT"; // CoreCLR supports only RyuJIT
+#else
+            // We are working on Full CLR, so there are only LegacyJIT and RyuJIT
+            var modules = GetJitModules().ToArray();
+            string modulesInfo = GetJitModulesInfo();
+            if (HasRyuJit())
+            {
+                var targetModule = modules.FirstOrDefault(m => m.Name == "clrjit");
+                return targetModule != null
+                    ? "RyuJIT-v" + targetModule.Version
+                    : "RyuJIT/" + modulesInfo;
+            }
+            else
+            {
+                var targetModule = modules.FirstOrDefault(m => m.Name == "compatjit" || m.Name == "mscorjit");
+                return targetModule != null
+                    ? "LegacyJIT-v" + targetModule.Version
+                    : "LegacyJIT/" + modulesInfo;
+            }
+#endif
         }
 
         internal static IntPtr GetCurrentAffinity()
@@ -160,7 +198,7 @@ namespace BenchmarkDotNet.Portability
             {
                 return Unknown;
             }
-            return isDebug.Value ? Debug : Release;
+            return isDebug.Value ? DebugConfigurationName : ReleaseConfigurationName;
         }
 
         internal static string GetDotNetCliRuntimeIdentifier()
@@ -210,6 +248,18 @@ namespace BenchmarkDotNet.Portability
                         value = j + 10;
                 }
                 return value == 20 + step;
+            }
+        }
+
+        public class JitModule
+        {
+            public string Name { get; }
+            public string Version { get; }
+
+            public JitModule(string name, string version)
+            {
+                Name = name;
+                Version = version;
             }
         }
     }

--- a/src/BenchmarkDotNet.Core/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet.Core/Portability/RuntimeInformation.cs
@@ -157,6 +157,11 @@ namespace BenchmarkDotNet.Portability
             if (IsMono())
                 return ""; // There is no helpful information about JIT on Mono
 #if CORE
+            // For now, we can say that CoreCLR supports only RyuJIT because we allow our users to run only x64 benchmark for Core.
+            // However if we enable 32bit support for .NET Core 1.1 it won't be true, because right now .NET Core is using Legacy Jit for 32bit.
+            // And 32bit .NET Core has support for Windows now only.
+            // NET Core 1.2 will move from leagacy Jitr for 32bits to RyuJIT which will be used by default.
+            // Most probably then also other OSes will get 32bit support.
             return "RyuJIT"; // CoreCLR supports only RyuJIT
 #else
             // We are working on Full CLR, so there are only LegacyJIT and RyuJIT

--- a/src/BenchmarkDotNet.Core/Reports/BenchmarkReportExtensions.cs
+++ b/src/BenchmarkDotNet.Core/Reports/BenchmarkReportExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Linq;
+using BenchmarkDotNet.Environments;
+using JetBrains.Annotations;
+
+namespace BenchmarkDotNet.Reports
+{
+    public static class BenchmarkReportExtensions
+    {
+        private const string DisplayedRuntimeInfoPrefix = "// " + BenchmarkEnvironmentInfo.RuntimeInfoPrefix;
+        private const string DisplayedGcInfoPrefix = "// " + BenchmarkEnvironmentInfo.GcInfoPrefix;
+
+        [CanBeNull]
+        public static string GetRuntimeInfo(this BenchmarkReport report) => report.GetInfoFromOutput(DisplayedRuntimeInfoPrefix);
+
+        [CanBeNull]
+        public static string GetGcInfo(this BenchmarkReport report) => report.GetInfoFromOutput(DisplayedGcInfoPrefix);
+
+        [CanBeNull]
+        private static string GetInfoFromOutput(this BenchmarkReport report, string prefix)
+        {
+            return (
+                from executeResults in report.ExecuteResults
+                from extraOutputLine in executeResults.ExtraOutput.Where(line => line.StartsWith(prefix))
+                select extraOutputLine.Substring(prefix.Length)).FirstOrDefault();
+        }
+    }
+}

--- a/src/BenchmarkDotNet.Core/Running/BenchmarkRunnerCore.cs
+++ b/src/BenchmarkDotNet.Core/Running/BenchmarkRunnerCore.cs
@@ -99,6 +99,7 @@ namespace BenchmarkDotNet.Running
             foreach (var report in reports)
             {
                 logger.WriteLineInfo(report.Benchmark.DisplayInfo);
+                logger.WriteLineStatistic($"Runtime = {report.GetRuntimeInfo()}; GC = {report.GetGcInfo()}");
                 var resultRuns = report.GetResultRuns();
                 if (resultRuns.IsEmpty())
                     logger.WriteLineError("There are no any results runs");

--- a/tests/BenchmarkDotNet.IntegrationTests/MultipleRuntimesTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MultipleRuntimesTest.cs
@@ -50,8 +50,8 @@ namespace BenchmarkDotNet.IntegrationTests
                 .ExecuteResults
                 .All(executeResult => executeResult.Data.Contains("Core")));
 
-            Assert.Contains("Clr 4", summary.JobRuntimes);
-            Assert.Contains("Core", summary.JobRuntimes);
+            Assert.Contains("Clr 4", summary.AllRuntimes);
+            Assert.Contains("Core", summary.AllRuntimes);
         }
     }
 


### PR DESCRIPTION
Many people share benchmark results via simple screenshots which include information about the environment. So, it would be cool to keep the environment info as small as possible but still print all the necessary information. I made some changes; there is the result:

Before (12 lines):
```ini
BenchmarkDotNet=v0.10.0-develop
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-4702MQ CPU 2.20GHz, ProcessorCount=8
Frequency=2143476 Hz, Resolution=466.5319 ns, Timer=TSC
Host Runtime=Clr 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
GC=Concurrent Workstation
JitModules=clrjit-v4.6.1586.0
Job Runtime(s):
        .NET Core 4.6.24628.01, Arch=64-bit  [RyuJIT]
        Clr 4.0.30319.42000, Arch=64-bit RELEASE
        Mono 4.6.2 (Visual Studio built mono), Arch=64-bit RELEASE
        Clr 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
```

After (9 lines):
```ini
BenchmarkDotNet=v0.10.0-develop
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-4702MQ CPU 2.20GHz, ProcessorCount=8
Frequency=2143476 Hz, Resolution=466.5319 ns, Timer=TSC
  [Host]       : Clr 4.0.30319.42000, 64bit RyuJIT-v4.6.1586.0
  Core         : .NET Core 4.6.24628.01, 64bit RyuJIT
  LegacyJitX64 : Clr 4.0.30319.42000, 64bit LegacyJIT-v4.6.1586.0
  Mono         : Mono 4.6.2 (Visual Studio built mono), 64bit
  RyuJitX64    : Clr 4.0.30319.42000, 64bit RyuJIT-v4.6.1586.0
```
Changes:
* JitModules now is a part of the runtime info. Also, we have smart logic which combines knowledge about JitModules and Jit kind into a short form
* We don't print the `Job Runtime(s):` line anymore. I think, our users will understand what is it without additional line with a hint.
* The list of runtimes includes the host runtime (always on the first place)
* Each runtime has a prefix with the JobId (sometimes it's hard to associate runtimes with jobs without an explicit hint).
* An indent of the runtime lines is two spaces instead of a tab (it allows to save two more symbols in these lines
* Now we print `32bit` and `64bit` instead of `Arch=32-bit` and `Arch=64-bit`. The reason is the same: we want to throw away all the unimportant information and print a small amount of characters which fit into a terminal with a small width.
* Now we also don't print information about GC in the summary because I don't think that it's the first importance information. I also added information about GC (and about runtime) for *each* job in the details section (which is before the summary).
* We don't print `RELEASE` anymore, only the `DEBUG` label will be printed.