### PR TITLE
Fixed typo in IntroBasic.cs

### DIFF
--- a/samples/BenchmarkDotNet.Samples/Intro/IntroBasic.cs
+++ b/samples/BenchmarkDotNet.Samples/Intro/IntroBasic.cs
@@ -14,7 +14,7 @@ namespace BenchmarkDotNet.Samples.Intro
         }
 
         // You can write a description for your method.
-        [Benchmark(Description = "Thread.Sleep(100)")]
+        [Benchmark(Description = "Thread.Sleep(10)")]
         public void SleepWithDescription()
         {
             Thread.Sleep(10);


### PR DESCRIPTION
There was a typo in the desription.