### PR TITLE
Add SummaryOrderPolicy.Defined to return benchmarks as instantiated

### DIFF
--- a/src/BenchmarkDotNet/Order/DefaultOrderProvider.cs
+++ b/src/BenchmarkDotNet/Order/DefaultOrderProvider.cs
@@ -32,12 +32,12 @@ namespace BenchmarkDotNet.Order
 
         public virtual IEnumerable<Benchmark> GetExecutionOrder(Benchmark[] benchmarks)
         {
-            var list = benchmarks.ToList();
             if (summaryOrderPolicy == SummaryOrderPolicy.Defined)
             {
                 return benchmarks;
             }
-
+            
+            var list = benchmarks.ToList();
             list.Sort(benchmarkComparer);
             return list;
         }

--- a/src/BenchmarkDotNet/Order/DefaultOrderProvider.cs
+++ b/src/BenchmarkDotNet/Order/DefaultOrderProvider.cs
@@ -33,6 +33,11 @@ namespace BenchmarkDotNet.Order
         public virtual IEnumerable<Benchmark> GetExecutionOrder(Benchmark[] benchmarks)
         {
             var list = benchmarks.ToList();
+            if (summaryOrderPolicy == SummaryOrderPolicy.Defined)
+            {
+                return benchmarks;
+            }
+
             list.Sort(benchmarkComparer);
             return list;
         }

--- a/src/BenchmarkDotNet/Order/SummaryOrderPolicy.cs
+++ b/src/BenchmarkDotNet/Order/SummaryOrderPolicy.cs
@@ -2,6 +2,6 @@
 {
     public enum SummaryOrderPolicy
     {
-        Default, FastestToSlowest, SlowestToFastest, Method
+        Default, FastestToSlowest, SlowestToFastest, Method, Defined
     }
 }


### PR DESCRIPTION
Fixes #720 

This is a pretty naive implementation of the `SummaryOrderPolicy.Defined`, just returning the incoming benchmarks without doing any sorting against the collection.

An alternative here would be to update the `BenchmarkComparer` to accept a `SummaryOrderPolicy` parameter, and to not do any comparison in that case, but I opted to not change the constructor of `BenchmarkComparer` in this case. Let me know if that's more in line with what you guys were thinking.