### PR TITLE
PerfView-based ETW log diagnoser

### DIFF
--- a/BenchmarkDotNet.sln
+++ b/BenchmarkDotNet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.10
+VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D6597E3A-6892-4A68-8E14-042FC941FDA2}"
 EndProject
@@ -54,6 +54,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BenchmarkDotNet.IntegrationTests", "tests\BenchmarkDotNet.IntegrationTests\BenchmarkDotNet.IntegrationTests.csproj", "{6A3CBB07-E337-488E-BDAC-ED96AF8ED608}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BenchmarkDotNet.IntegrationTests.ConfigPerAssembly", "tests\BenchmarkDotNet.IntegrationTests.ConfigPerAssembly\BenchmarkDotNet.IntegrationTests.ConfigPerAssembly.csproj", "{043F1DA4-CD51-45FD-805E-6571D67AA661}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BenchmarkDotNet.Diagnostics.PerfView", "src\BenchmarkDotNet.Diagnostics.PerfView\BenchmarkDotNet.Diagnostics.PerfView.csproj", "{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -233,6 +235,18 @@ Global
 		{043F1DA4-CD51-45FD-805E-6571D67AA661}.Release|x64.Build.0 = Release|Any CPU
 		{043F1DA4-CD51-45FD-805E-6571D67AA661}.Release|x86.ActiveCfg = Release|Any CPU
 		{043F1DA4-CD51-45FD-805E-6571D67AA661}.Release|x86.Build.0 = Release|Any CPU
+		{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240}.Debug|x64.Build.0 = Debug|Any CPU
+		{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240}.Debug|x86.Build.0 = Debug|Any CPU
+		{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240}.Release|x64.ActiveCfg = Release|Any CPU
+		{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240}.Release|x64.Build.0 = Release|Any CPU
+		{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240}.Release|x86.ActiveCfg = Release|Any CPU
+		{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -252,5 +266,6 @@ Global
 		{45FE17A7-0E04-48C0-8CDC-493CDA449F7A} = {14195214-591A-45B7-851A-19D3BA2413F9}
 		{6A3CBB07-E337-488E-BDAC-ED96AF8ED608} = {14195214-591A-45B7-851A-19D3BA2413F9}
 		{043F1DA4-CD51-45FD-805E-6571D67AA661} = {14195214-591A-45B7-851A-19D3BA2413F9}
+		{4C32FC7D-244B-4BD0-B5FB-08ACC41EB240} = {D6597E3A-6892-4A68-8E14-042FC941FDA2}
 	EndGlobalSection
 EndGlobal

--- a/src/BenchmarkDotNet.Diagnostics.PerfView/BenchmarkDotNet.Diagnostics.PerfView.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.PerfView/BenchmarkDotNet.Diagnostics.PerfView.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BenchmarkDotNet.Core\BenchmarkDotNet.Core.csproj" />
+    <ProjectReference Include="..\BenchmarkDotNet.Diagnostics.Windows\BenchmarkDotNet.Diagnostics.Windows.csproj" />
+    <ProjectReference Include="..\BenchmarkDotNet\BenchmarkDotNet.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="PerfView">
+      <HintPath>..\..\..\..\Downloads\PerfView.exe</HintPath>
+      <Aliases>PerfView</Aliases>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/src/BenchmarkDotNet.Diagnostics.PerfView/ETWHelper.cs
+++ b/src/BenchmarkDotNet.Diagnostics.PerfView/ETWHelper.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+using Microsoft.Diagnostics.Tracing.Stacks;
+
+namespace BenchmarkDotNet.Diagnostics.PerfView
+{
+    public static class ETWHelper
+    {
+        /// <summary>
+        /// Transforms ETL file to ETLX and returns TraceLog instance
+        /// </summary>
+        public static (TraceLog log, string etlxFile) GetTraceLog(string fileName)
+        {
+            string etlxFile = Path.ChangeExtension(fileName, ".etlx");
+            // workaround: This was sooo slow with attached debugger because lots of trace was produced
+            var li = System.Diagnostics.Trace.Listeners.Cast<System.Diagnostics.TraceListener>().ToArray();
+            for (int i = 0; i < System.Diagnostics.Trace.Listeners.Count; i++)
+            {
+                System.Diagnostics.Trace.Listeners.RemoveAt(0);
+            }
+            // only resolve symbols for currently loaded assemblies, don't waste time with others
+            var dllWhiteList = new HashSet<string>(AppDomain.CurrentDomain.GetAssemblies().Select(a => a.GetName().Name), StringComparer.OrdinalIgnoreCase);
+            var log = TraceLog.OpenOrConvert(fileName, new TraceLogOptions { ShouldResolveSymbols = name => dllWhiteList.Contains(name) });
+            System.Diagnostics.Trace.Listeners.AddRange(li);
+            return (log, etlxFile);
+        }
+
+        public static Dictionary<string, CallTreeItem> GetCallTree(StackSource stacks, out float timePerStack)
+        {
+            var callTree = new Dictionary<string, CallTreeItem>(StringComparer.OrdinalIgnoreCase);
+            var currentStack = new HashSet<string>();
+            void AddRecursively(StackSourceCallStackIndex index, int depth = 0, CallTreeItem parent = null)
+            {
+                var name = stacks.GetFrameName(stacks.GetFrameIndex(index), false);
+                if (name == "BROKEN") return;
+                var isRecursion = !currentStack.Add(name);
+                var caller = stacks.GetCallerIndex(index);
+                if (!callTree.TryGetValue(name, out var item)) callTree.Add(name, item = new CallTreeItem(name));
+                if (!isRecursion) item.IncSamples++;
+                if (depth == 0) item.Samples++;
+                else item.AddCallee(parent);
+                parent?.AddCaller(item);
+
+                if (caller != StackSourceCallStackIndex.Invalid) AddRecursively(caller, depth + 1, item);
+                if (!isRecursion) currentStack.Remove(name);
+            }
+            var metric = float.NaN;
+            stacks.ForEach(stack => {
+                if (float.IsNaN(metric)) metric = stack.Metric;
+                if (metric != stack.Metric) throw new Exception();
+                if (stack.Count != 1) throw new Exception();
+                AddRecursively(stack.StackIndex);
+                AddRecursively(stack.StackIndex);
+            });
+            timePerStack = metric;
+            return callTree;
+        }
+
+        /// <summary>
+        /// Gets inclusive time fractions spent in specified methods. First method is a baseline, all results are methodTime[i] / baselineTime. You probably want to use your main function as a baseline to filter out noise and only could percents of your benchmark run.
+        /// </summary>
+        public static IEnumerable<float> ComputeTimeFractions(Dictionary<string, CallTreeItem> callTree, string[] methodNames)
+        {
+            CallTreeItem FindMethod(string name)
+            {
+                if (callTree.TryGetValue(name, out var result)) return result;
+                else return callTree.FirstOrDefault(n => n.Key.StartsWith(name + "(", StringComparison.OrdinalIgnoreCase)).Value;
+            }
+
+            if (!(FindMethod(methodNames.First()) is CallTreeItem baseLine))
+            {
+            // baseline not found
+                foreach (var f in methodNames)
+                    yield return 0f;
+                yield break;
+            }
+            while (baseLine.Callers.Count == 1)
+                baseLine = baseLine.Callers.Single().Key;
+
+            foreach (var m in methodNames)
+            {
+                if (FindMethod(m) is CallTreeItem cti)
+                {
+                    yield return (float)cti.IncSamples / (float)baseLine.IncSamples;
+                }
+                else
+                    yield return 0f;
+            }
+        }
+
+
+        public class CallTreeItem
+        {
+            public CallTreeItem(string name)
+            {
+                this.Name = name;
+            }
+
+            public string Name { get; }
+            public ulong Samples { get; set; }
+            public ulong IncSamples { get; set; }
+            private Dictionary<CallTreeItem, int> _callees = null;
+            public IEnumerable<CallTreeItem> Callees => _callees?.Keys ?? Enumerable.Empty<CallTreeItem>();
+            public IEnumerable<KeyValuePair<CallTreeItem, int>> CalleesWithSampleCounts => _callees ?? Enumerable.Empty<KeyValuePair<CallTreeItem, int>>();
+            public void AddCallee(CallTreeItem cti)
+            {
+                (_callees ?? (_callees = new Dictionary<CallTreeItem, int>(2))).TryGetValue(cti, out int current);
+                _callees[cti] = current + 1;
+            }
+
+            public Dictionary<CallTreeItem, int> Callers { get; } = new Dictionary<CallTreeItem, int>(2);
+            public void AddCaller(CallTreeItem cti)
+            {
+                Callers.TryGetValue(cti, out int current);
+                Callers[cti] = current + 1;
+            }
+
+        }
+    }
+}

--- a/src/BenchmarkDotNet.Diagnostics.PerfView/EtwLogDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.PerfView/EtwLogDiagnoser.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Diagnostics.Windows;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
+
+namespace BenchmarkDotNet.Diagnostics.PerfView
+{
+    public class FileNameColumn : IColumn
+    {
+        private readonly Dictionary<Benchmark, string> fileName;
+
+        public FileNameColumn(Dictionary<Benchmark, string> fileName)
+        {
+            this.fileName = fileName;
+        }
+
+        public string Id => typeof(FileNameColumn).FullName;
+
+        public string ColumnName => "ETW log file";
+
+        public bool AlwaysShow => false;
+
+        public ColumnCategory Category => ColumnCategory.Custom;
+
+        public int PriorityInCategory => 0;
+        public bool IsNumeric => false;
+        public UnitType UnitType => UnitType.Dimensionless;
+        public string Legend => "File Name";
+
+        public string GetValue(Summary summary, Benchmark benchmark)
+        {
+            if (fileName.TryGetValue(benchmark, out var val) && File.Exists(val))
+                return val;
+            else return "-";
+        }
+
+        public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) => GetValue(summary, benchmark);
+
+        public bool IsAvailable(Summary summary) => true;
+
+        public bool IsDefault(Summary summary, Benchmark benchmark) => false;
+    }
+}

--- a/src/BenchmarkDotNet.Diagnostics.PerfView/MethodTimeFractionColumn.cs
+++ b/src/BenchmarkDotNet.Diagnostics.PerfView/MethodTimeFractionColumn.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+
+namespace BenchmarkDotNet.Diagnostics.PerfView
+{
+    public class MethodTimeFractionColumn : IColumn
+    {
+        private readonly string displayName;
+        private readonly IDictionary<Benchmark, float[]> measurements;
+        private readonly int mIndex;
+
+        public MethodTimeFractionColumn(string displayName, IDictionary<Benchmark, float[]> measurements, int mIndex)
+        {
+            this.displayName = displayName;
+            this.measurements = measurements;
+            this.mIndex = mIndex;
+        }
+        
+        public string Id => nameof(MethodTimeFractionColumn) + "_" + displayName;
+
+        public string ColumnName => $"{displayName}";
+
+        public bool AlwaysShow => false;
+
+        public ColumnCategory Category => ColumnCategory.Custom;
+
+        public int PriorityInCategory => mIndex + 1200;
+        public bool IsNumeric => true;
+        public UnitType UnitType => UnitType.Dimensionless;
+        public string Legend => "% of inclusive CPU stacks spent in the method";
+
+        public string GetValue(Summary summary, Benchmark benchmark) =>
+            measurements.TryGetValue(benchmark, out var times) ?
+            $"{times[mIndex] * 100f}%" :
+            "-";
+
+        public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style) =>
+            GetValue(summary, benchmark);
+
+        public bool IsAvailable(Summary summary) => true;
+
+        public bool IsDefault(Summary summary, Benchmark benchmark) => false;
+    }
+}

--- a/src/BenchmarkDotNet.Diagnostics.PerfView/PerfViewBenchmarkDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.PerfView/PerfViewBenchmarkDiagnoser.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
+
+namespace BenchmarkDotNet.Diagnostics.PerfView
+{
+    public class PerfViewBenchmarkDiagnoser : IDiagnoser
+    {
+        private readonly string tempPath;
+        private readonly (string key, string displayName)[] methodColumns;
+        private readonly int maxParallelism;
+        private readonly bool leaveTraces;
+
+        public PerfViewBenchmarkDiagnoser(string tempPath = null, (string key, string displayName)[] methodColumns = null, int? maxParallelism = null, bool leaveTraces = false)
+        {
+            this.tempPath = tempPath ?? Path.GetTempPath();
+            this.methodColumns = methodColumns ?? new (string key, string displayName)[0];
+            this.maxParallelism = maxParallelism ?? Environment.ProcessorCount;
+            this.leaveTraces = leaveTraces;
+        }
+
+        private Dictionary<Benchmark, string> logFile = new Dictionary<Benchmark, string>();
+        private ConcurrentDictionary<Benchmark, float[]> methodTimes = new ConcurrentDictionary<Benchmark, float[]>();
+        private ConcurrentQueue<Action> actionQueue = new ConcurrentQueue<Action>();
+
+        private PerfViewHandler.CollectionHandler commandProcessor = null;
+        private Benchmark currentBenchmark;
+
+        public IEnumerable<string> Ids => new[] { nameof(PerfViewBenchmarkDiagnoser) };
+        
+        public void AfterSetup(DiagnoserActionParameters parameters)
+        {
+        }
+
+        public void BeforeAnythingElse(DiagnoserActionParameters parameters)
+        {
+        }
+
+        private void ProcessTrace(Dictionary<string, ETWHelper.CallTreeItem> callTree, Benchmark benchmark)
+        {
+            var times = ETWHelper.ComputeTimeFractions(callTree, methodColumns.Select(t => t.key).ToArray()).ToArray();
+            //var serializedTree = callTree.OrderByDescending(k => k.Value.IncSamples).Select(t => $"\"{t.Key}\",{t.Value.IncSamples},{t.Value.Samples}");
+            //File.WriteAllLines(logFile[benchmark] + ".methods.csv", serializedTree);
+            methodTimes.TryAdd(benchmark, times);
+        }
+
+        public void BeforeCleanup()
+        {
+            var finishDelegate = commandProcessor.StopAndLazyMerge(leaveTraces);
+            var benchmark = currentBenchmark;
+            if (actionQueue.Count > 8) FlushQueue();
+            actionQueue.Enqueue(() => {
+                var stacks = finishDelegate();
+                ProcessTrace(stacks, benchmark);
+            });
+            commandProcessor = null;
+        }
+
+        void FlushQueue()
+        {
+            var list = new List<Action>();
+            while (actionQueue.TryDequeue(out var a)) list.Add(a);
+            Parallel.ForEach(list, a => a());
+        }
+
+        public void BeforeMainRun(DiagnoserActionParameters parameters)
+        {
+            if (commandProcessor != null) throw new Exception("Collection is already running.");
+
+            // workaround: too long file paths
+            var folderInfo = parameters.Benchmark.Parameters?.FolderInfo;
+            if (string.IsNullOrEmpty(folderInfo)) folderInfo = parameters.Benchmark.FolderInfo;
+            folderInfo = new string(folderInfo.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
+            string path = Path.Combine(tempPath, "benchmarkLogs", (parameters.Benchmark.Parameters?.FolderInfo ?? parameters.Benchmark.FolderInfo).Replace("/", "_") + "_" + Guid.NewGuid().ToString().Replace("-", "_") + ".etl.zip");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            logFile.Add(parameters.Benchmark, path);
+            try
+            {
+                commandProcessor = PerfViewHandler.StartCollection(path, parameters.Process);
+                currentBenchmark = parameters.Benchmark;
+            }
+            catch(Exception ex)
+            {
+                logFile.Remove(parameters.Benchmark);
+                new CompositeLogger(parameters.Config.GetLoggers().ToArray()).WriteLineError("Could not start ETW trace: " + ex);
+            }
+        }
+
+        public void DisplayResults(ILogger logger)
+        {
+        }
+
+        public IColumnProvider GetColumnProvider()
+        {
+            FlushQueue();
+            return new SimpleColumnProvider(
+                methodColumns.Select((m, i) => (IColumn)new MethodTimeFractionColumn(m.displayName, methodTimes, i))
+                .Concat(new[] { new FileNameColumn(logFile) }.Take(leaveTraces ? 1 : 0))
+                .ToArray()
+            );
+        }
+
+        public void ProcessResults(Benchmark benchmark, BenchmarkReport report)
+        {
+        }
+
+        public IEnumerable<ValidationError> Validate(ValidationParameters validationParameters)
+        {
+            yield break;
+        }
+
+        public void AfterGlobalSetup(DiagnoserActionParameters parameters)
+        {
+        }
+
+        public void BeforeGlobalCleanup()
+        {
+        }
+    }
+}

--- a/src/BenchmarkDotNet.Diagnostics.PerfView/PerfViewDomainMethods.cs
+++ b/src/BenchmarkDotNet.Diagnostics.PerfView/PerfViewDomainMethods.cs
@@ -1,0 +1,74 @@
+﻿extern alias PerfView;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using PerfView::PerfView;
+
+namespace BenchmarkDotNet.Diagnostics.PerfView
+{
+    static class PerfViewDomainMethods
+    {
+        static CommandLineArgs CreateArgs(string outFile, string processName = null)
+        {
+            var a = App.CommandLineArgs = new CommandLineArgs();
+            a.ParseArgs(new[] { "/NoGui"/*, "/KernelEvents:None"*/ });
+            a.RestartingToElevelate = ""; // this should prevent PerfView from trying to elevate itself
+            a.Zip = false;
+            a.Merge = false;
+            a.InMemoryCircularBuffer = false;
+            a.DotNetAllocSampled = false;
+            a.CpuSampleMSec = 1f; // 0.125f;
+            //a.StackCompression = true;
+
+            a.DataFile = outFile;
+            //a.Process = processName ?? a.Process;
+            a.NoNGenRundown = true;
+            a.NoV2Rundown = true;
+            a.NoRundown = true;
+            a.NoClrRundown = true;
+            a.TrustPdbs = true;
+            a.UnsafePDBMatch = true;
+            return a;
+        }
+
+        private static ConcurrentDictionary<int, (CommandProcessor, CommandLineArgs)> collectionHandles = new ConcurrentDictionary<int, (CommandProcessor, CommandLineArgs)>();
+        private static int collectionHandleIdCtr;
+        public static void RunCollection()
+        {
+            var path = (string)AppDomain.CurrentDomain.GetData("outFile");
+            var processName = (string)AppDomain.CurrentDomain.GetData("processName");
+
+            var commandProcessor = App.CommandProcessor = new CommandProcessor() { LogFile = Console.Out };
+            var commandArgs = CreateArgs(path, processName);
+            commandProcessor.Start(commandArgs);
+
+            var handle = Interlocked.Increment(ref collectionHandleIdCtr);
+            collectionHandles[handle] = (commandProcessor, commandArgs);
+            AppDomain.CurrentDomain.SetData("collectionHandle", handle);
+        }
+
+        public static void StopCollection()
+        {
+            var handle = (int)AppDomain.CurrentDomain.GetData("collectionHandle");
+            var rundown = (bool)AppDomain.CurrentDomain.GetData("doRundown");
+            var (proc, args) = collectionHandles[handle];
+            if (rundown)
+            {
+                args.NoRundown = args.NoNGenRundown = args.NoClrRundown = false;
+            }
+            collectionHandles.TryRemove(handle, out var _);
+            proc.Stop(args);
+        }
+
+        public static void MergeFile()
+        {
+            var file = (string)AppDomain.CurrentDomain.GetData("fileName");
+            var args = CreateArgs(file);
+            args.Zip = true;
+            args.Merge = false; // file is already merged into one
+            var processor = new CommandProcessor { LogFile = Console.Out };
+            processor.Merge(args);
+        }
+    }
+}

--- a/src/BenchmarkDotNet.Diagnostics.PerfView/PerfViewHandler.cs
+++ b/src/BenchmarkDotNet.Diagnostics.PerfView/PerfViewHandler.cs
@@ -1,0 +1,200 @@
+﻿extern alias PerfView;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+using Microsoft.Diagnostics.Tracing.Session;
+using Microsoft.Diagnostics.Tracing.Stacks;
+
+
+namespace BenchmarkDotNet.Diagnostics.PerfView
+{
+    public class PerfViewHandler
+    {
+        private static object locker = new object();
+        private static AppDomain perfViewDomain;
+
+        public static AppDomain GetPerfViewDomain()
+        {
+            if (perfViewDomain != null) return perfViewDomain;
+            lock (locker)
+            {
+                if (perfViewDomain != null) return perfViewDomain;
+                return perfViewDomain = CreatePerfViewDomain();
+            }
+        }
+
+        static AppDomain CreatePerfViewDomain()
+        {
+            var d = AppDomain.CreateDomain("PerfViewDomain");
+            d.DoCallBack(PerfViewDomainLaunch);
+            return d;
+        }
+
+
+        static void StopCollection(int collectionHandle, bool rundown)
+        {
+            var d = GetPerfViewDomain();
+            Console.WriteLine($"Stopping ETW collection, rundown: {rundown}");
+            lock (locker)
+            {
+                d.SetData("collectionHandle", collectionHandle);
+                d.SetData("doRundown", rundown);
+                d.DoCallBack(PerfViewDomainMethods.StopCollection);
+            }
+        }
+        static void MergeAndZip(string fileName)
+        {
+            var d = GetPerfViewDomain();
+            lock (locker)
+            {
+                d.SetData("fileName", fileName);
+                d.DoCallBack(PerfViewDomainMethods.MergeFile);
+            }
+        }
+
+        public static CollectionHandler StartCollection(string outFile, Process process)
+        {
+            if (outFile.EndsWith(".zip")) outFile = outFile.Remove(outFile.Length - 4);
+            var d = GetPerfViewDomain();
+            lock (locker)
+            {
+                d.SetData("outFile", outFile);
+                d.SetData("processName", process?.ProcessName);
+
+                d.DoCallBack(PerfViewDomainMethods.RunCollection);
+
+                var handle = (int)d.GetData("collectionHandle");
+                return new CollectionHandler(handle, process, outFile);
+            }
+        }
+
+        public class CollectionHandler
+        {
+            private readonly int collectionHandle;
+            private readonly Process process;
+            private readonly string outFile;
+
+            public CollectionHandler(int collectionHandle, Process process, string outFile)
+            {
+                this.collectionHandle = collectionHandle;
+                this.process = process;
+                this.outFile = Path.GetFullPath(outFile);
+            }
+            public Func<Dictionary<string, ETWHelper.CallTreeItem>> StopAndLazyMerge(bool leaveTraces)
+            {
+                bool rundown = !this.process.WaitForExit(500);
+                StopCollection(collectionHandle, rundown: rundown);
+                var pid = process.Id;
+
+                return () => {
+                    var tmpFile = outFile + ".merged.etl";
+                    if (File.Exists(tmpFile)) File.Delete(tmpFile);
+
+                    var allFiles = GetAllResultFiles(outFile);
+                    if (allFiles.Length > 1)
+                    {
+                        TraceEventSession.Merge(allFiles, tmpFile, TraceEventMergeOptions.Compress);
+                        File.Delete(outFile);
+                        File.Move(tmpFile, outFile);
+                    }
+                    else if (allFiles[0] != outFile)
+                        File.Move(allFiles[0], outFile);
+                    var (etlx, callTree) = TryGetCallTree(pid);
+
+                    if (!leaveTraces)
+                    {
+                        if (File.Exists(etlx)) File.Delete(etlx);
+                        File.Delete(outFile);
+                        foreach (var f in Directory.GetFiles(Path.GetDirectoryName(outFile)))
+                        {
+                            if (Path.GetFileName(f).StartsWith(Path.GetFileNameWithoutExtension(outFile)))
+                            {
+                                File.Delete(f);
+                            }
+                        }
+                    }
+                    else if (rundown)
+                    {
+
+                        Directory.CreateDirectory(Path.Combine(Path.GetDirectoryName(outFile), "symbols"));
+                        MergeAndZip(outFile);
+                    }
+                    else
+                    {
+                        Zip(outFile);
+                    }
+                    return callTree;
+                };
+            }
+
+            private (string etlx, Dictionary<string, ETWHelper.CallTreeItem> callTree) TryGetCallTree(int pid)
+            {
+                string maybeEtlx = null;
+                try
+                {
+                    var (tlog, etlx) = ETWHelper.GetTraceLog(outFile);
+                    maybeEtlx = etlx;
+                    using (tlog)
+                    {
+                        var proc = tlog.Processes.FirstOrDefault(p => p.ProcessID == pid);
+                        var stacks = new TraceEventStackSource(proc.EventsInProcess.Filter(t => t is SampledProfileTraceData));
+                        var callTree = ETWHelper.GetCallTree(stacks, out var timeModifier);
+                        //if (GetAllResultFiles(outFile) is var allFiles && allFiles.Length > 1)
+                        //{
+                        //    string tempName = Path.ChangeExtension(outFile, ".etl.new");
+                        //    TraceEventSession.Merge(allFiles, tempName);
+                        //    // Delete the originals.  
+                        //    foreach (var mergeInput in allFiles)
+                        //        File.Delete(mergeInput);
+                        //    // Place the output in its final resting place.  
+                        //    File.Move(tempName, outFile);
+                        //}
+                        return (etlx, callTree);
+                    }
+                }
+                catch(Exception ex)
+                {
+                    return (maybeEtlx, new Dictionary<string, ETWHelper.CallTreeItem>());
+                }
+            }
+
+
+            public static void Zip(string fileName)
+            {
+                var etlWriter = new ZippedETLWriter(fileName);
+                etlWriter.Zip = true;
+                etlWriter.CompressETL = true;
+                etlWriter.DeleteInputFile = true;
+                etlWriter.WriteArchive();
+            }
+
+            static string[] GetAllResultFiles(string etlFileName)
+            {
+                var dir = Path.GetDirectoryName(etlFileName);
+                if (dir.Length == 0)
+                    dir = ".";
+                var baseName = Path.GetFileNameWithoutExtension(etlFileName);
+                List<string> mergeInputs = new List<string>();
+                mergeInputs.Add(etlFileName);
+                mergeInputs.AddRange(Directory.GetFiles(dir, baseName + ".kernel*.etl"));
+                mergeInputs.AddRange(Directory.GetFiles(dir, baseName + ".clr*.etl"));
+                mergeInputs.AddRange(Directory.GetFiles(dir, baseName + ".user*.etl"));
+                return mergeInputs.ToArray();
+            }
+        }
+
+
+
+        public static void PerfViewDomainLaunch()
+        {
+            PerfView::PerfView.App.Unpack();
+            if (!PerfView::PerfView.App.IsElevated) throw new Exception("Application must be elevated.");
+        }
+    }
+}


### PR DESCRIPTION
I have added a concept of PerfView-based ETW log diagnoser. It collects an ETL trace using PerfView, analyses that after the run and reports how much was time spent in specified methods.

**Don't merge it, please**, it's not tested. Take it as an issue with attached code ;)

### Rationale
I'm invoking entire HTTP requests in my benchmarks, so it's not very clear what is the slow thing there. That would force me to profile each benchmark separately, which would be very annoying. Or to see how much would optimizing certain method help, I'd have to profile all benchmarks, which takes few hours and would overrun my hard-drive. So I tried to profile it automatically - start an ETW collection on every benchmark, then load the stacks and sum them for each method. This way I have split each request processing into several stages and separated certain core methods, so I can easily see, what slows it down. You can have a look at [a report](https://ipfs.io/ipfs/QmScnYdY8xoPeHPN85edPdLPbi3GvHrUGicvHAuyMdrAQE/reports/BenchmarkRun-001-2017-05-31-10-34-59/report.html). It's still pretty large and hard-to-read table, but much better and faster to compare than a bunch of open Perfviews.
I'm not very sure that the numbers are right, but they seem to be both reproducible and reasonable. It also seems that normal time measurements are not influenced much by the profiler. (compare a run [without profiler](https://ipfs.io/ipfs/QmUs3zeXJqCtoUhYfmGdhRxhcjKdJDcrcbjuKohZ6n5ogf/BenchmarkRun-001-2017-05-24-09-32-19-report.html) and [with profiler](https://ipfs.io/ipfs/QmQPf8p7ppyZeChRrqHyJ8UwveHQkEE2NKBhxGM2zQPrJw/BenchmarkRun-001-2017-05-25-04-51-30-report.html))

This report comes from [dotvvm-benchmarks](https://github.com/riganti/dotvvm-benchmarks) project where I originally wrote this diagnoser. In contrast to what was said in the discussion in #457, I actually wrote it in my "business time" for real project and for real value ;) (thanks @tomasherceg for paying for that stuff). I understand that BenchmarkDotNet is benchmarking library, not a profiler, but this is the information I want to have from my benchmarks. And I believe that are some other people that would like that info :)

### Issues
* The PerfView was quite hard to convince to collect the trace and I didn't manage to use it for trace analysis. It is referenced as .exe file and depends on its own version of Microsoft.Diagnostics.Tracing.TraceEvent bundled as an embedded resource, so it's not usable from my code. This causes collisions with NuGet version of the TraceEvent and forced me to put PerfView invocations into separate AppDomain. It also completely prevents any exchange of Microsoft.Diagnostics.Tracing.TraceEvent instances with PerfView code. I'm not very sure how to overcome this limitation in a cleaner way. I could probably copy the code from PerfView, because I'm not using much of it, but it would be nice to use more capabilities ;). Maybe it would be possible to fork it, edit the build process to use the NuGet version of `TraceEvent` and produce a `dll` instead of `exe`.

* Some tests and stuff like that are missing. I'm not sure how to do that, do you have any test for something simmilar I could look at?

### More cool stuff
IMO it also a has greater potential than just showing CPU time spent in certain methods, this is just the beginning - there is a lot of thing the diagnoser could use from the PerfView - report GcStats, count memory allocations (#457) or even render some graphs quite simply.

What do you think? Any idea what to do with the integration?
cc @adamsitnik 