### PR TITLE
Display VM name in summary section, fixes #574

### DIFF
--- a/src/BenchmarkDotNet.Core/Environments/HostEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet.Core/Environments/HostEnvironmentInfo.cs
@@ -84,21 +84,18 @@ namespace BenchmarkDotNet.Environments
 
         public override IEnumerable<string> ToFormattedString()
         {
-            yield return $"{BenchmarkDotNetCaption}=v{BenchmarkDotNetVersion}, OS={OsVersion.Value}, VM={GetInformationAboutHypervisor()}";
+            string vmName = VirtualMachineHypervisor.Value?.Name;
+            if (vmName == null)
+                yield return $"{BenchmarkDotNetCaption}=v{BenchmarkDotNetVersion}, OS={OsVersion.Value}";
+            else
+                yield return $"{BenchmarkDotNetCaption}=v{BenchmarkDotNetVersion}, OS={OsVersion.Value}, VM={vmName}";
+
             yield return $"Processor={ProcessorName.Value}, ProcessorCount={ProcessorCount}";
             if (HardwareTimerKind != HardwareTimerKind.Unknown)
                 yield return $"Frequency={ChronometerFrequency}, Resolution={ChronometerResolution}, Timer={HardwareTimerKind.ToString().ToUpper()}";
 #if !CLASSIC
             yield return $".NET Core SDK={DotNetSdkVersion.Value}";
 #endif
-        }
-
-        private string GetInformationAboutHypervisor()
-        {
-            if (VirtualMachineHypervisor.Value != null)
-                return VirtualMachineHypervisor.Value.Name;
-
-            return "Not detected";
         }
 
         internal bool IsDotNetCliInstalled() => !string.IsNullOrEmpty(DotNetSdkVersion.Value);

--- a/src/BenchmarkDotNet.Core/Environments/HostEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet.Core/Environments/HostEnvironmentInfo.cs
@@ -84,13 +84,21 @@ namespace BenchmarkDotNet.Environments
 
         public override IEnumerable<string> ToFormattedString()
         {
-            yield return $"{BenchmarkDotNetCaption}=v{BenchmarkDotNetVersion}, OS={OsVersion.Value}";
+            yield return $"{BenchmarkDotNetCaption}=v{BenchmarkDotNetVersion}, OS={OsVersion.Value}, VM={GetInformationAboutHypervisor()}";
             yield return $"Processor={ProcessorName.Value}, ProcessorCount={ProcessorCount}";
             if (HardwareTimerKind != HardwareTimerKind.Unknown)
                 yield return $"Frequency={ChronometerFrequency}, Resolution={ChronometerResolution}, Timer={HardwareTimerKind.ToString().ToUpper()}";
 #if !CLASSIC
             yield return $".NET Core SDK={DotNetSdkVersion.Value}";
 #endif
+        }
+
+        private string GetInformationAboutHypervisor()
+        {
+            if (VirtualMachineHypervisor.Value != null)
+                return VirtualMachineHypervisor.Value.Name;
+
+            return "Not detected";
         }
 
         internal bool IsDotNetCliInstalled() => !string.IsNullOrEmpty(DotNetSdkVersion.Value);

--- a/tests/BenchmarkDotNet.Tests/Builders/HostEnvironmentInfoBuilder.cs
+++ b/tests/BenchmarkDotNet.Tests/Builders/HostEnvironmentInfoBuilder.cs
@@ -25,10 +25,23 @@ namespace BenchmarkDotNet.Tests.Builders
         private string runtimeVersion = "Clr 4.0.x.mock";
         private VirtualMachineHypervisor virtualMachineHypervisor = HyperV.Default;
 
+        
+        public HostEnvironmentInfoBuilder WithVMHypervisor(VirtualMachineHypervisor hypervisor)
+        {
+            virtualMachineHypervisor = hypervisor;
+            return this;
+        }
+
+        public HostEnvironmentInfoBuilder WithoutVMHypervisor()
+        {
+            virtualMachineHypervisor = null;
+            return this;
+        }
+
         public HostEnvironmentInfo Build()
         {
-            return new MockFactory.MockHostEnvironmentInfo(architecture, benchmarkDotNetVersion, chronometerFrequency, configuration, 
-                dotNetSdkVersion, hardwareTimerKind, hasAttachedDebugger, hasRyuJit, isConcurrentGC, isServerGC, 
+            return new MockFactory.MockHostEnvironmentInfo(architecture, benchmarkDotNetVersion, chronometerFrequency, configuration,
+                dotNetSdkVersion, hardwareTimerKind, hasAttachedDebugger, hasRyuJit, isConcurrentGC, isServerGC,
                 jitInfo, jitModules, osVersion, processorCount, processorName, runtimeVersion, virtualMachineHypervisor);
         }
     }

--- a/tests/BenchmarkDotNet.Tests/Builders/HostEnvironmentInfoBuilder.cs
+++ b/tests/BenchmarkDotNet.Tests/Builders/HostEnvironmentInfoBuilder.cs
@@ -1,0 +1,35 @@
+﻿using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Horology;
+using BenchmarkDotNet.Portability;
+using BenchmarkDotNet.Tests.Mocks;
+
+namespace BenchmarkDotNet.Tests.Builders
+{
+    public class HostEnvironmentInfoBuilder
+    {
+        private string architecture = "64mock";
+        private string benchmarkDotNetVersion = "0.10.x-mock";
+        private Frequency chronometerFrequency = new Frequency(2531248);
+        private string configuration = "CONFIGURATION";
+        private string dotNetSdkVersion = "1.0.x.mock";
+        private HardwareTimerKind hardwareTimerKind = HardwareTimerKind.Tsc;
+        private bool hasAttachedDebugger = false;
+        private bool hasRyuJit = true;
+        private bool isConcurrentGC = false;
+        private bool isServerGC = false;
+        private string jitInfo = "RyuJIT-v4.6.x.mock";
+        private string jitModules = "clrjit-v4.6.x.mock";
+        private string osVersion = "Microsoft Windows NT 10.0.x.mock";
+        private int processorCount = 8;
+        private string processorName = "MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz";
+        private string runtimeVersion = "Clr 4.0.x.mock";
+        private VirtualMachineHypervisor virtualMachineHypervisor = HyperV.Default;
+
+        public HostEnvironmentInfo Build()
+        {
+            return new MockFactory.MockHostEnvironmentInfo(architecture, benchmarkDotNetVersion, chronometerFrequency, configuration, 
+                dotNetSdkVersion, hardwareTimerKind, hasAttachedDebugger, hasRyuJit, isConcurrentGC, isServerGC, 
+                jitInfo, jitModules, osVersion, processorCount, processorName, runtimeVersion, virtualMachineHypervisor);
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.Tests/Builders/HostEnvironmentInfoBuilder.cs
+++ b/tests/BenchmarkDotNet.Tests/Builders/HostEnvironmentInfoBuilder.cs
@@ -1,7 +1,7 @@
-﻿using BenchmarkDotNet.Environments;
+﻿using System;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Horology;
 using BenchmarkDotNet.Portability;
-using BenchmarkDotNet.Tests.Mocks;
 
 namespace BenchmarkDotNet.Tests.Builders
 {
@@ -25,7 +25,6 @@ namespace BenchmarkDotNet.Tests.Builders
         private string runtimeVersion = "Clr 4.0.x.mock";
         private VirtualMachineHypervisor virtualMachineHypervisor = HyperV.Default;
 
-        
         public HostEnvironmentInfoBuilder WithVMHypervisor(VirtualMachineHypervisor hypervisor)
         {
             virtualMachineHypervisor = hypervisor;
@@ -40,9 +39,37 @@ namespace BenchmarkDotNet.Tests.Builders
 
         public HostEnvironmentInfo Build()
         {
-            return new MockFactory.MockHostEnvironmentInfo(architecture, benchmarkDotNetVersion, chronometerFrequency, configuration,
+            return new MockHostEnvironmentInfo(architecture, benchmarkDotNetVersion, chronometerFrequency, configuration,
                 dotNetSdkVersion, hardwareTimerKind, hasAttachedDebugger, hasRyuJit, isConcurrentGC, isServerGC,
                 jitInfo, jitModules, osVersion, processorCount, processorName, runtimeVersion, virtualMachineHypervisor);
+        }
+    }
+
+    internal class MockHostEnvironmentInfo : HostEnvironmentInfo
+    {
+        public MockHostEnvironmentInfo(
+            string architecture, string benchmarkDotNetVersion, Frequency chronometerFrequency, string configuration, string dotNetSdkVersion,
+            HardwareTimerKind hardwareTimerKind, bool hasAttachedDebugger, bool hasRyuJit, bool isConcurrentGC, bool isServerGC,
+            string jitInfo, string jitModules, string osVersion, int processorCount,
+            string processorName, string runtimeVersion, VirtualMachineHypervisor virtualMachineHypervisor)
+        {
+            Architecture = architecture;
+            BenchmarkDotNetVersion = benchmarkDotNetVersion;
+            ChronometerFrequency = chronometerFrequency;
+            Configuration = configuration;
+            DotNetSdkVersion = new Lazy<string>(() => dotNetSdkVersion);
+            HardwareTimerKind = hardwareTimerKind;
+            HasAttachedDebugger = hasAttachedDebugger;
+            HasRyuJit = hasRyuJit;
+            IsConcurrentGC = isConcurrentGC;
+            IsServerGC = isServerGC;
+            JitInfo = jitInfo;
+            JitModules = jitModules;
+            OsVersion = new Lazy<string>(() => osVersion);
+            ProcessorCount = processorCount;
+            ProcessorName = new Lazy<string>(() => processorName);
+            RuntimeVersion = runtimeVersion;
+            VirtualMachineHypervisor = new Lazy<VirtualMachineHypervisor>(() => virtualMachineHypervisor);
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/Environments/HostEnvironmentInfoTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Environments/HostEnvironmentInfoTests.cs
@@ -24,7 +24,7 @@ namespace BenchmarkDotNet.Tests.Environments
             Assert.Equal(expected, line);
         }
 
-        private static IEnumerable<object[]> Hypervisors()
+        public static IEnumerable<object[]> Hypervisors()
         {
             yield return new object[] { HyperV.Default };
             yield return new object[] { VirtualBox.Default };

--- a/tests/BenchmarkDotNet.Tests/Environments/HostEnvironmentInfoTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Environments/HostEnvironmentInfoTests.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Portability;
+using BenchmarkDotNet.Tests.Builders;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.Environments
+{
+    public class HostEnvironmentInfoTests
+    {
+        [Theory]
+        [MemberData(nameof(Hypervisors))]
+        public void ReturnsHipervisorNameWhenItsDetected(VirtualMachineHypervisor hypervisor)
+        {
+            var info = new HostEnvironmentInfoBuilder()
+                .WithVMHypervisor(hypervisor)
+                .Build();
+
+            string line = info.ToFormattedString().First();
+
+            string expected = $"{HostEnvironmentInfo.BenchmarkDotNetCaption}=v{info.BenchmarkDotNetVersion}, " +
+                              $"OS={info.OsVersion.Value}, VM={hypervisor.Name}";
+            Assert.Equal(expected, line);
+        }
+
+        private static IEnumerable<object[]> Hypervisors()
+        {
+            yield return new object[] { HyperV.Default };
+            yield return new object[] { VirtualBox.Default };
+            yield return new object[] { VMware.Default };
+        }
+
+        [Fact]
+        public void DoesntReturnHypervisorNameWhenItsNotDetected()
+        {
+            var info = new HostEnvironmentInfoBuilder()
+                .WithoutVMHypervisor()
+                .Build();
+
+            string line = info.ToFormattedString().First();
+
+            string expected = $"{HostEnvironmentInfo.BenchmarkDotNetCaption}=v{info.BenchmarkDotNetVersion}, " +
+                              $"OS={info.OsVersion.Value}";
+            Assert.Equal(expected, line);
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/ApprovalTest.Exporters.Invariant.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/ApprovalTest.Exporters.Invariant.approved.txt
@@ -2,7 +2,7 @@
 AsciiDocExporter
 ############################################
 ....
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -34,7 +34,7 @@ HtmlExporter
 </head>
 <body>
 <pre><code>
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -323,7 +323,7 @@ JsonExporter-full-compressed
 MarkdownExporter-default
 ############################################
 
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -340,7 +340,7 @@ MarkdownExporter-atlassian
 ############################################
 {noformat}
 
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -356,7 +356,7 @@ WarmupCount=15
 MarkdownExporter-console
 ############################################
 
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -373,7 +373,7 @@ MarkdownExporter-github
 ############################################
 ``` ini
 
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -390,7 +390,7 @@ WarmupCount=15
 MarkdownExporter-stackoverflow
 ############################################
 
-    BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+    BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
     Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
     Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
       [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/ApprovalTest.Exporters.en-US.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/ApprovalTest.Exporters.en-US.approved.txt
@@ -2,7 +2,7 @@
 AsciiDocExporter
 ############################################
 ....
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -34,7 +34,7 @@ HtmlExporter
 </head>
 <body>
 <pre><code>
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -323,7 +323,7 @@ JsonExporter-full-compressed
 MarkdownExporter-default
 ############################################
 
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -340,7 +340,7 @@ MarkdownExporter-atlassian
 ############################################
 {noformat}
 
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -356,7 +356,7 @@ WarmupCount=15
 MarkdownExporter-console
 ############################################
 
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -373,7 +373,7 @@ MarkdownExporter-github
 ############################################
 ``` ini
 
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -390,7 +390,7 @@ WarmupCount=15
 MarkdownExporter-stackoverflow
 ############################################
 
-    BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+    BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
     Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
     Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
       [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/ApprovalTest.Exporters.ru-RU.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/ApprovalTest.Exporters.ru-RU.approved.txt
@@ -2,7 +2,7 @@
 AsciiDocExporter
 ############################################
 ....
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -34,7 +34,7 @@ HtmlExporter
 </head>
 <body>
 <pre><code>
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -323,7 +323,7 @@ JsonExporter-full-compressed
 MarkdownExporter-default
 ############################################
 
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -340,7 +340,7 @@ MarkdownExporter-atlassian
 ############################################
 {noformat}
 
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -356,7 +356,7 @@ WarmupCount=15
 MarkdownExporter-console
 ############################################
 
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -373,7 +373,7 @@ MarkdownExporter-github
 ############################################
 ``` ini
 
-BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
 Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
 Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
@@ -390,7 +390,7 @@ WarmupCount=15
 MarkdownExporter-stackoverflow
 ############################################
 
-    BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock
+    BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
     Processor=MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
     Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
       [Host] : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION

--- a/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
+++ b/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Jobs;
@@ -11,6 +10,7 @@ using BenchmarkDotNet.Horology;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Tests.Builders;
 using BenchmarkDotNet.Toolchains;
 using BenchmarkDotNet.Toolchains.Results;
 using BenchmarkDotNet.Validators;
@@ -24,7 +24,7 @@ namespace BenchmarkDotNet.Tests.Mocks
             return new Summary(
                 "MockSummary",
                 CreateReports(config),
-                MockHostEnvironmentInfo.Default,
+                new HostEnvironmentInfoBuilder().Build(),
                 config,
                 "",
                 TimeSpan.FromMinutes(1),
@@ -68,29 +68,29 @@ namespace BenchmarkDotNet.Tests.Mocks
 
         public class MockHostEnvironmentInfo : HostEnvironmentInfo
         {
-            public static MockHostEnvironmentInfo Default = new MockHostEnvironmentInfo
+            public MockHostEnvironmentInfo(
+                string architecture, string benchmarkDotNetVersion, Frequency chronometerFrequency, string configuration, string dotNetSdkVersion,
+                HardwareTimerKind hardwareTimerKind, bool hasAttachedDebugger, bool hasRyuJit, bool isConcurrentGC, bool isServerGC,
+                string jitInfo, string jitModules, string osVersion, int processorCount,
+                string processorName, string runtimeVersion, VirtualMachineHypervisor virtualMachineHypervisor)
             {
-                Architecture = "64mock",
-                BenchmarkDotNetVersion = "0.10.x-mock",
-                ChronometerFrequency = new Frequency(2531248),
-                Configuration = "CONFIGURATION",
-                DotNetSdkVersion = new Lazy<string>(() => "1.0.x.mock"),
-                HardwareTimerKind = HardwareTimerKind.Tsc,
-                HasAttachedDebugger = false,
-                HasRyuJit = true,
-                IsConcurrentGC = false,
-                IsServerGC = false,
-                JitInfo = "RyuJIT-v4.6.x.mock",
-                JitModules = "clrjit-v4.6.x.mock",
-                OsVersion = new Lazy<string>(() => "Microsoft Windows NT 10.0.x.mock"),
-                ProcessorCount = 8,
-                ProcessorName = new Lazy<string>(() => "MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"),
-                RuntimeVersion = "Clr 4.0.x.mock",
-                VirtualMachineHypervisor = new Lazy<VirtualMachineHypervisor>(() => HyperV.Default)
-            };
-
-            private MockHostEnvironmentInfo()
-            {
+                Architecture = architecture;
+                BenchmarkDotNetVersion = benchmarkDotNetVersion;
+                ChronometerFrequency = chronometerFrequency;
+                Configuration = configuration;
+                DotNetSdkVersion = new Lazy<string>(() => dotNetSdkVersion);
+                HardwareTimerKind = hardwareTimerKind;
+                HasAttachedDebugger = hasAttachedDebugger;
+                HasRyuJit = hasRyuJit;
+                IsConcurrentGC = isConcurrentGC;
+                IsServerGC = isServerGC;
+                JitInfo = jitInfo;
+                JitModules = jitModules;
+                OsVersion = new Lazy<string>(() => osVersion);
+                ProcessorCount = processorCount;
+                ProcessorName = new Lazy<string>(() => processorName);
+                RuntimeVersion = runtimeVersion;
+                VirtualMachineHypervisor = new Lazy<VirtualMachineHypervisor>(() => virtualMachineHypervisor);
             }
         }
     }

--- a/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
+++ b/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
@@ -5,9 +5,6 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Engines;
-using BenchmarkDotNet.Environments;
-using BenchmarkDotNet.Horology;
-using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Tests.Builders;
@@ -63,34 +60,6 @@ namespace BenchmarkDotNet.Tests.Mocks
             [Benchmark]
             public void Bar()
             {
-            }
-        }
-
-        public class MockHostEnvironmentInfo : HostEnvironmentInfo
-        {
-            public MockHostEnvironmentInfo(
-                string architecture, string benchmarkDotNetVersion, Frequency chronometerFrequency, string configuration, string dotNetSdkVersion,
-                HardwareTimerKind hardwareTimerKind, bool hasAttachedDebugger, bool hasRyuJit, bool isConcurrentGC, bool isServerGC,
-                string jitInfo, string jitModules, string osVersion, int processorCount,
-                string processorName, string runtimeVersion, VirtualMachineHypervisor virtualMachineHypervisor)
-            {
-                Architecture = architecture;
-                BenchmarkDotNetVersion = benchmarkDotNetVersion;
-                ChronometerFrequency = chronometerFrequency;
-                Configuration = configuration;
-                DotNetSdkVersion = new Lazy<string>(() => dotNetSdkVersion);
-                HardwareTimerKind = hardwareTimerKind;
-                HasAttachedDebugger = hasAttachedDebugger;
-                HasRyuJit = hasRyuJit;
-                IsConcurrentGC = isConcurrentGC;
-                IsServerGC = isServerGC;
-                JitInfo = jitInfo;
-                JitModules = jitModules;
-                OsVersion = new Lazy<string>(() => osVersion);
-                ProcessorCount = processorCount;
-                ProcessorName = new Lazy<string>(() => processorName);
-                RuntimeVersion = runtimeVersion;
-                VirtualMachineHypervisor = new Lazy<VirtualMachineHypervisor>(() => virtualMachineHypervisor);
             }
         }
     }

--- a/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
+++ b/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
@@ -8,6 +8,7 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Horology;
+using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains;
@@ -84,7 +85,8 @@ namespace BenchmarkDotNet.Tests.Mocks
                 OsVersion = new Lazy<string>(() => "Microsoft Windows NT 10.0.x.mock"),
                 ProcessorCount = 8,
                 ProcessorName = new Lazy<string>(() => "MockIntel(R) Core(TM) i7-6700HQ CPU 2.60GHz"),
-                RuntimeVersion = "Clr 4.0.x.mock"
+                RuntimeVersion = "Clr 4.0.x.mock",
+                VirtualMachineHypervisor = new Lazy<VirtualMachineHypervisor>(() => HyperV.Default)
             };
 
             private MockHostEnvironmentInfo()

--- a/tests/BenchmarkDotNet.Tests/Reports/DefaultColumnProvidersTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/DefaultColumnProvidersTests.cs
@@ -10,7 +10,7 @@ using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Tests.Mocks;
+using BenchmarkDotNet.Tests.Builders;
 using BenchmarkDotNet.Toolchains;
 using BenchmarkDotNet.Toolchains.Results;
 using BenchmarkDotNet.Validators;
@@ -48,7 +48,7 @@ namespace BenchmarkDotNet.Tests.Reports
             var summary = new Summary(
                 "MockSummary",
                 CreateBenchmarks(DefaultConfig.Instance).Select(b => CreateReport(b, hugeSd)).ToArray(),
-                MockFactory.MockHostEnvironmentInfo.Default,
+                new HostEnvironmentInfoBuilder().Build(),
                 DefaultConfig.Instance,
                 "",
                 TimeSpan.FromMinutes(1),

--- a/tests/BenchmarkDotNet.Tests/Reports/ScaledPrecisionTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/ScaledPrecisionTests.cs
@@ -9,7 +9,7 @@ using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Tests.Mocks;
+using BenchmarkDotNet.Tests.Builders;
 using BenchmarkDotNet.Toolchains;
 using BenchmarkDotNet.Toolchains.Results;
 using BenchmarkDotNet.Validators;
@@ -66,7 +66,7 @@ namespace BenchmarkDotNet.Tests.Reports
             var summary = new Summary(
                 "MockSummary",
                 benchmarkReports,
-                MockFactory.MockHostEnvironmentInfo.Default,
+                new HostEnvironmentInfoBuilder().Build(), 
                 DefaultConfig.Instance,
                 "",
                 TimeSpan.FromMinutes(1),


### PR DESCRIPTION
With this change, information about VM hypervisor will be printed next to the OS version.
`BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V`
If hypevisor is not found, user will see default message `VM=Not detected`

This information is helpful, because usually people don't publish warnings from the benchmark.