### PR TITLE
Generic Benchmark Attribute

### DIFF
--- a/samples/BenchmarkDotNet.Samples/Other/GenericBenchmarks.cs
+++ b/samples/BenchmarkDotNet.Samples/Other/GenericBenchmarks.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes.Jobs;
+
+namespace BenchmarkDotNet.Samples.Other
+{
+    [GenericBenchmark(typeof(int))]
+    [GenericBenchmark(typeof(char))]
+    public class GenericBenchmarks<T>
+    {
+        [Benchmark] public T Create() => Activator.CreateInstance<T>();
+    }
+}

--- a/src/BenchmarkDotNet/Attributes/GenericBenchmarkAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/GenericBenchmarkAttribute.cs
@@ -5,8 +5,8 @@ namespace BenchmarkDotNet.Attributes
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class GenericBenchmarkAttribute: Attribute
     {
-        public Type GenericType { get; }
+        public Type[] GenericType { get; }
 
-        public GenericBenchmarkAttribute(Type genericType) => GenericType = genericType;
+        public GenericBenchmarkAttribute(params Type[] genericType) => GenericType = genericType;
     }
 }

--- a/src/BenchmarkDotNet/Attributes/GenericBenchmarkAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/GenericBenchmarkAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace BenchmarkDotNet.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class GenericBenchmarkAttribute: Attribute
+    {
+        public Type GenericType { get; }
+
+        public GenericBenchmarkAttribute(Type genericType) => GenericType = genericType;
+    }
+}

--- a/src/BenchmarkDotNet/Helpers/GenericBuilderHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/GenericBuilderHelper.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Extensions;
+
+namespace BenchmarkDotNet.Helpers
+{
+    public static class GenericBuilderHelper
+    {
+        public static Type[] GetRunnableBenchmarks(IEnumerable<Type> types)
+            => types.Where(type => type.ContainsRunnableBenchmarks())
+                    .SelectMany(t => t.BuildGenericsIfNeeded())
+                    .Where(x => x.isSuccesed)
+                    .Select(x => x.result)
+                    .ToArray();
+    }
+}

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -17,8 +17,10 @@ namespace BenchmarkDotNet.Running
     {
         public static BenchmarkRunInfo TypeToBenchmarks(Type type, IConfig config = null)
         {
+            if (type.IsGenericTypeDefinition)
+                throw new ArgumentException($"{type.Name} is generic type definition, use BenchmarkSwitcher for it"); // for "open generic types" should be used BenchmarkSwitcher
+            
             var fullConfig = GetFullConfig(type, config);
-
             var allMethods = type.GetMethods();
             return MethodsToBenchmarksWithFullConfig(type, allMethods, fullConfig);
         }

--- a/src/BenchmarkDotNet/Running/TypeParser.cs
+++ b/src/BenchmarkDotNet/Running/TypeParser.cs
@@ -22,7 +22,9 @@ namespace BenchmarkDotNet.Running
 
         internal TypeParser(Type[] types, ILogger logger)
         {
-            allTypes = types.Where(type => type.ContainsRunnableBenchmarks()).ToArray();
+            allTypes = types.Where(type => type.ContainsRunnableBenchmarks())
+                            .SelectMany(t => t.BuildGenericsIfNeeded())
+                            .ToArray();
             this.logger = logger;
         }
 

--- a/tests/BenchmarkDotNet.Tests/GenericBuilderTests.cs
+++ b/tests/BenchmarkDotNet.Tests/GenericBuilderTests.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Helpers;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests
+{
+    public class GenericBuilderTests
+    {
+        [Fact]
+        public void TestBuildGenericWithOneArgument()
+        {
+            // Arrange & Act
+            var types = GenericBuilderHelper.GetRunnableBenchmarks(new [] {typeof(OneArgGenericBenchmark<>)});
+            
+            // Assert
+            Assert.Equal(types.Length, 2);
+        }
+        
+        [Fact]
+        public void TestBuildGenericWithTwoArguments()
+        {
+            // Arrange & Act
+            var types = GenericBuilderHelper.GetRunnableBenchmarks(new [] {typeof(TwoArgGenericBenchmark<,>)});
+            
+            // Assert
+            Assert.Equal(types.Length, 2);
+        }
+        
+        [Fact]
+        public void TestBuildGenericWithThreeArguments()
+        {
+            // Arrange & Act
+            var types = GenericBuilderHelper.GetRunnableBenchmarks(new [] {typeof(ThreeArgGenericBenchmark<,,>)});
+            
+            // Assert
+            Assert.Equal(types.Length, 2);
+        }
+        
+        [Fact]
+        public void TestBuildGenericWithWrongAttributes()
+        {
+            // Arrange & Act
+            var types = GenericBuilderHelper.GetRunnableBenchmarks(new [] {typeof(GenericBenchmarkWithWrongAttribute<,>)});
+            
+            // Assert
+            Assert.Equal(types.Length, 2);
+        }
+        
+        [Fact]
+        public void TestBuildGenericWithConstraints()
+        {
+            // Arrange & Act
+            var types = GenericBuilderHelper.GetRunnableBenchmarks(new [] {typeof(GenericBenchmarkWithConstraints<,>)});
+            
+            // Assert
+            Assert.Equal(types.Length, 2);
+        }
+        
+        [Fact]
+        public void TestBuildGenericWithConstraintsWrongArgs()
+        {
+            // Arrange & Act
+            var types = GenericBuilderHelper.GetRunnableBenchmarks(new [] {typeof(GenericBenchmarkWithConstraintsWrongArgs<,>)});
+            
+            // Assert
+            Assert.Equal(types.Length, 1);
+        }
+    }
+    
+    [GenericBenchmark(typeof(int))]
+    [GenericBenchmark(typeof(char))]
+    public class OneArgGenericBenchmark<T>
+    {
+        [Benchmark] public T CreateT() => Activator.CreateInstance<T>();
+    }
+    
+    [GenericBenchmark(typeof(int), typeof(char))]
+    [GenericBenchmark(typeof(char), typeof(string))]
+    public class TwoArgGenericBenchmark<T1, T2>
+    {
+        [Benchmark] public T1 CreateT1() => Activator.CreateInstance<T1>();
+
+        [Benchmark] public T2 CreateT2() => Activator.CreateInstance<T2>();
+    }
+    
+    [GenericBenchmark(typeof(int), typeof(char),  typeof(string))]
+    [GenericBenchmark(typeof(char), typeof(string), typeof(byte))]
+    public class ThreeArgGenericBenchmark<T1, T2, T3>
+    {
+        [Benchmark] public T1 CreateT1() => Activator.CreateInstance<T1>();
+
+        [Benchmark] public T2 CreateT2() => Activator.CreateInstance<T2>();
+        
+        [Benchmark] public T3 CreateT3() => Activator.CreateInstance<T3>();
+    }
+    
+    [GenericBenchmark(typeof(int), typeof(char))]
+    [GenericBenchmark(typeof(char), typeof(string))]
+    [GenericBenchmark(typeof(char))]
+    public class GenericBenchmarkWithWrongAttribute<T1, T2>
+    {
+        [Benchmark] public T1 CreateT1() => Activator.CreateInstance<T1>();
+
+        [Benchmark] public T2 CreateT2() => Activator.CreateInstance<T2>();
+    }
+    
+    [GenericBenchmark(typeof(int), typeof(char))]
+    [GenericBenchmark(typeof(char), typeof(byte))]
+    public class GenericBenchmarkWithConstraints<T1, T2> where T1 : struct
+                                                         where T2 : struct 
+    {
+        [Benchmark] public T1 CreateT1() => Activator.CreateInstance<T1>();
+
+        [Benchmark] public T2 CreateT2() => Activator.CreateInstance<T2>();
+    }
+    
+    [GenericBenchmark(typeof(int), typeof(char))]
+    [GenericBenchmark(typeof(char), typeof(string))]
+    public class GenericBenchmarkWithConstraintsWrongArgs<T1, T2> where T1 : struct
+                                                                  where T2 : struct 
+    {
+        [Benchmark] public T1 CreateT1() => Activator.CreateInstance<T1>();
+
+        [Benchmark] public T2 CreateT2() => Activator.CreateInstance<T2>();
+    }
+}


### PR DESCRIPTION
Allows to define generic parameter of benchmark class via attribute.
Solves https://github.com/dotnet/BenchmarkDotNet/issues/745
Example:

```C#
[GenericBenchmark(typeof(int))]
[GenericBenchmark(typeof(char))]
public class GenericBenchmarks<T>
{
    [Benchmark] public T Create() => Activator.CreateInstance<T>();
}
```