### PR TITLE
Plots...Examples...Added A config example in F#

### DIFF
--- a/docs/guide/Configs/Exporters.md
+++ b/docs/guide/Configs/Exporters.md
@@ -221,7 +221,7 @@ You can install [R](https://www.r-project.org/) to automatically get nice plots 
 <BenchmarkName>-<MethodName>-<JobName>-timelineSmooth.png
 ```
 
-A config example:
+A config example in C#:
 
 ```cs
 public class Config : ManualConfig
@@ -232,6 +232,37 @@ public class Config : ManualConfig
         Add(RPlotExporter.Default);
     }
 }
+```
+
+A config example in F#:
+
+```fs
+module MyBenchmark
+
+open BenchmarkDotNet.Attributes
+open BenchmarkDotNet.Configs
+open BenchmarkDotNet.Exporters
+open BenchmarkDotNet.Exporters.Csv
+open MyProjectUnderTest
+
+type MyConfig() as this =
+    inherit ManualConfig()
+    do
+        this.Add(CsvMeasurementsExporter.Default)
+        this.Add(RPlotExporter.Default)
+
+[<
+  MemoryDiagnoser; 
+  Config(typeof<MyConfig>);
+  RPlotExporter
+>]
+type MyPerformanceTests() =
+
+    let someTestData = getTestDataAsList ()
+
+    [<Benchmark>]
+    member __.SomeTestCase() = 
+        someTestData |> myFunctionUnderTest
 ```
 
 ## CSV


### PR DESCRIPTION
It took me at least two hours of experimenting to convert the C# example to a working F# example, so including this in the documentation should save other developers some trouble.

This example is also more complete than the C# example. It includes all the required open (like using/import/include) statements, as well as the required attributes for the benchmark class (in which the Benchmark methods are defined).