### PR TITLE
Fix exporters to use fully qualified filenames

### DIFF
--- a/src/BenchmarkDotNet.Core/Exporters/ExporterBase.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/ExporterBase.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Reports;
 
@@ -17,7 +18,8 @@ namespace BenchmarkDotNet.Exporters
 
         public IEnumerable<string> ExportToFiles(Summary summary, ILogger consoleLogger)
         {
-            var filePath = $"{Path.Combine(summary.ResultsDirectoryPath, summary.Title)}-{FileCaption}{FileNameSuffix}.{FileExtension}";
+            var fileName = GetFileName(summary);
+            var filePath = $"{Path.Combine(summary.ResultsDirectoryPath, fileName)}-{FileCaption}{FileNameSuffix}.{FileExtension}";
             if (File.Exists(filePath))
             {
                 try
@@ -27,7 +29,7 @@ namespace BenchmarkDotNet.Exporters
                 catch (IOException)
                 {
                     var uniqueString = System.DateTime.Now.ToString("yyyyMMdd-HHmmss");
-                    var alternativeFilePath = $"{Path.Combine(summary.ResultsDirectoryPath, summary.Title)}-{FileCaption}{FileNameSuffix}-{uniqueString}.{FileExtension}";
+                    var alternativeFilePath = $"{Path.Combine(summary.ResultsDirectoryPath, fileName)}-{FileCaption}{FileNameSuffix}-{uniqueString}.{FileExtension}";
                     consoleLogger.WriteLineError($"Could not overwrite file {filePath}. Exporting to {alternativeFilePath}");
                     filePath = alternativeFilePath;
                 }
@@ -38,7 +40,24 @@ namespace BenchmarkDotNet.Exporters
                 ExportToLog(summary, new StreamLogger(stream));
             }
 
-            return new [] { filePath };
+            return new[] { filePath };
+        }
+
+        private static string GetFileName(Summary summary)
+        {
+            string fileName;
+
+            var benchmarkTypes = summary.Benchmarks.Select(b => b.Target.Type.FullName).Distinct().ToArray();
+            if (benchmarkTypes.Length == 1)
+            {
+                fileName = benchmarkTypes[0];
+            }
+            else
+            {
+                fileName = summary.Title;
+            }
+
+            return fileName;
         }
     }
 }


### PR DESCRIPTION
This PR fixes exporters to use fully qualified filenames instead of simple type names.
## Issue
#529

##  Features
- Changes how `ExporterBase` handles file naming:
  - Uses `Type.FullName` instead of `Type.Name` as part of the filename
  - Uses `Summary.Title` as the filename, if multiple benchmarks have been joined into a single `Summary`
    - This convention follows the way `Summary.Title` is generated in [`BenchmarkRunnerCore r60`](https://github.com/dotnet/BenchmarkDotNet/blob/174c19dced6883c9f5d810303b7e969739e1cc2b/src/BenchmarkDotNet.Core/Running/BenchmarkRunnerCore.cs#L60)
- Adds two integration tests for the aforementioned features inside `BenchmarkDotNet.IntegrationTests.ExporterIOTests`:
  1) Asserts the exporter uses fully qualified type name as part of the filename
  2) Asserts joined summaries use `Summary.Title` as filename instead of the fully qualified type name


### Example filename
Before: `IntroExporters-report-brief.json`
After: `BenchmarkDotNet.Samples.Intro.IntroExporters-report-brief.json`

## Other notes
- These changes won't take into account multiple classes with a same name inside different namespaces when _joining summaries of multiple benchmarks_
  - For example benchmarks inside `NamespaceA.ClassA` and `NamespaceB.ClassA` wouldn't be considered as two different benchmark classes _for the filename_ when joining. `ClassA-report.txt` would be used as the filename instead of `BenchmarkRun-001-2017-09-21-03-42-28-report.txt`
> I think this is a rare corner case so I left its handling out of for now

I think that's about it! ✔️
Let me know if I missed something or if something needs improvement.