### PR TITLE
Allow sorting by the Method name in DefaultOrderProvider and OrderProviderAttribute

### DIFF
--- a/src/BenchmarkDotNet.Core/Order/DefaultOrderProvider.cs
+++ b/src/BenchmarkDotNet.Core/Order/DefaultOrderProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
@@ -53,15 +53,25 @@ namespace BenchmarkDotNet.Order
                     return benchmarks.OrderBy(b => summary[b].ResultStatistics.Mean);
                 case SummaryOrderPolicy.SlowestToFastest:
                     return benchmarks.OrderByDescending(b => summary[b].ResultStatistics.Mean);
+                case SummaryOrderPolicy.Method:
+                    return benchmarks.OrderBy(b => b.Target.MethodDisplayInfo);
                 default:
                     return GetExecutionOrder(benchmarks);
             }
         }
 
-        public string GetHighlightGroupKey(Benchmark benchmark) =>
-            summaryOrderPolicy == SummaryOrderPolicy.Default
-            ? benchmark.Parameters.DisplayInfo
-            : null;
+        public string GetHighlightGroupKey(Benchmark benchmark)
+        {
+            switch (summaryOrderPolicy)
+            {
+                case SummaryOrderPolicy.Default:
+                    return benchmark.Parameters.DisplayInfo;
+                case SummaryOrderPolicy.Method:
+                    return benchmark.Target.MethodDisplayInfo;
+                default:
+                    return null;
+            }
+        }
 
         public string GetLogicalGroupKey(IConfig config, Benchmark[] allBenchmarks, Benchmark benchmark)
         {

--- a/src/BenchmarkDotNet.Core/Order/SummaryOrderPolicy.cs
+++ b/src/BenchmarkDotNet.Core/Order/SummaryOrderPolicy.cs
@@ -2,6 +2,6 @@
 {
     public enum SummaryOrderPolicy
     {
-        Default, FastestToSlowest, SlowestToFastest
+        Default, FastestToSlowest, SlowestToFastest, Method
     }
 }


### PR DESCRIPTION
Running 
```C#
    [OrderProvider(SummaryOrderPolicy.Method, MethodOrderPolicy.Alphabetical)]
    [DryJob]
    public class IntroOrderAttr
    {
        [Params(1, 2, 3)]
        public int X { get; set; }

        [Benchmark]
        public void Slow() => Thread.Sleep(X * 100);

        [Benchmark]
        public void Fast() => Thread.Sleep(X * 50);
    }

```
Will produce:

| Method | X |      Mean | Error |
|------- |-- |----------:|------:|
|   **Fast** | **1** |  **50.02 ms** |    **NA** |
|   Fast | 2 | 100.37 ms |    NA |
|   Fast | 3 | 150.09 ms |    NA |
|   **Slow** | **1** | **100.57 ms** |    **NA** |
|   Slow | 2 | 200.80 ms |    NA |
|   Slow | 3 | 300.57 ms |    NA |