### PR TITLE
MarkdownExporter right-justifies numeric columns

### DIFF
--- a/src/BenchmarkDotNet.Core/Columns/BaselineScaledColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/BaselineScaledColumn.cs
@@ -91,6 +91,7 @@ namespace BenchmarkDotNet.Columns
         public bool AlwaysShow => true;
         public ColumnCategory Category => ColumnCategory.Baseline;
         public int PriorityInCategory => (int) Kind;
+        public bool IsNumeric => true;
         public UnitType UnitType => UnitType.Dimensionless;
         public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
         public override string ToString() => ColumnName;

--- a/src/BenchmarkDotNet.Core/Columns/IColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/IColumn.cs
@@ -40,6 +40,11 @@ namespace BenchmarkDotNet.Columns
         int PriorityInCategory { get; }
 
         /// <summary>
+        /// Defines if the column's value represents a number
+        /// </summary>
+        bool IsNumeric { get; }
+
+        /// <summary>
         /// Defines how to format column's value
         /// </summary>
         UnitType UnitType { get; }

--- a/src/BenchmarkDotNet.Core/Columns/JobCharacteristicColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/JobCharacteristicColumn.cs
@@ -32,6 +32,7 @@ namespace BenchmarkDotNet.Columns
         public bool AlwaysShow => false;
         public ColumnCategory Category => ColumnCategory.Job;
         public int PriorityInCategory => 0;
+        public bool IsNumeric => false;
         public UnitType UnitType => UnitType.Dimensionless;
         public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
 

--- a/src/BenchmarkDotNet.Core/Columns/ParamColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/ParamColumn.cs
@@ -23,6 +23,7 @@ namespace BenchmarkDotNet.Columns
         public ColumnCategory Category => ColumnCategory.Params;
         public int PriorityInCategory => 0;
         public override string ToString() => ColumnName;
+        public bool IsNumeric => false;
         public UnitType UnitType => UnitType.Dimensionless;
         public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
     }

--- a/src/BenchmarkDotNet.Core/Columns/RankColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/RankColumn.cs
@@ -34,6 +34,7 @@ namespace BenchmarkDotNet.Columns
         public bool IsAvailable(Summary summary) => true;
         public bool AlwaysShow => true;
         public ColumnCategory Category => ColumnCategory.Custom;
+        public bool IsNumeric => true;
         public UnitType UnitType => UnitType.Dimensionless;
         public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
         public int PriorityInCategory => (int) system;

--- a/src/BenchmarkDotNet.Core/Columns/StatisticColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/StatisticColumn.cs
@@ -74,6 +74,7 @@ namespace BenchmarkDotNet.Columns
         public bool AlwaysShow => true;
         public ColumnCategory Category => ColumnCategory.Statistics;
         public int PriorityInCategory => (int) priority;
+        public bool IsNumeric => true;
         public UnitType UnitType => type;
 
         private string Format(Statistics statistics, ISummaryStyle style)

--- a/src/BenchmarkDotNet.Core/Columns/TagColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/TagColumn.cs
@@ -24,6 +24,7 @@ namespace BenchmarkDotNet.Columns
         public bool AlwaysShow => true;
         public ColumnCategory Category => ColumnCategory.Custom;
         public int PriorityInCategory => 0;
+        public bool IsNumeric => false;
         public UnitType UnitType => UnitType.Dimensionless;
         public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
         public override string ToString() => ColumnName;

--- a/src/BenchmarkDotNet.Core/Columns/TargetMethodColumn.cs
+++ b/src/BenchmarkDotNet.Core/Columns/TargetMethodColumn.cs
@@ -18,6 +18,7 @@ namespace BenchmarkDotNet.Columns
         public bool AlwaysShow { get; }
         public ColumnCategory Category => ColumnCategory.Job;
         public int PriorityInCategory => 0;
+        public bool IsNumeric => false;
         public UnitType UnitType => UnitType.Dimensionless;
         public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
 

--- a/src/BenchmarkDotNet.Core/Diagnosers/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet.Core/Diagnosers/MemoryDiagnoser.cs
@@ -62,6 +62,7 @@ namespace BenchmarkDotNet.Diagnosers
             public bool AlwaysShow => true;
             public ColumnCategory Category => ColumnCategory.Diagnoser;
             public int PriorityInCategory => 0;
+            public bool IsNumeric => true;
             public UnitType UnitType => UnitType.Size;
             public string GetValue(Summary summary, Benchmark benchmark) => GetValue(summary, benchmark, SummaryStyle.Default);
 
@@ -93,6 +94,7 @@ namespace BenchmarkDotNet.Diagnosers
             public bool AlwaysShow => true;
             public ColumnCategory Category => ColumnCategory.Diagnoser;
             public int PriorityInCategory => 0;
+            public bool IsNumeric => true;
             public UnitType UnitType => UnitType.Dimensionless;
             public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
 

--- a/src/BenchmarkDotNet.Core/Exporters/MarkdownExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/MarkdownExporter.cs
@@ -139,7 +139,7 @@ namespace BenchmarkDotNet.Exporters
                     logger.Write(tableHeaderSeparator);
                 }
 
-                logger.WriteLineStatistic(string.Join("", table.Columns.Where(c => c.NeedToShow).Select(c => new string('-', c.Width) + " |")));
+                logger.WriteLineStatistic(string.Join("", table.Columns.Where(c => c.NeedToShow).Select(getDelimiterLineForColumn)));
             }
             var rowCounter = 0;
             var highlightRow = false;
@@ -159,6 +159,12 @@ namespace BenchmarkDotNet.Exporters
                 table.PrintLine(line, logger, string.Empty, tableColumnSeparator, highlightRow, table.FullContentStartOfGroup[rowCounter], startOfGroupInBold, boldMarkupFormat);
                 rowCounter++;
             }
+        }
+
+        private static string getDelimiterLineForColumn(SummaryTable.SummaryTableColumn column)
+        {
+            var justifier = column.Justify == SummaryTable.SummaryTableColumn.TextJustification.Left ? " " : ":";
+            return new string('-', column.Width) + justifier + "|";
         }
     }
 }

--- a/src/BenchmarkDotNet.Core/Exporters/MarkdownExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/MarkdownExporter.cs
@@ -139,7 +139,7 @@ namespace BenchmarkDotNet.Exporters
                     logger.Write(tableHeaderSeparator);
                 }
 
-                logger.WriteLineStatistic(string.Join("", table.Columns.Where(c => c.NeedToShow).Select(getDelimiterLineForColumn)));
+                logger.WriteLineStatistic(string.Join("", table.Columns.Where(c => c.NeedToShow).Select(column => new string('-', column.Width) + getJustificationIndicator(column.Justify) + "|")));
             }
             var rowCounter = 0;
             var highlightRow = false;
@@ -161,10 +161,17 @@ namespace BenchmarkDotNet.Exporters
             }
         }
 
-        private static string getDelimiterLineForColumn(SummaryTable.SummaryTableColumn column)
+        private static string getJustificationIndicator(SummaryTable.SummaryTableColumn.TextJustification textJustification)
         {
-            var justifier = column.Justify == SummaryTable.SummaryTableColumn.TextJustification.Left ? " " : ":";
-            return new string('-', column.Width) + justifier + "|";
+            switch (textJustification)
+            {
+                case SummaryTable.SummaryTableColumn.TextJustification.Left:
+                    return " ";
+                case SummaryTable.SummaryTableColumn.TextJustification.Right:
+                    return ":";
+                default:
+                    return " ";
+            }
         }
     }
 }

--- a/src/BenchmarkDotNet.Core/Reports/SummaryTable.cs
+++ b/src/BenchmarkDotNet.Core/Reports/SummaryTable.cs
@@ -69,7 +69,7 @@ namespace BenchmarkDotNet.Reports
             full.AddRange(FullContent);
             FullContentWithHeader = full.ToArray();
 
-            Columns = Enumerable.Range(0, columns.Length).Select(i => new SummaryTableColumn(this, i, columns[i].AlwaysShow)).ToArray();
+            Columns = Enumerable.Range(0, columns.Length).Select(i => new SummaryTableColumn(this, i, columns[i])).ToArray();
         }
 
         public class SummaryTableColumn
@@ -80,18 +80,27 @@ namespace BenchmarkDotNet.Reports
             public bool NeedToShow { get; }
             public int Width { get; }
             public bool IsDefault { get; }
+            public TextJustification Justify { get; }
 
-            public SummaryTableColumn(SummaryTable table, int index, bool alwaysShow)
+            public SummaryTableColumn(SummaryTable table, int index, IColumn column)
             {
                 Index = index;
                 Header = table.FullHeader[index];
                 Content = table.FullContent.Select(line => line[index]).ToArray();
-                NeedToShow = alwaysShow || Content.Distinct().Count() > 1;
+                NeedToShow = column.AlwaysShow || Content.Distinct().Count() > 1;
                 Width = Math.Max(Header.Length, Content.Any() ? Content.Max(line => line.Length) : 0) + 1;
                 IsDefault = table.IsDefault[index];
+
+                Justify = column.IsNumeric ? TextJustification.Right : TextJustification.Left;
             }
 
             public override string ToString() => Header;
+
+            public enum TextJustification
+            {
+                Left,
+                Right
+            }
         }
     }
 }

--- a/src/BenchmarkDotNet.Diagnostics.Windows/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/MemoryDiagnoser.cs
@@ -111,6 +111,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
             public bool AlwaysShow => true;
             public ColumnCategory Category => ColumnCategory.Diagnoser;
             public int PriorityInCategory => 0;
+            public bool IsNumeric => true;
             public UnitType UnitType => UnitType.Size;
             public string GetValue(Summary summary, Benchmark benchmark) => GetValue(summary, benchmark, SummaryStyle.Default);
 
@@ -146,6 +147,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
             public bool AlwaysShow => true;
             public ColumnCategory Category => ColumnCategory.Diagnoser;
             public int PriorityInCategory => 0;
+            public bool IsNumeric => true;
             public UnitType UnitType => UnitType.Dimensionless;
             public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
 

--- a/src/BenchmarkDotNet.Diagnostics.Windows/PmcDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/PmcDiagnoser.cs
@@ -219,6 +219,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
             public bool AlwaysShow => false;
             public ColumnCategory Category => ColumnCategory.Diagnoser;
             public int PriorityInCategory => 0;
+            public bool IsNumeric => true;
             public UnitType UnitType => UnitType.Dimensionless;
             public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
 
@@ -247,6 +248,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
             public bool AlwaysShow => false;
             public ColumnCategory Category => ColumnCategory.Diagnoser;
             public int PriorityInCategory => 1;
+            public bool IsNumeric => true;
             public UnitType UnitType => UnitType.Dimensionless;
             public string GetValue(Summary summary, Benchmark benchmark) => GetValue(summary, benchmark, SummaryStyle.Default);
 

--- a/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Loggers;
@@ -41,6 +42,26 @@ namespace BenchmarkDotNet.Tests.Reports
         {
             var gcModeColumn = CreateColumn("Platform");
             Assert.Equal(true, gcModeColumn.IsDefault);
+        }
+
+        [Fact]
+        public void NumericColumnIsRightJustified()
+        {
+            var config = ManualConfig.Create(DefaultConfig.Instance).With(StatisticColumn.Mean);
+            var summary = MockFactory.CreateSummary(config);
+            var table = new SummaryTable(summary);
+
+            Assert.Equal(SummaryTable.SummaryTableColumn.TextJustification.Right, table.Columns.First(c => c.Header == "Mean").Justify);
+        }
+
+        [Fact]
+        public void TextColumnIsLeftJustified()
+        {
+            var config = ManualConfig.Create(DefaultConfig.Instance).With(new ParamColumn("Param"));
+            var summary = MockFactory.CreateSummary(config);
+            var table = new SummaryTable(summary);
+
+            Assert.Equal(SummaryTable.SummaryTableColumn.TextJustification.Left, table.Columns.First(c => c.Header == "Param").Justify);
         }
     }
 }


### PR DESCRIPTION
Now that #396 is complete, I've made a more complete pass at #398, to right-justify numeric columns in the `MarkdownExporter`, which would resolve #397.

1. `IColumn` has a new `IsNumeric` property, which is set (what I believe to be) appropriately in all its implementations.
1. `SummaryTableColumn` uses `IsNumeric` to set a new `Justify` property to either `Left` or `Right`
1. `MarkdownExporter` uses `Justify` to determine whether to use `:` or ` ` as the justification indicator