### PR TITLE
Wrong xml doc comment

### DIFF
--- a/src/BenchmarkDotNet.Core/Attributes/IterationSetupAttribute.cs
+++ b/src/BenchmarkDotNet.Core/Attributes/IterationSetupAttribute.cs
@@ -4,7 +4,7 @@ using JetBrains.Annotations;
 namespace BenchmarkDotNet.Attributes
 {
     /// <summary>
-    /// Marks method to be executed after each benchmark iteration.
+    /// Marks method to be executed before each benchmark iteration.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     [MeansImplicitUse]


### PR DESCRIPTION
Wrong xml doc comment 
```c# 
     /// <summary>
    /// Marks method to be executed >after< each benchmark iteration. 
    /// </summary> 
    public class IterationSetupAttribute: Attribute  { }
```
It was copied from IterationCleanupAttribute, I guess.