### PR TITLE
Fix IDE0034: 'default' expression can be simplified

### DIFF
--- a/src/BenchmarkDotNet.Core/Characteristics/Characteristic.cs
+++ b/src/BenchmarkDotNet.Core/Characteristics/Characteristic.cs
@@ -16,7 +16,7 @@ namespace BenchmarkDotNet.Characteristics
             new Characteristic<T>(
                 GetMemberName(propertyGetterExpression),
                 GetDeclaringType(propertyGetterExpression),
-                null, default(T),
+                null, default,
                 false);
 
         public static Characteristic<T> Create<TOwner, T>(

--- a/src/BenchmarkDotNet.Core/Exporters/InstructionPointerExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/InstructionPointerExporter.cs
@@ -262,7 +262,7 @@ namespace BenchmarkDotNet.Exporters
             internal IReadOnlyList<IReadOnlyList<CodeWithCounters>> Instructions { get; set; }
             internal IReadOnlyDictionary<HardwareCounter, ulong> SumPerCounter { get; set; }
 
-            internal bool HasCounters => SumPerCounter.Values.Any(value => value != default(ulong));
+            internal bool HasCounters => SumPerCounter.Values.Any(value => value != default);
         }
     }
 }

--- a/src/BenchmarkDotNet.Core/Exporters/RawDisassemblyExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/RawDisassemblyExporter.cs
@@ -120,7 +120,7 @@ namespace BenchmarkDotNet.Exporters
         // we want to get sth like "00007ffb`a90f4560"
         internal static string FormatMethodAddress(ulong nativeCode)
         {
-            if(nativeCode == default(ulong))
+            if(nativeCode == default)
                 return string.Empty;
 
             var buffer = new StringBuilder(nativeCode.ToString("x"));

--- a/src/BenchmarkDotNet.Core/Extensions/CommonExtensions.cs
+++ b/src/BenchmarkDotNet.Core/Extensions/CommonExtensions.cs
@@ -91,7 +91,7 @@ namespace BenchmarkDotNet.Extensions
 
 #if !NETCOREAPP2_0 //  this method was added to the .NET Core 2.0 framework itself ;)
         public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
-            => dictionary.TryGetValue(key, out TValue value) ? value : default(TValue);
+            => dictionary.TryGetValue(key, out TValue value) ? value : default;
 #endif
 
         public static double Sqr(this double x) => x * x;

--- a/src/BenchmarkDotNet.Core/Horology/WindowsClock.cs
+++ b/src/BenchmarkDotNet.Core/Horology/WindowsClock.cs
@@ -27,7 +27,7 @@ namespace BenchmarkDotNet.Horology
         {
             if (!Portability.RuntimeInformation.IsWindows())
             {
-                qpf = default(long);
+                qpf = default;
                 return false;
             }
 
@@ -37,7 +37,7 @@ namespace BenchmarkDotNet.Horology
             }
             catch
             {
-                qpf = default(long);
+                qpf = default;
                 return false;
             }
         }

--- a/src/BenchmarkDotNet.Core/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet.Core/Portability/RuntimeInformation.cs
@@ -253,7 +253,7 @@ namespace BenchmarkDotNet.Portability
 #endif
         }
 
-        internal static IntPtr GetCurrentAffinity() => Process.GetCurrentProcess().TryGetAffinity() ?? default(IntPtr);
+        internal static IntPtr GetCurrentAffinity() => Process.GetCurrentProcess().TryGetAffinity() ?? default;
 
         internal static string GetConfiguration()
         {

--- a/src/BenchmarkDotNet.Core/Toolchains/InProcess/BenchmarkActionFactory_Implementations.cs
+++ b/src/BenchmarkDotNet.Core/Toolchains/InProcess/BenchmarkActionFactory_Implementations.cs
@@ -68,8 +68,8 @@ namespace BenchmarkDotNet.Toolchains.InProcess
                 }
             }
 
-            private static T IdleStatic() => default(T);
-            private T IdleInstance() => default(T);
+            private static T IdleStatic() => default;
+            private T IdleInstance() => default;
 
             private void InvokeSingleHardcoded() => result = callback();
 
@@ -160,7 +160,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess
                 }
             }
 
-            private T Idle() => default(T);
+            private T Idle() => default;
 
             // must be kept in sync with GenericTaskDeclarationsProvider.TargetMethodDelegate
             private T ExecuteBlocking() => startTaskCallback().GetAwaiter().GetResult();
@@ -209,7 +209,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess
                 }
             }
 
-            private T Idle() => default(T);
+            private T Idle() => default;
 
             // must be kept in sync with GenericTaskDeclarationsProvider.TargetMethodDelegate
             private T ExecuteBlocking() => startTaskCallback().GetAwaiter().GetResult();

--- a/tests/BenchmarkDotNet.IntegrationTests/CustomEngineTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/CustomEngineTests.cs
@@ -70,10 +70,10 @@ namespace BenchmarkDotNet.IntegrationTests
                 Console.WriteLine(EngineRunMessage);
 
                 return new RunResults(
-                    new List<Measurement>() { default(Measurement) }, 
-                    new List<Measurement>() { default(Measurement) },
+                    new List<Measurement>() { default }, 
+                    new List<Measurement>() { default },
                     false,
-                    default(GcStats));
+                    default);
             }
 
             public IHost Host { get; }

--- a/tests/BenchmarkDotNet.IntegrationTests/ExporterIOTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ExporterIOTests.cs
@@ -154,7 +154,7 @@ namespace BenchmarkDotNet.IntegrationTests
                                        buildResult: null,
                                        executeResults: null,
                                        allMeasurements: null,
-                                       gcStats: default(GcStats));
+                                       gcStats: default);
         }
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
@@ -40,7 +40,7 @@ namespace BenchmarkDotNet.IntegrationTests
             public DateTime? ReturnNotNullForNullableType() => DateTime.UtcNow;
 
             [Benchmark]
-            public DateTime ReturnDefaultValueForValueType() => default(DateTime);
+            public DateTime ReturnDefaultValueForValueType() => default;
 
             [Benchmark]
             public DateTime ReturnNonDefaultValueForValueType() => DateTime.UtcNow;

--- a/tests/BenchmarkDotNet.Tests/Engine/EngineResultStageTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Engine/EngineResultStageTests.cs
@@ -27,7 +27,7 @@ namespace BenchmarkDotNet.Tests.Engine
         [AssertionMethod]
         private static void CheckResults(int expectedResultCount, List<Measurement> measurements, bool removeOutliers)
         {
-            Assert.Equal(expectedResultCount, new RunResults(null, measurements, removeOutliers, default(GcStats)).GetMeasurements().Count());
+            Assert.Equal(expectedResultCount, new RunResults(null, measurements, removeOutliers, default).GetMeasurements().Count());
         }
 
         private static void Add(List<Measurement> measurements, int time)

--- a/tests/BenchmarkDotNet.Tests/Mocks/MockEngine.cs
+++ b/tests/BenchmarkDotNet.Tests/Mocks/MockEngine.cs
@@ -54,7 +54,7 @@ namespace BenchmarkDotNet.Tests.Mocks
 
         public void Jitting() { }
 
-        public RunResults Run() => default(RunResults);
+        public RunResults Run() => default;
 
         public void WriteLine() => output.WriteLine("");
         public void WriteLine(string line) => output.WriteLine(line);

--- a/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
+++ b/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
@@ -61,7 +61,7 @@ namespace BenchmarkDotNet.Tests.Mocks
             var measurements = Enumerable.Range(0, n)
                 .Select(index => new Measurement(1, IterationMode.Result, index + 1, 1, nanoseconds + index))
                 .ToList();
-            return new BenchmarkReport(benchmark, buildResult, buildResult, new List<ExecuteResult> { executeResult }, measurements, default(GcStats));
+            return new BenchmarkReport(benchmark, buildResult, buildResult, new List<ExecuteResult> { executeResult }, measurements, default);
         }
 
         [LongRunJob]

--- a/tests/BenchmarkDotNet.Tests/Reports/DefaultColumnProvidersTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/DefaultColumnProvidersTests.cs
@@ -71,7 +71,7 @@ namespace BenchmarkDotNet.Tests.Reports
                 new Measurement(1, IterationMode.Result, 5, 1, 1),
                 new Measurement(1, IterationMode.Result, 6, 1, 1),
             };
-            return new BenchmarkReport(benchmark, buildResult, buildResult, new List<ExecuteResult> { executeResult }, measurements, default(GcStats));
+            return new BenchmarkReport(benchmark, buildResult, buildResult, new List<ExecuteResult> { executeResult }, measurements, default);
         }
 
         private static IEnumerable<Benchmark> CreateBenchmarks(IConfig config) =>

--- a/tests/BenchmarkDotNet.Tests/Reports/ScaledPrecisionTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/ScaledPrecisionTests.cs
@@ -89,7 +89,7 @@ namespace BenchmarkDotNet.Tests.Reports
                     new Measurement(1, IterationMode.Result, 5, 1, measurementValue),
                     new Measurement(1, IterationMode.Result, 6, 1, measurementValue),
                 };
-            return new BenchmarkReport(benchmark, buildResult, buildResult, new List<ExecuteResult> { executeResult }, measurements, default(GcStats));
+            return new BenchmarkReport(benchmark, buildResult, buildResult, new List<ExecuteResult> { executeResult }, measurements, default);
         }
 
         private static IEnumerable<Benchmark> CreateBenchmarks(IConfig config) =>

--- a/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
@@ -122,7 +122,7 @@ namespace BenchmarkDotNet.Tests.Validators
             [GlobalSetup]
             public void Failing()
             {
-                if (Field == default(int))
+                if (Field == default)
                     throw new Exception("this should have never happened");
             }
 
@@ -149,7 +149,7 @@ namespace BenchmarkDotNet.Tests.Validators
             [GlobalSetup]
             public void Failing()
             {
-                if (Field == default(int))
+                if (Field == default)
                     throw new Exception("Field is missing Params attribute");
             }
 


### PR DESCRIPTION
This was suggested by VS2017 Code Analysis.