### PR TITLE
netcoreapp1.1 support for BenchmarkDotNet.Toolchains.Roslyn

### DIFF
--- a/src/BenchmarkDotNet.Toolchains.Roslyn/Toolchains/Classic/RoslynBuilder.cs
+++ b/src/BenchmarkDotNet.Toolchains.Roslyn/Toolchains/Classic/RoslynBuilder.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis;
 using System;
 using System.Linq;
+using System.Reflection;
 using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Jobs;
 using OurPlatform = BenchmarkDotNet.Environments.Platform;
@@ -86,7 +87,7 @@ namespace BenchmarkDotNet.Toolchains.Classic
 
         private static string[] GetFrameworkAssembliesPaths()
         {
-            var frameworkAssembliesDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location);
+            var frameworkAssembliesDirectory = Path.GetDirectoryName(typeof(object).GetTypeInfo().Assembly.Location);
             if (frameworkAssembliesDirectory == null)
             {
                 return new string[0];

--- a/src/BenchmarkDotNet.Toolchains.Roslyn/Toolchains/Classic/RoslynGenerator.cs
+++ b/src/BenchmarkDotNet.Toolchains.Roslyn/Toolchains/Classic/RoslynGenerator.cs
@@ -54,7 +54,7 @@ namespace BenchmarkDotNet.Toolchains.Classic
                     new[]
                     {
                         benchmark.Target.Type.GetTypeInfo().Assembly, // this assembly does not has to have a reference to BenchmarkDotNet (e.g. custom framework for benchmarking that internally uses BenchmarkDotNet
-                        typeof(Benchmark).Assembly, // BenchmarkDotNet.Core
+                        typeof(Benchmark).GetTypeInfo().Assembly, // BenchmarkDotNet.Core
                     })
                 .Distinct();
         }

--- a/src/BenchmarkDotNet.Toolchains.Roslyn/project.json
+++ b/src/BenchmarkDotNet.Toolchains.Roslyn/project.json
@@ -33,15 +33,22 @@
       }
     }
   },
+  "dependencies": {
+      "BenchmarkDotNet.Core": {
+          "target": "project"
+      },
+      "Microsoft.CodeAnalysis.CSharp": "1.3.2"
+  },
   "frameworks": {
     "net45": {
-      "dependencies": {
-        "BenchmarkDotNet.Core": {
-          "target": "project"
-        },
-        "Microsoft.CodeAnalysis.CSharp": "1.3.2",
-        "System.Threading.Tasks": "4.0.0"
-      }
+    },
+    "netcoreapp1.1": {
+        "dependencies": {
+            "Microsoft.NETCore.App": {
+                "type": "platform",
+                "version": "1.1.0"
+            }
+        }
     }
   }
 }


### PR DESCRIPTION
For some reason, I couldn't install BenchmarkDotNet.Toolchains.Roslyn in a new netcoreapp1.1-application without this fix.

@adamsitnik, could you check the fix? Is everything ok?