### PR TITLE
Build system: Update dotnet SDK and dotnet runtime. Enable FastTests netcoreapp1.1 on non-Windows. 

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -64,7 +64,7 @@ Task("FastTests")
         string[] targetVersions = IsRunningOnWindows() ? 
                 new []{"net46", "netcoreapp1.1", "netcoreapp2.0"}
                 :
-                new []{"netcoreapp2.0"};
+                new []{"netcoreapp1.1", "netcoreapp2.0"};
 
         foreach(var version in targetVersions)
         {
@@ -135,11 +135,11 @@ private string GetTestSettingsParameters(string tfm)
     var settings = $"-configuration {configuration} -stoponfail -maxthreads unlimited -nobuild  -framework {tfm}";
     if(string.Equals("netcoreapp2.0", tfm, StringComparison.OrdinalIgnoreCase))
     {
-        settings += " --fx-version 2.0.5";
+        settings += " --fx-version 2.0.6";
     }
     if(string.Equals("netcoreapp1.1", tfm, StringComparison.OrdinalIgnoreCase))
     {
-        settings += " --fx-version 1.1.6";
+        settings += " --fx-version 1.1.7";
     }
     
     return settings;

--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,7 @@ Param(
 )
 
 $CakeVersion = "0.26.1"
-$DotNetVersion = "2.1.4";
+$DotNetVersion = "2.1.101";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 
@@ -73,7 +73,7 @@ if (!(Test-Path $InstallPath)) {
 (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
 & $InstallPath\dotnet-install.ps1 -Version $DotNetVersion -InstallDir $InstallPath
 # We need to install the additional .NET Core runtime to run backward compatibility tests
-& $InstallPath\dotnet-install.ps1 -SharedRuntime -Version 1.1.6 -InstallDir $InstallPath;
+& $InstallPath\dotnet-install.ps1 -SharedRuntime -Version 1.1.7 -InstallDir $InstallPath;
 
 Remove-PathVariable "$InstallPath"
 $env:PATH = "$InstallPath;$env:PATH"

--- a/build.sh
+++ b/build.sh
@@ -47,9 +47,9 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
   mkdir "$SCRIPT_DIR/.dotnet"
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://dot.net/v1/dotnet-install.sh
-sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 2.1.4 --install-dir .dotnet --no-path
+sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 2.1.101 --install-dir .dotnet --no-path
 # We need to install the additional .NET Core runtime to run backward compatibility tests
-sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" -sharedruntime --version 1.1.6 --install-dir .dotnet --no-path
+sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" -sharedruntime --version 1.1.7 --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1


### PR DESCRIPTION
Update dotnet SDK (2.1.4 -> 2.1.101) and dotnet runtime (1.1.6 -> 1.1.7).
Enable FastTests run for netcoreapp1.1 on non-Windows environments.