### PR TITLE
adding validator for setup cleanup attributes

### DIFF
--- a/src/BenchmarkDotNet.Core/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet.Core/Configs/DefaultConfig.cs
@@ -49,6 +49,7 @@ namespace BenchmarkDotNet.Configs
         public IEnumerable<IValidator> GetValidators()
         {
             yield return BaselineValidator.FailOnError;
+            yield return SetupCleanupValidator.FailOnError;
             yield return JitOptimizationsValidator.DontFailOnError;
             yield return UnrollFactorValidator.Default;
         }

--- a/src/BenchmarkDotNet.Core/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet.Core/Running/BenchmarkConverter.cs
@@ -114,7 +114,7 @@ namespace BenchmarkDotNet.Running
                     AssertMethodIsNotGeneric(methodName, m);
 
                     return new Tuple<MethodInfo, TargetedAttribute>(m, attr);
-                })).ToArray();
+                })).OrderByDescending(x => x.Item2.Target ?? "").ToArray();
         }
 
         private static Target CreateTarget(

--- a/src/BenchmarkDotNet.Core/Validators/CompositeValidator.cs
+++ b/src/BenchmarkDotNet.Core/Validators/CompositeValidator.cs
@@ -8,6 +8,7 @@ namespace BenchmarkDotNet.Validators
         private static readonly IValidator[] MandatoryValidators = 
         {
             BaselineValidator.FailOnError,
+            SetupCleanupValidator.FailOnError,
             UnrollFactorValidator.Default,
             DiagnosersValidator.Default,
             CompilationValidator.Default,

--- a/src/BenchmarkDotNet.Core/Validators/SetupCleanupValidator.cs
+++ b/src/BenchmarkDotNet.Core/Validators/SetupCleanupValidator.cs
@@ -1,0 +1,89 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BenchmarkDotNet.Validators
+{
+    public class SetupCleanupValidator : IValidator
+    {
+        public static readonly SetupCleanupValidator FailOnError = new SetupCleanupValidator();
+
+        private SetupCleanupValidator() { }
+
+        public bool TreatsWarningsAsErrors => true; // it is a must!
+
+        public IEnumerable<ValidationError> Validate(ValidationParameters input)
+        {
+            var validationErrors = new List<ValidationError>();
+
+            foreach (var groupByType in input.Benchmarks.GroupBy(benchmark => benchmark.Target.Type))
+            {
+                var allMethods = groupByType.Key.GetAllMethods().ToArray();
+
+                validationErrors.AddRange(ValidateAttributes<GlobalSetupAttribute>(groupByType.Key.Name, allMethods));
+                validationErrors.AddRange(ValidateAttributes<GlobalCleanupAttribute>(groupByType.Key.Name, allMethods));
+                validationErrors.AddRange(ValidateAttributes<IterationSetupAttribute>(groupByType.Key.Name, allMethods));
+                validationErrors.AddRange(ValidateAttributes<IterationSetupAttribute>(groupByType.Key.Name, allMethods));
+            }
+
+            return validationErrors;
+        }
+
+        private IEnumerable<ValidationError> ValidateAttributes<T>(string benchmarkClassName, IEnumerable<MethodInfo> allMethods) where T : TargetedAttribute
+        {
+            var emptyTargetCount = 0;
+            var targetCount = new Dictionary<string, int>();
+
+            foreach (var method in allMethods)
+            {
+                var attributes = method.GetCustomAttributes(false).OfType<T>();
+
+                foreach (var attribute in attributes)
+                {
+                    if (string.IsNullOrEmpty(attribute.Target))
+                    {
+                        emptyTargetCount++;
+                    }
+                    else
+                    {
+                        var targets = attribute.Target.Split(',');
+
+                        foreach (string target in targets)
+                        {
+                            if (!targetCount.ContainsKey(target))
+                            {
+                                targetCount[target] = 1;
+                            }
+                            else
+                            {
+                                targetCount[target] += 1;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (emptyTargetCount > 1)
+            {
+                yield return new ValidationError(
+                    TreatsWarningsAsErrors,
+                    $"Only 1 [{typeof(T).Name}] in a class can have an empty target applied to it, class {benchmarkClassName} has {emptyTargetCount}");
+            }
+
+            foreach (var targetPair in targetCount)
+            {
+                if (targetPair.Value > 1)
+                {
+                    yield return new ValidationError(
+                        TreatsWarningsAsErrors,
+                        $"Only 1 [{typeof(T).Name}] in a class can \"Target = {targetPair.Key}\" applied to it, class {benchmarkClassName} has {targetPair.Value}");
+                }
+            }
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.IntegrationTests/GlobalCleanupAttributeTargetTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/GlobalCleanupAttributeTargetTest.cs
@@ -10,11 +10,12 @@ namespace BenchmarkDotNet.IntegrationTests
 {
     public class GlobalCleanupAttributeTargetTest : BenchmarkTestExecutor
     {
+        private const string BaselineGlobalCleanupCalled = "// ### Baseline GlobalCleanup called ###";
+        private const string BaselineBenchmarkCalled = "// ### Baseline Benchmark called ###";
         private const string FirstGlobalCleanupCalled = "// ### First GlobalCleanup called ###";
         private const string FirstBenchmarkCalled = "// ### First Benchmark called ###";
         private const string SecondGlobalCleanupCalled = "// ### Second GlobalCleanup called ###";
         private const string SecondBenchmarkCalled = "// ### Second Benchmark called ###";
-
 
         public GlobalCleanupAttributeTargetTest(ITestOutputHelper output) : base(output) { }
 
@@ -27,6 +28,11 @@ namespace BenchmarkDotNet.IntegrationTests
             CanExecute<GlobalCleanupAttributeTargetBenchmarks>(config);
 
             string log = logger.GetLog();
+
+            Assert.Contains(BaselineBenchmarkCalled + Environment.NewLine, log);
+            Assert.True(
+                log.IndexOf(BaselineBenchmarkCalled + Environment.NewLine) < 
+                log.IndexOf(BaselineGlobalCleanupCalled + Environment.NewLine));
 
             Assert.Contains(FirstGlobalCleanupCalled + Environment.NewLine, log);
             Assert.Contains(FirstBenchmarkCalled + Environment.NewLine, log);
@@ -44,6 +50,22 @@ namespace BenchmarkDotNet.IntegrationTests
         public class GlobalCleanupAttributeTargetBenchmarks
         {
             private int cleanupValue;
+
+            [Benchmark(Baseline = true)]
+            public void BaselineBenchmark()
+            {
+                cleanupValue = -1;
+
+                Console.WriteLine(BaselineBenchmarkCalled);
+            }
+
+            [GlobalCleanup]
+            public void BaselineCleanup()
+            {
+                Assert.Equal(-1, cleanupValue);
+
+                Console.WriteLine(BaselineGlobalCleanupCalled);
+            }
 
             [Benchmark]
             public void Benchmark1()

--- a/tests/BenchmarkDotNet.IntegrationTests/GlobalSetupAttributeTargetTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/GlobalSetupAttributeTargetTest.cs
@@ -10,6 +10,8 @@ namespace BenchmarkDotNet.IntegrationTests
 {
     public class GlobalSetupAttributeTargetTest : BenchmarkTestExecutor
     {
+        private const string BaselineGlobalSetupCalled = "// ### Baseline GlobalSetup called ###";
+        private const string BaselineBenchmarkCalled = "// ### Baseline Benchmark called ###";
         private const string FirstGlobalSetupCalled = "// ### First GlobalSetup called ###";
         private const string FirstBenchmarkCalled = "// ### First Benchmark called ###";
         private const string SecondGlobalSetupCalled = "// ### Second GlobalSetup called ###";
@@ -27,6 +29,11 @@ namespace BenchmarkDotNet.IntegrationTests
             
             string log = logger.GetLog();
 
+            Assert.Contains(BaselineGlobalSetupCalled + Environment.NewLine, log);
+            Assert.True(
+                log.IndexOf(BaselineGlobalSetupCalled + Environment.NewLine) < 
+                log.IndexOf(BaselineBenchmarkCalled + Environment.NewLine));
+
             Assert.Contains(FirstGlobalSetupCalled + Environment.NewLine, log);
             Assert.True(
                 log.IndexOf(FirstGlobalSetupCalled + Environment.NewLine) <
@@ -41,6 +48,22 @@ namespace BenchmarkDotNet.IntegrationTests
         public class GlobalSetupAttributeTargetBenchmarks
         {
             private int setupValue;
+
+            [GlobalSetup]
+            public void BaselineSetup()
+            {
+                setupValue = -1;
+
+                Console.WriteLine(BaselineGlobalSetupCalled);
+            }
+
+            [Benchmark(Baseline = true)]
+            public void BaselineBenchmark()
+            {
+                Assert.Equal(-1, setupValue);
+
+                Console.WriteLine(BaselineBenchmarkCalled);
+            }
 
             [GlobalSetup(Target = nameof(Benchmark1))]
             public void GlobalSetup1()

--- a/tests/BenchmarkDotNet.IntegrationTests/SetupCleanupValidatorTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/SetupCleanupValidatorTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class SetupCleanupValidatorTests : BenchmarkTestExecutor
+    {
+        public SetupCleanupValidatorTests(ITestOutputHelper output) : base(output) { }
+
+        #region Too Many Blank Targets
+
+        public class BlankTargetClass
+        {
+            [GlobalSetup]
+            public void SetupA()
+            {
+
+            }
+
+            [GlobalSetup]
+            public void SetupB()
+            {
+
+            }
+
+            [Benchmark]
+            public void Benchmark()
+            {
+
+            }
+        }
+
+        [Fact]
+        public void InvalidGlobalSetupTooManyBlankTargets()
+        {
+            var results = CanExecute<BlankTargetClass>(fullValidation: false);
+
+            Assert.True(results.HasCriticalValidationErrors);
+
+            var count = results.ValidationErrors.Count(v =>
+                v.IsCritical && v.Message.Contains("[GlobalSetupAttribute]") && v.Message.Contains("Blank"));
+
+            Assert.Equal(1, count);
+        }
+
+        #endregion
+
+        #region Too Many Targets
+
+        public class ExplicitTargetClass
+        {
+            [GlobalSetup(Target = nameof(Benchmark))]
+            public void SetupA()
+            {
+
+            }
+
+            [GlobalSetup(Target = nameof(Benchmark))]
+            public void SetupB()
+            {
+
+            }
+
+            [Benchmark]
+            public void Benchmark()
+            {
+
+            }
+        }
+
+        [Fact]
+        public void InvalidGlobalSetupTooManyExplicitTargets()
+        {
+            var results = CanExecute<ExplicitTargetClass>(fullValidation: false);
+
+            Assert.True(results.HasCriticalValidationErrors);
+
+            var count = results.ValidationErrors.Count(v =>
+                v.IsCritical && v.Message.Contains("[GlobalSetupAttribute]") && v.Message.Contains("Target = Benchmark"));
+
+            Assert.Equal(1, count);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
this is to address issue #511 adds a validator for setup cleanup attributes as well as prefers targeted setup and cleanup methods over non targeted.