### PR TITLE
fix bold markup for Atlassian exporter

### DIFF
--- a/src/BenchmarkDotNet.Core/Exporters/MarkdownExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/MarkdownExporter.cs
@@ -48,7 +48,8 @@ namespace BenchmarkDotNet.Exporters
             columnsStartWithSeparator = true,
             useCodeBlocks = true,
             codeBlockStart = "{noformat}",
-            codeBlockEnd = "{noformat}"
+            codeBlockEnd = "{noformat}",
+            boldMarkupFormat = "*{0}*"
         };
 
         private string prefix = string.Empty;
@@ -60,6 +61,7 @@ namespace BenchmarkDotNet.Exporters
         private string tableColumnSeparator = " |";
         private bool useHeaderSeparatingRow = true;
         private bool columnsStartWithSeparator = false;
+        private string boldMarkupFormat = "**{0}**";
 
         private MarkdownExporter()
         {
@@ -148,7 +150,7 @@ namespace BenchmarkDotNet.Exporters
                     logger.Write(tableColumnSeparator);
                 }
 
-                table.PrintLine(line, logger, string.Empty, tableColumnSeparator, highlightRow, table.FullContentStartOfGroup[rowCounter], startOfGroupInBold);
+                table.PrintLine(line, logger, string.Empty, tableColumnSeparator, highlightRow, table.FullContentStartOfGroup[rowCounter], startOfGroupInBold, boldMarkupFormat);
                 rowCounter++;
             }
         }

--- a/src/BenchmarkDotNet.Core/Reports/SummaryTableExtensions.cs
+++ b/src/BenchmarkDotNet.Core/Reports/SummaryTableExtensions.cs
@@ -46,7 +46,7 @@ namespace BenchmarkDotNet.Reports
         }
 
         public static void PrintLine(this SummaryTable table, string[] line, ILogger logger, string leftDel, string rightDel,
-                                     bool highlightRow, bool startOfGroup, bool startOfGroupInBold)
+                                     bool highlightRow, bool startOfGroup, bool startOfGroupInBold, string boldMarkupFormat)
         {
             for (int columnIndex = 0; columnIndex < table.ColumnCount; columnIndex++)
             {
@@ -56,7 +56,7 @@ namespace BenchmarkDotNet.Reports
                 }
 
                 var text = (startOfGroup && startOfGroupInBold)
-                    ? BuildBoldText(table, line, leftDel, rightDel, columnIndex)
+                    ? BuildBoldText(table, line, leftDel, rightDel, columnIndex, boldMarkupFormat)
                     : BuildStandardText(table, line, leftDel, rightDel, columnIndex);
 
                 if (highlightRow) // write the row in an alternative colour
@@ -84,17 +84,13 @@ namespace BenchmarkDotNet.Reports
             return buffer.ToString();
         }
 
-        private static string BuildBoldText(SummaryTable table, string[] line, string leftDel, string rightDel, int columnIndex)
+        private static string BuildBoldText(SummaryTable table, string[] line, string leftDel, string rightDel, int columnIndex, string boldMarkupFormat)
         {
-            const string markdownBold = "**";
-
             var buffer = GetClearBuffer();
 
             buffer.Append(leftDel);
             PadLeft(table, line, leftDel, rightDel, columnIndex, buffer);
-            buffer.Append(markdownBold);
-            buffer.Append(line[columnIndex]);
-            buffer.Append(markdownBold);
+            buffer.AppendFormat(boldMarkupFormat, line[columnIndex]);
             buffer.Append(rightDel);
 
             return buffer.ToString();


### PR DESCRIPTION
Atlassian uses single '*'s around text to make it bold where GitHub uses two. This fixes to allow customization of format for bold text which Atlassian exporter then overrides.