### PR TITLE
Warning about antivirus software after benchmark failure

### DIFF
--- a/docs/guide/FAQ.md
+++ b/docs/guide/FAQ.md
@@ -35,3 +35,5 @@ For example, you can use the `SimpleJob` or `ShortRunJob` attributes:
 [SimpleJob(launchCount: 1, warmupCount: 3, targetCount: 5, invocationCount:100, id: "QuickJob")]
 [ShortRunJob]
 ```
+* **Q** My benchmark unexpectedly stopped and I saw the information about error code. What can I do?  
+**A** BenchmarkDotNet generates, builds and runs new process for every benchmark. This behavior is sometimes interpreted by anti-virus as dangerous, and the process is killed. Use `EnvironmentAnalyser` to detect antivirus software and configure your benchmark to use `InProcessToolchain`.

--- a/src/BenchmarkDotNet.Core/Analysers/EnvironmentAnalyser.cs
+++ b/src/BenchmarkDotNet.Core/Analysers/EnvironmentAnalyser.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Toolchains.InProcess;
 
 namespace BenchmarkDotNet.Analysers
 {
@@ -24,6 +26,11 @@ namespace BenchmarkDotNet.Analysers
         {
             if (summary.HostEnvironmentInfo.HasAttachedDebugger)
                 yield return CreateWarning("Benchmark was executed with attached debugger");
+
+            var antivirusProducts = summary.HostEnvironmentInfo.AntivirusProducts.Value;
+            if (antivirusProducts.Any())
+                yield return CreateWarning("Found antivirus products: " + $"{string.Join(", ", antivirusProducts)}. " +
+                                           $"In case of any problems or hang, use {nameof(InProcessToolchain)} to avoid new process creation.");
         }
     }
 }

--- a/src/BenchmarkDotNet.Core/Analysers/EnvironmentAnalyser.cs
+++ b/src/BenchmarkDotNet.Core/Analysers/EnvironmentAnalyser.cs
@@ -46,7 +46,7 @@ namespace BenchmarkDotNet.Analysers
             sb.AppendLine();
 
             foreach (var av in avProducts)
-                sb.AppendLine($"\t - {av}");
+                sb.AppendLine($"        - {av}");
 
             sb.AppendLine($"Use {nameof(InProcessToolchain)} to avoid new process creation.");
 

--- a/src/BenchmarkDotNet.Core/Environments/HostEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet.Core/Environments/HostEnvironmentInfo.cs
@@ -56,6 +56,8 @@ namespace BenchmarkDotNet.Environments
 
         public HardwareTimerKind HardwareTimerKind { get; protected set; }
 
+        public Lazy<ICollection<Antivirus>> AntivirusProducts { get; protected set; }
+
         static HostEnvironmentInfo()
         {
             MainCultureInfo = (CultureInfo)CultureInfo.InvariantCulture.Clone();
@@ -72,6 +74,7 @@ namespace BenchmarkDotNet.Environments
             HardwareTimerKind = Chronometer.HardwareTimerKind;
             JitModules = RuntimeInformation.GetJitModulesInfo();
             DotNetSdkVersion = new Lazy<string>(DotNetCliCommandExecutor.GetDotNetSdkVersion);
+            AntivirusProducts = new Lazy<ICollection<Antivirus>>(RuntimeInformation.GetAntivirusProducts);
         }
 
         public new static HostEnvironmentInfo GetCurrent() => Current ?? (Current = new HostEnvironmentInfo());

--- a/src/BenchmarkDotNet.Core/Portability/Antivirus.cs
+++ b/src/BenchmarkDotNet.Core/Portability/Antivirus.cs
@@ -1,0 +1,16 @@
+﻿namespace BenchmarkDotNet.Portability
+{
+    public class Antivirus
+    {
+        public Antivirus(string name, string path)
+        {
+            Name = name;
+            Path = path;
+        }
+
+        public string Name { get; }
+        public string Path { get; }
+
+        public override string ToString() => $"{Name} ({Path})";
+    }
+}

--- a/src/BenchmarkDotNet.Core/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet.Core/Portability/RuntimeInformation.cs
@@ -15,7 +15,6 @@ using BenchmarkDotNet.Toolchains;
 using BenchmarkDotNet.Toolchains.CsProj;
 #if !CORE
 using System.Management;
-
 #endif
 
 namespace BenchmarkDotNet.Portability
@@ -100,7 +99,7 @@ namespace BenchmarkDotNet.Portability
 
             return Unknown;
         }
-        
+
         public static string GetNetCoreVersion()
         {
             var assembly = typeof(System.Runtime.GCSettings).GetTypeInfo().Assembly;
@@ -266,7 +265,7 @@ namespace BenchmarkDotNet.Portability
             }
         }
 
-        [DllImport("libc", SetLastError=true)]
+        [DllImport("libc", SetLastError = true)]
         private static extern int uname(IntPtr buf);
 
         private static string GetSysnameFromUname()
@@ -290,6 +289,37 @@ namespace BenchmarkDotNet.Portability
                 if (buf != IntPtr.Zero)
                     Marshal.FreeHGlobal(buf);
             }
+        }
+
+        internal static ICollection<Antivirus> GetAntivirusProducts()
+        {
+#if !CORE
+            var products = new List<Antivirus>();
+            if (IsWindows())
+            {
+                try
+                {
+                    var wmi = new ManagementObjectSearcher(@"root\SecurityCenter2", "SELECT * FROM AntiVirusProduct");
+                    ManagementObjectCollection data = wmi.Get();
+
+                    foreach (ManagementBaseObject o in data)
+                    {
+                        var av = (ManagementObject)o;
+                        if (av != null)
+                        {
+                            string name = av["displayName"].ToString();
+                            string path = av["pathToSignedProductExe"].ToString();
+                            products.Add(new Antivirus(name, path));
+                        }
+                    }
+                }
+                catch { }
+            }
+
+            return products;
+#else
+            return Array.Empty<Antivirus>();
+#endif
         }
     }
 }


### PR DESCRIPTION
According to the #364 

In case of invalid error code, analyzer prints warning about installed antivirus software and InProcessToolchain. 

Tested with Symantec and Windows Defender.