### PR TITLE
Single point of full config creation

### DIFF
--- a/src/BenchmarkDotNet.Core/Configs/ConfigExtensions.cs
+++ b/src/BenchmarkDotNet.Core/Configs/ConfigExtensions.cs
@@ -38,6 +38,11 @@ namespace BenchmarkDotNet.Configs
         public static IConfig KeepBenchmarkFiles(this IConfig config, bool value = true) => config.With(m => m.KeepBenchmarkFiles = value);
         public static IConfig RemoveBenchmarkFiles(this IConfig config) => config.KeepBenchmarkFiles(false);
 
+        public static ReadOnlyConfig AsReadOnly(this IConfig config) =>
+            config is ReadOnlyConfig r
+                ? r
+                : new ReadOnlyConfig(config);
+
         private static IConfig With(this IConfig config, Action<ManualConfig> addAction)
         {
             var manualConfig = ManualConfig.Create(config);

--- a/src/BenchmarkDotNet.Core/Configs/IConfig.cs
+++ b/src/BenchmarkDotNet.Core/Configs/IConfig.cs
@@ -22,7 +22,7 @@ namespace BenchmarkDotNet.Configs
         IEnumerable<Job> GetJobs();
         IEnumerable<IValidator> GetValidators();
         IEnumerable<HardwareCounter> GetHardwareCounters();
-        IEnumerable<IFilter> GetFilters();        
+        IEnumerable<IFilter> GetFilters();
 
         IOrderProvider GetOrderProvider();
         ISummaryStyle GetSummaryStyle();

--- a/src/BenchmarkDotNet.Core/Configs/ReadOnlyConfig.cs
+++ b/src/BenchmarkDotNet.Core/Configs/ReadOnlyConfig.cs
@@ -19,7 +19,6 @@ namespace BenchmarkDotNet.Configs
     [PublicAPI]
     public class ReadOnlyConfig : IConfig
     {
-        #region Fields & .ctor
         private readonly IConfig config;
 
         public ReadOnlyConfig([NotNull] IConfig config)
@@ -29,9 +28,7 @@ namespace BenchmarkDotNet.Configs
 
             this.config = config;
         }
-        #endregion
 
-        #region IConfig implementation
         public IEnumerable<IColumnProvider> GetColumnProviders() => config.GetColumnProviders();
         public IEnumerable<IExporter> GetExporters() => config.GetExporters();
         public IEnumerable<ILogger> GetLoggers() => config.GetLoggers();
@@ -48,7 +45,5 @@ namespace BenchmarkDotNet.Configs
         public ConfigUnionRule UnionRule => config.UnionRule;
 
         public bool KeepBenchmarkFiles => config.KeepBenchmarkFiles;
-
-        #endregion
     }
 }

--- a/src/BenchmarkDotNet.Core/Configs/ReadOnlyConfig.cs
+++ b/src/BenchmarkDotNet.Core/Configs/ReadOnlyConfig.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+
+using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Filters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Order;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Validators;
+
+using JetBrains.Annotations;
+
+namespace BenchmarkDotNet.Configs
+{
+    [PublicAPI]
+    public class ReadOnlyConfig : IConfig
+    {
+        #region Fields & .ctor
+        private readonly IConfig config;
+
+        public ReadOnlyConfig([NotNull] IConfig config)
+        {
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            this.config = config;
+        }
+        #endregion
+
+        #region IConfig implementation
+        public IEnumerable<IColumnProvider> GetColumnProviders() => config.GetColumnProviders();
+        public IEnumerable<IExporter> GetExporters() => config.GetExporters();
+        public IEnumerable<ILogger> GetLoggers() => config.GetLoggers();
+        public IEnumerable<IDiagnoser> GetDiagnosers() => config.GetDiagnosers();
+        public IEnumerable<IAnalyser> GetAnalysers() => config.GetAnalysers();
+        public IEnumerable<Job> GetJobs() => config.GetJobs();
+        public IEnumerable<IValidator> GetValidators() => config.GetValidators();
+        public IEnumerable<HardwareCounter> GetHardwareCounters() => config.GetHardwareCounters();
+        public IEnumerable<IFilter> GetFilters() => config.GetFilters();
+
+        public IOrderProvider GetOrderProvider() => config.GetOrderProvider();
+        public ISummaryStyle GetSummaryStyle() => config.GetSummaryStyle();
+
+        public ConfigUnionRule UnionRule => config.UnionRule;
+
+        public bool KeepBenchmarkFiles => config.KeepBenchmarkFiles;
+
+        #endregion
+    }
+}

--- a/src/BenchmarkDotNet.Core/Running/BenchmarkRunInfo.cs
+++ b/src/BenchmarkDotNet.Core/Running/BenchmarkRunInfo.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using BenchmarkDotNet.Configs;
+
+namespace BenchmarkDotNet.Running
+{
+    public class BenchmarkRunInfo
+    {
+        public BenchmarkRunInfo(Benchmark[] benchmarks, Type type, ReadOnlyConfig config)
+        {
+            Benchmarks = benchmarks;
+            Type = type;
+            Config = config;
+        }
+        public Benchmark[] Benchmarks { get; }
+        public Type Type { get; }
+        public ReadOnlyConfig Config { get; }
+    }
+}

--- a/src/BenchmarkDotNet.Core/Running/ClassicBenchmarkConverter.cs
+++ b/src/BenchmarkDotNet.Core/Running/ClassicBenchmarkConverter.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Runtime.Remoting.Activation;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Loggers;
@@ -54,19 +53,19 @@ namespace BenchmarkDotNet.Running
                     "System.Core.dll"
                 })
             {
-                CompilerOptions = "/unsafe /optimize", 
+                CompilerOptions = "/unsafe /optimize",
                 GenerateInMemory = false,
                 OutputAssembly = Path.Combine(
-                    Path.GetDirectoryName(typeof(Benchmark).Assembly.Location), 
+                    Path.GetDirectoryName(typeof(Benchmark).Assembly.Location),
                     $"{Path.GetFileNameWithoutExtension(Path.GetTempFileName())}.dll")
             };
-            
+
             compilerParameters.ReferencedAssemblies.Add(typeof(Benchmark).Assembly.Location);
             var compilerResults = cSharpCodeProvider.CompileAssemblyFromSource(compilerParameters, benchmarkContent);
             if (compilerResults.Errors.HasErrors)
             {
                 var logger = config?.GetCompositeLogger() ?? HostEnvironmentInfo.FallbackLogger;
-    
+
                 compilerResults.Errors.Cast<CompilerError>().ToList().ForEach(error => logger.WriteLineError(error.ErrorText));
                 return Array.Empty<BenchmarkRunInfo>();
             }

--- a/src/BenchmarkDotNet.Core/Running/ClassicBenchmarkConverter.cs
+++ b/src/BenchmarkDotNet.Core/Running/ClassicBenchmarkConverter.cs
@@ -1,9 +1,11 @@
 ﻿#if CLASSIC
 using System;
 using System.CodeDom.Compiler;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Runtime.Remoting.Activation;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Loggers;
@@ -13,7 +15,7 @@ namespace BenchmarkDotNet.Running
 {
     public static partial class BenchmarkConverter
     {
-        public static Benchmark[] UrlToBenchmarks(string url, IConfig config = null)
+        public static BenchmarkRunInfo[] UrlToBenchmarks(string url, IConfig config = null)
         {
             var logger = config?.GetCompositeLogger() ?? HostEnvironmentInfo.FallbackLogger;
 
@@ -29,18 +31,18 @@ namespace BenchmarkDotNet.Running
                 if (string.IsNullOrWhiteSpace(benchmarkContent))
                 {
                     logger.WriteLineHint($"content of '{url}' is empty.");
-                    return Array.Empty<Benchmark>();
+                    return Array.Empty<BenchmarkRunInfo>();
                 }
             }
             catch (Exception e)
             {
                 logger.WriteLineError("BuildException: " + e.Message);
-                return Array.Empty<Benchmark>();
+                return Array.Empty<BenchmarkRunInfo>();
             }
             return SourceToBenchmarks(benchmarkContent, config);
         }
 
-        public static Benchmark[] SourceToBenchmarks(string source, IConfig config = null)
+        public static BenchmarkRunInfo[] SourceToBenchmarks(string source, IConfig config = null)
         {
             string benchmarkContent = source;
             var cSharpCodeProvider = new CSharpCodeProvider();
@@ -66,18 +68,30 @@ namespace BenchmarkDotNet.Running
                 var logger = config?.GetCompositeLogger() ?? HostEnvironmentInfo.FallbackLogger;
     
                 compilerResults.Errors.Cast<CompilerError>().ToList().ForEach(error => logger.WriteLineError(error.ErrorText));
-                return Array.Empty<Benchmark>();
+                return Array.Empty<BenchmarkRunInfo>();
             }
-            return (
-                from type in compilerResults.CompiledAssembly.GetTypes()
-                from benchmark in TypeToBenchmarks(type, config)
-                let target = benchmark.Target
-                select new Benchmark(
-                    new Target(target.Type, target.Method, target.GlobalSetupMethod, target.GlobalCleanupMethod, 
-                        target.IterationSetupMethod, target.IterationCleanupMethod, 
-                        target.MethodDisplayInfo, benchmarkContent, target.Baseline, target.Categories, target.OperationsPerInvoke),
-                    benchmark.Job,
-                    benchmark.Parameters)).ToArray();
+
+            var types = compilerResults.CompiledAssembly.GetTypes();
+
+            var resultBenchmarks = new List<BenchmarkRunInfo>();
+            foreach (var type in types)
+            {
+                var runInfo = TypeToBenchmarks(type, config);
+                var benchmarks = runInfo.Benchmarks.Select(b =>
+                {
+                    var target = b.Target;
+                    return new Benchmark(
+                        new Target(target.Type, target.Method, target.GlobalSetupMethod, target.GlobalCleanupMethod,
+                            target.IterationSetupMethod, target.IterationCleanupMethod,
+                            target.MethodDisplayInfo, benchmarkContent, target.Baseline, target.Categories, target.OperationsPerInvoke),
+                        b.Job,
+                        b.Parameters);
+                });
+                resultBenchmarks.Add(
+                    new BenchmarkRunInfo(benchmarks.ToArray(), runInfo.Type, runInfo.Config));
+            }
+
+            return resultBenchmarks.ToArray();
         }
 
         private static string GetRawUrl(string url)

--- a/src/BenchmarkDotNet.Core/Running/TypeParser.cs
+++ b/src/BenchmarkDotNet.Core/Running/TypeParser.cs
@@ -88,7 +88,7 @@ namespace BenchmarkDotNet.Running
                 var allBenchmarks = typeInfo.GetBenchmarks();
                 var benchmarks = allBenchmarks
                     .Where(method => filters.methodPredicates.All(rule => rule(method)))
-                    .ToArray();                               
+                    .ToArray();
 
                 if (benchmarks.IsEmpty())
                     continue;

--- a/src/BenchmarkDotNet.Core/Validators/ValidationParameters.cs
+++ b/src/BenchmarkDotNet.Core/Validators/ValidationParameters.cs
@@ -18,5 +18,6 @@ namespace BenchmarkDotNet.Validators
 
         // to have backward compatibility for people who implemented IValidator(Benchmark[] benchmarks)
         public static implicit operator ValidationParameters(Benchmark[] benchmarks) => new ValidationParameters(benchmarks, null);
+        public static implicit operator ValidationParameters(BenchmarkRunInfo benchmarkRunInfo) => new ValidationParameters(benchmarkRunInfo.Benchmarks, null);
     }
 }

--- a/src/BenchmarkDotNet/Running/BenchmarkRunner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Reports;
@@ -9,21 +10,36 @@ namespace BenchmarkDotNet.Running
     public static class BenchmarkRunner
     {
         public static Summary Run<T>(IConfig config = null) =>
-            BenchmarkRunnerCore.Run(BenchmarkConverter.TypeToBenchmarks(typeof(T), config), config, ToolchainExtensions.GetToolchain);
+            BenchmarkRunnerCore.Run(BenchmarkConverter.TypeToBenchmarks(typeof(T), config), ToolchainExtensions.GetToolchain);
 
         public static Summary Run(Type type, IConfig config = null) =>
-            BenchmarkRunnerCore.Run(BenchmarkConverter.TypeToBenchmarks(type, config), config, ToolchainExtensions.GetToolchain);
+            BenchmarkRunnerCore.Run(BenchmarkConverter.TypeToBenchmarks(type, config), ToolchainExtensions.GetToolchain);
 
         public static Summary Run(Type type, MethodInfo[] methods, IConfig config = null) =>
-            BenchmarkRunnerCore.Run(BenchmarkConverter.MethodsToBenchmarks(type, methods, config), config, ToolchainExtensions.GetToolchain);
+            BenchmarkRunnerCore.Run(BenchmarkConverter.MethodsToBenchmarks(type, methods, config), ToolchainExtensions.GetToolchain);
 
-        public static Summary Run(Benchmark[] benchmarks, IConfig config) =>
-            BenchmarkRunnerCore.Run(benchmarks, config, ToolchainExtensions.GetToolchain);
+        public static Summary Run(Benchmark[] benchmarks, IConfig config)
+        {
+            var targetType = benchmarks?.FirstOrDefault()?.Target.Type;
+            return BenchmarkRunnerCore.Run(
+                new BenchmarkRunInfo(benchmarks, targetType, BenchmarkConverter.GetFullConfig(targetType, config)),
+                ToolchainExtensions.GetToolchain);
+        }
+
+        public static Summary Run(BenchmarkRunInfo benchmarks)
+        {
+            return BenchmarkRunnerCore.Run(benchmarks, ToolchainExtensions.GetToolchain);
+        }
+
+        public static Summary Run(BenchmarkRunInfo[] benchmarks)
+        {
+            return BenchmarkRunnerCore.Run(benchmarks, ToolchainExtensions.GetToolchain);
+        }
 
         public static Summary RunUrl(string url, IConfig config = null)
         {
 #if CLASSIC
-            return BenchmarkRunnerCore.Run(BenchmarkConverter.UrlToBenchmarks(url, config), config, ToolchainExtensions.GetToolchain);
+            return BenchmarkRunnerCore.Run(BenchmarkConverter.UrlToBenchmarks(url, config), ToolchainExtensions.GetToolchain);
 #else
             throw new NotSupportedException();
 #endif
@@ -32,7 +48,7 @@ namespace BenchmarkDotNet.Running
         public static Summary RunSource(string source, IConfig config = null)
         {
 #if CLASSIC
-            return BenchmarkRunnerCore.Run(BenchmarkConverter.SourceToBenchmarks(source,  config), config, ToolchainExtensions.GetToolchain);
+            return BenchmarkRunnerCore.Run(BenchmarkConverter.SourceToBenchmarks(source, config), ToolchainExtensions.GetToolchain);
 #else
             throw new NotSupportedException();
 #endif

--- a/src/BenchmarkDotNet/Running/BenchmarkRunner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunner.cs
@@ -26,15 +26,9 @@ namespace BenchmarkDotNet.Running
                 ToolchainExtensions.GetToolchain);
         }
 
-        public static Summary Run(BenchmarkRunInfo benchmarks)
-        {
-            return BenchmarkRunnerCore.Run(benchmarks, ToolchainExtensions.GetToolchain);
-        }
+        public static Summary Run(BenchmarkRunInfo benchmarks) => BenchmarkRunnerCore.Run(benchmarks, ToolchainExtensions.GetToolchain);
 
-        public static Summary Run(BenchmarkRunInfo[] benchmarks)
-        {
-            return BenchmarkRunnerCore.Run(benchmarks, ToolchainExtensions.GetToolchain);
-        }
+        public static Summary Run(BenchmarkRunInfo[] benchmarks) => BenchmarkRunnerCore.Run(benchmarks, ToolchainExtensions.GetToolchain);
 
         public static Summary RunUrl(string url, IConfig config = null)
         {

--- a/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
@@ -42,7 +42,7 @@ namespace BenchmarkDotNet.Running
         /// Run all available benchmarks.
         /// </summary>
         public IEnumerable<Summary> RunAll() => Run(new[] { "*" });
-        
+
         /// <summary>
         /// Run all available benchmarks and join them to a single summary
         /// </summary>
@@ -64,18 +64,18 @@ namespace BenchmarkDotNet.Running
                 DisplayOptions();
                 return Enumerable.Empty<Summary>();
             }
-            
+
             var effectiveConfig = ManualConfig.Union(config ?? DefaultConfig.Instance, ManualConfig.Parse(args));
             bool join = args.Any(arg => arg.EqualsWithIgnoreCase("--join"));
 
             if (join)
             {
                 var typesWithMethods = typeParser.MatchingTypesWithMethods(args);
-                var benchmarks = typesWithMethods.SelectMany(typeWithMethods => 
-                    typeWithMethods.AllMethodsInType 
-                        ? BenchmarkConverter.TypeToBenchmarks(typeWithMethods.Type, effectiveConfig) 
+                var benchmarks = typesWithMethods.Select(typeWithMethods =>
+                    typeWithMethods.AllMethodsInType
+                        ? BenchmarkConverter.TypeToBenchmarks(typeWithMethods.Type, effectiveConfig)
                         : BenchmarkConverter.MethodsToBenchmarks(typeWithMethods.Type, typeWithMethods.Methods, effectiveConfig)).ToArray();
-                summaries.Add(BenchmarkRunner.Run(benchmarks, effectiveConfig));
+                summaries.Add(BenchmarkRunner.Run(benchmarks));
             }
             else
             {
@@ -106,7 +106,7 @@ namespace BenchmarkDotNet.Running
             return summaries;
         }
 
-        public bool ShouldDisplayOptions(string[] args) 
+        public bool ShouldDisplayOptions(string[] args)
             => args.Select(a => a.ToLowerInvariant()).Any(a => a == "--help" || a == "-h");
 
         private void DisplayOptions()

--- a/tests/BenchmarkDotNet.IntegrationTests/ExporterIOTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ExporterIOTests.cs
@@ -104,7 +104,7 @@ namespace BenchmarkDotNet.IntegrationTests
             try
             {
                 actualFilePath = exporter.ExportToFiles(mockSummary, NullLogger.Instance).First();
-                
+
                 Assert.Equal(expectedFilePath, actualFilePath);
             }
             finally
@@ -113,7 +113,7 @@ namespace BenchmarkDotNet.IntegrationTests
                     File.Delete(actualFilePath);
             }
         }
-        
+
         private Summary GetMockSummary(string resultsDirectoryPath, params Type[] typesWithBenchmarks)
         {
             return new Summary(
@@ -126,7 +126,7 @@ namespace BenchmarkDotNet.IntegrationTests
                 validationErrors: new Validators.ValidationError[0]
             );
         }
-        
+
         private class MockExporter : ExporterBase
         {
             public int ExportCount = 0;
@@ -144,7 +144,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
         private Benchmark[] CreateBenchmarks(Type[] types)
         {
-            return types.SelectMany(type => BenchmarkConverter.TypeToBenchmarks(type)).ToArray();
+            return types.SelectMany(type => BenchmarkConverter.TypeToBenchmarks(type).Benchmarks).ToArray();
         }
 
         private BenchmarkReport CreateReport(Benchmark benchmark)

--- a/tests/BenchmarkDotNet.IntegrationTests/JitOptimizationsTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/JitOptimizationsTests.cs
@@ -53,7 +53,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
         private Benchmark[] CreateBenchmarks(Type targetBenchmarkType)
         {
-            return BenchmarkConverter.TypeToBenchmarks(targetBenchmarkType);
+            return BenchmarkConverter.TypeToBenchmarks(targetBenchmarkType).Benchmarks;
         }
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -148,11 +148,11 @@ namespace BenchmarkDotNet.IntegrationTests
             var config = CreateConfig(toolchain);
             var benchmarks = BenchmarkConverter.TypeToBenchmarks(benchmarkType, config);
 
-            var summary = BenchmarkRunner.Run(benchmarks, config);
+            var summary = BenchmarkRunner.Run(benchmarks);
 
             foreach (var benchmarkAllocationsValidator in benchmarksAllocationsValidators)
             {
-                var allocatingBenchmarks = benchmarks.Where(benchmark => benchmark.DisplayInfo.Contains(benchmarkAllocationsValidator.Key));
+                var allocatingBenchmarks = benchmarks.Benchmarks.Where(benchmark => benchmark.DisplayInfo.Contains(benchmarkAllocationsValidator.Key));
 
                 foreach (var benchmark in allocatingBenchmarks)
                 {
@@ -189,7 +189,7 @@ namespace BenchmarkDotNet.IntegrationTests
         {
             int total = SizeOfAllFields<T>();
 
-            if(!typeof(T).GetTypeInfo().IsValueType)
+            if (!typeof(T).GetTypeInfo().IsValueType)
                 total += IntPtr.Size * 2; // pointer to method table + object header word
 
             if (total % IntPtr.Size != 0) // aligning..

--- a/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
+++ b/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
@@ -37,7 +37,7 @@ namespace BenchmarkDotNet.Tests.Mocks
 
         private static Benchmark[] CreateBenchmarks(IConfig config)
         {
-            return BenchmarkConverter.TypeToBenchmarks(typeof(MockBenchmarkClass), config);
+            return BenchmarkConverter.TypeToBenchmarks(typeof(MockBenchmarkClass), config).Benchmarks;
         }
 
         private static BenchmarkReport CreateReport(Benchmark benchmark)

--- a/tests/BenchmarkDotNet.Tests/Reports/DefaultColumnProvidersTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/DefaultColumnProvidersTests.cs
@@ -75,7 +75,7 @@ namespace BenchmarkDotNet.Tests.Reports
         }
 
         private static IEnumerable<Benchmark> CreateBenchmarks(IConfig config) =>
-            BenchmarkConverter.TypeToBenchmarks(typeof(MockBenchmarkClass), config);
+            BenchmarkConverter.TypeToBenchmarks(typeof(MockBenchmarkClass), config).Benchmarks;
 
 
         [LongRunJob]

--- a/tests/BenchmarkDotNet.Tests/Running/BenchmarkConverterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Running/BenchmarkConverterTests.cs
@@ -14,8 +14,8 @@ namespace BenchmarkDotNet.Tests.Running
         public void ReadsAttributesFromBaseClass()
         {
             var derivedType = typeof(Derived);
-            Benchmark benchmark = BenchmarkConverter.TypeToBenchmarks(derivedType).Single();
-           
+            Benchmark benchmark = BenchmarkConverter.TypeToBenchmarks(derivedType).Benchmarks.Single();
+
             Assert.NotNull(benchmark);
             Assert.NotNull(benchmark.Target);
 

--- a/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
@@ -217,7 +217,7 @@ namespace BenchmarkDotNet.Tests.Validators
         [Fact]
         public void FieldsWithoutParamsValuesAreDiscovered()
         {
-            Assert.Empty(BenchmarkConverter.TypeToBenchmarks(typeof(FieldsWithoutParamsValues)));
+            Assert.Empty(BenchmarkConverter.TypeToBenchmarks(typeof(FieldsWithoutParamsValues)).Benchmarks);
         }
 
         public class FieldsWithoutParamsValues


### PR DESCRIPTION
This commit tries to solve the issue of full config creation. 
Some parts of current code create full configs [three times during benchmark run](https://github.com/dotnet/BenchmarkDotNet/blob/5fe5647a158b41d0c2c949b6e04bca44ec5ff1d7/tests/BenchmarkDotNet.IntegrationTests/BenchmarkTestExecutor.cs#L64), others [do not create full config at all](https://github.com/dotnet/BenchmarkDotNet/blob/f2b9c0750fe236d9f4dc80571a58392d0ec7660d/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs#L77).

The fix is following:
* A new type, `BenchmarkRunInfo` is introduced. It keeps together benchmarks, a full config and a type for which the config was created. In case when there are multiple types in a single run (like with `join` switch) the current behavior is preserved: config is created using first type.
* `XxxToBenchmarks()` methods now return `BenchmarkRunInfo`, runner methods that accept `BenchmarkRunInfo` DO NOT create full config, all others use full config that returned from `XxxToBenchmarks()` call.

As a bonus I've added a `ReadOnlyConfig` class that allows to prevent errors like "passing a partial config to methods that expect full one". The class may be removed if not needed.

P.S. The build fails due to https://github.com/dotnet/BenchmarkDotNet/commit/9076a69f4e4e471d7820e12aef9b736c6d64a60f commit, branch build is fine, https://ci.appveyor.com/project/ig-sinicyn/benchmarkdotnet/build/0.10.9.47