### PR TITLE
Fix type of local in EmitInvokeMultipleBody

### DIFF
--- a/src/BenchmarkDotNet.Core/Toolchains/InProcess/BenchmarkActionFactory_Base.cs
+++ b/src/BenchmarkDotNet.Core/Toolchains/InProcess/BenchmarkActionFactory_Base.cs
@@ -167,7 +167,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess
                 bool hasStoreField = !noReturnValue && storeResultField != null;
 
                 var g = dynamicMethod.GetILGenerator();
-                g.DeclareLocal(typeof(int));
+                g.DeclareLocal(typeof(long));
 
                 var loopStart = g.DefineLabel();
                 var loopCondition = g.DefineLabel();


### PR DESCRIPTION
The correct type is `long` as indicated in the preceding comments.
This fixes a 32bit RyuJIT crash when running in-process tests: https://github.com/dotnet/coreclr/issues/13476