### PR TITLE
Fix minor bugs in JsonExporter

### DIFF
--- a/src/BenchmarkDotNet.Core/Exporters/Json/JsonExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/Json/JsonExporter.cs
@@ -4,7 +4,7 @@
     {
         public static readonly IExporter Brief = new JsonExporter("-brief", indentJson: true, excludeMeasurements: true);
         public static readonly IExporter Full = new JsonExporter("-full", indentJson: true, excludeMeasurements: false);
-        public static readonly IExporter BriefCompressed = new JsonExporter("-brief-compressed", indentJson: false, excludeMeasurements: false);
+        public static readonly IExporter BriefCompressed = new JsonExporter("-brief-compressed", indentJson: false, excludeMeasurements: true);
         public static readonly IExporter FullCompressed = new JsonExporter("-full-compressed", indentJson: false, excludeMeasurements: false);
 
         public static readonly IExporter Default = FullCompressed;

--- a/src/BenchmarkDotNet.Core/Exporters/Json/JsonExporterBase.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/Json/JsonExporterBase.cs
@@ -28,8 +28,8 @@ namespace BenchmarkDotNet.Exporters.Json
             {
                 HostEnvironmentInfo.BenchmarkDotNetCaption,
                 summary.HostEnvironmentInfo.BenchmarkDotNetVersion,
-                summary.HostEnvironmentInfo.OsVersion,
-                summary.HostEnvironmentInfo.ProcessorName,
+                OsVersion = summary.HostEnvironmentInfo.OsVersion.Value,
+                ProcessorName = summary.HostEnvironmentInfo.ProcessorName.Value,
                 summary.HostEnvironmentInfo.ProcessorCount,
                 summary.HostEnvironmentInfo.RuntimeVersion,
                 summary.HostEnvironmentInfo.Architecture,

--- a/src/BenchmarkDotNet.Core/Exporters/Json/SimpleJson.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/Json/SimpleJson.cs
@@ -1212,13 +1212,13 @@ namespace SimpleJson
         private static void ResetIndentationLevel()
         {
             indentationLevel = 0;
-            indentationText = "\n" + new string(' ', indentationLevel * spacesPerIndent);
+            indentationText = Environment.NewLine + new string(' ', indentationLevel * spacesPerIndent);
         }
 
         private static void HandleIndent(int change)
         {
             indentationLevel += change;
-            indentationText = "\n" + new string(' ', indentationLevel * spacesPerIndent);
+            indentationText = Environment.NewLine + new string(' ', indentationLevel * spacesPerIndent);
         }
 
         private static IJsonSerializerStrategy _currentJsonSerializerStrategy;

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/ApprovalTest.Exporters.Invariant.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/ApprovalTest.Exporters.Invariant.approved.txt
@@ -59,14 +59,8 @@ JsonExporter-brief
    "HostEnvironmentInfo":{
       "BenchmarkDotNetCaption":"BenchmarkDotNet",
       "BenchmarkDotNetVersion":"0.10.x-mock",
-      "OsVersion":{
-         "IsValueCreated":true,
-         "Value":"Microsoft Windows NT 10.0.x.mock"
-      },
-      "ProcessorName":{
-         "IsValueCreated":true,
-         "Value":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"
-      },
+      "OsVersion":"Microsoft Windows NT 10.0.x.mock",
+      "ProcessorName":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz",
       "ProcessorCount":8,
       "RuntimeVersion":"Clr 4.0.x.mock",
       "Architecture":"64mock",
@@ -181,7 +175,7 @@ JsonExporter-brief
 ############################################
 JsonExporter-brief-compressed
 ############################################
-{"Title":"MockSummary","HostEnvironmentInfo":{"BenchmarkDotNetCaption":"BenchmarkDotNet","BenchmarkDotNetVersion":"0.10.x-mock","OsVersion":{"IsValueCreated":true,"Value":"Microsoft Windows NT 10.0.x.mock"},"ProcessorName":{"IsValueCreated":true,"Value":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"},"ProcessorCount":8,"RuntimeVersion":"Clr 4.0.x.mock","Architecture":"64mock","HasAttachedDebugger":false,"HasRyuJit":true,"Configuration":"CONFIGURATION","JitModules":"clrjit-v4.6.x.mock","DotNetCliVersion":"1.0.x.mock","ChronometerFrequency":{"Hertz":2531248},"HardwareTimerKind":"Tsc"},"Benchmarks":[{"DisplayInfo":"MockBenchmarkClass.Foo: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Foo","MethodTitle":"Foo","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]},{"DisplayInfo":"MockBenchmarkClass.Bar: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Bar","MethodTitle":"Bar","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]}]}
+{"Title":"MockSummary","HostEnvironmentInfo":{"BenchmarkDotNetCaption":"BenchmarkDotNet","BenchmarkDotNetVersion":"0.10.x-mock","OsVersion":"Microsoft Windows NT 10.0.x.mock","ProcessorName":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz","ProcessorCount":8,"RuntimeVersion":"Clr 4.0.x.mock","Architecture":"64mock","HasAttachedDebugger":false,"HasRyuJit":true,"Configuration":"CONFIGURATION","JitModules":"clrjit-v4.6.x.mock","DotNetCliVersion":"1.0.x.mock","ChronometerFrequency":{"Hertz":2531248},"HardwareTimerKind":"Tsc"},"Benchmarks":[{"DisplayInfo":"MockBenchmarkClass.Foo: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Foo","MethodTitle":"Foo","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}}},{"DisplayInfo":"MockBenchmarkClass.Bar: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Bar","MethodTitle":"Bar","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}}}]}
 ############################################
 JsonExporter-full
 ############################################
@@ -190,14 +184,8 @@ JsonExporter-full
    "HostEnvironmentInfo":{
       "BenchmarkDotNetCaption":"BenchmarkDotNet",
       "BenchmarkDotNetVersion":"0.10.x-mock",
-      "OsVersion":{
-         "IsValueCreated":true,
-         "Value":"Microsoft Windows NT 10.0.x.mock"
-      },
-      "ProcessorName":{
-         "IsValueCreated":true,
-         "Value":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"
-      },
+      "OsVersion":"Microsoft Windows NT 10.0.x.mock",
+      "ProcessorName":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz",
       "ProcessorCount":8,
       "RuntimeVersion":"Clr 4.0.x.mock",
       "Architecture":"64mock",
@@ -330,7 +318,7 @@ JsonExporter-full
 ############################################
 JsonExporter-full-compressed
 ############################################
-{"Title":"MockSummary","HostEnvironmentInfo":{"BenchmarkDotNetCaption":"BenchmarkDotNet","BenchmarkDotNetVersion":"0.10.x-mock","OsVersion":{"IsValueCreated":true,"Value":"Microsoft Windows NT 10.0.x.mock"},"ProcessorName":{"IsValueCreated":true,"Value":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"},"ProcessorCount":8,"RuntimeVersion":"Clr 4.0.x.mock","Architecture":"64mock","HasAttachedDebugger":false,"HasRyuJit":true,"Configuration":"CONFIGURATION","JitModules":"clrjit-v4.6.x.mock","DotNetCliVersion":"1.0.x.mock","ChronometerFrequency":{"Hertz":2531248},"HardwareTimerKind":"Tsc"},"Benchmarks":[{"DisplayInfo":"MockBenchmarkClass.Foo: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Foo","MethodTitle":"Foo","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]},{"DisplayInfo":"MockBenchmarkClass.Bar: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Bar","MethodTitle":"Bar","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]}]}
+{"Title":"MockSummary","HostEnvironmentInfo":{"BenchmarkDotNetCaption":"BenchmarkDotNet","BenchmarkDotNetVersion":"0.10.x-mock","OsVersion":"Microsoft Windows NT 10.0.x.mock","ProcessorName":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz","ProcessorCount":8,"RuntimeVersion":"Clr 4.0.x.mock","Architecture":"64mock","HasAttachedDebugger":false,"HasRyuJit":true,"Configuration":"CONFIGURATION","JitModules":"clrjit-v4.6.x.mock","DotNetCliVersion":"1.0.x.mock","ChronometerFrequency":{"Hertz":2531248},"HardwareTimerKind":"Tsc"},"Benchmarks":[{"DisplayInfo":"MockBenchmarkClass.Foo: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Foo","MethodTitle":"Foo","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]},{"DisplayInfo":"MockBenchmarkClass.Bar: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Bar","MethodTitle":"Bar","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]}]}
 ############################################
 MarkdownExporter-default
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/ApprovalTest.Exporters.en-US.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/ApprovalTest.Exporters.en-US.approved.txt
@@ -59,14 +59,8 @@ JsonExporter-brief
    "HostEnvironmentInfo":{
       "BenchmarkDotNetCaption":"BenchmarkDotNet",
       "BenchmarkDotNetVersion":"0.10.x-mock",
-      "OsVersion":{
-         "IsValueCreated":true,
-         "Value":"Microsoft Windows NT 10.0.x.mock"
-      },
-      "ProcessorName":{
-         "IsValueCreated":true,
-         "Value":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"
-      },
+      "OsVersion":"Microsoft Windows NT 10.0.x.mock",
+      "ProcessorName":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz",
       "ProcessorCount":8,
       "RuntimeVersion":"Clr 4.0.x.mock",
       "Architecture":"64mock",
@@ -181,7 +175,7 @@ JsonExporter-brief
 ############################################
 JsonExporter-brief-compressed
 ############################################
-{"Title":"MockSummary","HostEnvironmentInfo":{"BenchmarkDotNetCaption":"BenchmarkDotNet","BenchmarkDotNetVersion":"0.10.x-mock","OsVersion":{"IsValueCreated":true,"Value":"Microsoft Windows NT 10.0.x.mock"},"ProcessorName":{"IsValueCreated":true,"Value":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"},"ProcessorCount":8,"RuntimeVersion":"Clr 4.0.x.mock","Architecture":"64mock","HasAttachedDebugger":false,"HasRyuJit":true,"Configuration":"CONFIGURATION","JitModules":"clrjit-v4.6.x.mock","DotNetCliVersion":"1.0.x.mock","ChronometerFrequency":{"Hertz":2531248},"HardwareTimerKind":"Tsc"},"Benchmarks":[{"DisplayInfo":"MockBenchmarkClass.Foo: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Foo","MethodTitle":"Foo","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]},{"DisplayInfo":"MockBenchmarkClass.Bar: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Bar","MethodTitle":"Bar","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]}]}
+{"Title":"MockSummary","HostEnvironmentInfo":{"BenchmarkDotNetCaption":"BenchmarkDotNet","BenchmarkDotNetVersion":"0.10.x-mock","OsVersion":"Microsoft Windows NT 10.0.x.mock","ProcessorName":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz","ProcessorCount":8,"RuntimeVersion":"Clr 4.0.x.mock","Architecture":"64mock","HasAttachedDebugger":false,"HasRyuJit":true,"Configuration":"CONFIGURATION","JitModules":"clrjit-v4.6.x.mock","DotNetCliVersion":"1.0.x.mock","ChronometerFrequency":{"Hertz":2531248},"HardwareTimerKind":"Tsc"},"Benchmarks":[{"DisplayInfo":"MockBenchmarkClass.Foo: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Foo","MethodTitle":"Foo","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}}},{"DisplayInfo":"MockBenchmarkClass.Bar: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Bar","MethodTitle":"Bar","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}}}]}
 ############################################
 JsonExporter-full
 ############################################
@@ -190,14 +184,8 @@ JsonExporter-full
    "HostEnvironmentInfo":{
       "BenchmarkDotNetCaption":"BenchmarkDotNet",
       "BenchmarkDotNetVersion":"0.10.x-mock",
-      "OsVersion":{
-         "IsValueCreated":true,
-         "Value":"Microsoft Windows NT 10.0.x.mock"
-      },
-      "ProcessorName":{
-         "IsValueCreated":true,
-         "Value":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"
-      },
+      "OsVersion":"Microsoft Windows NT 10.0.x.mock",
+      "ProcessorName":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz",
       "ProcessorCount":8,
       "RuntimeVersion":"Clr 4.0.x.mock",
       "Architecture":"64mock",
@@ -330,7 +318,7 @@ JsonExporter-full
 ############################################
 JsonExporter-full-compressed
 ############################################
-{"Title":"MockSummary","HostEnvironmentInfo":{"BenchmarkDotNetCaption":"BenchmarkDotNet","BenchmarkDotNetVersion":"0.10.x-mock","OsVersion":{"IsValueCreated":true,"Value":"Microsoft Windows NT 10.0.x.mock"},"ProcessorName":{"IsValueCreated":true,"Value":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"},"ProcessorCount":8,"RuntimeVersion":"Clr 4.0.x.mock","Architecture":"64mock","HasAttachedDebugger":false,"HasRyuJit":true,"Configuration":"CONFIGURATION","JitModules":"clrjit-v4.6.x.mock","DotNetCliVersion":"1.0.x.mock","ChronometerFrequency":{"Hertz":2531248},"HardwareTimerKind":"Tsc"},"Benchmarks":[{"DisplayInfo":"MockBenchmarkClass.Foo: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Foo","MethodTitle":"Foo","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]},{"DisplayInfo":"MockBenchmarkClass.Bar: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Bar","MethodTitle":"Bar","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]}]}
+{"Title":"MockSummary","HostEnvironmentInfo":{"BenchmarkDotNetCaption":"BenchmarkDotNet","BenchmarkDotNetVersion":"0.10.x-mock","OsVersion":"Microsoft Windows NT 10.0.x.mock","ProcessorName":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz","ProcessorCount":8,"RuntimeVersion":"Clr 4.0.x.mock","Architecture":"64mock","HasAttachedDebugger":false,"HasRyuJit":true,"Configuration":"CONFIGURATION","JitModules":"clrjit-v4.6.x.mock","DotNetCliVersion":"1.0.x.mock","ChronometerFrequency":{"Hertz":2531248},"HardwareTimerKind":"Tsc"},"Benchmarks":[{"DisplayInfo":"MockBenchmarkClass.Foo: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Foo","MethodTitle":"Foo","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]},{"DisplayInfo":"MockBenchmarkClass.Bar: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Bar","MethodTitle":"Bar","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]}]}
 ############################################
 MarkdownExporter-default
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/ApprovalTest.Exporters.ru-RU.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/ApprovalTest.Exporters.ru-RU.approved.txt
@@ -59,14 +59,8 @@ JsonExporter-brief
    "HostEnvironmentInfo":{
       "BenchmarkDotNetCaption":"BenchmarkDotNet",
       "BenchmarkDotNetVersion":"0.10.x-mock",
-      "OsVersion":{
-         "IsValueCreated":true,
-         "Value":"Microsoft Windows NT 10.0.x.mock"
-      },
-      "ProcessorName":{
-         "IsValueCreated":true,
-         "Value":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"
-      },
+      "OsVersion":"Microsoft Windows NT 10.0.x.mock",
+      "ProcessorName":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz",
       "ProcessorCount":8,
       "RuntimeVersion":"Clr 4.0.x.mock",
       "Architecture":"64mock",
@@ -181,7 +175,7 @@ JsonExporter-brief
 ############################################
 JsonExporter-brief-compressed
 ############################################
-{"Title":"MockSummary","HostEnvironmentInfo":{"BenchmarkDotNetCaption":"BenchmarkDotNet","BenchmarkDotNetVersion":"0.10.x-mock","OsVersion":{"IsValueCreated":true,"Value":"Microsoft Windows NT 10.0.x.mock"},"ProcessorName":{"IsValueCreated":true,"Value":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"},"ProcessorCount":8,"RuntimeVersion":"Clr 4.0.x.mock","Architecture":"64mock","HasAttachedDebugger":false,"HasRyuJit":true,"Configuration":"CONFIGURATION","JitModules":"clrjit-v4.6.x.mock","DotNetCliVersion":"1.0.x.mock","ChronometerFrequency":{"Hertz":2531248},"HardwareTimerKind":"Tsc"},"Benchmarks":[{"DisplayInfo":"MockBenchmarkClass.Foo: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Foo","MethodTitle":"Foo","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]},{"DisplayInfo":"MockBenchmarkClass.Bar: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Bar","MethodTitle":"Bar","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]}]}
+{"Title":"MockSummary","HostEnvironmentInfo":{"BenchmarkDotNetCaption":"BenchmarkDotNet","BenchmarkDotNetVersion":"0.10.x-mock","OsVersion":"Microsoft Windows NT 10.0.x.mock","ProcessorName":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz","ProcessorCount":8,"RuntimeVersion":"Clr 4.0.x.mock","Architecture":"64mock","HasAttachedDebugger":false,"HasRyuJit":true,"Configuration":"CONFIGURATION","JitModules":"clrjit-v4.6.x.mock","DotNetCliVersion":"1.0.x.mock","ChronometerFrequency":{"Hertz":2531248},"HardwareTimerKind":"Tsc"},"Benchmarks":[{"DisplayInfo":"MockBenchmarkClass.Foo: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Foo","MethodTitle":"Foo","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}}},{"DisplayInfo":"MockBenchmarkClass.Bar: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Bar","MethodTitle":"Bar","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}}}]}
 ############################################
 JsonExporter-full
 ############################################
@@ -190,14 +184,8 @@ JsonExporter-full
    "HostEnvironmentInfo":{
       "BenchmarkDotNetCaption":"BenchmarkDotNet",
       "BenchmarkDotNetVersion":"0.10.x-mock",
-      "OsVersion":{
-         "IsValueCreated":true,
-         "Value":"Microsoft Windows NT 10.0.x.mock"
-      },
-      "ProcessorName":{
-         "IsValueCreated":true,
-         "Value":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"
-      },
+      "OsVersion":"Microsoft Windows NT 10.0.x.mock",
+      "ProcessorName":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz",
       "ProcessorCount":8,
       "RuntimeVersion":"Clr 4.0.x.mock",
       "Architecture":"64mock",
@@ -330,7 +318,7 @@ JsonExporter-full
 ############################################
 JsonExporter-full-compressed
 ############################################
-{"Title":"MockSummary","HostEnvironmentInfo":{"BenchmarkDotNetCaption":"BenchmarkDotNet","BenchmarkDotNetVersion":"0.10.x-mock","OsVersion":{"IsValueCreated":true,"Value":"Microsoft Windows NT 10.0.x.mock"},"ProcessorName":{"IsValueCreated":true,"Value":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"},"ProcessorCount":8,"RuntimeVersion":"Clr 4.0.x.mock","Architecture":"64mock","HasAttachedDebugger":false,"HasRyuJit":true,"Configuration":"CONFIGURATION","JitModules":"clrjit-v4.6.x.mock","DotNetCliVersion":"1.0.x.mock","ChronometerFrequency":{"Hertz":2531248},"HardwareTimerKind":"Tsc"},"Benchmarks":[{"DisplayInfo":"MockBenchmarkClass.Foo: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Foo","MethodTitle":"Foo","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]},{"DisplayInfo":"MockBenchmarkClass.Bar: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Bar","MethodTitle":"Bar","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]}]}
+{"Title":"MockSummary","HostEnvironmentInfo":{"BenchmarkDotNetCaption":"BenchmarkDotNet","BenchmarkDotNetVersion":"0.10.x-mock","OsVersion":"Microsoft Windows NT 10.0.x.mock","ProcessorName":"MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz","ProcessorCount":8,"RuntimeVersion":"Clr 4.0.x.mock","Architecture":"64mock","HasAttachedDebugger":false,"HasRyuJit":true,"Configuration":"CONFIGURATION","JitModules":"clrjit-v4.6.x.mock","DotNetCliVersion":"1.0.x.mock","ChronometerFrequency":{"Hertz":2531248},"HardwareTimerKind":"Tsc"},"Benchmarks":[{"DisplayInfo":"MockBenchmarkClass.Foo: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Foo","MethodTitle":"Foo","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]},{"DisplayInfo":"MockBenchmarkClass.Bar: LongRun(LaunchCount=3, TargetCount=100, WarmupCount=15)","Namespace":"BenchmarkDotNet.Tests.Mocks","Type":"MockBenchmarkClass","Method":"Bar","MethodTitle":"Bar","Parameters":"","Statistics":{"N":1,"Min":1,"LowerFence":1,"Q1":1,"Median":1,"Mean":1,"Q3":1,"UpperFence":1,"Max":1,"InterquartileRange":0,"Outliers":[],"StandardError":0,"Variance":0,"StandardDeviation":0,"Skewness":NaN,"Kurtosis":NaN,"ConfidenceInterval":{"N":1,"Mean":1,"StandardError":0,"Level":12,"Margin":NaN,"Lower":NaN,"Upper":NaN},"Percentiles":{"P0":1,"P25":1,"P50":1,"P67":1,"P80":1,"P85":1,"P90":1,"P95":1,"P100":1}},"Measurements":[{"IterationMode":"Result","LaunchIndex":1,"IterationIndex":1,"Operations":1,"Nanoseconds":1}]}]}
 ############################################
 MarkdownExporter-default
 ############################################


### PR DESCRIPTION
This is a pull request for some minor bugs found from JsonExporter behavior while working on the [XmlExporter](https://github.com/dotnet/BenchmarkDotNet/issues/157). Here is some more context from the [comments](https://github.com/dotnet/BenchmarkDotNet/issues/157#issuecomment-300711076)

Fixes:

1. JsonExporter.BriefCompressed didn't correctly exclude the `Measurements`-property
2. JsonExport was showing incorrectly Lazy-type's `IsValueCreated` and `Value` properties in output instead just showing the actual value
3. SimpleJson uses `"\n"` as a line change, so I changed it to `Environment.NewLine` to match the rest of the approval test file line change style. Otherwise I couldn't get a `pass` from the exporter tests. I was getting `LF` line changes for the Json parts even though the approved file had `CRLF` line changes.
This change is based on the fact that the `AccumulationLogger` used in the exporter tests uses [`StringBuilder.AppendLine`](https://msdn.microsoft.com/en-us/library/cb3sbadh(v=vs.110).aspx) internally that uses `Environment.NewLine` as the default line change. I don't really know if this change could affect people running unix systems.. Is this something @alinasmirnova or maybe @mattwarren could comment on?

I ran both the "Classic" tests and "Core" tests like the contribution document suggested and both passed
* Core tests skipped 2 tests: `CanEnableServerGcMode` and `Test`, is this normal?

This is my first pull request so I'm gladly taking any feedback!
Pinging also @AndreyAkinshin and @adamsitnik 
