### PR TITLE
generate IParams for users in smart way

### DIFF
--- a/docs/guide/Advanced/Arguments.md
+++ b/docs/guide/Advanced/Arguments.md
@@ -46,7 +46,7 @@ public class IntroArguments
 
 In case you want to use a lot of values, you should use `[ArgumentsSource]`.
 
-You can mark one or several fields or properties in your class by the `ArgumentsSource` attribute. In this attribute, you have to specify the name of public method/property which is going to provide the values (something that implements `IEnumerable`). The source must be within benchmarked type! If the values are complex types (not compile-time constants) you should implement `IParam` interface. See [more](Params.md#IParam).
+You can mark one or several fields or properties in your class by the `ArgumentsSource` attribute. In this attribute, you have to specify the name of public method/property which is going to provide the values (something that implements `IEnumerable`). The source must be within benchmarked type! 
 
 ```cs
 public class IntroArgumentsSource
@@ -71,6 +71,51 @@ public class IntroArgumentsSource
 |    Pow |  2 |  2 | 40.624 ns | 0.3413 ns | 0.3192 ns |
 |    Pow |  4 |  4 | 40.537 ns | 0.0560 ns | 0.0524 ns |
 |    Pow | 10 | 10 | 40.395 ns | 0.3274 ns | 0.3063 ns |
+
+If the values are complex types you need to override `ToString` method to change the display names used in the results.
+
+```cs
+[DryJob]
+public class WithNonPrimitiveArgumentsSource
+{
+    [Benchmark]
+    [ArgumentsSource(nameof(NonPrimitive))]
+    public void Simple(SomeClass someClass, SomeStruct someStruct)
+    {
+        for (int i = 0; i < someStruct.RangeEnd; i++)
+            Console.WriteLine($"// array.Values[{i}] = {someClass.Values[i]}");
+    }
+
+    public IEnumerable<object[]> NonPrimitive()
+    {
+        yield return new object[] { new SomeClass(Enumerable.Range(0, 10).ToArray()), new SomeStruct(10) };
+        yield return new object[] { new SomeClass(Enumerable.Range(0, 15).ToArray()), new SomeStruct(15) };
+    }
+
+    public class SomeClass
+    {
+        public SomeClass(int[] initialValues) => Values = initialValues.Select(val => val * 2).ToArray();
+
+        public int[] Values { get; }
+
+        public override string ToString() => $"{Values.Length} items";
+    }
+
+    public struct SomeStruct
+    {
+        public SomeStruct(int rangeEnd) => RangeEnd = rangeEnd;
+
+        public int RangeEnd { get; }
+
+        public override string ToString() => $"{RangeEnd}";
+    }
+}
+```
+
+| Method | someClass | someStruct |     Mean | Error |
+|------- |---------- |----------- |---------:|------:|
+| Simple |  10 items |         10 | 887.2 us |    NA |
+| Simple |  15 items |         15 | 963.1 us |    NA |
 
 
 ## Allocation cost

--- a/docs/guide/Advanced/Params.md
+++ b/docs/guide/Advanced/Params.md
@@ -33,7 +33,7 @@ public class IntroParams
 
 In case you want to use a lot of values, you should use `[ParamsSource]`.
 
-You can mark one or several fields or properties in your class by the `ParamsSource` attribute. In this attribute, you have to specify the name of public method/property which is going to provide the values (something that implements `IEnumerable`). The source must be within benchmarked type! If the values are complex types (not compile-time constants) you should implement `IParam` interface (see below).
+You can mark one or several fields or properties in your class by the `ParamsSource` attribute. In this attribute, you have to specify the name of public method/property which is going to provide the values (something that implements `IEnumerable`). The source must be within benchmarked type!
 
 ## Example (ParamsSource)
 
@@ -65,56 +65,4 @@ public class IntroParamsSource
 
 # IParam
 
- In case you want to use values which are not compile-time constants, you have to create a type which implements `IParam` interface. This is required because internally BenchmarkDotNet generates and compiles code for every benchmark. We know how to deal with primitive types, but we don't want to implement complex logic for creating complex types. This responsibility is transferred to the users ;)
-
-## Example (IParam)
-
-```cs
-public class IntroIParam
-{
-    public struct VeryCustomStruct
-    {
-        public readonly int X, Y;
-
-        public VeryCustomStruct(int x, int y)
-        {
-            X = x;
-            Y = y;
-        }
-    }
-
-    public class CustomParam : IParam
-    {
-        private readonly VeryCustomStruct value;
-
-        public CustomParam(VeryCustomStruct value) => this.value = value;
-
-        public object Value => value;
-
-        public string DisplayText => $"({value.X},{value.Y})";
-
-        public string ToSourceCode() => $"new VeryCustomStruct({value.X}, {value.Y})";
-    }
-
-    [ParamsSource(nameof(Parameters))]
-    public VeryCustomStruct Field;
-
-    public IEnumerable<IParam> Parameters()
-    {
-        yield return new CustomParam(new VeryCustomStruct(100, 10));
-        yield return new CustomParam(new VeryCustomStruct(100, 20));
-        yield return new CustomParam(new VeryCustomStruct(200, 10));
-        yield return new CustomParam(new VeryCustomStruct(200, 20));
-    }
-
-    [Benchmark]
-    public void Benchmark() => Thread.Sleep(Field.X + Field.Y);
-}
-```
-
-|    Method |    Field |     Mean |     Error |    StdDev |
-|---------- |--------- |---------:|----------:|----------:|
-| Benchmark | (100,10) | 110.4 ms | 0.1148 ms | 0.1074 ms |
-| Benchmark | (100,20) | 120.4 ms | 0.0843 ms | 0.0788 ms |
-| Benchmark | (200,10) | 210.4 ms | 0.0892 ms | 0.0834 ms |
-| Benchmark | (200,20) | 220.4 ms | 0.0949 ms | 0.0887 ms |
+ You don't need to use `IParam` anymore since `0.11.0`. Just use complex types as you wish and override `ToString` method to change the display names used in the results.

--- a/src/BenchmarkDotNet/Helpers/SourceCodeHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/SourceCodeHelper.cs
@@ -38,5 +38,37 @@ namespace BenchmarkDotNet.Helpers
                 return ((IFormattable)value).ToString(null, CultureInfo.InvariantCulture);
             return value.ToString();
         }
+
+        public static bool IsCompilationTimeConstant(object value)
+        {
+            if (value == null)
+                return true;
+            if (value is bool)
+                return true;
+            if (value is string text)
+                return true;
+            if (value is char)
+                return true;
+            if (value is float)
+                return true;
+            if (value is double)
+                return true;
+            if (value is decimal)
+                return true;
+            if (ReflectionUtils.GetTypeInfo(value.GetType()).IsEnum)
+                return true;
+            if (value is Type)
+                return true;
+            if (!ReflectionUtils.GetTypeInfo(value.GetType()).IsValueType) // the difference!!
+                return false;
+            if (value is TimeInterval)
+                return true;
+            if (value is IntPtr)
+                return true;
+            if (value is IFormattable)
+                return true;
+
+            return false;
+        }
     }
 }

--- a/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
+++ b/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using BenchmarkDotNet.Code;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Helpers;
+
+namespace BenchmarkDotNet.Parameters
+{
+    static internal class SmartParamBuilder
+    {
+        internal static object[] CreateForParams(MemberInfo source, object[] values)
+        {
+            if (values.IsEmpty() || values.All(value => SourceCodeHelper.IsCompilationTimeConstant(value)))
+                return values;
+
+            return values.Select((value, index) => new SmartParamameter(source, value, index)).ToArray();
+        }
+
+        internal static ParameterInstances CreateForArguments(MethodInfo benchmark, ParameterDefinition[] parameterDefinitions, (MemberInfo source, object[] values) valuesInfo, int sourceIndex)
+        {
+            var unwrappedValue = valuesInfo.values[sourceIndex];
+
+            if (unwrappedValue is object[] array)
+            {
+                if (parameterDefinitions.Length != array.Length)
+                    throw new InvalidOperationException($"Benchmark {benchmark.Name} has invalid number of arguments provided by [ArgumentsSource({valuesInfo.source.Name})]! {array.Length} instead of {parameterDefinitions.Length}.");
+
+                return new ParameterInstances(
+                    array.Select((value, argumentIndex) => Create(parameterDefinitions, value, valuesInfo.source, sourceIndex, argumentIndex)).ToArray());
+            }
+            else if (parameterDefinitions.Length == 1)
+            {
+                return new ParameterInstances(
+                    new[] { Create(parameterDefinitions, unwrappedValue, valuesInfo.source, sourceIndex, argumentIndex: 0) });
+            }
+            else throw new NotSupportedException($"Benchmark {benchmark.Name} has invalid type of arguments provided by [ArgumentsSource({valuesInfo.source.Name})]. It should be IEnumerable<object[]> or IEnumerable<object>.");
+        }
+
+        private static ParameterInstance Create(ParameterDefinition[] parameterDefinitions, object value, MemberInfo source, int sourceIndex, int argumentIndex)
+        {
+            if (SourceCodeHelper.IsCompilationTimeConstant(value))
+                return new ParameterInstance(parameterDefinitions[argumentIndex], value);
+
+            return new ParameterInstance(parameterDefinitions[argumentIndex], new SmartArgument(parameterDefinitions, value, source, sourceIndex, argumentIndex));
+        }
+    }
+
+    internal class SmartArgument : IParam
+    {
+        private readonly ParameterDefinition[] parameterDefinitions;
+        private readonly MemberInfo source;
+        private readonly int sourceIndex;
+        private readonly int argumentIndex;
+
+        public SmartArgument(ParameterDefinition[] parameterDefinitions, object value, MemberInfo source, int sourceIndex, int argumentIndex)
+        {
+            this.parameterDefinitions = parameterDefinitions;
+            Value = value;
+            this.source = source;
+            this.sourceIndex = sourceIndex;
+            this.argumentIndex = argumentIndex;
+        }
+
+        public object Value { get; }
+
+        public string DisplayText => Value.ToString();
+
+        public string ToSourceCode()
+        {
+            var cast = $"({Value.GetType().GetCorrectCSharpTypeNameWithoutRef()})"; // it's an object so we need to cast it to the right type
+
+            var callPostfix = source is PropertyInfo ? string.Empty : "()";
+
+            var indexPostfix = parameterDefinitions.Length > 1 
+                ? $"[{argumentIndex}]" // IEnumerable<object[]> 
+                : string.Empty; // IEnumerable<object>
+
+            // we just execute (cast)source.ToArray()[case][argumentIndex]; 
+            // we know that source is IEnumberable so we can do that!
+            return $"{cast}{source.Name}{callPostfix}.ToArray()[{sourceIndex}]{indexPostfix};"; 
+        }
+    }
+
+    internal class SmartParamameter : IParam
+    {
+        private readonly MemberInfo source;
+        private readonly MethodBase method;
+        private readonly int index;
+
+        public SmartParamameter(MemberInfo source, object value, int index)
+        {
+            this.source = source;
+            this.method = source is PropertyInfo property ? property.GetMethod : source as MethodInfo;
+            Value = value;
+            this.index = index;
+        }
+
+        public object Value { get; }
+
+        public string DisplayText => Value.ToString();
+
+        public string ToSourceCode()
+        {
+            var cast = $"({Value.GetType().GetCorrectCSharpTypeNameWithoutRef()})";
+
+            var instancePrefix = method.IsStatic ? source.DeclaringType.GetCorrectCSharpTypeNameWithoutRef() : "instance";
+
+            var callPostfix = source is PropertyInfo ? string.Empty : "()";
+
+            // we just execute (cast)source.ToArray()[index]; 
+            return $"{cast}{instancePrefix}.{source.Name}{callPostfix}.ToArray()[{index}];";
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Code;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Filters;
@@ -185,11 +186,15 @@ namespace BenchmarkDotNet.Running
                         GetValidValues(member.Attribute.Values, member.ParameterType),
                         false))
                 .Concat(allParamsSourceMembers.Select(member =>
-                    new ParameterDefinition(
-                        member.Name,
-                        member.IsStatic,
-                        GetValidValuesForParamsSource(type, member.Attribute.Name),
-                        false)))
+                {
+                    var paramsValues = GetValidValuesForParamsSource(type, member.Attribute.Name);
+                    return new ParameterDefinition(
+                       member.Name,
+                       member.IsStatic,
+                       SmartParamBuilder.CreateForParams(paramsValues.source, paramsValues.values),
+                       false);
+                    
+                }))
                 .ToArray();
 
             return new ParameterDefinitions(definitions);
@@ -220,23 +225,10 @@ namespace BenchmarkDotNet.Running
                 yield break;
 
             var argumentsSourceAttribute = benchmark.GetCustomAttribute<ArgumentsSourceAttribute>();
-            foreach (var unwrappedValue in GetValidValuesForParamsSource(target, argumentsSourceAttribute.Name))
-            {
-                if (unwrappedValue is object[] array)
-                {
-                    if (parameterDefinitions.Length != array.Length)
-                        throw new InvalidOperationException($"Benchmark {benchmark.Name} has invalid number of arguments provided by [ArgumentsSource({argumentsSourceAttribute.Name})]! {array.Length} instead of {parameterDefinitions.Length}.");
 
-                    yield return new ParameterInstances(
-                        array.Select((value, index) => new ParameterInstance(parameterDefinitions[index], value)).ToArray());
-                }
-                else if (parameterDefinitions.Length == 1)
-                {
-                    yield return new ParameterInstances(
-                        new [] { new ParameterInstance(parameterDefinitions[0], unwrappedValue) });
-                }
-                else throw new NotSupportedException($"Benchmark {benchmark.Name} has invalid type of arguments provided by [ArgumentsSource({argumentsSourceAttribute.Name})]. It should be IEnumerable<object[]> or IEnumerable<object>.");
-            }
+            var valuesInfo = GetValidValuesForParamsSource(target, argumentsSourceAttribute.Name);
+            for (int sourceIndex = 0; sourceIndex < valuesInfo.values.Length; sourceIndex++)
+                yield return SmartParamBuilder.CreateForArguments(benchmark, parameterDefinitions, valuesInfo, sourceIndex);
         }
 
         private static string[] GetCategories(MethodInfo method)
@@ -297,23 +289,23 @@ namespace BenchmarkDotNet.Running
             return values;
         }
 
-        private static object[] GetValidValuesForParamsSource(Type parentType, string sourceName)
+        private static (MemberInfo source, object[] values) GetValidValuesForParamsSource(Type parentType, string sourceName)
         {
             var paramsSourceMethod = parentType.GetAllMethods().SingleOrDefault(method => method.Name == sourceName && method.IsPublic);
 
             if (paramsSourceMethod != default(MethodInfo))
-                return ToArray(
+                return (paramsSourceMethod, ToArray(
                     paramsSourceMethod.Invoke(paramsSourceMethod.IsStatic ? null : Activator.CreateInstance(parentType), null),
                     paramsSourceMethod,
-                    parentType);
+                    parentType));
 
             var paramsSourceProperty = parentType.GetAllProperties().SingleOrDefault(property => property.Name == sourceName && property.GetMethod.IsPublic);
 
             if (paramsSourceProperty != default(PropertyInfo))
-                return ToArray(
+                return (paramsSourceProperty, ToArray(
                     paramsSourceProperty.GetValue(paramsSourceProperty.GetMethod.IsStatic ? null : Activator.CreateInstance(parentType)),
                     paramsSourceProperty,
-                    parentType);
+                    parentType));
 
             throw new InvalidOperationException($"{parentType.Name} has no public, accessible method/property called {sourceName}, unable to read values for [ParamsSource]");
         }

--- a/src/BenchmarkDotNet/Templates/BenchmarkProgram.txt
+++ b/src/BenchmarkDotNet/Templates/BenchmarkProgram.txt
@@ -2,7 +2,7 @@ $ShadowCopyDefines$
 $ExtraDefines$
 using System;
 using System.Diagnostics;
-using System.Linq;
+using System.Linq; // must not be removed, used by SmartParameter and SmartArgument
 using System.Threading;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/src/BenchmarkDotNet/Templates/BenchmarkType.txt
+++ b/src/BenchmarkDotNet/Templates/BenchmarkType.txt
@@ -3,7 +3,7 @@
     {
         public static void Run(IHost host)
         {
-            Runnable_$ID$ instance = new Runnable_$ID$();
+            Runnable_$ID$ instance = new Runnable_$ID$(); // do NOT change name "instance" (used in SmartParamameter)
             $ParamsContent$
 
             host.WriteLine();

--- a/tests/BenchmarkDotNet.IntegrationTests/ArgumentsAttributeTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ArgumentsAttributeTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,6 +19,9 @@ namespace BenchmarkDotNet.IntegrationTests
 
         [Fact]
         public void ArgumentsCanBePassedByReferenceToBenchmark() => CanExecute<WithRefArguments>();
+
+        [Fact]
+        public void NonCompileTimeConstantsCanBeReturnedFromSource() => CanExecute<WithComplexTypesReturnedFromSources>();
     }
 
     public class WithArguments
@@ -61,4 +65,57 @@ namespace BenchmarkDotNet.IntegrationTests
         }
     }
 
+    public class WithComplexTypesReturnedFromSources
+    {
+        [ParamsSource(nameof(DictionaryAsParam))]
+        public Dictionary<int, string> DictionaryParamInstance;
+
+        [ParamsSource(nameof(SameButStatic))]
+        public Dictionary<int, string> DictionaryParamStatic;
+
+        [Benchmark]
+        [ArgumentsSource(nameof(NonPrimitive))]
+        public void Simple(SomeClass someClass, SomeStruct someStruct)
+        {
+            if (DictionaryParamInstance[1234] != "it's an instance getter")
+                throw new InvalidOperationException("Incorrect dictionary (instance");
+
+            if (DictionaryParamStatic[1234] != "it's a static getter")
+                throw new InvalidOperationException("Incorrect dictionary (instance");
+
+            if (!(someStruct.RangeEnd == 100 || someStruct.RangeEnd == 1000))
+                throw new InvalidOperationException("Incorrect struct values were passed");
+
+            if (someStruct.RangeEnd != someClass.Values.Length)
+                throw new InvalidOperationException("Incorrect length");
+
+            for (int i = 0; i < someStruct.RangeEnd; i++)
+                if (someClass.Values[i] != i * 2)
+                    throw new InvalidOperationException("Incorrect array values were passed");
+        }
+
+        public IEnumerable<object[]> NonPrimitive()
+        {
+            yield return new object[] { new SomeClass(Enumerable.Range(0, 100).ToArray()), new SomeStruct(100) };
+            yield return new object[] { new SomeClass(Enumerable.Range(0, 1000).ToArray()), new SomeStruct(1000) };
+        }
+
+        public IEnumerable<object> DictionaryAsParam => new object[] { new Dictionary<int, string>() { { 1234, "it's an instance getter" } } };
+
+        public static IEnumerable<object> SameButStatic => new object[] { new Dictionary<int, string>() { { 1234, "it's a static getter" } } };
+
+        public class SomeClass
+        {
+            public SomeClass(int[] initialValues) => Values = initialValues.Select(val => val * 2).ToArray();
+
+            public int[] Values { get; }
+        }
+
+        public struct SomeStruct
+        {
+            public SomeStruct(int rangeEnd) => RangeEnd = rangeEnd;
+
+            public int RangeEnd { get; }
+        }
+    }
 }


### PR DESCRIPTION
This change generates the right `IParam` for the users for any complex types returned by `[ArgumentsSource]` and `[ParamsSource]` 

I was tired of writing another IParam when I realized that I don't need to do that.

Idea: 

1. generate code which is going to call the `[Source]` getter/method 
2. it always returns `IEnumerable` so we can call `ToArray()` on it
3. use array indexer to get the argument

Examples and auto-generated code:

```cs
[ParamsSource(nameof(DictionaryAsParam))]
public Dictionary<int, string> DictionaryParamInstance;

public IEnumerable<object> DictionaryAsParam => new object[] { new Dictionary<int, string>() { { 1234, "it's an instance getter" } } };

generates:
Runnable_0 instance = new Runnable_0(); 
instance.DictionaryParamInstance= (System.Collections.Generic.Dictionary<System.Int32, System.String>)instance.DictionaryAsParam().ToArray()[0];;
```

```cs
[Benchmark]
[ArgumentsSource(nameof(NonPrimitive))]
public void Simple(SomeClass someClass, SomeStruct someStruct)

public IEnumerable<object[]> NonPrimitive()
{
    yield return new object[] { new SomeClass(Enumerable.Range(0, 100).ToArray()), new SomeStruct(100) };
    yield return new object[] { new SomeClass(Enumerable.Range(0, 1000).ToArray()), new SomeStruct(1000) };
}

__argField0 = (BenchmarkDotNet.IntegrationTests.WithNonPrimitiveArgumentsSource.SomeClass)NonPrimitive().ToArray()[0][0];;
__argField1 = (BenchmarkDotNet.IntegrationTests.WithNonPrimitiveArgumentsSource.SomeStruct)NonPrimitive().ToArray()[0][1];;
```

