### PR TITLE
Markdown exporter makes all columns after the first right-justified

### DIFF
--- a/src/BenchmarkDotNet.Core/Exporters/MarkdownExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/MarkdownExporter.cs
@@ -139,7 +139,7 @@ namespace BenchmarkDotNet.Exporters
                     logger.Write(tableHeaderSeparator);
                 }
 
-                logger.WriteLineStatistic(string.Join("", table.Columns.Where(c => c.NeedToShow).Select(c => new string('-', c.Width) + " |")));
+                logger.WriteLineStatistic(string.Join("", table.Columns.Where(c => c.NeedToShow).Select(c => new string('-', c.Width) + (c.Index == 0 ? " |" : ":|"))));
             }
             var rowCounter = 0;
             var highlightRow = false;


### PR DESCRIPTION
This is a potential quick-fix for #397.

As far as I can tell, at least in all the results I have seen, all columns after the first are numeric, and therefore should be right-justified.

Alternatively, the fixed-width versions of these tables have every column right-justified, so if we want to go that route, the inline ternary could be removed and all columns could be delimited by `:|`.

A more complete solution would be for columns to have an `IsNumeric` property, or something like it, that would help identify intended alignment in display tables.

Let me know which you think would be best!