### PR TITLE
Follow up to #737

### DIFF
--- a/docs/guide/Configs/Validators.md
+++ b/docs/guide/Configs/Validators.md
@@ -8,3 +8,4 @@ Available validators are:
 * `BaselineValidator.FailOnError` - it checks if more than 1 Benchmark per class has `Baseline = true` applied. This validator is mandatory.
 * `JitOptimizationsValidator.(Dont)FailOnError` - it checks whether any of the referenced assemblies is non-optimized. DontFailOnError version is enabled by default.
 * `ExecutionValidator.(Dont)FailOnError` - it checks if it is possible to run your benchmarks by executing each of them once. Optional.
+* `ReturnValueValidator.(Dont)FailOnError` - it checks if non-void benchmarks return equal values. Optional.

--- a/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
@@ -99,10 +99,10 @@ namespace BenchmarkDotNet.Extensions
         public static int RoundToInt(this double x) => (int) Math.Round(x);
         public static long RoundToLong(this double x) => (long) Math.Round(x);
 
-        public static IEnumerable<TItem> DistinctBy<TItem, TValue>(this IEnumerable<TItem> items, Func<TItem, TValue> selector)
+        internal static IEnumerable<TItem> DistinctBy<TItem, TValue>(this IEnumerable<TItem> items, Func<TItem, TValue> selector)
             => DistinctBy(items, selector, EqualityComparer<TValue>.Default);
 
-        public static IEnumerable<TItem> DistinctBy<TItem, TValue>(this IEnumerable<TItem> items, Func<TItem, TValue> selector, IEqualityComparer<TValue> equalityComparer)
+        internal static IEnumerable<TItem> DistinctBy<TItem, TValue>(this IEnumerable<TItem> items, Func<TItem, TValue> selector, IEqualityComparer<TValue> equalityComparer)
         {
             var seen = new HashSet<TValue>(equalityComparer);
 

--- a/src/BenchmarkDotNet/Validators/ReturnValueValidator.cs
+++ b/src/BenchmarkDotNet/Validators/ReturnValueValidator.cs
@@ -23,17 +23,6 @@ namespace BenchmarkDotNet.Validators
         {
             foreach (var parameterGroup in benchmarks.GroupBy(i => i.Parameters, ParameterInstancesEqualityComparer.Instance))
             {
-                try
-                {
-                    InProcessRunner.FillMembers(benchmarkTypeInstance, parameterGroup.First());
-                }
-                catch (Exception ex)
-                {
-                    errors.Add(new ValidationError(
-                        TreatsWarningsAsErrors,
-                        $"Failed to set benchmark parameters: '{parameterGroup.First().Parameters.DisplayInfo}', exception was: '{GetDisplayExceptionMessage(ex)}'"));
-                }
-
                 var results = new List<(Benchmark benchmark, object returnValue)>();
                 bool hasErrorsInGroup = false;
 
@@ -41,6 +30,7 @@ namespace BenchmarkDotNet.Validators
                 {
                     try
                     {
+                        InProcessRunner.FillMembers(benchmarkTypeInstance, benchmark);
                         var result = benchmark.Target.Method.Invoke(benchmarkTypeInstance, null);
 
                         if (benchmark.Target.Method.ReturnType != typeof(void))

--- a/tests/BenchmarkDotNet.Tests/Validators/ReturnValueValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/ReturnValueValidatorTests.cs
@@ -238,6 +238,22 @@ namespace BenchmarkDotNet.Tests.Validators
             public override int GetHashCode() => 0;
         }
 
+        [Fact]
+        public void ConsistentBenchmarksAlteringParameterAreOmitted()
+            => AssertConsistent<ConsistentAlterParam>();
+
+        public class ConsistentAlterParam
+        {
+            [Params(10, 20, 30)]
+            public int Value { get; set; }
+
+            [Benchmark]
+            public int Foo() => ++Value;
+
+            [Benchmark]
+            public int Bar() => ++Value;
+        }
+
         private static void AssertConsistent<TBenchmark>()
         {
             var validationErrors = ReturnValueValidator.FailOnError.Validate(BenchmarkConverter.TypeToBenchmarks(typeof(TBenchmark))).ToList();


### PR DESCRIPTION
@adamsitnik Here are some minor things I should have included in #737 but forgot to think about:

- I haven't noticed that `CommonExtensions` is public, I didn't mean for the `DistinctBy` extension to be exported, so I made the method internal. This is because this is a popular extension method to have in your toolkit, and I don't want to introduce ambiguities in code that uses BenchmarkDotNet and already has such a method in scope.
- I now set the parameters before each benchmark run in case a benchmark modifies them for some reason (which is probably a bad idea but I think this should be supported).
- I mentioned `ReturnValueValidator` in the docs.
