### PR TITLE
Quick fix Disassembler.Program.GetMethod when more than one method found just return null

### DIFF
--- a/build/pack.bat
+++ b/build/pack.bat
@@ -1,0 +1,7 @@
+dotnet pack .\src\BenchmarkDotNet.Core\BenchmarkDotNet.Core.csproj -c Release
+dotnet pack .\src\BenchmarkDotNet.Toolchains.Roslyn\BenchmarkDotNet.Toolchains.Roslyn.csproj -c Release
+dotnet pack .\src\BenchmarkDotNet\BenchmarkDotNet.csproj -c Release
+dotnet pack .\src\BenchmarkDotNet.Diagnostics.Windows\BenchmarkDotNet.Diagnostics.Windows.csproj  -c Release
+rmdir artifacts /s /q
+mkdir artifacts
+for /R %%x in (BenchmarkDotNet*.nupkg) do copy "%%x" "artifacts/" /Y

--- a/src/BenchmarkDotNet.Disassembler.x64/Program.cs
+++ b/src/BenchmarkDotNet.Disassembler.x64/Program.cs
@@ -384,9 +384,13 @@ namespace BenchmarkDotNet.Disassembler
             // so the last chance is to try to match them by... name (I don't like it, but I have no better idea for now)
             var unifiedSignature = CecilNameToClrmdName(methodReference);
 
-            return declaringType
-                .Methods
-                .SingleOrDefault(method => method.GetFullSignature() == unifiedSignature);
+            var methodsMatchingSignature = declaringType.Methods
+                .Where(method => method.GetFullSignature() == unifiedSignature).ToArray();
+            if (methodsMatchingSignature.Length == 1)
+            {
+                return methodsMatchingSignature[0];
+            }
+            return null;
         }
 
 


### PR DESCRIPTION
Quick fix for issue reported later in https://github.com/dotnet/BenchmarkDotNet/issues/612

Had build issues also https://github.com/dotnet/BenchmarkDotNet/issues/614

Note this does simply ignores the case when more than one method found... didn't know how to add a test or debug this, but simply added this and now BDN at least doesn't crash when there is this issue.
  