### PR TITLE
Fixed information about MemoryDiagnoser.

### DIFF
--- a/docs/guide/Overview.md
+++ b/docs/guide/Overview.md
@@ -271,7 +271,7 @@ A **diagnoser** can attach to your benchmark and get some useful info.
 
 The current Diagnosers are:
 
-- GC and Memory Allocation (`MemoryDiagnoser`) which is cross platform, built-in and enabled by default.
+- GC and Memory Allocation (`MemoryDiagnoser`) which is cross platform, built-in and **is not enabled by default anymore**.
 - JIT Inlining Events (`InliningDiagnoser`). You can find this diagnoser in a separated package with diagnosers for Windows (`BenchmarkDotNet.Diagnostics.Windows`): [![NuGet](https://img.shields.io/nuget/v/BenchmarkDotNet.svg)](https://www.nuget.org/packages/BenchmarkDotNet.Diagnostics.Windows/)
 
 


### PR DESCRIPTION
Same as in `Diagnosers.md`.

Also maybe instead of having same information on two places, the `Overview.md` could just contain link to the `Diagnosers.md`, where all (more anyway) the detailed information is.