### PR TITLE
Upgrade build tools

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -161,7 +161,11 @@ private string GetTestSettingsParameters(string tfm)
     var settings = $"-configuration Release -stoponfail -maxthreads unlimited -nobuild  -framework {tfm}";
     if(string.Equals("netcoreapp2.0", tfm, StringComparison.OrdinalIgnoreCase))
     {
-        settings += " --fx-version 2.0.3";
+        settings += " --fx-version 2.0.5";
+    }
+    if(string.Equals("netcoreapp1.1", tfm, StringComparison.OrdinalIgnoreCase))
+    {
+        settings += " --fx-version 1.1.6";
     }
     
     return settings;

--- a/build.ps1
+++ b/build.ps1
@@ -31,8 +31,8 @@ Param(
     [string[]]$ScriptArgs
 )
 
-$CakeVersion = "0.23.0"
-$DotNetVersion = "2.0.3";
+$CakeVersion = "0.24.0"
+$DotNetVersion = "2.1.4";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 
@@ -73,7 +73,7 @@ if (!(Test-Path $InstallPath)) {
 (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
 & $InstallPath\dotnet-install.ps1 -Version $DotNetVersion -InstallDir $InstallPath
 # We need to install the additional .NET Core runtime to run backward compatibility tests
-& $InstallPath\dotnet-install.ps1 -SharedRuntime -Version 1.1.4 -InstallDir $InstallPath;
+& $InstallPath\dotnet-install.ps1 -SharedRuntime -Version 1.1.6 -InstallDir $InstallPath;
 
 Remove-PathVariable "$InstallPath"
 $env:PATH = "$InstallPath;$env:PATH"

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 TOOLS_DIR=$SCRIPT_DIR/tools
 NUGET_EXE=$TOOLS_DIR/nuget.exe
 NUGET_URL=https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-CAKE_VERSION=0.23.0
+CAKE_VERSION=0.24.0
 CAKE_EXE=$TOOLS_DIR/Cake.$CAKE_VERSION/Cake.exe
 
 # Define default arguments.
@@ -47,9 +47,9 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
   mkdir "$SCRIPT_DIR/.dotnet"
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://dot.net/v1/dotnet-install.sh
-sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 2.0.3 --install-dir .dotnet --no-path
+sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 2.1.4 --install-dir .dotnet --no-path
 # We need to install the additional .NET Core runtime to run backward compatibility tests
-sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" -sharedruntime --version 1.1.4 --install-dir .dotnet --no-path
+sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" -sharedruntime --version 1.1.6 --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1


### PR DESCRIPTION
- Cake build 0.23.0 -> 0.24.0
- .NET Core SDK 2.0.3 -> 2.1.4
- .NET Core Runtime 1.1.4 -> 1.1.6 and 2.0.3 -> 2.0.5

Explicitly set a version of the installed .NET Core runtime to use to run netcoreapp1.1 tests. It closes #614.