### PR TITLE
Propagate benchmark to hooks

### DIFF
--- a/src/BenchmarkDotNet.Core/Toolchains/DotNetCli/DotNetCliGenerator.cs
+++ b/src/BenchmarkDotNet.Core/Toolchains/DotNetCli/DotNetCliGenerator.cs
@@ -74,7 +74,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             return false;
         }
 
-        protected override void Cleanup(ArtifactsPaths artifactsPaths)
+        protected override void Cleanup(Benchmark benchmark, ArtifactsPaths artifactsPaths)
         {
             if (!Directory.Exists(artifactsPaths.BuildArtifactsDirectoryPath))
             {

--- a/src/BenchmarkDotNet.Core/Toolchains/DotNetCli/DotNetCliGenerator.cs
+++ b/src/BenchmarkDotNet.Core/Toolchains/DotNetCli/DotNetCliGenerator.cs
@@ -100,7 +100,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             }
         }
 
-        protected override void CopyAllRequiredFiles(ArtifactsPaths artifactsPaths)
+        protected override void CopyAllRequiredFiles(Benchmark benchmark, ArtifactsPaths artifactsPaths)
         {
             if (!Directory.Exists(artifactsPaths.BinariesDirectoryPath))
             {

--- a/src/BenchmarkDotNet.Core/Toolchains/GeneratorBase.cs
+++ b/src/BenchmarkDotNet.Core/Toolchains/GeneratorBase.cs
@@ -22,7 +22,7 @@ namespace BenchmarkDotNet.Toolchains
 
                 Cleanup(artifactsPaths);
 
-                CopyAllRequiredFiles(artifactsPaths);
+                CopyAllRequiredFiles(benchmark, artifactsPaths);
 
                 GenerateCode(benchmark, artifactsPaths);
                 GenerateAppConfig(benchmark, artifactsPaths, resolver);
@@ -45,7 +45,7 @@ namespace BenchmarkDotNet.Toolchains
 
         protected abstract void Cleanup(ArtifactsPaths artifactsPaths);
 
-        protected virtual void CopyAllRequiredFiles(ArtifactsPaths artifactsPaths) { }
+        protected virtual void CopyAllRequiredFiles(Benchmark benchmark, ArtifactsPaths artifactsPaths) { }
 
         protected virtual void GenerateProject(Benchmark benchmark, ArtifactsPaths artifactsPaths, IResolver resolver, ILogger logger) { }
 

--- a/src/BenchmarkDotNet.Core/Toolchains/GeneratorBase.cs
+++ b/src/BenchmarkDotNet.Core/Toolchains/GeneratorBase.cs
@@ -20,7 +20,7 @@ namespace BenchmarkDotNet.Toolchains
             {
                 artifactsPaths = GetArtifactsPaths(benchmark, config, rootArtifactsFolderPath);
 
-                Cleanup(artifactsPaths);
+                Cleanup(benchmark, artifactsPaths);
 
                 CopyAllRequiredFiles(benchmark, artifactsPaths);
 
@@ -43,7 +43,7 @@ namespace BenchmarkDotNet.Toolchains
 
         protected virtual string GetProjectFilePath(string binariesDirectoryPath) => string.Empty;
 
-        protected abstract void Cleanup(ArtifactsPaths artifactsPaths);
+        protected abstract void Cleanup(Benchmark benchmark, ArtifactsPaths artifactsPaths);
 
         protected virtual void CopyAllRequiredFiles(Benchmark benchmark, ArtifactsPaths artifactsPaths) { }
 
@@ -62,7 +62,7 @@ namespace BenchmarkDotNet.Toolchains
             string executablePath = Path.Combine(binariesDirectoryPath, $"{programName}{RuntimeInformation.ExecutableExtension}");
 
             return new ArtifactsPaths(
-                cleanup: Cleanup,
+                cleanup: artifactsPaths => Cleanup(benchmark, artifactsPaths),
                 rootArtifactsFolderPath: rootArtifactsFolderPath,
                 buildArtifactsDirectoryPath: buildArtifactsDirectoryPath,
                 binariesDirectoryPath: binariesDirectoryPath,

--- a/src/BenchmarkDotNet.Toolchains.Roslyn/Generator.cs
+++ b/src/BenchmarkDotNet.Toolchains.Roslyn/Generator.cs
@@ -19,7 +19,7 @@ namespace BenchmarkDotNet.Toolchains.Roslyn
             => Path.GetDirectoryName(benchmark.Target.Type.GetTypeInfo().Assembly.Location);
 
         [PublicAPI]
-        protected override void Cleanup(ArtifactsPaths artifactsPaths)
+        protected override void Cleanup(Benchmark benchmark, ArtifactsPaths artifactsPaths)
         {
             DelteIfExists(artifactsPaths.ProgramCodePath);
             DelteIfExists(artifactsPaths.AppConfigPath);


### PR DESCRIPTION
`Cleanup` and `CopyRequiredFiles` did not receive the benchmark. Now they do. Unfortunately this is a breaking change, but I think it's worth it, since now all hook signatures are uniform (these were the only two hooks not receiving the benchmark object).

In my case, I am copying in different versions of a benchmark's dependencies, so I need to move the `BuildArtifactsDirectoryPath` outside of the benchmark's bindir, where the `BuildArtifactsDirectoryPath` defaults to for the Roslyn Generator, and then copy everything from the benchmark bindir there. This means that in my case, both `Cleanup` and `CopyRequiredFiles` hooks need to know where the benchmark type is located. 