### PR TITLE
if IterationSetup is provided, and InvocationCount and UnrollFactor are not, run benchmark once per iteration to avoid user confusion

### DIFF
--- a/src/BenchmarkDotNet/Running/Benchmark.cs
+++ b/src/BenchmarkDotNet/Running/Benchmark.cs
@@ -16,7 +16,7 @@ namespace BenchmarkDotNet.Running
 
         public override string ToString() => DisplayInfo;
 
-        public Benchmark(Target target, Job job, ParameterInstances parameters)
+        private Benchmark(Target target, Job job, ParameterInstances parameters)
         {
             Target = target;
             Job = job;
@@ -28,5 +28,8 @@ namespace BenchmarkDotNet.Running
         public bool IsBaseline() => Target.Baseline || Job.Meta.IsBaseline;
 
         public bool HasArguments => Parameters != null && Parameters.Items.Any(parameter => parameter.IsArgument);
+
+        public static Benchmark Create(Target target, Job job, ParameterInstances parameters)
+            => new Benchmark(target, job.MakeSettingsUserFriendly(target), parameters);
     }
 }

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -66,7 +66,7 @@ namespace BenchmarkDotNet.Running
                     from job in jobs
                     from parameterInstance in parameterInstancesList
                     from argumentDefinition in argumentsDefinitions
-                    select new Benchmark(target, job, new ParameterInstances(parameterInstance.Items.Concat(argumentDefinition.Items).ToArray()))
+                    select Benchmark.Create(target, job, new ParameterInstances(parameterInstance.Items.Concat(argumentDefinition.Items).ToArray()))
                 );
             }
 

--- a/src/BenchmarkDotNet/Running/ClassicBenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/ClassicBenchmarkConverter.cs
@@ -78,7 +78,7 @@ namespace BenchmarkDotNet.Running
                 var benchmarks = runInfo.Benchmarks.Select(b =>
                 {
                     var target = b.Target;
-                    return new Benchmark(
+                    return Benchmark.Create(
                         new Target(target.Type, target.Method, target.GlobalSetupMethod, target.GlobalCleanupMethod,
                             target.IterationSetupMethod, target.IterationCleanupMethod,
                             target.MethodDisplayInfo, benchmarkContent, target.Baseline, target.Categories, target.OperationsPerInvoke),

--- a/tests/BenchmarkDotNet.Tests/CodeGeneratorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/CodeGeneratorTests.cs
@@ -22,7 +22,7 @@ namespace BenchmarkDotNet.Tests
                     .Single(method => method.Name == "AsyncVoidMethod");
 
             var target = new Target(typeof(CodeGeneratorTests), asyncVoidMethod);
-            var benchmark = new Benchmark(target, Job.Default, null);
+            var benchmark = Benchmark.Create(target, Job.Default, null);
 
             Assert.Throws<NotSupportedException>(() => CodeGenerator.Generate(new BuildPartition(new[] { new BenchmarkBuildInfo(benchmark, ManualConfig.CreateEmpty().AsReadOnly(), 0) }, BenchmarkRunner.DefaultResolver)));
         }

--- a/tests/BenchmarkDotNet.Tests/Running/BenchmarkConverterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Running/BenchmarkConverterTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using Xunit;
 
@@ -69,6 +71,43 @@ namespace BenchmarkDotNet.Tests.Running
             public override void Cleanup()
             {
             }
+        }
+
+        [Fact]
+        public void IfIterationSetupIsProvidedTheBenchmarkShouldRunOncePerIteration()
+        {
+            var benchmark = BenchmarkConverter.TypeToBenchmarks(typeof(Derived)).Benchmarks.Single();
+            
+            Assert.Equal(1, benchmark.Job.Run.InvocationCount);
+            Assert.Equal(1, benchmark.Job.Run.UnrollFactor);
+        }
+        
+        [Fact]
+        public void InvocationCountIsRespectedForBenchmarksWithIterationSetup()
+        {
+            const int InvocationCount = 100;
+            
+            var benchmark = BenchmarkConverter.TypeToBenchmarks(typeof(Derived), 
+                DefaultConfig.Instance.With(Job.Default
+                    .WithInvocationCount(InvocationCount)))
+                .Benchmarks.Single();
+            
+            Assert.Equal(InvocationCount, benchmark.Job.Run.InvocationCount);
+            Assert.NotNull(benchmark.Target.IterationSetupMethod);
+        }
+        
+        [Fact]
+        public void UnrollFactorIsRespectedForBenchmarksWithIterationSetup()
+        {
+            const int UnrollFactor = 13;
+            
+            var benchmark = BenchmarkConverter.TypeToBenchmarks(typeof(Derived), 
+                    DefaultConfig.Instance.With(Job.Default
+                        .WithUnrollFactor(UnrollFactor)))
+                .Benchmarks.Single();
+            
+            Assert.Equal(UnrollFactor, benchmark.Job.Run.UnrollFactor);
+            Assert.NotNull(benchmark.Target.IterationSetupMethod);
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/Validators/CompilationValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/CompilationValidatorTests.cs
@@ -20,7 +20,7 @@ namespace BenchmarkDotNet.Tests.Validators
             var parameters = new ValidationParameters(
                 new[]
                 {
-                    new Benchmark(
+                    Benchmark.Create(
                         new Target(
                             typeof(CompilationValidatorTests),
                             method.Method),


### PR DESCRIPTION
fixes #730

Example:

```cs
public class FileSample
{
    private readonly string filePath = Path.GetTempFileName();

    [IterationSetup]
    public void Create()
    {
        using (File.Create(filePath)) { }
    }

    [Benchmark]
    public void Remove() => File.Delete(filePath);
}
```

/cc @stephentoub @nietras 