### PR TITLE
Allow restore and build command override

### DIFF
--- a/src/BenchmarkDotNet.Core/Toolchains/CsProj/CsProjBuilder.cs
+++ b/src/BenchmarkDotNet.Core/Toolchains/CsProj/CsProjBuilder.cs
@@ -6,9 +6,9 @@ namespace BenchmarkDotNet.Toolchains.CsProj
     [PublicAPI]
     public class CsProjBuilder : DotNetCliBuilder
     {
-        internal override string RestoreCommand => "restore --no-dependencies";
+        protected override string RestoreCommand => "restore --no-dependencies";
 
-        internal override string GetBuildCommand(string frameworkMoniker, bool justTheProjectItself, string configuration)
+        protected override string GetBuildCommand(string frameworkMoniker, bool justTheProjectItself, string configuration)
             => $"build --framework {frameworkMoniker} --configuration {configuration} --no-restore"
                + (justTheProjectItself ? " --no-dependencies" : string.Empty);
 

--- a/src/BenchmarkDotNet.Core/Toolchains/CsProj/CsProjBuilder.cs
+++ b/src/BenchmarkDotNet.Core/Toolchains/CsProj/CsProjBuilder.cs
@@ -6,9 +6,9 @@ namespace BenchmarkDotNet.Toolchains.CsProj
     [PublicAPI]
     public class CsProjBuilder : DotNetCliBuilder
     {
-        protected override string RestoreCommand => "restore --no-dependencies";
+        public override string RestoreCommand => "restore --no-dependencies";
 
-        protected override string GetBuildCommand(string frameworkMoniker, bool justTheProjectItself, string configuration)
+        public override string GetBuildCommand(string frameworkMoniker, bool justTheProjectItself, string configuration)
             => $"build --framework {frameworkMoniker} --configuration {configuration} --no-restore"
                + (justTheProjectItself ? " --no-dependencies" : string.Empty);
 

--- a/src/BenchmarkDotNet.Core/Toolchains/DotNetCli/DotNetCliBuilder.cs
+++ b/src/BenchmarkDotNet.Core/Toolchains/DotNetCli/DotNetCliBuilder.cs
@@ -16,7 +16,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
         private string CustomDotNetCliPath { get; }
 
-        protected abstract string RestoreCommand { get; }
+        public abstract string RestoreCommand { get; }
 
         [PublicAPI]
         public DotNetCliBuilder(string targetFrameworkMoniker, string customDotNetCliPath = null)
@@ -25,7 +25,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             CustomDotNetCliPath = customDotNetCliPath;
         }
 
-        protected abstract string GetBuildCommand(string frameworkMoniker, bool justTheProjectItself, string configuration);
+        public abstract string GetBuildCommand(string frameworkMoniker, bool justTheProjectItself, string configuration);
 
         public BuildResult Build(GenerateResult generateResult, ILogger logger, Benchmark benchmark, IResolver resolver)
         {

--- a/src/BenchmarkDotNet.Core/Toolchains/DotNetCli/DotNetCliBuilder.cs
+++ b/src/BenchmarkDotNet.Core/Toolchains/DotNetCli/DotNetCliBuilder.cs
@@ -16,7 +16,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
         private string CustomDotNetCliPath { get; }
 
-        internal abstract string RestoreCommand { get; }
+        protected abstract string RestoreCommand { get; }
 
         [PublicAPI]
         public DotNetCliBuilder(string targetFrameworkMoniker, string customDotNetCliPath = null)
@@ -25,7 +25,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             CustomDotNetCliPath = customDotNetCliPath;
         }
 
-        internal abstract string GetBuildCommand(string frameworkMoniker, bool justTheProjectItself, string configuration);
+        protected abstract string GetBuildCommand(string frameworkMoniker, bool justTheProjectItself, string configuration);
 
         public BuildResult Build(GenerateResult generateResult, ILogger logger, Benchmark benchmark, IResolver resolver)
         {


### PR DESCRIPTION
Needed to provide a custom build command like so:

    public class AspNetCoreProjBuilder : DotNetCliBuilder
    {
        protected override string GetBuildCommand(string frameworkMoniker, bool justTheProjectItself, string configuration)
            => $"publish --framework {frameworkMoniker} --configuration {configuration} --no-restore"
               + (justTheProjectItself ? " --no-dependencies" : string.Empty);

        public AspNetCoreProjBuilder(string targetFrameworkMoniker, string customDotNetCliPath)
            : base(targetFrameworkMoniker, customDotNetCliPath)
        {
        }
    }

Hence "publish" as opposed to "build".

Have included the restore command in case someone would like to change that too as it makes sense to allow them to.