### PR TITLE
Add Intrinsic Popcnt Benchmark to samples

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -19,7 +19,7 @@
   <PropertyGroup Condition=" '$(IsVisualBasic)' != 'true' And '$(TargetFramework)' == 'net46' ">
     <DefineConstants>$(DefineConstants);CLASSIC</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(IsVisualBasic)' != 'true' And ('$(TargetFramework)' == 'netcoreapp1.1' Or '$(TargetFramework)' == 'netcoreapp2.0') ">
+  <PropertyGroup Condition=" '$(IsVisualBasic)' != 'true' And ('$(TargetFramework)' == 'netcoreapp1.1' Or '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1') ">
     <DefineConstants>$(DefineConstants);CORE</DefineConstants>
   </PropertyGroup>
 

--- a/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.Samples</AssemblyTitle>
-    <TargetFrameworks>net46;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <RuntimeIdentifiers Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">win7-x64;win7-x86</RuntimeIdentifiers>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Hello,
thanks to the work of @fiigii and others in https://github.com/dotnet/coreclr/issues/15506,  I'd like to add the popcnt intrinsic methods to the algo_bitcount sample.
For that I did:
1. Add netcoreapp2.1 to common.props so it is recognized with constant CORE
2. Add netcoreapp2.1 to the samples project
3. Add a manual config to the algo_bitcount.cs example with jobs for three runtimes to compare results more easily
4. Add the intrinsic bitcount methods (simple and thrice unrolled) behind defines for NETCOREAPP2_1
5. I fixed a bug in PopCountParallel2 (it did not iterate the loop properly)

If you run the netcoreapp2.1 version of benchmarkdotnet.samples.dll it will run those benchmarks, unfortunately it tries to run them for the non-2.1 jobs too (they fail obviously), I did not find any way to solve that, I tried filters but they are apparently not job specific.

The output looks like this:

``` ini

BenchmarkDotNet=v0.10.12.20180117-develop, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.192)
Intel Core i7-4790K CPU 4.00GHz (Haswell), 1 CPU, 8 logical cores and 4 physical cores
Frequency=3906245 Hz, Resolution=256.0003 ns, Timer=TSC
.NET Core SDK=2.2.0-preview1-007813
  [Host]            : .NET Core 2.1.0-preview1-26013-05 (Framework 4.6.26013.03), 64bit RyuJIT
  Core2.0-x64       : .NET Core 2.0.3 (Framework 4.6.25815.02), 64bit RyuJIT
  Core2.1-x64       : .NET Core 2.1.0-preview1-26013-05 (Framework 4.6.26013.03), 64bit RyuJIT
  NET4.7_RyuJIT-x64 : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2600.0

Jit=RyuJit  Platform=X64  

```
|                          Method |               Job | Runtime |     Toolchain |        Mean |       Error |      StdDev |
|-------------------------------- |------------------ |-------- |-------------- |------------:|------------:|------------:|
|                       PopCount1 |       Core2.0-x64 |    Core | .NET Core 2.0 |  3,655.8 ns |   0.7093 ns |   0.5923 ns |
|                       PopCount2 |       Core2.0-x64 |    Core | .NET Core 2.0 |  2,745.1 ns |   1.8941 ns |   1.5816 ns |
|                       PopCount3 |       Core2.0-x64 |    Core | .NET Core 2.0 |  2,524.8 ns |   1.2167 ns |   0.9500 ns |
|                       PopCount4 |       Core2.0-x64 |    Core | .NET Core 2.0 | 73,521.9 ns |  95.4018 ns |  84.5712 ns |
|               PopCountParallel2 |       Core2.0-x64 |    Core | .NET Core 2.0 |  2,293.2 ns |   4.0483 ns |   3.3805 ns |
|               PopCountIntrinsic |       Core2.0-x64 |    Core | .NET Core 2.0 |          NA |          NA |          NA |
| PopCountIntrinsicUnrolledThrice |       Core2.0-x64 |    Core | .NET Core 2.0 |          NA |          NA |          NA |
|                       PopCount1 |       Core2.1-x64 |    Core | .NET Core 2.1 |  3,884.4 ns |   0.5068 ns |   0.4492 ns |
|                       PopCount2 |       Core2.1-x64 |    Core | .NET Core 2.1 |  2,753.5 ns |   0.6893 ns |   0.5756 ns |
|                       PopCount3 |       Core2.1-x64 |    Core | .NET Core 2.1 |          NA |          NA |          NA |
|                       PopCount4 |       Core2.1-x64 |    Core | .NET Core 2.1 | 73,567.5 ns |  46.1666 ns |  38.5512 ns |
|               PopCountParallel2 |       Core2.1-x64 |    Core | .NET Core 2.1 |  2,289.6 ns |   0.4476 ns |   0.3495 ns |
|               PopCountIntrinsic |       Core2.1-x64 |    Core | .NET Core 2.1 |    478.0 ns |   0.2974 ns |   0.2636 ns |
| PopCountIntrinsicUnrolledThrice |       Core2.1-x64 |    Core | .NET Core 2.1 |    424.7 ns |   0.7286 ns |   0.6459 ns |
|                       PopCount1 | NET4.7_RyuJIT-x64 |     Clr |       Default |  3,885.4 ns |   1.8239 ns |   1.4240 ns |
|                       PopCount2 | NET4.7_RyuJIT-x64 |     Clr |       Default |  2,746.8 ns |   0.3978 ns |   0.3106 ns |
|                       PopCount3 | NET4.7_RyuJIT-x64 |     Clr |       Default |  2,747.5 ns |   4.2562 ns |   3.9812 ns |
|                       PopCount4 | NET4.7_RyuJIT-x64 |     Clr |       Default | 73,945.6 ns | 689.7399 ns | 575.9640 ns |
|               PopCountParallel2 | NET4.7_RyuJIT-x64 |     Clr |       Default |  2,277.4 ns |  10.2518 ns |   9.5896 ns |
|               PopCountIntrinsic | NET4.7_RyuJIT-x64 |     Clr |       Default |          NA |          NA |          NA |
| PopCountIntrinsicUnrolledThrice | NET4.7_RyuJIT-x64 |     Clr |       Default |          NA |          NA |          NA |

Benchmarks with issues:
  Algo_BitCount.PopCountIntrinsic: Core2.0-x64(Runtime=Core, Toolchain=.NET Core 2.0)
  Algo_BitCount.PopCountIntrinsicUnrolledThrice: Core2.0-x64(Runtime=Core, Toolchain=.NET Core 2.0)
  Algo_BitCount.PopCount3: Core2.1-x64(Runtime=Core, Toolchain=.NET Core 2.1)
  Algo_BitCount.PopCountIntrinsic: NET4.7_RyuJIT-x64(Jit=RyuJit, Platform=X64, Runtime=Clr)
  Algo_BitCount.PopCountIntrinsicUnrolledThrice: NET4.7_RyuJIT-x64(Jit=RyuJit, Platform=X64, Runtime=Clr)

(I don't know why popcount 3 failed on 2.1)

