### PR TITLE
Exports file to temporary location if target is locked

### DIFF
--- a/src/BenchmarkDotNet.Core/Exporters/ExporterBase.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/ExporterBase.cs
@@ -26,7 +26,8 @@ namespace BenchmarkDotNet.Exporters
                 }
                 catch (IOException)
                 {
-                    var alternativeFilePath = Path.GetTempPath() + Path.GetFileNameWithoutExtension(Path.GetRandomFileName()) + $"-{summary.Title}-{FileCaption}{FileNameSuffix}.{FileExtension}";
+                    var uniqueString = System.DateTime.Now.ToString("yyyyMMdd-HHmmss");
+                    var alternativeFilePath = $"{Path.Combine(summary.ResultsDirectoryPath, summary.Title)}-{FileCaption}{FileNameSuffix}-{uniqueString}.{FileExtension}";
                     consoleLogger.WriteLineError($"Could not overwrite file {filePath}. Exporting to {alternativeFilePath}");
                     filePath = alternativeFilePath;
                 }

--- a/src/BenchmarkDotNet.Core/Exporters/ExporterBase.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/ExporterBase.cs
@@ -20,7 +20,16 @@ namespace BenchmarkDotNet.Exporters
             var filePath = $"{Path.Combine(summary.ResultsDirectoryPath, summary.Title)}-{FileCaption}{FileNameSuffix}.{FileExtension}";
             if (File.Exists(filePath))
             {
-                File.Delete(filePath);
+                try
+                {
+                    File.Delete(filePath);
+                }
+                catch (IOException)
+                {
+                    var alternativeFilePath = Path.GetTempPath() + Path.GetFileNameWithoutExtension(Path.GetRandomFileName()) + $"-{summary.Title}-{FileCaption}{FileNameSuffix}.{FileExtension}";
+                    consoleLogger.WriteLineError($"Could not overwrite file {filePath}. Exporting to {alternativeFilePath}");
+                    filePath = alternativeFilePath;
+                }
             }
 
             using (var stream = Portability.StreamWriter.FromPath(filePath))

--- a/tests/BenchmarkDotNet.IntegrationTests/ExporterIOTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ExporterIOTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class ExporterIOTests : BenchmarkTestExecutor
+    {
+        public ExporterIOTests(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void ExporterWritesToFile()
+        {
+            string resultsDirectoryPath = Path.GetTempPath();
+            var exporter = new MockExporter();
+            var mockSummary = GetMockSummary(resultsDirectoryPath);
+            var filePath = $"{Path.Combine(mockSummary.ResultsDirectoryPath, mockSummary.Title)}-report.txt"; // ExporterBase default
+
+            try
+            {
+                exporter.ExportToFiles(mockSummary, NullLogger.Instance);
+
+                Assert.Equal(1, exporter.ExportCount);
+                Assert.True(File.Exists(filePath));
+            }
+            finally
+            {
+                if (File.Exists(filePath))
+                    File.Delete(filePath);
+            }
+        }
+
+        [Fact]
+        public void ExporterWorksWhenFileIsLocked()
+        {
+            string resultsDirectoryPath = Path.GetTempPath();
+            var exporter = new MockExporter();
+            var mockSummary = GetMockSummary(resultsDirectoryPath);
+            var filePath = $"{Path.Combine(mockSummary.ResultsDirectoryPath, mockSummary.Title)}-report.txt"; // ExporterBase default
+
+            try
+            {
+                exporter.ExportToFiles(mockSummary, NullLogger.Instance);
+
+                Assert.Equal(1, exporter.ExportCount);
+                Assert.True(File.Exists(filePath));
+                using (var handle = File.OpenRead(filePath)) // Gets a lock on the target file
+                {
+                    exporter.ExportToFiles(mockSummary, NullLogger.Instance);
+                    Assert.Equal(2, exporter.ExportCount);
+                }
+                var savedFiles = Directory.EnumerateFiles(Path.GetDirectoryName(filePath), Path.GetFileNameWithoutExtension(filePath) + "*");
+                Assert.Equal(2, savedFiles.Count());
+            }
+            finally
+            {
+                if (File.Exists(filePath))
+                    File.Delete(filePath);
+                var otherFiles = Directory.EnumerateFiles(Path.GetDirectoryName(filePath), Path.GetFileNameWithoutExtension(filePath) + "*");
+                foreach (var file in otherFiles)
+                    File.Delete(file);
+            }
+        }
+
+        private Summary GetMockSummary(string resultsDirectoryPath)
+        {
+            return new Summary(
+                title: "bdn-test",
+                reports: new List<BenchmarkReport>(),
+                hostEnvironmentInfo: Environments.HostEnvironmentInfo.GetCurrent(),
+                config: Configs.DefaultConfig.Instance,
+                resultsDirectoryPath: resultsDirectoryPath,
+                totalTime: System.TimeSpan.Zero,
+                validationErrors: new Validators.ValidationError[0]
+            );
+        }
+
+        private class MockExporter : ExporterBase
+        {
+            public int ExportCount = 0;
+
+            public override void ExportToLog(Summary summary, ILogger logger)
+            {
+                ExportCount++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #414 
When a target file exists and is locked, currently BDN crashes and some of the data is lost.
This PR makes BDN export data under randomly-unique name to a temporary location and print a message to the log:
![image](https://cloud.githubusercontent.com/assets/1673956/24834984/3f63433e-1ca9-11e7-8410-26badc3e7d62.png)
```
// * Export *
Could not overwrite file C:\src\BenchmarkDotNet\samples\BenchmarkDotNet.Samples\BenchmarkDotNet.Artifacts\results\Algo_BitCount-report.csv. Exporting to C:\Users\amadeusz\AppData\Local\Temp\uvkf5nub-Algo_BitCount-report.csv
  C:\Users\amadeusz\AppData\Local\Temp\uvkf5nub-Algo_BitCount-report.csv
  BenchmarkDotNet.Artifacts\results\Algo_BitCount-report-github.md
  BenchmarkDotNet.Artifacts\results\Algo_BitCount-report.html
```

I'm not fully convinced that this sufficiently notifies user that the report in expected location is out of date, but I think this is better than data loss after a long running benchmark.