### PR TITLE
Make RoslynToolchain types public

### DIFF
--- a/src/BenchmarkDotNet.Toolchains.Roslyn/Builder.cs
+++ b/src/BenchmarkDotNet.Toolchains.Roslyn/Builder.cs
@@ -6,16 +6,19 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.Results;
+using JetBrains.Annotations;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using OurPlatform = BenchmarkDotNet.Environments.Platform;
 
 namespace BenchmarkDotNet.Toolchains.Roslyn
 {
+    [PublicAPI]
     public class Builder : IBuilder
     {
         private static readonly Lazy<AssemblyMetadata[]> FrameworkAssembliesMetadata = new Lazy<AssemblyMetadata[]>(GetFrameworkAssembliesMetadata);
 
+        [PublicAPI]
         public BuildResult Build(GenerateResult generateResult, ILogger logger, Benchmark benchmark, IResolver resolver)
         {
             logger.WriteLineInfo($"BuildScript: {generateResult.ArtifactsPaths.BuildScriptFilePath}");

--- a/src/BenchmarkDotNet.Toolchains.Roslyn/Builder.cs
+++ b/src/BenchmarkDotNet.Toolchains.Roslyn/Builder.cs
@@ -12,7 +12,7 @@ using OurPlatform = BenchmarkDotNet.Environments.Platform;
 
 namespace BenchmarkDotNet.Toolchains.Roslyn
 {
-    internal class Builder : IBuilder
+    public class Builder : IBuilder
     {
         private static readonly Lazy<AssemblyMetadata[]> FrameworkAssembliesMetadata = new Lazy<AssemblyMetadata[]>(GetFrameworkAssembliesMetadata);
 

--- a/src/BenchmarkDotNet.Toolchains.Roslyn/Generator.cs
+++ b/src/BenchmarkDotNet.Toolchains.Roslyn/Generator.cs
@@ -10,7 +10,7 @@ using BenchmarkDotNet.Running;
 
 namespace BenchmarkDotNet.Toolchains.Roslyn
 {
-    internal class Generator : GeneratorBase
+    public class Generator : GeneratorBase
     {
         protected override string GetBuildArtifactsDirectoryPath(Benchmark benchmark, string programName)
             => Path.GetDirectoryName(benchmark.Target.Type.GetTypeInfo().Assembly.Location);

--- a/src/BenchmarkDotNet.Toolchains.Roslyn/Generator.cs
+++ b/src/BenchmarkDotNet.Toolchains.Roslyn/Generator.cs
@@ -7,14 +7,18 @@ using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Running;
+using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Toolchains.Roslyn
 {
+    [PublicAPI]
     public class Generator : GeneratorBase
     {
+        [PublicAPI]
         protected override string GetBuildArtifactsDirectoryPath(Benchmark benchmark, string programName)
             => Path.GetDirectoryName(benchmark.Target.Type.GetTypeInfo().Assembly.Location);
 
+        [PublicAPI]
         protected override void Cleanup(ArtifactsPaths artifactsPaths)
         {
             DelteIfExists(artifactsPaths.ProgramCodePath);
@@ -23,6 +27,7 @@ namespace BenchmarkDotNet.Toolchains.Roslyn
             DelteIfExists(artifactsPaths.ExecutablePath);
         }
 
+        [PublicAPI]
         protected override void GenerateBuildScript(Benchmark benchmark, ArtifactsPaths artifactsPaths, IResolver resolver)
         {
             var prefix = RuntimeInformation.IsWindows() ? "" : "#!/bin/bash\n";

--- a/src/BenchmarkDotNet.Toolchains.Roslyn/RoslynToolchain.cs
+++ b/src/BenchmarkDotNet.Toolchains.Roslyn/RoslynToolchain.cs
@@ -9,6 +9,7 @@ namespace BenchmarkDotNet.Toolchains.Roslyn
     /// <summary>
     /// Build a benchmark program with the Roslyn compiler.
     /// </summary>
+    [PublicAPI]
     public class RoslynToolchain : Toolchain
     {
         [PublicAPI]
@@ -16,6 +17,7 @@ namespace BenchmarkDotNet.Toolchains.Roslyn
         {
         }
 
+        [PublicAPI]
         public override bool IsSupported(Benchmark benchmark, ILogger logger, IResolver resolver)
         {
             if (!base.IsSupported(benchmark, logger, resolver))


### PR DESCRIPTION
I need to extend the Roslyn Generator and Builder with custom build steps for our codebase, so I made the types public. Now they have the same visibility as the dotnet CLI generators and builders.

Also considered more general solutions that would allow API users to extend any toolchain without caring what it is:
1. make the GeneratorBase's protected hook methods public, so I can then decorate a GeneratorBase with my own hook implementations which would call the inner hooks and then do something extra
2. replace GeneratorBases's protected hook methods with public delegates, thus transforming inheritance to composition. API users could then start with some default compositions (roslyn / CLI) and add to the existing delegates.

In the end I went with this implementation since it's small, simple, and does not break backcompat.