### PR TITLE
Better detection of Rscript in RPlotExporter

### DIFF
--- a/docs/guide/Configs/Exporters.md
+++ b/docs/guide/Configs/Exporters.md
@@ -207,8 +207,7 @@ Example of `IntroJsonExport-report-brief.json`:
 
 ## Plots
 
-If you have installed [R](https://www.r-project.org/), defined `%R_HOME%` variable and used `RPlotExporter.Default` and `CsvMeasurementsExporter.Default` 
-in your config, you will also get nice plots with help of the `BuildPlots.R` script in your bin directory. 
+You can install [R](https://www.r-project.org/) to automatically get nice plots of your benchmark results. First, make sure `Rscript.exe` or `Rscript` is in your path, or define an R_HOME environment variable pointing to the R installation directory (containing the `bin` directory). Use `RPlotExporter.Default` and `CsvMeasurementsExporter.Default` in your config, and the `BuildPlots.R` script in your bin directory will take care of the rest.
 
 ### Examples
 

--- a/src/BenchmarkDotNet.Core/Exporters/CompositeExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/CompositeExporter.cs
@@ -33,9 +33,9 @@ namespace BenchmarkDotNet.Exporters
                 exporter.ExportToLog(summary, logger);
         }
 
-        public IEnumerable<string> ExportToFiles(Summary summary)
+        public IEnumerable<string> ExportToFiles(Summary summary, ILogger consoleLogger)
         {
-            return exporters.SelectMany(exporter => exporter.ExportToFiles(summary));
+            return exporters.SelectMany(exporter => exporter.ExportToFiles(summary, consoleLogger));
         }
     }
 }

--- a/src/BenchmarkDotNet.Core/Exporters/ExporterBase.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/ExporterBase.cs
@@ -13,7 +13,7 @@ namespace BenchmarkDotNet.Exporters
 
         public abstract void ExportToLog(Summary summary, ILogger logger);
 
-        public IEnumerable<string> ExportToFiles(Summary summary)
+        public IEnumerable<string> ExportToFiles(Summary summary, ILogger consoleLogger)
         {
             var filePath = $"{Path.Combine(summary.ResultsDirectoryPath, summary.Title)}-{FileCaption}{FileNameSuffix}.{FileExtension}";
             using (var stream = Portability.StreamWriter.FromPath(filePath))

--- a/src/BenchmarkDotNet.Core/Exporters/IExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/IExporter.cs
@@ -7,6 +7,6 @@ namespace BenchmarkDotNet.Exporters
     public interface IExporter
     {
         void ExportToLog(Summary summary, ILogger logger);
-        IEnumerable<string> ExportToFiles(Summary summary);
+        IEnumerable<string> ExportToFiles(Summary summary, ILogger consoleLogger);
     }
 }

--- a/src/BenchmarkDotNet.Core/Exporters/RPlotExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/RPlotExporter.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using BenchmarkDotNet.Exporters.Csv;
 using BenchmarkDotNet.Helpers;
 using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Properties;
 using BenchmarkDotNet.Reports;
 
@@ -36,33 +38,51 @@ namespace BenchmarkDotNet.Exporters
             lock (buildScriptLock)
                 File.WriteAllText(scriptFullPath, script);
 
-            // TODO: implement smart autodetection of the R bin folder
+            var rscriptExecutable = RuntimeInformation.IsWindows() ? "Rscript.exe" : "Rscript";
+            string rscriptPath;
             var rHome = Environment.GetEnvironmentVariable("R_HOME");
-            if (Directory.Exists(rHome))
+            if (rHome != null)
             {
-                var start = new ProcessStartInfo
+                rscriptPath = Path.Combine(rHome, "bin", rscriptExecutable);
+                if (!File.Exists(rscriptPath))
                 {
-                    UseShellExecute = false,
-                    RedirectStandardOutput = false,
-                    CreateNoWindow = true,
-                    FileName = Path.Combine(rHome, "Rscript.exe"),
-                    WorkingDirectory = summary.ResultsDirectoryPath,
-                    Arguments = $"\"{scriptFullPath}\" \"{fileNamePrefix}-measurements.csv\""
-                };
-                using (var process = Process.Start(start))
-                    process?.WaitForExit();
-                yield return fileNamePrefix + "-boxplot.png";
-                yield return fileNamePrefix + "-barplot.png";
+                    consoleLogger.WriteLineError($"RPlotExporter requires R_HOME to point to the directory containing bin{Path.DirectorySeparatorChar}{rscriptExecutable} (currently points to {rHome})");
+                    yield break;
+                }
             }
-            else
+            else // No R_HOME, try the path
             {
-                // TODO: print warning, if the folder is not found
+                rscriptPath = FindInPath(rscriptExecutable);
+                if (rscriptPath == null)
+                {
+                    consoleLogger.WriteLineError($"RPlotExporter couldn't find {rscriptExecutable} in your PATH and no R_HOME environment variable is defined");
+                    yield break;
+                }
             }
+
+            var start = new ProcessStartInfo
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = false,
+                CreateNoWindow = true,
+                FileName = rscriptPath,
+                WorkingDirectory = summary.ResultsDirectoryPath,
+                Arguments = $"\"{scriptFullPath}\" \"{fileNamePrefix}-measurements.csv\""
+            };
+            using (var process = Process.Start(start))
+                process?.WaitForExit();
+            yield return fileNamePrefix + "-boxplot.png";
+            yield return fileNamePrefix + "-barplot.png";
         }
 
         public void ExportToLog(Summary summary, ILogger logger)
         {
             throw new NotSupportedException();
         }
+
+        static string FindInPath(string name) => Environment.GetEnvironmentVariable("PATH")
+            .Split(Path.PathSeparator)
+            .Select(p => Path.Combine(p, name))
+            .FirstOrDefault(File.Exists);
     }
 }

--- a/src/BenchmarkDotNet.Core/Exporters/RPlotExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/RPlotExporter.cs
@@ -22,7 +22,7 @@ namespace BenchmarkDotNet.Exporters
             get { yield return CsvMeasurementsExporter.Default; }
         }
 
-        public IEnumerable<string> ExportToFiles(Summary summary)
+        public IEnumerable<string> ExportToFiles(Summary summary, ILogger consoleLogger)
         {
             const string scriptFileName = "BuildPlots.R";
             yield return scriptFileName;

--- a/src/BenchmarkDotNet.Core/Running/BenchmarkRunnerCore.cs
+++ b/src/BenchmarkDotNet.Core/Running/BenchmarkRunnerCore.cs
@@ -87,7 +87,7 @@ namespace BenchmarkDotNet.Running
 
             logger.WriteLineHeader("// * Export *");
             var currentDirectory = Directory.GetCurrentDirectory();
-            foreach (var file in config.GetCompositeExporter().ExportToFiles(summary))
+            foreach (var file in config.GetCompositeExporter().ExportToFiles(summary, logger))
             {
                 logger.WriteLineInfo($"  {file.Replace(currentDirectory, string.Empty).Trim('/', '\\')}");
             }

--- a/tests/BenchmarkDotNet.IntegrationTests/BaselineScaledColumnTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/BaselineScaledColumnTest.cs
@@ -95,7 +95,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
             public void ExportToLog(Summary summary, BenchmarkDotNet.Loggers.ILogger logger) => ExportCalled = true;
 
-            public IEnumerable<string> ExportToFiles(Summary summary)
+            public IEnumerable<string> ExportToFiles(Summary summary, BenchmarkDotNet.Loggers.ILogger consoleLogger)
             {
                 ExportToFileCalled = true;
                 return Enumerable.Empty<string>();

--- a/tests/BenchmarkDotNet.Tests/ExporterDependancyTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ExporterDependancyTests.cs
@@ -36,7 +36,7 @@ namespace BenchmarkDotNet.Tests
             get { yield return TestExporterDependancy.Default; }
         }
 
-        public IEnumerable<string> ExportToFiles(Summary summary) => Enumerable.Empty<string>();
+        public IEnumerable<string> ExportToFiles(Summary summary, ILogger consoleLogger) => Enumerable.Empty<string>();
 
         public void ExportToLog(Summary summary, ILogger logger) { }
     }
@@ -45,7 +45,7 @@ namespace BenchmarkDotNet.Tests
     {
         public static readonly TestExporterDependancy Default = new TestExporterDependancy();
 
-        public IEnumerable<string> ExportToFiles(Summary summary) => Enumerable.Empty<string>();
+        public IEnumerable<string> ExportToFiles(Summary summary, ILogger consoleLogger) => Enumerable.Empty<string>();
 
         public void ExportToLog(Summary summary, ILogger logger) { }
     }


### PR DESCRIPTION
Fixes #337.

RPlotExporter now logs an error if Rscript.exe isn't found and aborts. It may not be visible enough (is throwing an exception better?)