### PR TITLE
Improve .NET Framework version detection

### DIFF
--- a/src/BenchmarkDotNet/Helpers/FrameworkVersionHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/FrameworkVersionHelper.cs
@@ -53,7 +53,14 @@ namespace BenchmarkDotNet.Helpers
         
         // Reference Assemblies exists when Developer Pack is installed
         private static bool IsDeveloperPackInstalled(string version) => Directory.Exists(Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), @"Reference Assemblies\Microsoft\Framework\.NETFramework", 'v' + version));
+            GetProgramFilesX86DirectoryPath(), @"Reference Assemblies\Microsoft\Framework\.NETFramework", 'v' + version));
 
+        private static string GetProgramFilesX86DirectoryPath()
+        {
+            var folder = Environment.Is64BitOperatingSystem
+                ? Environment.SpecialFolder.ProgramFilesX86
+                : Environment.SpecialFolder.ProgramFiles;
+            return Environment.GetFolderPath(folder);
+        }
     }
 }

--- a/src/BenchmarkDotNet/Helpers/FrameworkVersionHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/FrameworkVersionHelper.cs
@@ -53,14 +53,11 @@ namespace BenchmarkDotNet.Helpers
         
         // Reference Assemblies exists when Developer Pack is installed
         private static bool IsDeveloperPackInstalled(string version) => Directory.Exists(Path.Combine(
-            GetProgramFilesX86DirectoryPath(), @"Reference Assemblies\Microsoft\Framework\.NETFramework", 'v' + version));
+            ProgramFilesX86DirectoryPath, @"Reference Assemblies\Microsoft\Framework\.NETFramework", 'v' + version));
 
-        private static string GetProgramFilesX86DirectoryPath()
-        {
-            var folder = Environment.Is64BitOperatingSystem
+        private static readonly string ProgramFilesX86DirectoryPath = Environment.GetFolderPath(
+            Environment.Is64BitOperatingSystem
                 ? Environment.SpecialFolder.ProgramFilesX86
-                : Environment.SpecialFolder.ProgramFiles;
-            return Environment.GetFolderPath(folder);
-        }
+                : Environment.SpecialFolder.ProgramFiles);
     }
 }

--- a/src/BenchmarkDotNet/Helpers/FrameworkVersionHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/FrameworkVersionHelper.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using JetBrains.Annotations;
+
+namespace BenchmarkDotNet.Helpers
+{
+    internal static class FrameworkVersionHelper
+    {
+        // magic numbers come from https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
+        // should be ordered by release number
+        private static readonly (int minReleaseNumber, string version)[] FrameworkVersions =
+        {
+            (461808, "4.7.2"),
+            (461308, "4.7.1"),
+            (460798, "4.7"),
+            (394802, "4.6.2"),
+            (394254, "4.6.1")
+        };
+        
+        private static int? GetReleaseNumberFromWindowsRegistry()
+        {
+            using (var ndpKey = Microsoft.Win32.RegistryKey
+                .OpenBaseKey(Microsoft.Win32.RegistryHive.LocalMachine, Microsoft.Win32.RegistryView.Registry32)
+                .OpenSubKey(@"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\"))
+            {
+                if (ndpKey == null)
+                    return null;
+                return Convert.ToInt32(ndpKey.GetValue("Release"));
+            }
+        }
+        
+        [NotNull]
+        internal static string GetCurrentNetFrameworkVersion()
+        {
+            if (!(GetReleaseNumberFromWindowsRegistry() is int releaseNumber))
+                return "?";
+
+            return FrameworkVersions
+                       .FirstOrDefault(v => releaseNumber >= v.minReleaseNumber)
+                       .version ?? "?";
+        }
+
+        internal static string GetLatestNetDeveloperPackVersion()
+        {
+            if (!(GetReleaseNumberFromWindowsRegistry() is int releaseNumber))
+                return null;
+
+            return FrameworkVersions
+                       .FirstOrDefault(v => releaseNumber >= v.minReleaseNumber && IsDeveloperPackInstalled(v.version))
+                       .version;
+        }
+        
+        // Reference Assemblies exists when Developer Pack is installed
+        private static bool IsDeveloperPackInstalled(string version) => Directory.Exists(Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), @"Reference Assemblies\Microsoft\Framework\.NETFramework", 'v' + version));
+
+    }
+}

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -189,7 +189,7 @@ namespace BenchmarkDotNet.Portability
             }
             else if (IsFullFramework)
             {
-                string frameworkVersion = CsProjClassicNetToolchain.GetCurrentNetFrameworkVersion();
+                string frameworkVersion = FrameworkVersionHelper.GetCurrentNetFrameworkVersion();
                 string clrVersion = Environment.Version.ToString();
                 return $".NET Framework {frameworkVersion} (CLR {clrVersion})";
             }

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
@@ -1,8 +1,9 @@
 ﻿using System;
-using System.IO;
+using System.Collections.Generic;
 using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Helpers;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Portability;
@@ -26,6 +27,16 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         [PublicAPI] public static readonly IToolchain Net471 = new CsProjClassicNetToolchain("net471");
         [PublicAPI] public static readonly IToolchain Net472 = new CsProjClassicNetToolchain("net472");
         private static readonly IToolchain Default = Net46; // the lowest version we support
+
+        private static readonly Dictionary<string, IToolchain> Toolchains = new Dictionary<string, IToolchain>
+        {
+            { "4.6", Net46 },
+            { "4.6.1", Net461 },
+            { "4.6.2", Net462 },
+            { "4.7", Net47 },
+            { "4.7.1", Net471 },
+            { "4.7.2", Net472 }
+        };
 
         [PublicAPI]
         public static readonly Lazy<IToolchain> Current = new Lazy<IToolchain>(GetCurrentVersion);
@@ -76,50 +87,10 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         {
             if (!RuntimeInformation.IsWindows())
                 return Net46; // we return .NET 4.6 which during validaiton will tell the user about lack of support
-
-            return GetCurrentVersionBasedOnWindowsRegistry(true);
-        }
-
-        // this logic is put to a separate method to avoid any assembly loading issues on non Windows systems
-        // Reference Assemblies exists when Developer Pack is installed
-        private static IToolchain GetCurrentVersionBasedOnWindowsRegistry(bool withDeveloperPack)
-        {   
-            using (var ndpKey = Microsoft.Win32.RegistryKey
-                .OpenBaseKey(Microsoft.Win32.RegistryHive.LocalMachine, Microsoft.Win32.RegistryView.Registry32)
-                .OpenSubKey("SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full\\"))
-            {
-                if (ndpKey == null)
-                    return Default;
-
-                int releaseKey = Convert.ToInt32(ndpKey.GetValue("Release"));
-                // magic numbers come from https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
-                if (releaseKey >= 461808 && (!withDeveloperPack || IsDeveloperPackInstalled(@"4.7.2")))
-                    return Net472;
-                if (releaseKey >= 461308 && (!withDeveloperPack || IsDeveloperPackInstalled(@"4.7.1")))
-                    return Net471;
-                if (releaseKey >= 460798 && (!withDeveloperPack || IsDeveloperPackInstalled(@"4.7")))
-                    return Net47;
-                if (releaseKey >= 394802 && (!withDeveloperPack || IsDeveloperPackInstalled(@"4.6.2")))
-                    return Net462;
-                if (releaseKey >= 394254 && (!withDeveloperPack || IsDeveloperPackInstalled(@"4.6.1")))
-                    return Net461;
-
-                return Default;
-            }
-        }
-
-        private static bool IsDeveloperPackInstalled(string version) => Directory.Exists(Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), @"Reference Assemblies\Microsoft\Framework\.NETFramework", 'v' + version));
-
-        // TODO: Move to a better place
-        [NotNull]
-        internal static string GetCurrentNetFrameworkVersion()
-        {
-            var toolchain = GetCurrentVersionBasedOnWindowsRegistry(false) as CsProjClassicNetToolchain;
-            if (toolchain == null)
-                return "?";
-            string version = toolchain.targetFrameworkMoniker.Replace("net", "");
-            return string.Join(".", version.ToCharArray());
+            
+            // this logic is put to a separate method to avoid any assembly loading issues on non Windows systems
+            var version = FrameworkVersionHelper.GetLatestNetDeveloperPackVersion();
+            return Toolchains.TryGetValue(version, out var toolchain) ? toolchain : Default;
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
@@ -82,7 +82,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
 
         // this logic is put to a separate method to avoid any assembly loading issues on non Windows systems
         // Reference Assemblies exists when Developer Pack is installed
-        private static IToolchain GetCurrentVersionBasedOnWindowsRegistry(bool withRefAssemblies)
+        private static IToolchain GetCurrentVersionBasedOnWindowsRegistry(bool withDeveloperPack)
         {   
             using (var ndpKey = Microsoft.Win32.RegistryKey
                 .OpenBaseKey(Microsoft.Win32.RegistryHive.LocalMachine, Microsoft.Win32.RegistryView.Registry32)
@@ -93,20 +93,23 @@ namespace BenchmarkDotNet.Toolchains.CsProj
 
                 int releaseKey = Convert.ToInt32(ndpKey.GetValue("Release"));
                 // magic numbers come from https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
-                if (releaseKey >= 461808 && (!withRefAssemblies || Directory.Exists(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2")))
+                if (releaseKey >= 461808 && (!withDeveloperPack || IsDeveloperPackInstalled(@"4.7.2")))
                     return Net472;
-                if (releaseKey >= 461308 && (!withRefAssemblies || Directory.Exists(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.1")))
+                if (releaseKey >= 461308 && (!withDeveloperPack || IsDeveloperPackInstalled(@"4.7.1")))
                     return Net471;
-                if (releaseKey >= 460798 && (!withRefAssemblies || Directory.Exists(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7")))
+                if (releaseKey >= 460798 && (!withDeveloperPack || IsDeveloperPackInstalled(@"4.7")))
                     return Net47;
-                if (releaseKey >= 394802 && (!withRefAssemblies || Directory.Exists(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2")))
+                if (releaseKey >= 394802 && (!withDeveloperPack || IsDeveloperPackInstalled(@"4.6.2")))
                     return Net462;
-                if (releaseKey >= 394254 && (!withRefAssemblies || Directory.Exists(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1")))
+                if (releaseKey >= 394254 && (!withDeveloperPack || IsDeveloperPackInstalled(@"4.6.1")))
                     return Net461;
 
                 return Default;
             }
         }
+
+        private static bool IsDeveloperPackInstalled(string version) => Directory.Exists(Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), @"Reference Assemblies\Microsoft\Framework\.NETFramework", 'v' + version));
 
         // TODO: Move to a better place
         [NotNull]

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
@@ -91,7 +91,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
                     return Default;
 
                 int releaseKey = Convert.ToInt32(ndpKey.GetValue("Release"));
-                // magic numbers come from https://msdn.microsoft.com/en-us/library/hh925568(v=vs.110).aspx
+                // magic numbers come from https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
                 if (releaseKey >= 461808 && Directory.Exists(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2"))
                     return Net472;
                 if (releaseKey >= 461308 && Directory.Exists(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.1"))

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
@@ -24,6 +24,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         [PublicAPI] public static readonly IToolchain Net462 = new CsProjClassicNetToolchain("net462");
         [PublicAPI] public static readonly IToolchain Net47 = new CsProjClassicNetToolchain("net47");
         [PublicAPI] public static readonly IToolchain Net471 = new CsProjClassicNetToolchain("net471");
+        [PublicAPI] public static readonly IToolchain Net472 = new CsProjClassicNetToolchain("net472");
         private static readonly IToolchain Default = Net46; // the lowest version we support
 
         [PublicAPI]
@@ -91,6 +92,8 @@ namespace BenchmarkDotNet.Toolchains.CsProj
 
                 int releaseKey = Convert.ToInt32(ndpKey.GetValue("Release"));
                 // magic numbers come from https://msdn.microsoft.com/en-us/library/hh925568(v=vs.110).aspx
+                if (releaseKey >= 461808 && Directory.Exists(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2"))
+                    return Net472;
                 if (releaseKey >= 461308 && Directory.Exists(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.1"))
                     return Net471;
                 if (releaseKey >= 460798 && Directory.Exists(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7"))


### PR DESCRIPTION
1) Add .NET Framework 4.7.2 version constant
2) Check for Reference Assemblies directory existence only for Toolchain select. This directory exists only when Developer Pack is installed. I think it would be better to display the version of framework (runtime, not sdk) in benchmarks output
3) Remove hardcoded Program Files directory path. It fix version detection on 32bit systems.
4) Refactor: move framework version detection from CsProjClassicNetToolchain, get rid of code clones