### PR TITLE
Update cakebuild scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ os:
   - osx
 sudo: required
 dist: trusty
+osx_image: xcode9.1 # OS X 10.12
 mono: latest
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ os:
   - osx
 sudo: required
 dist: trusty
-group: edge
-osx_image: xcode8.3
 mono: latest
 
 addons:
@@ -34,11 +32,7 @@ addons:
 #---------------------------------#		
 #       build configuration       #		
 #---------------------------------#
-
-before_install:  
-  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
-
 before_script:
- - chmod +x build.sh
+  - chmod +x build.sh
 script:
   - ./build.sh

--- a/build.cake
+++ b/build.cake
@@ -42,7 +42,7 @@ Task("Clean")
 
         if(BuildSystem.IsLocalBuild)
         {
-            DeleteDirectories(GetDirectories("./**/obj") + GetDirectories("./**/bin"), 
+            DeleteDirectories(GetDirectories("./**/obj") + GetDirectories("./**/bin") - GetDirectories("./**/netcoreapp*"), 
                 new DeleteDirectorySettings 
                     {
                         Recursive = true,

--- a/build.cake
+++ b/build.cake
@@ -91,7 +91,7 @@ Task("Build")
     });
 
 Task("FastTests")
-    .IsDependentOn("Clean")
+    .IsDependentOn("Build")
     .WithCriteria(!skipTests)
     .Does(() =>
     {
@@ -99,7 +99,7 @@ Task("FastTests")
     });
 
 Task("BackwardCompatibilityTests")
-    .IsDependentOn("Clean")
+    .IsDependentOn("Build")
     .WithCriteria(!skipTests)
     .Does(() =>
     {
@@ -115,7 +115,7 @@ Task("BackwardCompatibilityTests")
     });
     
 Task("SlowTestsNet46")
-    .IsDependentOn("Clean")
+    .IsDependentOn("Build")
     .WithCriteria(!skipTests && isRunningOnWindows)
     .Does(() =>
     {
@@ -123,7 +123,7 @@ Task("SlowTestsNet46")
     });    
     
 Task("SlowTestsNetCore2")
-    .IsDependentOn("Clean")
+    .IsDependentOn("Build")
     .WithCriteria(!skipTests)
     .Does(() =>
     {
@@ -131,7 +131,7 @@ Task("SlowTestsNetCore2")
     });       
 
 Task("Pack")
-    .IsDependentOn("Clean")
+    .IsDependentOn("Build")
     .WithCriteria((IsOnAppVeyorAndNotPR || string.Equals(target, "pack", StringComparison.OrdinalIgnoreCase)) && isRunningOnWindows)
     .Does(() =>
     {

--- a/build.cake
+++ b/build.cake
@@ -119,9 +119,7 @@ Task("SlowTestsNet46")
     .WithCriteria(!skipTests && isRunningOnWindows)
     .Does(() =>
     {
-        var testSettings = GetTestSettings("net46");
-        testSettings.Filter = "Category=!BackwardCompatibility";
-        DotNetCoreTest("./tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj", testSettings);
+        DotNetCoreTest("./tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj", GetTestSettings("net46"));
     });    
     
 Task("SlowTestsNetCore2")
@@ -129,9 +127,7 @@ Task("SlowTestsNetCore2")
     .WithCriteria(!skipTests)
     .Does(() =>
     {
-        var testSettings = GetTestSettings("netcoreapp2.0");
-        testSettings.Filter = "Category=!BackwardCompatibility";
-        DotNetCoreTest("./tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj", testSettings);
+        DotNetCoreTest("./tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj", GetTestSettings("netcoreapp2.0"));
     });       
 
 Task("Pack")

--- a/build.cake
+++ b/build.cake
@@ -42,7 +42,11 @@ Task("Clean")
 
         if(BuildSystem.IsLocalBuild)
         {
-            DeleteDirectories(GetDirectories("./**/obj") + GetDirectories("./**/bin") - GetDirectories("./**/netcoreapp*"), 
+            var directoriesToClean = GetDirectories("./**/obj") 
+                                     + GetDirectories("./**/bin") 
+                                     - GetDirectories("./**/debug")
+                                     - GetDirectories("./**/release");
+            DeleteDirectories(directoriesToClean, 
                 new DeleteDirectorySettings 
                     {
                         Recursive = true,

--- a/build.cake
+++ b/build.cake
@@ -80,6 +80,7 @@ Task("Build")
                 var isMSBuildSupported = monoVersion != null && System.Text.RegularExpressions.Regex.IsMatch(monoVersion,@"([5-9]|\d{2,})\.\d+\.\d+(\.\d+)?");
                 if(isMSBuildSupported)
                 {
+                    Information(string.Format("Auto-detected ToolPath value is `{0}`", buildSettings.ToolPath));
                     buildSettings.ToolPath = new FilePath(@"/usr/lib/mono/msbuild/15.0/bin/MSBuild.dll");
                     Information(string.Format("Mono supports MSBuild. Override ToolPath value with `{0}`", buildSettings.ToolPath));
                 }

--- a/build.ps1
+++ b/build.ps1
@@ -16,7 +16,7 @@ No tasks will be executed.
 .PARAMETER ScriptArgs
 Remaining arguments are added here.
 .LINK
-http://cakebuild.net
+https://cakebuild.net
 #>
 
 [CmdletBinding()]
@@ -31,11 +31,13 @@ Param(
     [string[]]$ScriptArgs
 )
 
-$CakeVersion = "0.21.1"
-$DotNetChannel = "preview";
+$CakeVersion = "0.23.0"
 $DotNetVersion = "2.0.0";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+
+# Temporarily skip verification and opt-in to new in-proc NuGet
+$ENV:CAKE_NUGET_USEINPROCESSCLIENT='true'
 
 # Make sure tools folder exists
 $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
@@ -66,25 +68,21 @@ Function Remove-PathVariable([string]$VariableToRemove)
     }
 }
 
-# Get .NET Core CLI path if installed.
-$FoundDotNetCliVersion = $null;
-if (Get-Command dotnet -ErrorAction SilentlyContinue) {
-    $FoundDotNetCliVersion = dotnet --version;
+# Install .NET Core CLI
+$InstallPath = Join-Path $PSScriptRoot ".dotnet"
+if (!(Test-Path $InstallPath)) {
+    mkdir -Force $InstallPath | Out-Null;
 }
+(New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
+& $InstallPath\dotnet-install.ps1 -Version $DotNetVersion -InstallDir $InstallPath
+# We need to install the additional .NET Core runtime to run backward compatibility tests
+& $InstallPath\dotnet-install.ps1 -SharedRuntime -Version 1.1.2 -InstallDir $InstallPath;
 
-if($FoundDotNetCliVersion -ne $DotNetVersion) {
-    $InstallPath = Join-Path $PSScriptRoot ".dotnet"
-    if (!(Test-Path $InstallPath)) {
-        mkdir -Force $InstallPath | Out-Null;
-    }
-    (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
-    & $InstallPath\dotnet-install.ps1 -Channel $DotNetChannel -Version $DotNetVersion -InstallDir $InstallPath;
+Remove-PathVariable "$InstallPath"
+$env:PATH = "$InstallPath;$env:PATH"
 
-    Remove-PathVariable "$InstallPath"
-    $env:PATH = "$InstallPath;$env:PATH"
-    $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-    $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
-}
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+$env:DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 ###########################################################################
 # INSTALL NUGET
@@ -107,7 +105,7 @@ if (!(Test-Path $CakePath)) {
     Write-Host "Installing Cake..."
     Invoke-Expression "&`"$NugetPath`" install Cake -Version $CakeVersion -OutputDirectory `"$ToolPath`"" | Out-Null;
     if ($LASTEXITCODE -ne 0) {
-        Throw "An error occured while restoring Cake from NuGet."
+        Throw "An error occurred while restoring Cake from NuGet."
     }
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -76,7 +76,7 @@ if (!(Test-Path $InstallPath)) {
 (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
 & $InstallPath\dotnet-install.ps1 -Version $DotNetVersion -InstallDir $InstallPath
 # We need to install the additional .NET Core runtime to run backward compatibility tests
-& $InstallPath\dotnet-install.ps1 -SharedRuntime -Version 1.1.2 -InstallDir $InstallPath;
+& $InstallPath\dotnet-install.ps1 -SharedRuntime -Version 1.1.4 -InstallDir $InstallPath;
 
 Remove-PathVariable "$InstallPath"
 $env:PATH = "$InstallPath;$env:PATH"

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,8 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://dot.net/v1/dotnet-install.sh
 sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 2.0.0 --install-dir .dotnet --no-path
+# We need to install the additional .NET Core runtime to run backward compatibility tests
+sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" -sharedruntime --version 1.1.2 --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/build.sh
+++ b/build.sh
@@ -52,7 +52,7 @@ fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://dot.net/v1/dotnet-install.sh
 sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 2.0.0 --install-dir .dotnet --no-path
 # We need to install the additional .NET Core runtime to run backward compatibility tests
-sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" -sharedruntime --version 1.1.2 --install-dir .dotnet --no-path
+sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" -sharedruntime --version 1.1.4 --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/build.sh
+++ b/build.sh
@@ -10,8 +10,11 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 TOOLS_DIR=$SCRIPT_DIR/tools
 NUGET_EXE=$TOOLS_DIR/nuget.exe
 NUGET_URL=https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-CAKE_VERSION=0.21.1
+CAKE_VERSION=0.23.0
 CAKE_EXE=$TOOLS_DIR/Cake.$CAKE_VERSION/Cake.exe
+
+# Temporarily skip verification and opt-in to new in-proc NuGet
+export CAKE_NUGET_USEINPROCESSCLIENT="true"
 
 # Define default arguments.
 TARGET="Default"
@@ -64,7 +67,7 @@ if [ ! -f "$NUGET_EXE" ]; then
     echo "Downloading NuGet..."
     curl -Lsfo "$NUGET_EXE" $NUGET_URL
     if [ $? -ne 0 ]; then
-        echo "An error occured while downloading nuget.exe."
+        echo "An error occurred while downloading nuget.exe."
         exit 1
     fi
 fi


### PR DESCRIPTION
- Add installation step to get the required .NET Core runtime to run backward compatibility tests (Windows, Linux).
- Clean up travis CI definition (since .NET Core 2.0 openssl prerequisite is not required).
- Replace CleanDirectories(delete and create) and  with DeleteDirectories(only delete) command.
- Updated Cake tool to version 0.23.0
- Fix prerequisite step that is required to run Tests tasks properly (e.g. build.ps1 -Target BackwardCompatibilityTests)