### PR TITLE
Fix xunit warnings connected to usage of Assert.Equal() to check for Null

### DIFF
--- a/tests/BenchmarkDotNet.Tests/Portability/Cpu/ProcCpuInfoParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Portability/Cpu/ProcCpuInfoParserTests.cs
@@ -9,20 +9,20 @@ namespace BenchmarkDotNet.Tests.Portability.Cpu
         public void EmptyTest()
         {
             var parser = ProcCpuInfoParser.ParseOutput(string.Empty);
-            Assert.Equal(null, parser.ProcessorName);
-            Assert.Equal(null, parser.PhysicalProcessorCount);
-            Assert.Equal(null, parser.PhysicalCoreCount);
-            Assert.Equal(null, parser.LogicalCoreCount);
+            Assert.Null(parser.ProcessorName);
+            Assert.Null(parser.PhysicalProcessorCount);
+            Assert.Null(parser.PhysicalCoreCount);
+            Assert.Null(parser.LogicalCoreCount);
         }
 
         [Fact]
         public void MalformedTest()
         {
             var parser = ProcCpuInfoParser.ParseOutput("malformedkey: malformedvalue\n\nmalformedkey2: malformedvalue2");
-            Assert.Equal(null, parser.ProcessorName);
-            Assert.Equal(null, parser.PhysicalProcessorCount);
-            Assert.Equal(null, parser.PhysicalCoreCount);
-            Assert.Equal(null, parser.LogicalCoreCount);
+            Assert.Null(parser.ProcessorName);
+            Assert.Null(parser.PhysicalProcessorCount);
+            Assert.Null(parser.PhysicalCoreCount);
+            Assert.Null(parser.LogicalCoreCount);
         }
 
         [Fact]

--- a/tests/BenchmarkDotNet.Tests/Portability/Cpu/SysctlCpuInfoParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Portability/Cpu/SysctlCpuInfoParserTests.cs
@@ -9,20 +9,20 @@ namespace BenchmarkDotNet.Tests.Portability.Cpu
         public void EmptyTest()
         {
             var parser = SysctlCpuInfoParser.ParseOutput(string.Empty);
-            Assert.Equal(null, parser.ProcessorName);
-            Assert.Equal(null, parser.PhysicalProcessorCount);
-            Assert.Equal(null, parser.PhysicalCoreCount);
-            Assert.Equal(null, parser.LogicalCoreCount);
+            Assert.Null(parser.ProcessorName);
+            Assert.Null(parser.PhysicalProcessorCount);
+            Assert.Null(parser.PhysicalCoreCount);
+            Assert.Null(parser.LogicalCoreCount);
         }
 
         [Fact]
         public void MalformedTest()
         {
             var parser = SysctlCpuInfoParser.ParseOutput("malformedkey=malformedvalue\n\nmalformedkey2=malformedvalue2");
-            Assert.Equal(null, parser.ProcessorName);
-            Assert.Equal(null, parser.PhysicalProcessorCount);
-            Assert.Equal(null, parser.PhysicalCoreCount);
-            Assert.Equal(null, parser.LogicalCoreCount);
+            Assert.Null(parser.ProcessorName);
+            Assert.Null(parser.PhysicalProcessorCount);
+            Assert.Null(parser.PhysicalCoreCount);
+            Assert.Null(parser.LogicalCoreCount);
         }
 
         [Fact]

--- a/tests/BenchmarkDotNet.Tests/Portability/Cpu/WmicCpuInfoParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Portability/Cpu/WmicCpuInfoParserTests.cs
@@ -9,20 +9,20 @@ namespace BenchmarkDotNet.Tests.Portability.Cpu
         public void EmptyTest()
         {
             var parser = WmicCpuInfoParser.ParseOutput(string.Empty);
-            Assert.Equal(null, parser.ProcessorName);
-            Assert.Equal(null, parser.PhysicalProcessorCount);
-            Assert.Equal(null, parser.PhysicalCoreCount);
-            Assert.Equal(null, parser.LogicalCoreCount);
+            Assert.Null(parser.ProcessorName);
+            Assert.Null(parser.PhysicalProcessorCount);
+            Assert.Null(parser.PhysicalCoreCount);
+            Assert.Null(parser.LogicalCoreCount);
         }
 
         [Fact]
         public void MalformedTest()
         {
             var parser = WmicCpuInfoParser.ParseOutput("malformedkey=malformedvalue\n\nmalformedkey2=malformedvalue2");
-            Assert.Equal(null, parser.ProcessorName);
-            Assert.Equal(null, parser.PhysicalProcessorCount);
-            Assert.Equal(null, parser.PhysicalCoreCount);
-            Assert.Equal(null, parser.LogicalCoreCount);
+            Assert.Null(parser.ProcessorName);
+            Assert.Null(parser.PhysicalProcessorCount);
+            Assert.Null(parser.PhysicalCoreCount);
+            Assert.Null(parser.LogicalCoreCount);
         }
 
         [Fact]


### PR DESCRIPTION
Replace Assert.Equal(null,...) with Assert.Null(...) to simplify asserts and fix warnings from xunit analyzers.