### PR TITLE
Fix false allocations detection

### DIFF
--- a/src/BenchmarkDotNet.Core/Engines/Engine.cs
+++ b/src/BenchmarkDotNet.Core/Engines/Engine.cs
@@ -120,8 +120,8 @@ namespace BenchmarkDotNet.Engines
 
             // we enable monitoring after pilot & warmup, just to ignore the memory allocated by these runs
             EnableMonitoring();
-            var initialGcStats = GcStats.ReadInitial(IsDiagnoserAttached);
             if(IsDiagnoserAttached) Host.BeforeMainRun();
+            var initialGcStats = GcStats.ReadInitial(IsDiagnoserAttached);
 
             var main = targetStage.RunMain(invokeCount, UnrollFactor, forceSpecific: Strategy == RunStrategy.Monitoring);
 


### PR DESCRIPTION
` Host.BeforeMainRun();` should run _before_ gc stats init as some host implementations (in-process, as example) may allocate during notification.

**UPD:** Allocation in InProcessHost is triggered by [WriteLine method](https://github.com/dotnet/BenchmarkDotNet/blob/610f3b72808bd76837facf6cd75acf70a30eb772/src/BenchmarkDotNet.Core/Toolchains/InProcess/InProcessHost.cs#L84):
```cs
                case HostSignal.BeforeMainRun:
                    diagnoser?.BeforeMainRun(diagnoserActionParameters);
                    WriteLine(Engine.Signals.BeforeMainRun);
                    break;
```