### PR TITLE
don't execute long operations more than once per iteration

### DIFF
--- a/samples/BenchmarkDotNet.Samples/Intro/IntroInProcessWrongEnv.cs
+++ b/samples/BenchmarkDotNet.Samples/Intro/IntroInProcessWrongEnv.cs
@@ -5,6 +5,7 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Order;
+using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Toolchains.InProcess;
 
 namespace BenchmarkDotNet.Samples.Intro
@@ -18,7 +19,7 @@ namespace BenchmarkDotNet.Samples.Intro
         {
             public Config()
             {
-                var wrongPlatform = IntPtr.Size == sizeof(int)
+                var wrongPlatform = RuntimeInformation.GetCurrentPlatform() == Platform.X86
                     ? Platform.X64
                     : Platform.X86;
 

--- a/src/BenchmarkDotNet/Diagnosers/WindowsDisassembler.cs
+++ b/src/BenchmarkDotNet/Diagnosers/WindowsDisassembler.cs
@@ -156,7 +156,7 @@ namespace BenchmarkDotNet.Diagnosers
                     return !isWow64;
                 }
 
-                return IntPtr.Size == 8; // todo: find the way to cover all scenarios for .NET Core
+                return Portability.RuntimeInformation.GetCurrentPlatform() == Platform.X64; // todo: find the way to cover all scenarios for .NET Core
             }
 
             [DllImport("kernel32.dll", SetLastError = true, CallingConvention = CallingConvention.Winapi)]

--- a/src/BenchmarkDotNet/Engines/Engine.cs
+++ b/src/BenchmarkDotNet/Engines/Engine.cs
@@ -44,6 +44,7 @@ namespace BenchmarkDotNet.Engines
 
         internal Engine(
             IHost host,
+            IResolver resolver,
             Action dummy1Action, Action dummy2Action, Action dummy3Action, Action<long> idleAction, Action<long> mainAction, Job targetJob,
             Action globalSetupAction, Action globalCleanupAction, Action iterationSetupAction, Action iterationCleanupAction, long operationsPerInvoke,
             bool includeMemoryStats)
@@ -63,7 +64,7 @@ namespace BenchmarkDotNet.Engines
             OperationsPerInvoke = operationsPerInvoke;
             this.includeMemoryStats = includeMemoryStats;
 
-            Resolver = new CompositeResolver(BenchmarkRunner.DefaultResolver, EngineResolver.Instance);
+            Resolver = resolver;
 
             Clock = targetJob.ResolveValue(InfrastructureMode.ClockCharacteristic, Resolver);
             ForceAllocations = targetJob.ResolveValue(GcMode.ForceCharacteristic, Resolver);

--- a/src/BenchmarkDotNet/Engines/Engine.cs
+++ b/src/BenchmarkDotNet/Engines/Engine.cs
@@ -41,7 +41,6 @@ namespace BenchmarkDotNet.Engines
         private readonly EngineWarmupStage warmupStage;
         private readonly EngineTargetStage targetStage;
         private readonly bool includeMemoryStats;
-        private bool isJitted;
 
         internal Engine(
             IHost host,
@@ -78,22 +77,10 @@ namespace BenchmarkDotNet.Engines
             targetStage = new EngineTargetStage(this);
         }
 
-        public void Jitting()
-        {
-            // first signal about jitting is raised from auto-generated Program.cs, look at BenchmarkProgram.txt
-            Dummy1Action.Invoke();
-            MainAction.Invoke(1);
-            Dummy2Action.Invoke();
-            IdleAction.Invoke(1);
-            Dummy3Action.Invoke();
-            isJitted = true;
-        }
+        public void Dispose() => GlobalCleanupAction?.Invoke();
 
         public RunResults Run()
         {
-            if (Strategy.NeedsJitting() != isJitted)
-                throw new Exception($"You must{(Strategy.NeedsJitting() ? "" : " not")} call Jitting() first (Strategy = {Strategy})!");
-
             long invokeCount = InvocationCount;
             IReadOnlyList<Measurement> idle = null;
 

--- a/src/BenchmarkDotNet/Engines/EngineFactory.cs
+++ b/src/BenchmarkDotNet/Engines/EngineFactory.cs
@@ -68,7 +68,11 @@ namespace BenchmarkDotNet.Engines
             => TimeInterval.FromNanoseconds(jit.GetAverageNanoseconds()) > iterationTime;
 
         private static Measurement Jit(Engine engine)
-            => engine.RunIteration(new IterationData(IterationMode.Jit, index: -1, invokeCount: 1, unrollFactor: 1));
+        {
+            DeadCodeEliminationHelper.KeepAliveWithoutBoxing(engine.RunIteration(new IterationData(IterationMode.IdleJit, index: -1, invokeCount: 1, unrollFactor: 1))); // don't forget to JIT idle
+            
+            return engine.RunIteration(new IterationData(IterationMode.Jit, index: -1, invokeCount: 1, unrollFactor: 1));
+        }
 
         private static Engine CreateEngine(EngineParameters engineParameters, IResolver resolver, Job job, Action<long> idle, Action<long> main)
             => new Engine(

--- a/src/BenchmarkDotNet/Engines/EngineFactory.cs
+++ b/src/BenchmarkDotNet/Engines/EngineFactory.cs
@@ -1,39 +1,85 @@
 using System;
+using BenchmarkDotNet.Horology;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Reports;
 
 namespace BenchmarkDotNet.Engines
 {
-    // TODO: Default instance?
     public class EngineFactory : IEngineFactory
     {
-        public IEngine Create(EngineParameters engineParameters)
+        public IEngine CreateReadyToRun(EngineParameters engineParameters)
         {
-            if (engineParameters.MainAction == null)
-                throw new ArgumentNullException(nameof(engineParameters.MainAction));
+            if (engineParameters.MainSingleAction == null)
+                throw new ArgumentNullException(nameof(engineParameters.MainSingleAction));
+            if (engineParameters.MainMultiAction == null)
+                throw new ArgumentNullException(nameof(engineParameters.MainMultiAction));
             if (engineParameters.Dummy1Action == null)
                 throw new ArgumentNullException(nameof(engineParameters.Dummy1Action));
             if (engineParameters.Dummy2Action == null)
                 throw new ArgumentNullException(nameof(engineParameters.Dummy2Action));
             if (engineParameters.Dummy3Action == null)
                 throw new ArgumentNullException(nameof(engineParameters.Dummy3Action));
-            if (engineParameters.IdleAction == null)
-                throw new ArgumentNullException(nameof(engineParameters.IdleAction));
+            if (engineParameters.IdleSingleAction == null)
+                throw new ArgumentNullException(nameof(engineParameters.IdleSingleAction));
+            if (engineParameters.IdleMultiAction == null)
+                throw new ArgumentNullException(nameof(engineParameters.IdleMultiAction));
             if(engineParameters.TargetJob == null)
                 throw new ArgumentNullException(nameof(engineParameters.TargetJob));
+            
+            engineParameters.GlobalSetupAction?.Invoke();
 
-            return new Engine(
+            var needsJitting = engineParameters.TargetJob.ResolveValue(RunMode.RunStrategyCharacteristic, engineParameters.Resolver).NeedsJitting();
+            if (!needsJitting)
+            {
+                // whatever it is, we can not interfere
+                return CreateEngine(engineParameters, engineParameters.TargetJob, engineParameters.IdleMultiAction, engineParameters.MainMultiAction);
+            }
+
+            var needsPilot = !engineParameters.TargetJob.HasValue(RunMode.InvocationCountCharacteristic);
+            if (needsPilot) 
+            {
+                var singleActionEngine = CreateEngine(engineParameters, engineParameters.TargetJob, engineParameters.IdleSingleAction, engineParameters.MainSingleAction);
+
+                var iterationTime = engineParameters.Resolver.Resolve(engineParameters.TargetJob, RunMode.IterationTimeCharacteristic);
+                if (ShouldExecuteOncePerIteration(Jit(singleActionEngine), iterationTime))
+                {
+                    var reconfiguredJob = engineParameters.TargetJob.WithInvocationCount(1).WithUnrollFactor(1); // todo: consider if we should set the warmup count to 1!
+
+                    return CreateEngine(engineParameters, reconfiguredJob, engineParameters.IdleSingleAction, engineParameters.MainSingleAction);
+                }
+            }
+
+            // it's either a job with explicit configuration or not-very time consuming benchmark, just create the engine, Jit and return
+            var multiActionEngine = CreateEngine(engineParameters, engineParameters.TargetJob, engineParameters.IdleMultiAction, engineParameters.MainMultiAction);
+                
+            DeadCodeEliminationHelper.KeepAliveWithoutBoxing(Jit(multiActionEngine));
+
+            return multiActionEngine;
+        }
+
+        /// <summary>
+        /// returns true if it takes longer than the desired iteration time (0,5s by default) to execute benchmark once
+        /// </summary>
+        private static bool ShouldExecuteOncePerIteration(Measurement jit, TimeInterval iterationTime)
+            => TimeInterval.FromNanoseconds(jit.GetAverageNanoseconds()) > iterationTime;
+
+        private static Measurement Jit(Engine engine)
+            => engine.RunIteration(new IterationData(IterationMode.Jit, index: -1, invokeCount: 1, unrollFactor: 1));
+
+        private static Engine CreateEngine(EngineParameters engineParameters, Job job, Action<long> idle, Action<long> main)
+            => new Engine(
                 engineParameters.Host,
                 engineParameters.Dummy1Action,
                 engineParameters.Dummy2Action,
                 engineParameters.Dummy3Action,
-                engineParameters.IdleAction,
-                engineParameters.MainAction,
-                engineParameters.TargetJob,
+                idle,
+                main,
+                job,
                 engineParameters.GlobalSetupAction,
                 engineParameters.GlobalCleanupAction,
                 engineParameters.IterationSetupAction,
                 engineParameters.IterationCleanupAction,
                 engineParameters.OperationsPerInvoke,
                 engineParameters.MeasureGcStats);
-        }
     }
 }

--- a/src/BenchmarkDotNet/Engines/EngineFactory.cs
+++ b/src/BenchmarkDotNet/Engines/EngineFactory.cs
@@ -72,9 +72,15 @@ namespace BenchmarkDotNet.Engines
 
         private static Measurement Jit(Engine engine, int unrollFactor)
         {
+            engine.Dummy1Action.Invoke();
+
             DeadCodeEliminationHelper.KeepAliveWithoutBoxing(engine.RunIteration(new IterationData(IterationMode.IdleJitting, index: 1, invokeCount: unrollFactor, unrollFactor: unrollFactor))); // don't forget to JIT idle
             
+            engine.Dummy2Action.Invoke();
+
             var result = engine.RunIteration(new IterationData(IterationMode.MainJitting, index: 1, invokeCount: unrollFactor, unrollFactor: unrollFactor));
+
+            engine.Dummy3Action.Invoke();
 
             engine.WriteLine();
             

--- a/src/BenchmarkDotNet/Engines/EngineParameters.cs
+++ b/src/BenchmarkDotNet/Engines/EngineParameters.cs
@@ -7,11 +7,13 @@ namespace BenchmarkDotNet.Engines
     public class EngineParameters
     {
         public IHost Host { get; set; }
-        public Action<long> MainAction { get; set; }
+        public Action<long> MainSingleAction { get; set; }
+        public Action<long> MainMultiAction { get; set; }
         public Action Dummy1Action { get; set; }
         public Action Dummy2Action { get; set; }
         public Action Dummy3Action { get; set; }
-        public Action<long> IdleAction { get; set; }
+        public Action<long> IdleSingleAction { get; set; }
+        public Action<long> IdleMultiAction { get; set; }
         public Job TargetJob { get; set; } = Job.Default;
         public long OperationsPerInvoke { get; set; } = 1;
         public Action GlobalSetupAction { get; set; } = null;

--- a/src/BenchmarkDotNet/Engines/EngineParameters.cs
+++ b/src/BenchmarkDotNet/Engines/EngineParameters.cs
@@ -1,11 +1,15 @@
 using System;
 using BenchmarkDotNet.Characteristics;
+using BenchmarkDotNet.Horology;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
 
 namespace BenchmarkDotNet.Engines
 {
     public class EngineParameters
     {
+        public static readonly IResolver DefaultResolver = new CompositeResolver(BenchmarkRunner.DefaultResolver, EngineResolver.Instance);
+        
         public IHost Host { get; set; }
         public Action<long> MainSingleAction { get; set; }
         public Action<long> MainMultiAction { get; set; }
@@ -16,10 +20,20 @@ namespace BenchmarkDotNet.Engines
         public Action<long> IdleMultiAction { get; set; }
         public Job TargetJob { get; set; } = Job.Default;
         public long OperationsPerInvoke { get; set; } = 1;
-        public Action GlobalSetupAction { get; set; } = null;
-        public Action GlobalCleanupAction { get; set; } = null;
-        public Action IterationSetupAction { get; set; } = null;
-        public Action IterationCleanupAction { get; set; } = null;
+        public Action GlobalSetupAction { get; set; }
+        public Action GlobalCleanupAction { get; set; }
+        public Action IterationSetupAction { get; set; }
+        public Action IterationCleanupAction { get; set; }
         public bool MeasureGcStats { get; set; }
+        
+        public bool NeedsJitting => TargetJob.ResolveValue(RunMode.RunStrategyCharacteristic, DefaultResolver).NeedsJitting();
+
+        public bool HasInvocationCount => TargetJob.HasValue(RunMode.InvocationCountCharacteristic);
+        
+        public bool HasUnrollFactor => TargetJob.HasValue(RunMode.UnrollFactorCharacteristic);
+
+        public int UnrollFactor => TargetJob.ResolveValue(RunMode.UnrollFactorCharacteristic, DefaultResolver);
+        
+        public TimeInterval IterationTime => TargetJob.ResolveValue(RunMode.IterationTimeCharacteristic, DefaultResolver);
     }
 }

--- a/src/BenchmarkDotNet/Engines/EngineParameters.cs
+++ b/src/BenchmarkDotNet/Engines/EngineParameters.cs
@@ -20,7 +20,6 @@ namespace BenchmarkDotNet.Engines
         public Action GlobalCleanupAction { get; set; } = null;
         public Action IterationSetupAction { get; set; } = null;
         public Action IterationCleanupAction { get; set; } = null;
-        public IResolver Resolver { get; set; }
         public bool MeasureGcStats { get; set; }
     }
 }

--- a/src/BenchmarkDotNet/Engines/IEngine.cs
+++ b/src/BenchmarkDotNet/Engines/IEngine.cs
@@ -6,7 +6,7 @@ using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Engines
 {
-    public interface IEngine
+    public interface IEngine : IDisposable
     {
         [NotNull]
         IHost Host { get; }
@@ -35,12 +35,6 @@ namespace BenchmarkDotNet.Engines
         IResolver Resolver { get; }
 
         Measurement RunIteration(IterationData data);
-
-        /// <summary>
-        /// must perform jitting via warmup calls
-        /// <remarks>is called after first call to GlobalSetup, from the auto-generated benchmark process</remarks>
-        /// </summary>
-        void Jitting();
 
         RunResults Run();
     }

--- a/src/BenchmarkDotNet/Engines/IEngineFactory.cs
+++ b/src/BenchmarkDotNet/Engines/IEngineFactory.cs
@@ -2,6 +2,6 @@ namespace BenchmarkDotNet.Engines
 {
     public interface IEngineFactory
     {
-        IEngine Create(EngineParameters engineParameters);
+        IEngine CreateReadyToRun(EngineParameters engineParameters);
     }
 }

--- a/src/BenchmarkDotNet/Engines/IterationMode.cs
+++ b/src/BenchmarkDotNet/Engines/IterationMode.cs
@@ -40,6 +40,6 @@
         /// <summary>
         /// executing benchmark for the purpose of JIT wamup
         /// </summary>
-        Jit, IdleJit
+        MainJitting, IdleJitting
     }
 }

--- a/src/BenchmarkDotNet/Engines/IterationMode.cs
+++ b/src/BenchmarkDotNet/Engines/IterationMode.cs
@@ -35,6 +35,11 @@
         /// <summary>
         /// Unknown 
         /// </summary>
-        Unknown
+        Unknown,
+        
+        /// <summary>
+        /// executing benchmark for the purpose of JIT wamup
+        /// </summary>
+        Jit
     }
 }

--- a/src/BenchmarkDotNet/Engines/IterationMode.cs
+++ b/src/BenchmarkDotNet/Engines/IterationMode.cs
@@ -40,6 +40,6 @@
         /// <summary>
         /// executing benchmark for the purpose of JIT wamup
         /// </summary>
-        Jit
+        Jit, IdleJit
     }
 }

--- a/src/BenchmarkDotNet/Engines/IterationModeExtensions.cs
+++ b/src/BenchmarkDotNet/Engines/IterationModeExtensions.cs
@@ -3,6 +3,6 @@
     public static class IterationModeExtensions
     {
         public static bool IsIdle(this IterationMode mode) 
-            => mode == IterationMode.IdleWarmup || mode == IterationMode.IdleTarget || mode == IterationMode.IdleJit;
+            => mode == IterationMode.IdleWarmup || mode == IterationMode.IdleTarget || mode == IterationMode.IdleJitting;
     }
 }

--- a/src/BenchmarkDotNet/Engines/IterationModeExtensions.cs
+++ b/src/BenchmarkDotNet/Engines/IterationModeExtensions.cs
@@ -3,6 +3,6 @@
     public static class IterationModeExtensions
     {
         public static bool IsIdle(this IterationMode mode) 
-            => mode == IterationMode.IdleWarmup || mode == IterationMode.IdleTarget;
+            => mode == IterationMode.IdleWarmup || mode == IterationMode.IdleTarget || mode == IterationMode.IdleJit;
     }
 }

--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -4,6 +4,7 @@ using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Running;
 using JetBrains.Annotations;
 
@@ -31,7 +32,7 @@ namespace BenchmarkDotNet.Extensions
         {
             int cpuMask = (1 << Environment.ProcessorCount) - 1;
 
-            return IntPtr.Size == sizeof(Int64) 
+            return RuntimeInformation.GetCurrentPlatform() == Platform.X64
                 ? new IntPtr(processorAffinity.ToInt64() & cpuMask)
                 : new IntPtr(processorAffinity.ToInt32() & cpuMask);
         }

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -61,7 +61,7 @@ namespace BenchmarkDotNet.Portability
 
         internal static string ScriptFileExtension => IsWindows() ? ".bat" : ".sh";
 
-        internal static string GetArchitecture() => IntPtr.Size == 4 ? "32bit" : "64bit";
+        internal static string GetArchitecture() => GetCurrentPlatform() == Platform.X86 ? "32bit" : "64bit";
 
         internal static bool IsWindows()
         {
@@ -246,7 +246,7 @@ namespace BenchmarkDotNet.Portability
             if (IsNetCore)
                 return true;
 
-            return IntPtr.Size == 8
+            return GetCurrentPlatform() == Platform.X64
                    && GetConfiguration() != DebugConfigurationName
                    && !new JitHelper().IsMsX64();
         }

--- a/src/BenchmarkDotNet/Reports/Measurement.cs
+++ b/src/BenchmarkDotNet/Reports/Measurement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Extensions;
@@ -12,6 +13,8 @@ namespace BenchmarkDotNet.Reports
     public struct Measurement : IComparable<Measurement>
     {
         private static readonly Measurement Error = new Measurement(-1, IterationMode.Unknown, 0, 0, 0);
+
+        private static readonly int IterationModeNameMaxWidth = Enum.GetNames(typeof(IterationMode)).Max(text => text.Length);
 
         public IterationMode IterationMode { get; }
 
@@ -48,10 +51,13 @@ namespace BenchmarkDotNet.Reports
 
         public string ToOutputLine()
         {
+            string alignedIterationMode = IterationMode.ToString().PadRight(IterationModeNameMaxWidth, ' ');
+            
             // Usually, a benchmarks takes more than 10 iterations (rarely more than 99)
             // PadLeft(2, ' ') looks like a good trade-off between alignment and amount of characters
             string alignedIterationIndex = IterationIndex.ToString().PadLeft(2, ' ');
-            return $"{IterationMode} {alignedIterationIndex}: {GetDisplayValue()}";
+            
+            return $"{alignedIterationMode} {alignedIterationIndex}: {GetDisplayValue()}";
         }
 
         private string GetDisplayValue() => $"{Operations} op, {Nanoseconds.ToStr("0.00")} ns, {GetAverageTime()}";

--- a/src/BenchmarkDotNet/Templates/BenchmarkType.txt
+++ b/src/BenchmarkDotNet/Templates/BenchmarkType.txt
@@ -20,11 +20,13 @@
             var engineParameters = new BenchmarkDotNet.Engines.EngineParameters()
             {
                 Host = host,
-                MainAction = instance.MainMultiAction,
+                MainMultiAction = instance.MainMultiAction,
+                MainSingleAction = instance.MainSingleAction,
                 Dummy1Action = instance.Dummy1,
                 Dummy2Action = instance.Dummy2,
                 Dummy3Action = instance.Dummy3,
-                IdleAction = instance.IdleMultiAction,
+                IdleSingleAction = instance.IdleSingleAction,
+                IdleMultiAction = instance.IdleMultiAction,
                 GlobalSetupAction = instance.globalSetupAction,
                 GlobalCleanupAction = instance.globalCleanupAction,
                 IterationSetupAction = instance.iterationSetupAction,
@@ -115,6 +117,12 @@
             }
         }
 
+        private void IdleSingleAction(long _)
+        {
+            $LoadArguments$
+            consumer.Consume(idleDelegate($PassArguments$));
+        }
+        
         private void MainMultiAction(long invokeCount)
         {
             $LoadArguments$
@@ -124,6 +132,12 @@
             }
         }
 
+        private void MainSingleAction(long _)
+        {
+            $LoadArguments$
+            consumer.Consume(targetDelegate($PassArguments$)$ConsumeField$);
+        }
+        
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         public $TargetMethodReturnType$ $DiassemblerEntryMethodName$()
         {
@@ -149,6 +163,14 @@
             DeadCodeEliminationHelper.KeepAliveWithoutBoxing(result);
         }
 
+        private void IdleSingleAction(long _)
+        {
+            $LoadArguments$
+            $IdleMethodReturnTypeName$ result = default($IdleMethodReturnTypeName$);
+            result = idleDelegate($PassArguments$);
+            DeadCodeEliminationHelper.KeepAliveWithoutBoxing(result);
+        }
+
         private void MainMultiAction(long invokeCount)
         {
             $LoadArguments$
@@ -157,6 +179,14 @@
             {
                 result = targetDelegate($PassArguments$);@Unroll@
             }
+            NonGenericKeepAliveWithoutBoxing(result);
+        }
+
+        private void MainSingleAction(long _)
+        {
+            $LoadArguments$
+            $TargetMethodReturnType$ result = default($TargetMethodReturnType$);
+            result = targetDelegate($PassArguments$);
             NonGenericKeepAliveWithoutBoxing(result);
         }
 
@@ -189,6 +219,14 @@
             }
             DeadCodeEliminationHelper.KeepAliveWithoutBoxing(value);
         }
+        
+        private void IdleSingleAction(long _)
+        {
+            $LoadArguments$
+            $IdleMethodReturnTypeName$ value = default($IdleMethodReturnTypeName$);
+            value = idleDelegate($PassArguments$);
+            DeadCodeEliminationHelper.KeepAliveWithoutBoxing(value);
+        }
 
         private $TargetMethodReturnType$ mainDefaultValueHolder = default($TargetMethodReturnType$);
 
@@ -200,6 +238,14 @@
             {
                 alias = targetDelegate($PassArguments$);@Unroll@
             }
+            DeadCodeEliminationHelper.KeepAliveWithoutBoxing(ref alias);
+        }
+        
+        private void MainSingleAction(long _)
+        {
+            $LoadArguments$
+            ref $TargetMethodReturnType$ alias = ref mainDefaultValueHolder;
+            alias = targetDelegate($PassArguments$);
             DeadCodeEliminationHelper.KeepAliveWithoutBoxing(ref alias);
         }
 
@@ -225,6 +271,12 @@
             }
         }
 
+        private void IdleSingleAction(long _)
+        {
+            $LoadArguments$
+            idleDelegate($PassArguments$);
+        }
+        
         private void MainMultiAction(long invokeCount)
         {
             $LoadArguments$
@@ -232,6 +284,12 @@
             {
                 targetDelegate($PassArguments$);@Unroll@
             }
+        }
+        
+        private void MainSingleAction(long _)
+        {
+            $LoadArguments$
+            targetDelegate($PassArguments$);
         }
 
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]

--- a/src/BenchmarkDotNet/Templates/BenchmarkType.txt
+++ b/src/BenchmarkDotNet/Templates/BenchmarkType.txt
@@ -34,23 +34,14 @@
                 MeasureGcStats = $MeasureGcStats$
             };
 
-            var engine = new $EngineFactoryType$().Create(engineParameters);
+            using (var engine = new $EngineFactoryType$().CreateReadyToRun(engineParameters))
+            {
+                var results = engine.Run();
 
-            instance?.globalSetupAction();
-            instance?.iterationSetupAction();
+                host.ReportResults(results); // printing costs memory, do this after runs
 
-            if (job.ResolveValue(RunMode.RunStrategyCharacteristic, EngineResolver.Instance).NeedsJitting())
-				engine.Jitting(); // does first call to main action, must be executed after globalSetup() and iterationSetup()!
-
-            instance?.iterationCleanupAction();
-
-            var results = engine.Run();
-
-            instance?.globalCleanupAction();
-
-            host.ReportResults(results); // printing costs memory, do this after runs
-
-			instance.__TrickTheJIT__(); // compile the method for disassembler, but without actual run of the benchmark ;)
+                instance.__TrickTheJIT__(); // compile the method for disassembler, but without actual run of the benchmark ;)
+			}
         }
 
         public delegate $IdleMethodReturnTypeName$ IdleDelegate($ArgumentsDefinition$);

--- a/src/BenchmarkDotNet/Toolchains/InProcess/InProcessRunner.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/InProcessRunner.cs
@@ -112,10 +112,12 @@ namespace BenchmarkDotNet.Toolchains.InProcess
                 var engineParameters = new EngineParameters
                 {
                     Host = host,
+                    MainSingleAction = _ => mainAction.InvokeSingle(),
                     MainMultiAction = mainAction.InvokeMultiple,
                     Dummy1Action = dummy1.InvokeSingle,
                     Dummy2Action = dummy2.InvokeSingle,
                     Dummy3Action = dummy3.InvokeSingle,
+                    IdleSingleAction = _ => idleAction.InvokeSingle(),
                     IdleMultiAction = idleAction.InvokeMultiple,
                     GlobalSetupAction = globalSetupAction.InvokeSingle,
                     GlobalCleanupAction = globalCleanupAction.InvokeSingle,

--- a/tests/BenchmarkDotNet.IntegrationTests/AllSetupAndCleanupTargetSpecificBenchmarkTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/AllSetupAndCleanupTargetSpecificBenchmarkTest.cs
@@ -11,7 +11,6 @@ namespace BenchmarkDotNet.IntegrationTests
 {
     public class AllSetupAndCleanupTargetSpecificBenchmarkTest : BenchmarkTestExecutor
     {
-
         private const string FirstPrefix = "// ### First Called: ";
         private const string FirstGlobalSetupCalled = FirstPrefix + "GlobalSetup";
         private const string FirstGlobalCleanupCalled = FirstPrefix + "GlobalCleanup";
@@ -31,25 +30,22 @@ namespace BenchmarkDotNet.IntegrationTests
         private readonly string[] firstExpectedLogLines = {
             "// ### First Called: GlobalSetup",
 
-            "// ### First Called: IterationSetup (1)", // IterationSetup Jitting
-            "// ### First Called: IterationCleanup (1)", // IterationCleanup Jitting
-            
-            "// ### First Called: IterationSetup (2)", // MainWarmup1
+            "// ### First Called: IterationSetup (1)", // MainWarmup1
             "// ### First Called: Benchmark", // MainWarmup1
-            "// ### First Called: IterationCleanup (2)", // MainWarmup1
-            "// ### First Called: IterationSetup (3)", // MainWarmup2
+            "// ### First Called: IterationCleanup (1)", // MainWarmup1
+            "// ### First Called: IterationSetup (2)", // MainWarmup2
             "// ### First Called: Benchmark", // MainWarmup2
-            "// ### First Called: IterationCleanup (3)", // MainWarmup2
+            "// ### First Called: IterationCleanup (2)", // MainWarmup2
             
-            "// ### First Called: IterationSetup (4)", // MainTarget1
+            "// ### First Called: IterationSetup (3)", // MainTarget1
             "// ### First Called: Benchmark", // MainTarget1
-            "// ### First Called: IterationCleanup (4)", // MainTarget1
-            "// ### First Called: IterationSetup (5)", // MainTarget2
+            "// ### First Called: IterationCleanup (3)", // MainTarget1
+            "// ### First Called: IterationSetup (4)", // MainTarget2
             "// ### First Called: Benchmark", // MainTarget2
-            "// ### First Called: IterationCleanup (5)", // MainTarget2
-            "// ### First Called: IterationSetup (6)", // MainTarget3
+            "// ### First Called: IterationCleanup (4)", // MainTarget2
+            "// ### First Called: IterationSetup (5)", // MainTarget3
             "// ### First Called: Benchmark", // MainTarget3
-            "// ### First Called: IterationCleanup (6)", // MainTarget3
+            "// ### First Called: IterationCleanup (5)", // MainTarget3
             
             "// ### First Called: GlobalCleanup"
         };
@@ -57,25 +53,22 @@ namespace BenchmarkDotNet.IntegrationTests
         private readonly string[] secondExpectedLogLines = {
             "// ### Second Called: GlobalSetup",
 
-            "// ### Second Called: IterationSetup (1)", // IterationSetup Jitting
-            "// ### Second Called: IterationCleanup (1)", // IterationCleanup Jitting
-            
-            "// ### Second Called: IterationSetup (2)", // MainWarmup1
+            "// ### Second Called: IterationSetup (1)", // MainWarmup1
             "// ### Second Called: Benchmark", // MainWarmup1
-            "// ### Second Called: IterationCleanup (2)", // MainWarmup1
-            "// ### Second Called: IterationSetup (3)", // MainWarmup2
+            "// ### Second Called: IterationCleanup (1)", // MainWarmup1
+            "// ### Second Called: IterationSetup (2)", // MainWarmup2
             "// ### Second Called: Benchmark", // MainWarmup2
-            "// ### Second Called: IterationCleanup (3)", // MainWarmup2
+            "// ### Second Called: IterationCleanup (2)", // MainWarmup2
             
-            "// ### Second Called: IterationSetup (4)", // MainTarget1
+            "// ### Second Called: IterationSetup (3)", // MainTarget1
             "// ### Second Called: Benchmark", // MainTarget1
-            "// ### Second Called: IterationCleanup (4)", // MainTarget1
-            "// ### Second Called: IterationSetup (5)", // MainTarget2
+            "// ### Second Called: IterationCleanup (3)", // MainTarget1
+            "// ### Second Called: IterationSetup (4)", // MainTarget2
             "// ### Second Called: Benchmark", // MainTarget2
-            "// ### Second Called: IterationCleanup (5)", // MainTarget2
-            "// ### Second Called: IterationSetup (6)", // MainTarget3
+            "// ### Second Called: IterationCleanup (4)", // MainTarget2
+            "// ### Second Called: IterationSetup (5)", // MainTarget3
             "// ### Second Called: Benchmark", // MainTarget3
-            "// ### Second Called: IterationCleanup (6)", // MainTarget3
+            "// ### Second Called: IterationCleanup (5)", // MainTarget3
             
             "// ### Second Called: GlobalCleanup"
         };

--- a/tests/BenchmarkDotNet.IntegrationTests/AllSetupAndCleanupTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/AllSetupAndCleanupTest.cs
@@ -22,25 +22,22 @@ namespace BenchmarkDotNet.IntegrationTests
         private readonly string[] expectedLogLines = {
             "// ### Called: GlobalSetup",
             
-            "// ### Called: IterationSetup (1)", // IterationSetup Jitting
-            "// ### Called: IterationCleanup (1)", // IterationCleanup Jitting
-            
-            "// ### Called: IterationSetup (2)", // MainWarmup1
+            "// ### Called: IterationSetup (1)", // MainWarmup1
             "// ### Called: Benchmark", // MainWarmup1
-            "// ### Called: IterationCleanup (2)", // MainWarmup1
-            "// ### Called: IterationSetup (3)", // MainWarmup2
+            "// ### Called: IterationCleanup (1)", // MainWarmup1
+            "// ### Called: IterationSetup (2)", // MainWarmup2
             "// ### Called: Benchmark", // MainWarmup2
-            "// ### Called: IterationCleanup (3)", // MainWarmup2
+            "// ### Called: IterationCleanup (2)", // MainWarmup2
             
-            "// ### Called: IterationSetup (4)", // MainTarget1
+            "// ### Called: IterationSetup (3)", // MainTarget1
             "// ### Called: Benchmark", // MainTarget1
-            "// ### Called: IterationCleanup (4)", // MainTarget1
-            "// ### Called: IterationSetup (5)", // MainTarget2
+            "// ### Called: IterationCleanup (3)", // MainTarget1
+            "// ### Called: IterationSetup (4)", // MainTarget2
             "// ### Called: Benchmark", // MainTarget2
-            "// ### Called: IterationCleanup (5)", // MainTarget2
-            "// ### Called: IterationSetup (6)", // MainTarget3
+            "// ### Called: IterationCleanup (4)", // MainTarget2
+            "// ### Called: IterationSetup (5)", // MainTarget3
             "// ### Called: Benchmark", // MainTarget3
-            "// ### Called: IterationCleanup (6)", // MainTarget3
+            "// ### Called: IterationCleanup (5)", // MainTarget3
             
             "// ### Called: GlobalCleanup"
         };

--- a/tests/BenchmarkDotNet.IntegrationTests/CoreRtTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/CoreRtTests.cs
@@ -17,7 +17,7 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void CoreRtIsSupported()
         {
-            if (IntPtr.Size == sizeof(int)) // CoreRT does not support 32bit yet
+            if (RuntimeInformation.GetCurrentPlatform() == Platform.X86) // CoreRT does not support 32bit yet
                 return;
             
             var config = ManualConfig.CreateEmpty()

--- a/tests/BenchmarkDotNet.IntegrationTests/CoreRtTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/CoreRtTests.cs
@@ -17,6 +17,9 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void CoreRtIsSupported()
         {
+            if (IntPtr.Size == sizeof(int)) // CoreRT does not support 32bit yet
+                return;
+            
             var config = ManualConfig.CreateEmpty()
                 .With(Job.Dry
                     .With(Runtime.CoreRT)

--- a/tests/BenchmarkDotNet.IntegrationTests/CustomEngineTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/CustomEngineTests.cs
@@ -54,12 +54,18 @@ namespace BenchmarkDotNet.IntegrationTests
 
         public class CustomFactory : IEngineFactory
         {
-            public IEngine CreateReadyToRun(EngineParameters engineParameters) 
-                => new CustomEngine
+            public IEngine CreateReadyToRun(EngineParameters engineParameters)
+            {
+                var engine = new CustomEngine
                 {
                     GlobalCleanupAction = engineParameters.GlobalCleanupAction,
                     GlobalSetupAction = engineParameters.GlobalSetupAction
                 };
+                
+                engine.GlobalSetupAction?.Invoke(); // engine factory is now supposed to create an engine which is ready to run (hence the method name change) 
+
+                return engine;
+            }
         }
 
         public class CustomEngine : IEngine

--- a/tests/BenchmarkDotNet.IntegrationTests/CustomEngineTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/CustomEngineTests.cs
@@ -54,7 +54,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
         public class CustomFactory : IEngineFactory
         {
-            public IEngine Create(EngineParameters engineParameters) 
+            public IEngine CreateReadyToRun(EngineParameters engineParameters) 
                 => new CustomEngine
                 {
                     GlobalCleanupAction = engineParameters.GlobalCleanupAction,
@@ -75,6 +75,8 @@ namespace BenchmarkDotNet.IntegrationTests
                     default);
             }
 
+            public void Dispose() => GlobalCleanupAction?.Invoke();
+            
             public IHost Host { get; }
             public void WriteLine() { }
             public void WriteLine(string line) { }
@@ -87,7 +89,6 @@ namespace BenchmarkDotNet.IntegrationTests
             public IResolver Resolver { get; }
 
             public Measurement RunIteration(IterationData data) { throw new NotImplementedException(); }
-            public void Jitting() { }
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/Engine/EngineFactoryTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Engine/EngineFactoryTests.cs
@@ -146,7 +146,7 @@ namespace BenchmarkDotNet.Tests.Engine
         public void DontRunThePilotIfThePilotRequirementIsMetDuringWarmup()
         {
             var unrollFactor = Job.Default.ResolveValue(RunMode.UnrollFactorCharacteristic, DefaultResolver);
-            var mediumTime =  TimeSpan.FromMilliseconds(IterationTime.TotalMilliseconds / unrollFactor);
+            var mediumTime =  TimeSpan.FromMilliseconds((IterationTime.TotalMilliseconds / unrollFactor) * 2);
             
             void MediumSingle(long _)
             {

--- a/tests/BenchmarkDotNet.Tests/Engine/EngineFactoryTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Engine/EngineFactoryTests.cs
@@ -39,10 +39,10 @@ namespace BenchmarkDotNet.Tests.Engine
             var engine = new EngineFactory().CreateReadyToRun(engineParameters);
 
             Assert.Equal(1, timesGlobalSetupCalled);
-            Assert.Equal(1, timesIterationSetupCalled);
+            Assert.Equal(1 + 1, timesIterationSetupCalled); // 1x for Idle, 1x for Target
             Assert.Equal(1, timesBenchmarkCalled);
             Assert.Equal(1, timesIdleCalled);
-            Assert.Equal(1, timesIterationCleanupCalled);
+            Assert.Equal(1 + 1, timesIterationCleanupCalled); // 1x for Idle, 1x for Target
             Assert.Equal(0, timesGlobalCleanupCalled); // cleanup is called as part of dispode
 
             Assert.Equal(1, engine.TargetJob.Run.InvocationCount); // call the benchmark once per iteration
@@ -80,10 +80,10 @@ namespace BenchmarkDotNet.Tests.Engine
             var engine = new EngineFactory().CreateReadyToRun(engineParameters);
 
             Assert.Equal(1, timesGlobalSetupCalled);
-            Assert.Equal(2, timesIterationSetupCalled); // once for single and & once for 16
+            Assert.Equal((1+1) * (1+1), timesIterationSetupCalled); // (once for single and & once for 16) x (1x for Idle + 1x for Target)
             Assert.Equal(1 + 16, timesBenchmarkCalled);
             Assert.Equal(1 + 16, timesIdleCalled);
-            Assert.Equal(2, timesIterationCleanupCalled); // once for single and & once for 16
+            Assert.Equal((1+1) * (1+1), timesIterationCleanupCalled); // (once for single and & once for 16) x (1x for Idle + 1x for Target)
             Assert.Equal(0, timesGlobalCleanupCalled);
 
             Assert.False(engine.TargetJob.Run.HasValue(RunMode.InvocationCountCharacteristic));

--- a/tests/BenchmarkDotNet.Tests/Engine/EngineFactoryTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Engine/EngineFactoryTests.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.Engine
+{
+    public class EngineFactoryTests
+    {
+        int timesBenchmarkCalled = 0, timesGlobalSetupCalled = 0, timesGlobalCleanupCalled = 0, timesIterationSetupCalled = 0, timesIterationCleanupCalled = 0;
+
+        void GlobalSetup() => timesGlobalSetupCalled++;
+        void IterationSetup() => timesIterationSetupCalled++;
+        void IterationCleanup() => timesIterationCleanupCalled++;
+        void GlobalCleanup() => timesGlobalCleanupCalled++;
+        
+        void Throwing(long _) => throw new InvalidOperationException("must NOT be called");
+        
+        void VeryTimeConsumingSingle(long _)
+        {
+            timesBenchmarkCalled++;
+            Thread.Sleep(TimeSpan.FromMilliseconds(EngineResolver.Instance.Resolve(Job.Default, RunMode.IterationTimeCharacteristic).ToMilliseconds()));
+        }
+        
+        void InstantSingle(long _) => timesBenchmarkCalled++;
+
+        void Instant16(long _) => timesBenchmarkCalled += 16;
+
+        [Fact]
+        public void VeryTimeConsumingBenchmarksAreExecutedOncePerIterationForDefaultSettings()
+        {
+            var engineParameters = CreateEngineParameters(singleAction: VeryTimeConsumingSingle, multiAction: Throwing, job: Job.Default);
+
+            var engine = new EngineFactory().CreateReadyToRun(engineParameters);
+
+            Assert.Equal(1, timesGlobalSetupCalled);
+            Assert.Equal(1, timesIterationSetupCalled);
+            Assert.Equal(1, timesBenchmarkCalled);
+            Assert.Equal(1, timesIterationCleanupCalled);
+            Assert.Equal(0, timesGlobalCleanupCalled); // cleanup is called as part of dispode
+
+            Assert.Equal(1, engine.TargetJob.Run.InvocationCount); // call the benchmark once per iteration
+            Assert.Equal(1, engine.TargetJob.Run.UnrollFactor); // no unroll factor
+
+            engine.Dispose(); // cleanup is called as part of dispode
+
+            Assert.Equal(1, timesGlobalCleanupCalled);
+        }
+        
+        [Fact]
+        public void ForJobsThatDontRequireJittingOnlyGlobalSetupIsCalled()
+        {
+            var engineParameters = CreateEngineParameters(singleAction: Throwing, multiAction: Throwing, job: Job.Dry);
+
+            var engine = new EngineFactory().CreateReadyToRun(engineParameters);
+
+            Assert.Equal(1, timesGlobalSetupCalled);
+            Assert.Equal(0, timesIterationSetupCalled);
+            Assert.Equal(0, timesBenchmarkCalled);
+            Assert.Equal(0, timesIterationCleanupCalled);
+            Assert.Equal(0, timesGlobalCleanupCalled); 
+
+            engine.Dispose();
+
+            Assert.Equal(1, timesGlobalCleanupCalled);
+        }
+        
+        [Fact]
+        public void NonVeryTimeConsumingBenchmarksAreExecutedMoreThanOncePerIterationWithUnrollFactorForDefaultSettings()
+        {
+            var engineParameters = CreateEngineParameters(singleAction: InstantSingle, multiAction: Instant16, job: Job.Default);
+
+            var engine = new EngineFactory().CreateReadyToRun(engineParameters);
+
+            Assert.Equal(1, timesGlobalSetupCalled);
+            Assert.Equal(2, timesIterationSetupCalled); // once for single and & once for 16
+            Assert.Equal(1 + 16, timesBenchmarkCalled);
+            Assert.Equal(2, timesIterationCleanupCalled); // once for single and & once for 16
+            Assert.Equal(0, timesGlobalCleanupCalled);
+
+            Assert.False(engine.TargetJob.Run.HasValue(RunMode.InvocationCountCharacteristic));
+
+            engine.Dispose();
+
+            Assert.Equal(1, timesGlobalCleanupCalled);
+        }
+
+        private EngineParameters CreateEngineParameters(Action<long> singleAction, Action<long> multiAction, Job job)
+            => new EngineParameters
+            {
+                Dummy1Action = () => { },
+                Dummy2Action = () => { },
+                Dummy3Action = () => { },
+                GlobalSetupAction = GlobalSetup,
+                GlobalCleanupAction = GlobalCleanup,
+                Host = new ConsoleHost(TextWriter.Null, TextReader.Null),
+                IdleMultiAction = _ => { },
+                IdleSingleAction = _ => { },
+                IterationCleanupAction = IterationCleanup,
+                IterationSetupAction = IterationSetup,
+                MainMultiAction = multiAction,
+                MainSingleAction = singleAction,
+                Resolver = EngineResolver.Instance,
+                TargetJob = job
+            };
+    }
+}

--- a/tests/BenchmarkDotNet.Tests/Engine/EngineFactoryTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Engine/EngineFactoryTests.cs
@@ -80,7 +80,7 @@ namespace BenchmarkDotNet.Tests.Engine
         public void ForJobsThatDontRequirePilotTheGlobalSetupIsCalledAndMultiActionCodeGetsJitted() 
             => AssertGlobalSetupWasCalledAndMultiActionGotJitted(Job.Default.WithInvocationCount(100));
 
-        public void AssertGlobalSetupWasCalledAndMultiActionGotJitted(Job job)
+        private void AssertGlobalSetupWasCalledAndMultiActionGotJitted(Job job)
         {
             var engineParameters = CreateEngineParameters(mainSingleAction: Throwing, mainMultiAction: Instant16, job: job);
 

--- a/tests/BenchmarkDotNet.Tests/Mocks/MockEngine.cs
+++ b/tests/BenchmarkDotNet.Tests/Mocks/MockEngine.cs
@@ -22,6 +22,8 @@ namespace BenchmarkDotNet.Tests.Mocks
             this.measure = measure;
             TargetJob = job;
         }
+        
+        public void Dispose() => GlobalSetupAction?.Invoke();
 
         [UsedImplicitly]
         public IHost Host { get; }
@@ -51,8 +53,6 @@ namespace BenchmarkDotNet.Tests.Mocks
             WriteLine(measurement.ToOutputLine());
             return measurement;
         }
-
-        public void Jitting() { }
 
         public RunResults Run() => default;
 


### PR DESCRIPTION
Background: because of the default unroll factor = 16, every iteration was invoking benchmark at least 16 times. 

So if the benchmark took 1s, then:

1. jitting took 16x1s
2. warmup took 6 (MinIterationCount for EngineWarmupStage)  x 16 x 1s = 96 s
3. every target iteration was taking 16s

**Note:** In the default mode, this was described in our docs and was possible to change with custom config. We just did not have the time to fix it.


This PR introduces following changes:

1. EngineFactory is supposed to create an engine which is "ready to run", which means it's supposed to call `GlobalSetup`. (hence the method name change `Create` => `CreateReadyToRun`)
2. Engine implements `IDisposable`, which calls `GlobalCleanup`
3. When the strategy requires us to jit the code first (default mode) and to run the pilot (no explicit value for invocationCount), the engine factory does jitting and **also checks how long does it take to run the benchmark once** (unrol factor=invocation count=1).
 a. If it took longer than IterationTime (0.5s by default), the engine is created for job with one invocation per iteration
 b. otherwise, old rules applies
4. Strategies which don't require jitting don't follow this path (by design)
5. I had to duplicate both the C# and IL we generate to have possibility to choose the mode and keep the Engine immutable. It does not look as bad as  I expected it to look ;)
6. Because the changes applies mostly to `EngineFactory`, I was able to write some nice unit tests (not integration tests)

```cs
public class Sleeep
{
    [Benchmark] public void Sleep1s() => Thread.Sleep(TimeSpan.FromSeconds(1));
}
```

Before: Total time: 00:06:16 (376.01 sec)
After:   Total time: 00:00:27 (27.88 sec)

This fixes #736, makes #730 easy and contributes to #550.

@AndreyAkinshin please take a look ;)
@krzysztofcwalina this fixes the issue you have faced in ML.NET