### PR TITLE
Allows picking showing and hiding measurement units in reports

### DIFF
--- a/src/BenchmarkDotNet.Core/Columns/BaselineScaledColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/BaselineScaledColumn.cs
@@ -91,6 +91,8 @@ namespace BenchmarkDotNet.Columns
         public bool AlwaysShow => true;
         public ColumnCategory Category => ColumnCategory.Baseline;
         public int PriorityInCategory => (int) Kind;
+        public UnitType UnitType => UnitType.Dimensionless;
+        public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
         public override string ToString() => ColumnName;
         public bool IsDefault(Summary summary, Benchmark benchmark) => false;
     }

--- a/src/BenchmarkDotNet.Core/Columns/IColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/IColumn.cs
@@ -16,7 +16,15 @@ namespace BenchmarkDotNet.Columns
         /// </summary>
         string ColumnName { get; }
 
+        /// <summary>
+        /// Value in this column formatted using the default style.
+        /// </summary>
         string GetValue(Summary summary, Benchmark benchmark);
+
+        /// <summary>
+        /// Value in this column formatted using the specified style.
+        /// </summary>
+        string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style);
 
         bool IsDefault(Summary summary, Benchmark benchmark);
 
@@ -30,5 +38,10 @@ namespace BenchmarkDotNet.Columns
         /// Defines order of column in the same category.
         /// </summary>
         int PriorityInCategory { get; }
+
+        /// <summary>
+        /// Defines how to format column's value
+        /// </summary>
+        UnitType UnitType { get; }
     }
 }

--- a/src/BenchmarkDotNet.Core/Columns/JobCharacteristicColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/JobCharacteristicColumn.cs
@@ -32,6 +32,8 @@ namespace BenchmarkDotNet.Columns
         public bool AlwaysShow => false;
         public ColumnCategory Category => ColumnCategory.Job;
         public int PriorityInCategory => 0;
+        public UnitType UnitType => UnitType.Dimensionless;
+        public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
 
         public bool IsDefault(Summary summary, Benchmark benchmark) => !benchmark.Job.HasValue(characteristic);
 

--- a/src/BenchmarkDotNet.Core/Columns/ParamColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/ParamColumn.cs
@@ -23,5 +23,7 @@ namespace BenchmarkDotNet.Columns
         public ColumnCategory Category => ColumnCategory.Params;
         public int PriorityInCategory => 0;
         public override string ToString() => ColumnName;
+        public UnitType UnitType => UnitType.Dimensionless;
+        public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
     }
 }

--- a/src/BenchmarkDotNet.Core/Columns/RankColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/RankColumn.cs
@@ -34,6 +34,8 @@ namespace BenchmarkDotNet.Columns
         public bool IsAvailable(Summary summary) => true;
         public bool AlwaysShow => true;
         public ColumnCategory Category => ColumnCategory.Custom;
+        public UnitType UnitType => UnitType.Dimensionless;
+        public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
         public int PriorityInCategory => (int) system;
         public override string ToString() => ColumnName;
     }

--- a/src/BenchmarkDotNet.Core/Columns/SizeUnit.cs
+++ b/src/BenchmarkDotNet.Core/Columns/SizeUnit.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BenchmarkDotNet.Columns
+{
+    public class SizeUnit
+    {
+        public string Name { get; }
+        public string Description { get; }
+        public long ByteAmount { get; }
+
+        public SizeUnit(string name, string description, long byteAmount)
+        {
+            Name = name;
+            Description = description;
+            ByteAmount = byteAmount;
+        }
+
+        public const long BytesInKiloByte = 1000L;
+        public static readonly SizeUnit B = new SizeUnit("B", "Byte", 1L);
+        public static readonly SizeUnit KB = new SizeUnit("kB", "Kilobyte", BytesInKiloByte);
+        public static readonly SizeUnit MB = new SizeUnit("MB", "Megabyte", BytesInKiloByte * BytesInKiloByte);
+        public static readonly SizeUnit GB = new SizeUnit("GB", "Gigabyte", BytesInKiloByte * BytesInKiloByte * BytesInKiloByte);
+        public static readonly SizeUnit TB = new SizeUnit("TB", "Terabyte", BytesInKiloByte * BytesInKiloByte * BytesInKiloByte * BytesInKiloByte);
+        public static readonly SizeUnit[] All = { B, KB, MB, GB, TB };
+
+        public static SizeUnit GetBestSizeUnit(params long[] values)
+        {
+            if (!values.Any())
+                return SizeUnit.B;
+            // Use the largest unit to display the smallest recorded measurement without loss of precision.
+            var minValue = values.Min();
+            foreach (var sizeUnit in All)
+            {
+                if (minValue < sizeUnit.ByteAmount * BytesInKiloByte)
+                    return sizeUnit;
+            }
+            return All.Last();
+        }
+
+        public static double Convert(long value, SizeUnit from, SizeUnit to) => value * (double)@from.ByteAmount / (to ?? GetBestSizeUnit(value)).ByteAmount;
+    }
+}

--- a/src/BenchmarkDotNet.Core/Columns/StatisticColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/StatisticColumn.cs
@@ -18,7 +18,7 @@ namespace BenchmarkDotNet.Columns
         public static readonly IColumn StdErr = new StatisticColumn("StdErr", s => s.StandardError, Priority.Main);
         public static readonly IColumn StdDev = new StatisticColumn("StdDev", s => s.StandardDeviation, Priority.Main);
 
-        public static readonly IColumn OperationsPerSecond = new StatisticColumn("Op/s", s => 1.0 * 1000 * 1000 * 1000 / s.Mean, Priority.Additional, false);
+        public static readonly IColumn OperationsPerSecond = new StatisticColumn("Op/s", s => 1.0 * 1000 * 1000 * 1000 / s.Mean, Priority.Additional, UnitType.Dimensionless);
 
         public static readonly IColumn Min = new StatisticColumn("Min", s => s.Min, Priority.Quartile);
         public static readonly IColumn Q1 = new StatisticColumn("Q1", s => s.Q1, Priority.Quartile);
@@ -26,8 +26,8 @@ namespace BenchmarkDotNet.Columns
         public static readonly IColumn Q3 = new StatisticColumn("Q3", s => s.Q3, Priority.Quartile);
         public static readonly IColumn Max = new StatisticColumn("Max", s => s.Max, Priority.Quartile);
 
-        public static readonly IColumn Skewness = new StatisticColumn("Skewness", s => s.Skewness, Priority.Additional ,false);
-        public static readonly IColumn Kurtosis = new StatisticColumn("Kurtosis", s => s.Kurtosis, Priority.Additional, false);
+        public static readonly IColumn Skewness = new StatisticColumn("Skewness", s => s.Skewness, Priority.Additional, UnitType.Dimensionless);
+        public static readonly IColumn Kurtosis = new StatisticColumn("Kurtosis", s => s.Kurtosis, Priority.Additional, UnitType.Dimensionless);
 
         public static readonly IColumn P0 = new StatisticColumn("P0", s => s.Percentiles.P0, Priority.Percentiles);
         public static readonly IColumn P25 = new StatisticColumn("P25", s => s.Percentiles.P25, Priority.Percentiles);
@@ -51,33 +51,37 @@ namespace BenchmarkDotNet.Columns
         public static readonly IColumn[] AllStatistics = { Mean, StdErr, StdDev, OperationsPerSecond, Min, Q1, Median, Q3, Max };
 
         private readonly Func<Statistics, double> calc;
-        private readonly bool isTimeColumn;
         public string Id => nameof(StatisticColumn) + "." + ColumnName;
         public string ColumnName { get; }
         private readonly Priority priority;
+        private readonly UnitType type;
 
-        private StatisticColumn(string columnName, Func<Statistics, double> calc, Priority priority, bool isTimeColumn = true)
+        private StatisticColumn(string columnName, Func<Statistics, double> calc, Priority priority, UnitType type = UnitType.Time)
         {
             this.calc = calc;
             this.priority = priority;
-            this.isTimeColumn = isTimeColumn;
+            this.type = type;
             ColumnName = columnName;
         }
 
-        public string GetValue(Summary summary, Benchmark benchmark) =>
-            Format(summary[benchmark].ResultStatistics, summary.TimeUnit);
+        public string GetValue(Summary summary, Benchmark benchmark)
+            => Format(summary[benchmark].ResultStatistics, SummaryStyle.Default);
+
+        public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style)
+            => Format(summary[benchmark].ResultStatistics, style);
 
         public bool IsAvailable(Summary summary) => true;
         public bool AlwaysShow => true;
         public ColumnCategory Category => ColumnCategory.Statistics;
         public int PriorityInCategory => (int) priority;
+        public UnitType UnitType => type;
 
-        private string Format(Statistics statistics, TimeUnit timeUnit)
+        private string Format(Statistics statistics, ISummaryStyle style)
         {
             if (statistics == null)
                 return "NA";
             double value = calc(statistics);
-            return isTimeColumn ? value.ToTimeStr(timeUnit) : value.ToStr();
+            return type == UnitType.Time ? value.ToTimeStr(style.TimeUnit, 1, style.PrintUnitsInContent) : value.ToStr();
         }
 
         public override string ToString() => ColumnName;

--- a/src/BenchmarkDotNet.Core/Columns/TagColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/TagColumn.cs
@@ -24,6 +24,8 @@ namespace BenchmarkDotNet.Columns
         public bool AlwaysShow => true;
         public ColumnCategory Category => ColumnCategory.Custom;
         public int PriorityInCategory => 0;
+        public UnitType UnitType => UnitType.Dimensionless;
+        public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
         public override string ToString() => ColumnName;
     }
 }

--- a/src/BenchmarkDotNet.Core/Columns/TargetMethodColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/TargetMethodColumn.cs
@@ -18,6 +18,8 @@ namespace BenchmarkDotNet.Columns
         public bool AlwaysShow { get; }
         public ColumnCategory Category => ColumnCategory.Job;
         public int PriorityInCategory => 0;
+        public UnitType UnitType => UnitType.Dimensionless;
+        public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
 
         private TargetMethodColumn(string columnName, Func<Benchmark, string> valueProvider, bool alwaysShow = false)
         {

--- a/src/BenchmarkDotNet.Core/Columns/UnitType.cs
+++ b/src/BenchmarkDotNet.Core/Columns/UnitType.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BenchmarkDotNet.Columns
+{
+    public enum UnitType
+    {
+        Dimensionless,
+        Time,
+        Size
+    }
+}

--- a/src/BenchmarkDotNet.Core/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet.Core/Configs/DefaultConfig.cs
@@ -9,6 +9,7 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Validators;
+using BenchmarkDotNet.Reports;
 
 namespace BenchmarkDotNet.Configs
 {
@@ -57,6 +58,8 @@ namespace BenchmarkDotNet.Configs
         public ConfigUnionRule UnionRule => ConfigUnionRule.Union;
 
         public bool KeepBenchmarkFiles => false;
+
+        public ISummaryStyle GetSummaryStyle() => SummaryStyle.Default;
 
         public IEnumerable<IDiagnoser> GetDiagnosers() => Array.Empty<IDiagnoser>();
     }

--- a/src/BenchmarkDotNet.Core/Configs/IConfig.cs
+++ b/src/BenchmarkDotNet.Core/Configs/IConfig.cs
@@ -7,6 +7,7 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Validators;
+using BenchmarkDotNet.Reports;
 
 namespace BenchmarkDotNet.Configs
 {
@@ -21,6 +22,7 @@ namespace BenchmarkDotNet.Configs
         IEnumerable<IValidator> GetValidators();
 
         IOrderProvider GetOrderProvider();
+        ISummaryStyle GetSummaryStyle();
 
         ConfigUnionRule UnionRule { get; }
 

--- a/src/BenchmarkDotNet.Core/Configs/ManualConfig.cs
+++ b/src/BenchmarkDotNet.Core/Configs/ManualConfig.cs
@@ -10,6 +10,7 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Validators;
+using BenchmarkDotNet.Reports;
 
 namespace BenchmarkDotNet.Configs
 {
@@ -23,6 +24,7 @@ namespace BenchmarkDotNet.Configs
         private readonly List<IValidator> validators = new List<IValidator>();
         private readonly List<Job> jobs = new List<Job>();
         private IOrderProvider orderProvider = null;
+        private ISummaryStyle summaryStyle = null;
 
         public IEnumerable<IColumnProvider> GetColumnProviders() => columnProviders;
         public IEnumerable<IExporter> GetExporters() => exporters;
@@ -31,6 +33,7 @@ namespace BenchmarkDotNet.Configs
         public IEnumerable<IAnalyser> GetAnalysers() => analysers;
         public IEnumerable<IValidator> GetValidators() => validators;
         public IEnumerable<Job> GetJobs() => jobs;
+        public ISummaryStyle GetSummaryStyle() => summaryStyle;
 
         public IOrderProvider GetOrderProvider() => orderProvider;
 
@@ -47,6 +50,7 @@ namespace BenchmarkDotNet.Configs
         public void Add(params IValidator[] newValidators) => validators.AddRange(newValidators);
         public void Add(params Job[] newJobs) => jobs.AddRange(newJobs.Select(j => j.Freeze())); // DONTTOUCH: please DO NOT remove .Freeze() call.
         public void Set(IOrderProvider provider) => orderProvider = provider ?? orderProvider;
+        public void Set(ISummaryStyle style) => summaryStyle = style ?? summaryStyle;
 
         public void Add(IConfig config)
         {
@@ -59,6 +63,7 @@ namespace BenchmarkDotNet.Configs
             validators.AddRange(config.GetValidators());
             orderProvider = config.GetOrderProvider() ?? orderProvider;
             KeepBenchmarkFiles |= config.KeepBenchmarkFiles;
+            summaryStyle = summaryStyle ?? config.GetSummaryStyle();
         }
 
         public IEnumerable<IDiagnoser> GetDiagnosers()

--- a/src/BenchmarkDotNet.Core/Diagnosers/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet.Core/Diagnosers/MemoryDiagnoser.cs
@@ -62,13 +62,16 @@ namespace BenchmarkDotNet.Diagnosers
             public bool AlwaysShow => true;
             public ColumnCategory Category => ColumnCategory.Diagnoser;
             public int PriorityInCategory => 0;
+            public UnitType UnitType => UnitType.Size;
+            public string GetValue(Summary summary, Benchmark benchmark) => GetValue(summary, benchmark, SummaryStyle.Default);
 
-            public string GetValue(Summary summary, Benchmark benchmark)
+            public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style)
             {
                 if (!results.ContainsKey(benchmark) || benchmark.Job.Env.Runtime is MonoRuntime)
                     return "N/A";
 
-                return results[benchmark].BytesAllocatedPerOperation.ToFormattedBytes();
+                var value = results[benchmark].BytesAllocatedPerOperation;
+                return UnitType == UnitType.Size ? value.ToSizeStr(style.SizeUnit, 1, style.PrintUnitsInContent) : ((double)value).ToStr();
             }
         }
 
@@ -90,6 +93,8 @@ namespace BenchmarkDotNet.Diagnosers
             public bool AlwaysShow => true;
             public ColumnCategory Category => ColumnCategory.Diagnoser;
             public int PriorityInCategory => 0;
+            public UnitType UnitType => UnitType.Dimensionless;
+            public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
 
             public bool IsAvailable(Summary summary)
                 => summary.Reports.Any(report => report.GcStats.GetCollectionsCount(generation) != 0);

--- a/src/BenchmarkDotNet.Core/Exporters/Csv/CsvExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/Csv/CsvExporter.cs
@@ -1,24 +1,32 @@
-﻿using BenchmarkDotNet.Loggers;
+﻿using System;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Reports;
 
 namespace BenchmarkDotNet.Exporters.Csv
 {
     public class CsvExporter : ExporterBase
     {
+        private readonly ISummaryStyle style;
         private readonly CsvSeparator separator;
         protected override string FileExtension => "csv";
 
-        public static readonly IExporter Default = new CsvExporter(CsvSeparator.CurrentCulture);
+        public static readonly IExporter Default = new CsvExporter(CsvSeparator.CurrentCulture, SummaryStyle.Default);
 
-        public CsvExporter(CsvSeparator separator)
+        public CsvExporter(CsvSeparator separator) : this (separator, SummaryStyle.Default)
         {
+        }
+
+        public CsvExporter(CsvSeparator separator, ISummaryStyle style)
+        {
+            this.style = style;
             this.separator = separator;
         }
 
         public override void ExportToLog(Summary summary, ILogger logger)
         {
             string realSeparator = separator.ToRealSeparator();
-            foreach (var line in summary.Table.FullContentWithHeader)
+            foreach (var line in summary.GetTable(style).FullContentWithHeader)
             {
                 for (int i = 0; i < line.Length;)
                 {

--- a/src/BenchmarkDotNet.Core/Exporters/Csv/CsvMeasurementsExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/Csv/CsvMeasurementsExporter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Characteristics;
+using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
@@ -12,16 +13,18 @@ namespace BenchmarkDotNet.Exporters.Csv
 {
     public class CsvMeasurementsExporter : ExporterBase
     {
-        public static readonly CsvMeasurementsExporter Default = new CsvMeasurementsExporter(CsvSeparator.CurrentCulture);
+        public static readonly CsvMeasurementsExporter Default = new CsvMeasurementsExporter(CsvSeparator.CurrentCulture, SummaryStyle.Default);
+        public static CsvMeasurementsExporter WithStyle(SummaryStyle style) => new CsvMeasurementsExporter(CsvSeparator.CurrentCulture, style);
 
         private static readonly CharacteristicPresenter Presenter = CharacteristicPresenter.SummaryPresenter;
 
         private static readonly Lazy<MeasurementColumn[]> Columns = new Lazy<MeasurementColumn[]>(BuildColumns);
 
         private readonly CsvSeparator separator;
-        public CsvMeasurementsExporter(CsvSeparator separator)
+        public CsvMeasurementsExporter(CsvSeparator separator, ISummaryStyle style = null)
         {
             this.separator = separator;
+            Style = style ?? SummaryStyle.Default;
         }
 
         public string Separator => separator.ToRealSeparator();
@@ -29,6 +32,8 @@ namespace BenchmarkDotNet.Exporters.Csv
         protected override string FileExtension => "csv";
 
         protected override string FileCaption => "measurements";
+
+        public ISummaryStyle Style { get; private set; }
 
         public static Job[] GetJobs(Summary summary) => summary.Benchmarks.Select(b => b.Job).ToArray();
 

--- a/src/BenchmarkDotNet.Core/Extensions/CommonExtensions.cs
+++ b/src/BenchmarkDotNet.Core/Extensions/CommonExtensions.cs
@@ -3,15 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Horology;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Reports;
 
 namespace BenchmarkDotNet.Extensions
 {
-    internal static class CommonExtensions
+    public static class CommonExtensions
     {
-        const int BytesInKiloByte = 1000; // 1000 vs 1024 thing..
-
-        static readonly string[] SizeSuffixes = { "B", "kB", "MB", "GB", "TB" };
-
         public static List<T> ToSortedList<T>(this IEnumerable<T> values)
         {
             var list = new List<T>();
@@ -20,24 +18,34 @@ namespace BenchmarkDotNet.Extensions
             return list;
         }
 
-        public static string ToTimeStr(this double value, TimeUnit unit = null, int unitNameWidth = 1)
+        public static string ToTimeStr(this double value, TimeUnit unit = null, int unitNameWidth = 1, bool showUnit = true)
         {
             unit = unit ?? TimeUnit.GetBestTimeUnit(value);
             var unitValue = TimeUnit.Convert(value, TimeUnit.Nanosecond, unit);
-            var unitName = unit.Name.PadLeft(unitNameWidth);
-            return $"{unitValue.ToStr("N4")} {unitName}";
+            if (showUnit)
+            {
+                var unitName = unit.Name.PadLeft(unitNameWidth);
+                return $"{unitValue.ToStr("N4")} {unitName}";
+            }
+            else
+            {
+                return $"{unitValue.ToStr("N4")}";
+            }
         }
 
-        internal static string ToFormattedBytes(this long bytes)
+        public static string ToSizeStr(this long value, SizeUnit unit = null, int unitNameWidth = 1, bool showUnit = true)
         {
-            int i;
-            double dblSByte = bytes;
-            for (i = 0; i < SizeSuffixes.Length && bytes >= BytesInKiloByte; i++, bytes /= BytesInKiloByte)
+            unit = unit ?? SizeUnit.GetBestSizeUnit(value);
+            var unitValue = SizeUnit.Convert(value, SizeUnit.B, unit);
+            if (showUnit)
             {
-                dblSByte = bytes / (double)BytesInKiloByte;
+                var unitName = unit.Name.PadLeft(unitNameWidth);
+                return string.Format(HostEnvironmentInfo.MainCultureInfo, "{0:0.##} {1}", unitValue, unitName);
             }
-
-            return string.Format(HostEnvironmentInfo.MainCultureInfo, "{0:0.##} {1}", dblSByte, SizeSuffixes[i]);
+            else
+            {
+                return string.Format(HostEnvironmentInfo.MainCultureInfo, "{0:0.##}", unitValue);
+            }
         }
 
         public static string ToStr(this double value, string format = "0.##")
@@ -51,6 +59,25 @@ namespace BenchmarkDotNet.Extensions
             // Unfortunately, Mono doesn't have the second overload (with object instead of params object[]).            
             var args = new object[] { value };
             return string.Format(HostEnvironmentInfo.MainCultureInfo, $"{{0:{format}}}", args);
+        }
+
+        /// <summary>
+        /// Gets column title formatted using the specified style
+        /// </summary>
+        public static string GetColumnTitle(this IColumn column, ISummaryStyle style)
+        {
+            if (!style.PrintUnitsInHeader)
+                return column.ColumnName;
+
+            switch (column.UnitType)
+            {
+                case UnitType.Size:
+                    return $"{column.ColumnName} [{style.SizeUnit.Name}]";
+                case UnitType.Time:
+                    return $"{column.ColumnName} [{style.TimeUnit.Name}]";
+                default:
+                    return column.ColumnName;
+            }
         }
 
         public static bool IsNullOrEmpty<T>(this IReadOnlyCollection<T> value) => value == null || value.Count == 0;

--- a/src/BenchmarkDotNet.Core/Reports/ISummaryStyle.cs
+++ b/src/BenchmarkDotNet.Core/Reports/ISummaryStyle.cs
@@ -1,0 +1,16 @@
+﻿using BenchmarkDotNet.Horology;
+using BenchmarkDotNet.Columns;
+
+namespace BenchmarkDotNet.Reports
+{
+    public interface ISummaryStyle
+    {
+        bool PrintUnitsInHeader { get; }
+        bool PrintUnitsInContent { get; }
+        SizeUnit SizeUnit { get; }
+        TimeUnit TimeUnit { get; }
+
+        ISummaryStyle WithTimeUnit(TimeUnit timeUnit);
+        ISummaryStyle WithSizeUnit(SizeUnit sizeUnit);
+    }
+}

--- a/src/BenchmarkDotNet.Core/Reports/Summary.cs
+++ b/src/BenchmarkDotNet.Core/Reports/Summary.cs
@@ -17,7 +17,7 @@ namespace BenchmarkDotNet.Reports
         public string Title { get; }
         public Benchmark[] Benchmarks { get; }
         public BenchmarkReport[] Reports { get; }
-        public TimeUnit TimeUnit { get; }
+        public ISummaryStyle Style { get; }
         public HostEnvironmentInfo HostEnvironmentInfo { get; }
         public IConfig Config { get; }
         public string ResultsDirectoryPath { get; }
@@ -51,8 +51,7 @@ namespace BenchmarkDotNet.Reports
             Benchmarks = orderProvider.GetSummaryOrder(Benchmarks, this).ToArray();
             Reports = Benchmarks.Select(b => reportMap[b]).ToArray();
 
-            TimeUnit = TimeUnit.GetBestTimeUnit(reports.Where(r => r.ResultStatistics != null).Select(r => r.ResultStatistics.Mean).ToArray());
-            Table = new SummaryTable(this);
+            Table = GetTable(config.GetSummaryStyle());
             shortInfos = new Dictionary<Job, string>();
             jobs = new Lazy<Job[]>(() => Benchmarks.Select(b => b.Job).ToArray());
             AllRuntimes = BuildAllRuntimes();
@@ -62,7 +61,7 @@ namespace BenchmarkDotNet.Reports
             : this(title, hostEnvironmentInfo, config, resultsDirectoryPath, totalTime, validationErrors)
         {
             Benchmarks = benchmarks;
-            Table = new SummaryTable(this);
+            Table = GetTable(config.GetSummaryStyle());
             Reports = reports ?? Array.Empty<BenchmarkReport>();
         }
 
@@ -75,6 +74,11 @@ namespace BenchmarkDotNet.Reports
             TotalTime = totalTime;
             ValidationErrors = validationErrors;
             Reports = Array.Empty<BenchmarkReport>();
+        }
+
+        internal SummaryTable GetTable(ISummaryStyle style)
+        {
+            return new SummaryTable(this, style);
         }
 
         internal static Summary CreateFailed(Benchmark[] benchmarks, string title, HostEnvironmentInfo hostEnvironmentInfo, IConfig config, string resultsDirectoryPath, ValidationError[] validationErrors)

--- a/src/BenchmarkDotNet.Core/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet.Core/Reports/SummaryStyle.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Horology;
+using BenchmarkDotNet.Columns;
+
+namespace BenchmarkDotNet.Reports
+{
+    public class SummaryStyle : ISummaryStyle
+    {
+        public bool PrintUnitsInHeader { get; set; } = false;
+        public bool PrintUnitsInContent { get; set; } = true;
+        public SizeUnit SizeUnit { get; set; } = null;
+        public TimeUnit TimeUnit { get; set; } = null;
+
+        public static SummaryStyle Default => new SummaryStyle()
+        {
+            PrintUnitsInHeader = false,
+            PrintUnitsInContent = true,
+            SizeUnit = null,
+            TimeUnit = null
+        };
+
+        public ISummaryStyle WithTimeUnit(TimeUnit timeUnit)
+        {
+            return new SummaryStyle()
+            {
+                PrintUnitsInHeader = this.PrintUnitsInHeader,
+                PrintUnitsInContent = this.PrintUnitsInContent,
+                SizeUnit = this.SizeUnit,
+                TimeUnit = timeUnit
+            };
+        }
+
+        public ISummaryStyle WithSizeUnit(SizeUnit sizeUnit)
+        {
+            return new SummaryStyle()
+            {
+                PrintUnitsInHeader = this.PrintUnitsInHeader,
+                PrintUnitsInContent = this.PrintUnitsInContent,
+                SizeUnit = sizeUnit,
+                TimeUnit = this.TimeUnit
+            };
+        }
+    }
+}

--- a/src/BenchmarkDotNet.Diagnostics.Windows/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/MemoryDiagnoser.cs
@@ -1,17 +1,18 @@
 ﻿using System;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
 using Microsoft.Diagnostics.Tracing.Parsers;
 using Microsoft.Diagnostics.Tracing.Parsers.Clr;
 using Microsoft.Diagnostics.Tracing.Session;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using BenchmarkDotNet.Environments;
-using BenchmarkDotNet.Validators;
 
 namespace BenchmarkDotNet.Diagnostics.Windows
 {
@@ -110,16 +111,16 @@ namespace BenchmarkDotNet.Diagnostics.Windows
             public bool AlwaysShow => true;
             public ColumnCategory Category => ColumnCategory.Diagnoser;
             public int PriorityInCategory => 0;
+            public UnitType UnitType => UnitType.Size;
+            public string GetValue(Summary summary, Benchmark benchmark) => GetValue(summary, benchmark, SummaryStyle.Default);
 
-            public string GetValue(Summary summary, Benchmark benchmark)
+            public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style)
             {
-                if (results.ContainsKey(benchmark) && results[benchmark] != null)
-                {
-                    var result = results[benchmark];
-                    // TODO scale this based on the minimum value in the column, i.e. use B/KB/MB as appropriate
-                    return (result.AllocatedBytes / (double) result.TotalOperations).ToString("N2");
-                }
-                return "N/A";
+                if (!results.ContainsKey(benchmark) || results[benchmark] == null)
+                    return "N/A";
+
+                var value = results[benchmark].AllocatedBytes / (double)results[benchmark].TotalOperations;
+                return UnitType == UnitType.Size ? ((long)value).ToSizeStr(style.SizeUnit, 1, style.PrintUnitsInContent) : value.ToStr();
             }
         }
 
@@ -145,6 +146,8 @@ namespace BenchmarkDotNet.Diagnostics.Windows
             public bool AlwaysShow => true;
             public ColumnCategory Category => ColumnCategory.Diagnoser;
             public int PriorityInCategory => 0;
+            public UnitType UnitType => UnitType.Dimensionless;
+            public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
 
             public string GetValue(Summary summary, Benchmark benchmark)
             {

--- a/src/BenchmarkDotNet.Diagnostics.Windows/PmcDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/PmcDiagnoser.cs
@@ -213,6 +213,8 @@ namespace BenchmarkDotNet.Diagnostics.Windows
             public bool AlwaysShow => false;
             public ColumnCategory Category => ColumnCategory.Diagnoser;
             public int PriorityInCategory => 0;
+            public UnitType UnitType => UnitType.Dimensionless;
+            public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
 
             private Dictionary<Benchmark, PmcStats> Results { get; }
             private HardwareCounter Counter { get; }
@@ -242,6 +244,8 @@ namespace BenchmarkDotNet.Diagnostics.Windows
             public bool AlwaysShow => false;
             public ColumnCategory Category => ColumnCategory.Diagnoser;
             public int PriorityInCategory => 1;
+            public UnitType UnitType => UnitType.Dimensionless;
+            public string GetValue(Summary summary, Benchmark benchmark) => GetValue(summary, benchmark, SummaryStyle.Default);
 
             private Dictionary<Benchmark, PmcStats> Results { get; }
 
@@ -252,9 +256,9 @@ namespace BenchmarkDotNet.Diagnostics.Windows
                         && benchmark.Job.Diagnoser.HardwareCounters.Contains(HardwareCounter.BranchInstructions)
                         && benchmark.Job.Diagnoser.HardwareCounters.Contains(HardwareCounter.BranchMispredictions));
 
-            public string GetValue(Summary summary, Benchmark benchmark)
+            public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style)
                 => Results.TryGetValue(benchmark, out var stats) && stats.Counters.ContainsKey(HardwareCounter.BranchMispredictions) && stats.Counters.ContainsKey(HardwareCounter.BranchInstructions)
-                    ? (stats.Counters[HardwareCounter.BranchMispredictions].Count / (double)stats.Counters[HardwareCounter.BranchInstructions].Count).ToString("P2")
+                    ? (stats.Counters[HardwareCounter.BranchMispredictions].Count / (double)stats.Counters[HardwareCounter.BranchInstructions].Count).ToString(style.PrintUnitsInContent ? "P2" : String.Empty)
                     : "-";
         }
     }


### PR DESCRIPTION
Introduces ISummaryStyle which can be added to the IConfig and to participating exporters (currently CsvExporter).

The style controls whether units appear in headers, whether they appear in the data and what are the units. If user did not specify units in the style, SummaryTable will set recommended units based on report results.

Participating implementations of IColumn (currently StatisticColumn and two AllocationColumn) render their headers and values based on ISummaryStyle

Closes #146 - Ability to specify units / easier comparison
Closes #118 - Raw data in CSV exports
Resolves a TODO in Windows.MemoryDiagnoser

This PR is a squashed version of #396 