### PR TITLE
Target Setup methods for specific Benchmarks

### DIFF
--- a/docs/guide/Advanced/SetupAndCleanup.md
+++ b/docs/guide/Advanced/SetupAndCleanup.md
@@ -117,3 +117,48 @@ The order of method calls:
 // GlobalCleanup
 ```
 
+## Target 
+
+Sometimes it's useful to run setup or cleanups for specific benchmarks. All four setup and cleanup attributes have a Target property that allow the setup/cleanup method to be run for one or more specific benchmark methods.   
+
+```cs
+[SimpleJob(RunStrategy.Monitoring, launchCount: 0, warmupCount: 0, targetCount: 1)]
+public class SetupAndCleanupExample
+{
+  [GlobalSetup(Target = nameof(BenchmarkA))]
+  public void GlobalSetupA() => Console.WriteLine("// " + "GlobalSetup A");
+  
+  [Benchmark]
+  public void BenchmarkA() => Console.WriteLine("// " + "Benchmark A");
+  
+  [GlobalSetup(Target = nameof(BenchmarkB) + "," + nameof(BenchmarkC))]
+  public void GlobalSetupB() => Console.WriteLine("// " + "GlobalSetup B");
+  
+  [Benchmark]
+  public void BenchmarkB() => Console.WriteLine("// " + "Benchmark B");
+  
+  [Benchmark]
+  public void BenchmarkC() => Console.WriteLine("// " + "Benchmark C");
+  
+  [Benchmark]
+  public void BenchmarkD() => Console.WriteLine("// " + "Benchmark D");
+}
+```
+
+The order of method calls:
+
+```
+// GlobalSetup A
+
+// Benchmark A
+
+// GlobalSetup B
+
+// Benchmark B
+
+// GlobalSetup B
+
+// Benchmark C
+
+// Benchmark D
+```

--- a/src/BenchmarkDotNet.Core/Attributes/GlobalCleanupAttribute.cs
+++ b/src/BenchmarkDotNet.Core/Attributes/GlobalCleanupAttribute.cs
@@ -9,7 +9,7 @@ namespace BenchmarkDotNet.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     [MeansImplicitUse]    
-    public class GlobalCleanupAttribute: Attribute
-    {        
+    public class GlobalCleanupAttribute: TargetedAttribute
+    {
     }
 }

--- a/src/BenchmarkDotNet.Core/Attributes/GlobalSetupAttribute.cs
+++ b/src/BenchmarkDotNet.Core/Attributes/GlobalSetupAttribute.cs
@@ -9,7 +9,7 @@ namespace BenchmarkDotNet.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     [MeansImplicitUse]
-    public class GlobalSetupAttribute: Attribute
+    public class GlobalSetupAttribute: TargetedAttribute
     {
     }
 }

--- a/src/BenchmarkDotNet.Core/Attributes/IterationCleanupAttribute.cs
+++ b/src/BenchmarkDotNet.Core/Attributes/IterationCleanupAttribute.cs
@@ -8,7 +8,7 @@ namespace BenchmarkDotNet.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     [MeansImplicitUse]
-    public class IterationCleanupAttribute : Attribute
-    {        
+    public class IterationCleanupAttribute : TargetedAttribute
+    {
     }
 }

--- a/src/BenchmarkDotNet.Core/Attributes/IterationSetupAttribute.cs
+++ b/src/BenchmarkDotNet.Core/Attributes/IterationSetupAttribute.cs
@@ -8,7 +8,7 @@ namespace BenchmarkDotNet.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     [MeansImplicitUse]
-    public class IterationSetupAttribute: Attribute
-    {        
+    public class IterationSetupAttribute: TargetedAttribute
+    {
     }
 }

--- a/src/BenchmarkDotNet.Core/Attributes/TargetedAttribute.cs
+++ b/src/BenchmarkDotNet.Core/Attributes/TargetedAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BenchmarkDotNet.Attributes
+{
+    /// <summary>
+    /// Base class for attributes that are targeted at one method
+    /// </summary>
+    public abstract class TargetedAttribute : Attribute
+    {
+        /// <summary>
+        /// Target method for attribute
+        /// </summary>
+        public string Target { get; set; }
+    }
+}

--- a/tests/BenchmarkDotNet.IntegrationTests/AllSetupAndCleanupTargetSpecificBenchmarkTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/AllSetupAndCleanupTargetSpecificBenchmarkTest.cs
@@ -1,0 +1,148 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Tests.Loggers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class AllSetupAndCleanupTargetSpecificBenchmarkTest : BenchmarkTestExecutor
+    {
+
+        private const string FirstPrefix = "// ### First Called: ";
+        private const string FirstGlobalSetupCalled = FirstPrefix + "GlobalSetup";
+        private const string FirstGlobalCleanupCalled = FirstPrefix + "GlobalCleanup";
+        private const string FirstIterationSetupCalled = FirstPrefix + "IterationSetup";
+        private const string FirstIterationCleanupCalled = FirstPrefix + "IterationCleanup";
+        private const string FirstBenchmarkCalled = FirstPrefix + "Benchmark";
+
+        private const string SecondPrefix = "// ### Second Called: ";
+        private const string SecondGlobalSetupCalled = SecondPrefix + "GlobalSetup";
+        private const string SecondGlobalCleanupCalled = SecondPrefix + "GlobalCleanup";
+        private const string SecondIterationSetupCalled = SecondPrefix + "IterationSetup";
+        private const string SecondIterationCleanupCalled = SecondPrefix + "IterationCleanup";
+        private const string SecondBenchmarkCalled = SecondPrefix + "Benchmark";
+
+        private const string OutputDelimeter = "===========================================================";
+
+        private readonly string[] firstExpectedLogLines = {
+            "// ### First Called: GlobalSetup",
+
+            "// ### First Called: IterationSetup (1)", // IterationSetup Jitting
+            "// ### First Called: IterationCleanup (1)", // IterationCleanup Jitting
+            
+            "// ### First Called: IterationSetup (2)", // MainWarmup1
+            "// ### First Called: Benchmark", // MainWarmup1
+            "// ### First Called: IterationCleanup (2)", // MainWarmup1
+            "// ### First Called: IterationSetup (3)", // MainWarmup2
+            "// ### First Called: Benchmark", // MainWarmup2
+            "// ### First Called: IterationCleanup (3)", // MainWarmup2
+            
+            "// ### First Called: IterationSetup (4)", // MainTarget1
+            "// ### First Called: Benchmark", // MainTarget1
+            "// ### First Called: IterationCleanup (4)", // MainTarget1
+            "// ### First Called: IterationSetup (5)", // MainTarget2
+            "// ### First Called: Benchmark", // MainTarget2
+            "// ### First Called: IterationCleanup (5)", // MainTarget2
+            "// ### First Called: IterationSetup (6)", // MainTarget3
+            "// ### First Called: Benchmark", // MainTarget3
+            "// ### First Called: IterationCleanup (6)", // MainTarget3
+            
+            "// ### First Called: GlobalCleanup"
+        };
+        
+        private readonly string[] secondExpectedLogLines = {
+            "// ### Second Called: GlobalSetup",
+
+            "// ### Second Called: IterationSetup (1)", // IterationSetup Jitting
+            "// ### Second Called: IterationCleanup (1)", // IterationCleanup Jitting
+            
+            "// ### Second Called: IterationSetup (2)", // MainWarmup1
+            "// ### Second Called: Benchmark", // MainWarmup1
+            "// ### Second Called: IterationCleanup (2)", // MainWarmup1
+            "// ### Second Called: IterationSetup (3)", // MainWarmup2
+            "// ### Second Called: Benchmark", // MainWarmup2
+            "// ### Second Called: IterationCleanup (3)", // MainWarmup2
+            
+            "// ### Second Called: IterationSetup (4)", // MainTarget1
+            "// ### Second Called: Benchmark", // MainTarget1
+            "// ### Second Called: IterationCleanup (4)", // MainTarget1
+            "// ### Second Called: IterationSetup (5)", // MainTarget2
+            "// ### Second Called: Benchmark", // MainTarget2
+            "// ### Second Called: IterationCleanup (5)", // MainTarget2
+            "// ### Second Called: IterationSetup (6)", // MainTarget3
+            "// ### Second Called: Benchmark", // MainTarget3
+            "// ### Second Called: IterationCleanup (6)", // MainTarget3
+            
+            "// ### Second Called: GlobalCleanup"
+        };
+
+        public AllSetupAndCleanupTargetSpecificBenchmarkTest(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void AllSetupAndCleanupMethodRunsForSpecificBenchmarkTest()
+        {
+            var logger = new OutputLogger(Output);
+            var miniJob = Job.Default.With(RunStrategy.Monitoring).WithWarmupCount(2).WithTargetCount(3).WithInvocationCount(1).WithUnrollFactor(1).WithId("MiniJob");
+            var config = CreateSimpleConfig(logger, miniJob);
+
+            CanExecute<AllSetupAndCleanupAttributeSpecificTargetsBenchmarks>(config);
+            Output.WriteLine(OutputDelimeter);
+            Output.WriteLine(OutputDelimeter);
+            Output.WriteLine(OutputDelimeter);
+
+            var firstActualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(FirstPrefix)).ToArray();
+            foreach (string line in firstActualLogLines)
+                Output.WriteLine(line);
+            Assert.Equal(firstExpectedLogLines, firstActualLogLines);
+            
+            var secondActualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(SecondPrefix)).ToArray();
+            foreach (string line in secondActualLogLines)
+                Output.WriteLine(line);
+            Assert.Equal(secondExpectedLogLines, secondActualLogLines);
+        }
+
+        public class AllSetupAndCleanupAttributeSpecificTargetsBenchmarks
+        {
+            private int setupCounter;
+            private int cleanupCounter;
+
+            [IterationSetup(Target = nameof(FirstBenchmark))]
+            public void FirstIterationSetup() => Console.WriteLine(FirstIterationSetupCalled + " (" + ++setupCounter + ")");
+
+            [IterationCleanup(Target = nameof(FirstBenchmark))]
+            public void FirstIterationCleanup() => Console.WriteLine(FirstIterationCleanupCalled + " (" + ++cleanupCounter + ")");
+
+            [GlobalSetup(Target = nameof(FirstBenchmark))]
+            public void FirstGlobalSetup() => Console.WriteLine(FirstGlobalSetupCalled);
+
+            [GlobalCleanup(Target = nameof(FirstBenchmark))]
+            public void FirstGlobalCleanup() => Console.WriteLine(FirstGlobalCleanupCalled);
+
+            [Benchmark]
+            public void FirstBenchmark() => Console.WriteLine(FirstBenchmarkCalled);
+            
+
+            [IterationSetup(Target = nameof(SecondBenchmark))]
+            public void SecondIterationSetup() => Console.WriteLine(SecondIterationSetupCalled + " (" + ++setupCounter + ")");
+
+            [IterationCleanup(Target = nameof(SecondBenchmark))]
+            public void SecondIterationCleanup() => Console.WriteLine(SecondIterationCleanupCalled + " (" + ++cleanupCounter + ")");
+
+            [GlobalSetup(Target = nameof(SecondBenchmark))]
+            public void SecondGlobalSetup() => Console.WriteLine(SecondGlobalSetupCalled);
+
+            [GlobalCleanup(Target = nameof(SecondBenchmark))]
+            public void SecondGlobalCleanup() => Console.WriteLine(SecondGlobalCleanupCalled);
+
+            [Benchmark]
+            public void SecondBenchmark() => Console.WriteLine(SecondBenchmarkCalled);
+        }
+
+    }
+}

--- a/tests/BenchmarkDotNet.IntegrationTests/GlobalCleanupAttributeTargetTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/GlobalCleanupAttributeTargetTest.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Tests.Loggers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class GlobalCleanupAttributeTargetTest : BenchmarkTestExecutor
+    {
+        private const string FirstGlobalCleanupCalled = "// ### First GlobalCleanup called ###";
+        private const string FirstBenchmarkCalled = "// ### First Benchmark called ###";
+        private const string SecondGlobalCleanupCalled = "// ### Second GlobalCleanup called ###";
+        private const string SecondBenchmarkCalled = "// ### Second Benchmark called ###";
+
+
+        public GlobalCleanupAttributeTargetTest(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void GlobalCleanupTargetSpecificMethodTest()
+        {
+            var logger = new OutputLogger(Output);
+            var config = CreateSimpleConfig(logger);
+
+            CanExecute<GlobalCleanupAttributeTargetBenchmarks>(config);
+
+            string log = logger.GetLog();
+
+            Assert.Contains(FirstGlobalCleanupCalled + Environment.NewLine, log);
+            Assert.Contains(FirstBenchmarkCalled + Environment.NewLine, log);
+            Assert.True(
+                log.IndexOf(FirstBenchmarkCalled + Environment.NewLine) <
+                log.IndexOf(FirstGlobalCleanupCalled + Environment.NewLine));
+
+            Assert.Contains(SecondGlobalCleanupCalled + Environment.NewLine, log);
+            Assert.Contains(SecondBenchmarkCalled + Environment.NewLine, log);
+            Assert.True(
+                log.IndexOf(SecondBenchmarkCalled + Environment.NewLine) <
+                log.IndexOf(SecondGlobalCleanupCalled + Environment.NewLine));
+        }
+
+        public class GlobalCleanupAttributeTargetBenchmarks
+        {
+            private int cleanupValue;
+
+            [Benchmark]
+            public void Benchmark1()
+            {
+                cleanupValue = 1;
+
+                Console.WriteLine(FirstBenchmarkCalled);
+            }
+
+            [GlobalCleanup(Target = nameof(Benchmark1))]
+            public void GlobalCleanup1()
+            {
+                Assert.Equal(1, cleanupValue);
+
+                Console.WriteLine(FirstGlobalCleanupCalled);
+            }
+
+            [Benchmark]
+            public void Benchmark2()
+            {
+                cleanupValue = 2;
+
+                Console.WriteLine(SecondBenchmarkCalled);
+            }
+
+            [GlobalCleanup(Target = nameof(Benchmark2))]
+            public void GlobalCleanup2()
+            {
+                Assert.Equal(2, cleanupValue);
+
+                Console.WriteLine(SecondGlobalCleanupCalled);
+            }
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.IntegrationTests/GlobalSetupAttributeTargetTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/GlobalSetupAttributeTargetTest.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Tests.Loggers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class GlobalSetupAttributeTargetTest : BenchmarkTestExecutor
+    {
+        private const string FirstGlobalSetupCalled = "// ### First GlobalSetup called ###";
+        private const string FirstBenchmarkCalled = "// ### First Benchmark called ###";
+        private const string SecondGlobalSetupCalled = "// ### Second GlobalSetup called ###";
+        private const string SecondBenchmarkCalled = "// ### Second Benchmark called ###";
+
+        public GlobalSetupAttributeTargetTest(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void GlobalSetupTargetSpecificMethodTest()
+        {
+            var logger = new OutputLogger(Output);
+            var config = CreateSimpleConfig(logger);
+
+            CanExecute<GlobalSetupAttributeTargetBenchmarks>(config);
+            
+            string log = logger.GetLog();
+
+            Assert.Contains(FirstGlobalSetupCalled + Environment.NewLine, log);
+            Assert.True(
+                log.IndexOf(FirstGlobalSetupCalled + Environment.NewLine) <
+                log.IndexOf(FirstBenchmarkCalled + Environment.NewLine));
+
+            Assert.Contains(SecondGlobalSetupCalled + Environment.NewLine, log);
+            Assert.True(
+                log.IndexOf(SecondGlobalSetupCalled + Environment.NewLine) <
+                log.IndexOf(SecondBenchmarkCalled + Environment.NewLine));
+        }
+
+        public class GlobalSetupAttributeTargetBenchmarks
+        {
+            private int setupValue;
+
+            [GlobalSetup(Target = nameof(Benchmark1))]
+            public void GlobalSetup1()
+            {
+                setupValue = 1;
+
+                Console.WriteLine(FirstGlobalSetupCalled);
+            }
+
+            [Benchmark]
+            public void Benchmark1()
+            {
+                Assert.Equal(1, setupValue);
+
+                Console.WriteLine(FirstBenchmarkCalled);
+            }
+            
+            [GlobalSetup(Target = nameof(Benchmark2))]
+            public void GlobalSetup2()
+            {
+                setupValue = 2;
+
+                Console.WriteLine(SecondGlobalSetupCalled);
+            }
+
+            [Benchmark]
+            public void Benchmark2()
+            {
+                Assert.Equal(2, setupValue);
+
+                Console.WriteLine(SecondBenchmarkCalled);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is for issue #469. It adds a Target property to the Setup and Cleanup attributes allowing setup methods to be targeted at specific benchmark methods.
