### PR TITLE
Fix typo in WithCustomBuildConfiguration API

### DIFF
--- a/src/BenchmarkDotNet.Core/Jobs/JobExtensions.cs
+++ b/src/BenchmarkDotNet.Core/Jobs/JobExtensions.cs
@@ -38,7 +38,7 @@ namespace BenchmarkDotNet.Jobs
         public static Job With(this Job job, IToolchain toolchain) => job.WithCore(j => j.Infrastructure.Toolchain = toolchain);
         public static Job With(this Job job, IClock clock) => job.WithCore(j => j.Infrastructure.Clock = clock);
         public static Job With(this Job job, IEngineFactory engineFactory) => job.WithCore(j => j.Infrastructure.EngineFactory = engineFactory);
-        public static Job WithCustomBuildConfiguration(this Job job, string buildConfiguraiton) => job.WithCore(j => j.Infrastructure.BuildConfiguration = buildConfiguraiton);
+        public static Job WithCustomBuildConfiguration(this Job job, string buildConfiguration) => job.WithCore(j => j.Infrastructure.BuildConfiguration = buildConfiguration);
         public static Job With(this Job job, IReadOnlyList<EnvironmentVariable> environmentVariables) => job.WithCore(j => j.Infrastructure.EnvironmentVariables = environmentVariables);
         public static Job With(this Job job, IReadOnlyList<Argument> arguments) => job.WithCore(j => j.Infrastructure.Arguments = arguments);
 


### PR DESCRIPTION
Technically renaming a parameter is a breaking change. I think in practice it's unlikely that any users of that API specified `buildConfiguraiton` using a named parameter, though.