### PR TITLE
#495 - Unit test for reading attributes from the base class

### DIFF
--- a/tests/BenchmarkDotNet.Tests/Running/BenchmarkConverterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Running/BenchmarkConverterTests.cs
@@ -13,14 +13,23 @@ namespace BenchmarkDotNet.Tests.Running
         [Fact]
         public void ReadsAttributesFromBaseClass()
         {
-            Benchmark benchmark = BenchmarkConverter.TypeToBenchmarks(typeof(Derived)).Single();
+            var derivedType = typeof(Derived);
+            Benchmark benchmark = BenchmarkConverter.TypeToBenchmarks(derivedType).Single();
            
             Assert.NotNull(benchmark);
             Assert.NotNull(benchmark.Target);
+
             Assert.NotNull(benchmark.Target.IterationSetupMethod);
+            Assert.Equal(benchmark.Target.IterationSetupMethod.DeclaringType, derivedType);
+
             Assert.NotNull(benchmark.Target.IterationCleanupMethod);
+            Assert.Equal(benchmark.Target.IterationCleanupMethod.DeclaringType, derivedType);
+
             Assert.NotNull(benchmark.Target.GlobalCleanupMethod);
+            Assert.Equal(benchmark.Target.GlobalCleanupMethod.DeclaringType, derivedType);
+
             Assert.NotNull(benchmark.Target.GlobalSetupMethod);
+            Assert.Equal(benchmark.Target.GlobalSetupMethod.DeclaringType, derivedType);
         }
 
         public abstract class Base

--- a/tests/BenchmarkDotNet.Tests/Running/BenchmarkConverterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Running/BenchmarkConverterTests.cs
@@ -1,0 +1,65 @@
+﻿using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.Running
+{
+    public class BenchmarkConverterTests
+    {
+        /// <summary>
+        /// https://github.com/dotnet/BenchmarkDotNet/issues/495
+        /// </summary>
+        [Fact]
+        public void ReadsAttributesFromBaseClass()
+        {
+            Benchmark benchmark = BenchmarkConverter.TypeToBenchmarks(typeof(Derived)).Single();
+           
+            Assert.NotNull(benchmark);
+            Assert.NotNull(benchmark.Target);
+            Assert.NotNull(benchmark.Target.IterationSetupMethod);
+            Assert.NotNull(benchmark.Target.IterationCleanupMethod);
+            Assert.NotNull(benchmark.Target.GlobalCleanupMethod);
+            Assert.NotNull(benchmark.Target.GlobalSetupMethod);
+        }
+
+        public abstract class Base
+        {
+            [GlobalSetup]
+            public abstract void GlobalSetup();
+
+            [GlobalCleanup]
+            public abstract void GlobalCleanup();
+
+            [IterationSetup]
+            public abstract void Setup();
+
+            [IterationCleanup]
+            public abstract void Cleanup();
+
+            [Benchmark]
+            public void Test()
+            {
+            }
+        }
+
+        public class Derived : Base
+        {
+            public override void GlobalSetup()
+            {
+            }
+
+            public override void GlobalCleanup()
+            {
+            }
+
+            public override void Setup()
+            {
+            }
+
+            public override void Cleanup()
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
#495 was fixed by @ipjohnson in 557246db by using `GetCustomAttributes` instead of `ReflectionExtensions::HasAttribute`. Version `v0.10.9` has this fix.

To be sure, I've added a unit test for expected behaviour 