### PR TITLE
have two main actions: with unroll and without, for no unroll icrease the step by 1 in pilot (not *2)

### DIFF
--- a/src/BenchmarkDotNet/Engines/EngineFactory.cs
+++ b/src/BenchmarkDotNet/Engines/EngineFactory.cs
@@ -10,20 +10,20 @@ namespace BenchmarkDotNet.Engines
     {
         public IEngine CreateReadyToRun(EngineParameters engineParameters)
         {
-            if (engineParameters.MainSingleAction == null)
-                throw new ArgumentNullException(nameof(engineParameters.MainSingleAction));
-            if (engineParameters.MainMultiAction == null)
-                throw new ArgumentNullException(nameof(engineParameters.MainMultiAction));
+            if (engineParameters.MainActionNoUnroll == null)
+                throw new ArgumentNullException(nameof(engineParameters.MainActionNoUnroll));
+            if (engineParameters.MainActionUnroll == null)
+                throw new ArgumentNullException(nameof(engineParameters.MainActionUnroll));
             if (engineParameters.Dummy1Action == null)
                 throw new ArgumentNullException(nameof(engineParameters.Dummy1Action));
             if (engineParameters.Dummy2Action == null)
                 throw new ArgumentNullException(nameof(engineParameters.Dummy2Action));
             if (engineParameters.Dummy3Action == null)
                 throw new ArgumentNullException(nameof(engineParameters.Dummy3Action));
-            if (engineParameters.IdleSingleAction == null)
-                throw new ArgumentNullException(nameof(engineParameters.IdleSingleAction));
-            if (engineParameters.IdleMultiAction == null)
-                throw new ArgumentNullException(nameof(engineParameters.IdleMultiAction));
+            if (engineParameters.IdleActionNoUnroll == null)
+                throw new ArgumentNullException(nameof(engineParameters.IdleActionNoUnroll));
+            if (engineParameters.IdleActionUnroll == null)
+                throw new ArgumentNullException(nameof(engineParameters.IdleActionUnroll));
             if(engineParameters.TargetJob == null)
                 throw new ArgumentNullException(nameof(engineParameters.TargetJob));
 
@@ -44,20 +44,32 @@ namespace BenchmarkDotNet.Engines
             }
             
             var singleActionEngine = CreateSingleActionEngine(engineParameters);
-            if (Jit(singleActionEngine, ++jitIndex, invokeCount: 1, unrollFactor: 1) > engineParameters.IterationTime)
+            var singleInvocationTime = Jit(singleActionEngine, ++jitIndex, invokeCount: 1, unrollFactor: 1);
+            
+            if (singleInvocationTime > engineParameters.IterationTime)
                 return singleActionEngine; // executing once takes longer than iteration time => long running benchmark, needs no pilot and no overhead
 
-            var multiActionEngine = CreateMultiActionEngine(engineParameters);
             int defaultUnrollFactor = Job.Default.ResolveValue(RunMode.UnrollFactorCharacteristic, EngineParameters.DefaultResolver);
 
-            if (Jit(multiActionEngine, ++jitIndex, invokeCount: defaultUnrollFactor, unrollFactor: defaultUnrollFactor) > engineParameters.IterationTime) 
-            {   // executing defaultUnrollFactor times takes longer than iteration time => medium running benchmark, needs no pilot and no overhead
-                var defaultUnrollFactorTimesPerIterationNoPilotNoOverhead = CreateJobWhichDoesNotNeedPilotAndOverheadEvaluation(engineParameters.TargetJob, 
-                    invocationCount: defaultUnrollFactor, unrollFactor: defaultUnrollFactor); // run the benchmark exactly once per iteration
+            double timesPerIteration = engineParameters.IterationTime / singleInvocationTime; // how many times can we run given benchmark per iteration
+
+            if (timesPerIteration < 1.5) // example: IterationTime is 0.5s, but single invocation takes 0.4s => we don't want to run it twice per iteration
+                return singleActionEngine;
+
+            int roundedUpTimesPerIteration = (int)Math.Ceiling(timesPerIteration);
+            
+            if (roundedUpTimesPerIteration < defaultUnrollFactor) // if we run it defaultUnrollFactor times per iteration, it's going to take longer than IterationTime
+            {
+                var fewTimesPerIterationButNotMoreThanUnrollFactor = CreateJobWhichDoesNotNeedPilotAndOverheadEvaluation(engineParameters.TargetJob, 
+                    invocationCount: roundedUpTimesPerIteration, unrollFactor: 1); // run the benchmark exactly that many times to fit in iteration time
                 
-                return CreateEngine(engineParameters, defaultUnrollFactorTimesPerIterationNoPilotNoOverhead, engineParameters.IdleMultiAction, engineParameters.MainMultiAction);
+                return CreateEngine(engineParameters, fewTimesPerIterationButNotMoreThanUnrollFactor, engineParameters.IdleActionNoUnroll, engineParameters.MainActionNoUnroll);
             }
             
+            var multiActionEngine = CreateMultiActionEngine(engineParameters);
+
+            DeadCodeEliminationHelper.KeepAliveWithoutBoxing(Jit(multiActionEngine, ++jitIndex, invokeCount: defaultUnrollFactor, unrollFactor: defaultUnrollFactor));
+
             return multiActionEngine;
         }
 
@@ -80,13 +92,13 @@ namespace BenchmarkDotNet.Engines
         }
 
         private static Engine CreateMultiActionEngine(EngineParameters engineParameters) 
-            => CreateEngine(engineParameters, engineParameters.TargetJob, engineParameters.IdleMultiAction, engineParameters.MainMultiAction);
+            => CreateEngine(engineParameters, engineParameters.TargetJob, engineParameters.IdleActionUnroll, engineParameters.MainActionUnroll);
 
         private static Engine CreateSingleActionEngine(EngineParameters engineParameters) 
             => CreateEngine(engineParameters,
                 CreateJobWhichDoesNotNeedPilotAndOverheadEvaluation(engineParameters.TargetJob, invocationCount: 1, unrollFactor: 1), // run the benchmark exactly once per iteration
-                engineParameters.IdleSingleAction, 
-                engineParameters.MainSingleAction);
+                engineParameters.IdleActionNoUnroll, 
+                engineParameters.MainActionNoUnroll);
         
         private static Job CreateJobWhichDoesNotNeedPilotAndOverheadEvaluation(Job sourceJob, int invocationCount, int unrollFactor)
             => sourceJob

--- a/src/BenchmarkDotNet/Engines/EngineParameters.cs
+++ b/src/BenchmarkDotNet/Engines/EngineParameters.cs
@@ -11,13 +11,13 @@ namespace BenchmarkDotNet.Engines
         public static readonly IResolver DefaultResolver = new CompositeResolver(BenchmarkRunner.DefaultResolver, EngineResolver.Instance);
         
         public IHost Host { get; set; }
-        public Action<long> MainSingleAction { get; set; }
-        public Action<long> MainMultiAction { get; set; }
+        public Action<long> MainActionNoUnroll { get; set; }
+        public Action<long> MainActionUnroll { get; set; }
         public Action Dummy1Action { get; set; }
         public Action Dummy2Action { get; set; }
         public Action Dummy3Action { get; set; }
-        public Action<long> IdleSingleAction { get; set; }
-        public Action<long> IdleMultiAction { get; set; }
+        public Action<long> IdleActionNoUnroll { get; set; }
+        public Action<long> IdleActionUnroll { get; set; }
         public Job TargetJob { get; set; } = Job.Default;
         public long OperationsPerInvoke { get; set; } = 1;
         public Action GlobalSetupAction { get; set; }

--- a/src/BenchmarkDotNet/Engines/EnginePilotStage.cs
+++ b/src/BenchmarkDotNet/Engines/EnginePilotStage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Horology;
 using BenchmarkDotNet.Jobs;
 
@@ -67,7 +68,10 @@ namespace BenchmarkDotNet.Engines
                 if (invokeCount >= MaxInvokeCount)
                     break;
 
-                invokeCount *= 2;
+                if (unrollFactor == 1 && invokeCount < EnvResolver.DefaultUnrollFactorForThroughput)
+                    invokeCount += 1;
+                else
+                    invokeCount *= 2;
             }
             WriteLine();
 

--- a/src/BenchmarkDotNet/Environments/EnvResolver.cs
+++ b/src/BenchmarkDotNet/Environments/EnvResolver.cs
@@ -8,6 +8,8 @@ namespace BenchmarkDotNet.Environments
 {
     public class EnvResolver : Resolver
     {
+        public const int DefaultUnrollFactorForThroughput = 16;
+
         public static readonly IResolver Instance = new CompositeResolver(new EnvResolver(), GcResolver.Instance);
 
         private EnvResolver()
@@ -26,7 +28,7 @@ namespace BenchmarkDotNet.Environments
                 switch (strategy)
                 {
                     case RunStrategy.Throughput:
-                        return 16;
+                        return DefaultUnrollFactorForThroughput;
                     case RunStrategy.ColdStart:
                     case RunStrategy.Monitoring:
                         return 1;

--- a/src/BenchmarkDotNet/Templates/BenchmarkType.txt
+++ b/src/BenchmarkDotNet/Templates/BenchmarkType.txt
@@ -24,13 +24,13 @@
             var engineParameters = new BenchmarkDotNet.Engines.EngineParameters()
             {
                 Host = host,
-                MainMultiAction = instance.MainMultiAction,
-                MainSingleAction = instance.MainSingleAction,
+                MainActionUnroll = instance.MainActionUnroll,
+                MainActionNoUnroll = instance.MainActionNoUnroll,
                 Dummy1Action = instance.Dummy1,
                 Dummy2Action = instance.Dummy2,
                 Dummy3Action = instance.Dummy3,
-                IdleSingleAction = instance.IdleSingleAction,
-                IdleMultiAction = instance.IdleMultiAction,
+                IdleActionNoUnroll = instance.IdleActionNoUnroll,
+                IdleActionUnroll = instance.IdleActionUnroll,
                 GlobalSetupAction = instance.globalSetupAction,
                 GlobalCleanupAction = instance.globalCleanupAction,
                 IterationSetupAction = instance.iterationSetupAction,
@@ -112,7 +112,7 @@
 
         private Consumer consumer = new Consumer();
 
-        private void IdleMultiAction(long invokeCount)
+        private void IdleActionUnroll(long invokeCount)
         {
             $LoadArguments$
             for (long i = 0; i < invokeCount; i++)
@@ -121,13 +121,16 @@
             }
         }
 
-        private void IdleSingleAction(long _)
+        private void IdleActionNoUnroll(long invokeCount)
         {
             $LoadArguments$
-            consumer.Consume(idleDelegate($PassArguments$));
+            for (long i = 0; i < invokeCount; i++)
+            {
+                consumer.Consume(idleDelegate($PassArguments$));
+            }
         }
         
-        private void MainMultiAction(long invokeCount)
+        private void MainActionUnroll(long invokeCount)
         {
             $LoadArguments$
             for (long i = 0; i < invokeCount; i++)
@@ -136,10 +139,13 @@
             }
         }
 
-        private void MainSingleAction(long _)
+        private void MainActionNoUnroll(long invokeCount)
         {
             $LoadArguments$
-            consumer.Consume(targetDelegate($PassArguments$)$ConsumeField$);
+            for (long i = 0; i < invokeCount; i++)
+            {
+                consumer.Consume(targetDelegate($PassArguments$)$ConsumeField$);
+            }
         }
         
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
@@ -156,7 +162,7 @@
 
 #elif RETURNS_NON_CONSUMABLE_STRUCT_$ID$
 
-        private void IdleMultiAction(long invokeCount)
+        private void IdleActionUnroll(long invokeCount)
         {
             $LoadArguments$
             $IdleMethodReturnTypeName$ result = default($IdleMethodReturnTypeName$);
@@ -167,15 +173,18 @@
             DeadCodeEliminationHelper.KeepAliveWithoutBoxing(result);
         }
 
-        private void IdleSingleAction(long _)
+        private void IdleActionNoUnroll(long invokeCount)
         {
             $LoadArguments$
             $IdleMethodReturnTypeName$ result = default($IdleMethodReturnTypeName$);
-            result = idleDelegate($PassArguments$);
+            for (long i = 0; i < invokeCount; i++)
+            {
+                result = idleDelegate($PassArguments$);
+            }
             DeadCodeEliminationHelper.KeepAliveWithoutBoxing(result);
         }
 
-        private void MainMultiAction(long invokeCount)
+        private void MainActionUnroll(long invokeCount)
         {
             $LoadArguments$
             $TargetMethodReturnType$ result = default($TargetMethodReturnType$);
@@ -186,11 +195,14 @@
             NonGenericKeepAliveWithoutBoxing(result);
         }
 
-        private void MainSingleAction(long _)
+        private void MainActionNoUnroll(long invokeCount)
         {
             $LoadArguments$
             $TargetMethodReturnType$ result = default($TargetMethodReturnType$);
-            result = targetDelegate($PassArguments$);
+            for (long i = 0; i < invokeCount; i++)
+            {
+                result = targetDelegate($PassArguments$);
+            }
             NonGenericKeepAliveWithoutBoxing(result);
         }
 
@@ -213,7 +225,7 @@
 
 #elif RETURNS_BYREF_$ID$
 
-        private void IdleMultiAction(long invokeCount)
+        private void IdleActionUnroll(long invokeCount)
         {
             $LoadArguments$
             $IdleMethodReturnTypeName$ value = default($IdleMethodReturnTypeName$);
@@ -224,17 +236,20 @@
             DeadCodeEliminationHelper.KeepAliveWithoutBoxing(value);
         }
         
-        private void IdleSingleAction(long _)
+        private void IdleActionNoUnroll(long invokeCount)
         {
             $LoadArguments$
             $IdleMethodReturnTypeName$ value = default($IdleMethodReturnTypeName$);
-            value = idleDelegate($PassArguments$);
+            for (long i = 0; i < invokeCount; i++)
+            {
+                value = idleDelegate($PassArguments$);
+            }
             DeadCodeEliminationHelper.KeepAliveWithoutBoxing(value);
         }
 
         private $TargetMethodReturnType$ mainDefaultValueHolder = default($TargetMethodReturnType$);
 
-        private void MainMultiAction(long invokeCount)
+        private void MainActionUnroll(long invokeCount)
         {
             $LoadArguments$
             ref $TargetMethodReturnType$ alias = ref mainDefaultValueHolder;
@@ -245,11 +260,14 @@
             DeadCodeEliminationHelper.KeepAliveWithoutBoxing(ref alias);
         }
         
-        private void MainSingleAction(long _)
+        private void MainActionNoUnroll(long invokeCount)
         {
             $LoadArguments$
             ref $TargetMethodReturnType$ alias = ref mainDefaultValueHolder;
-            alias = targetDelegate($PassArguments$);
+            for (long i = 0; i < invokeCount; i++)
+            {
+                alias = targetDelegate($PassArguments$);
+            }
             DeadCodeEliminationHelper.KeepAliveWithoutBoxing(ref alias);
         }
 
@@ -266,7 +284,7 @@
         }
 #elif RETURNS_VOID_$ID$
 
-        private void IdleMultiAction(long invokeCount)
+        private void IdleActionUnroll(long invokeCount)
         {
             $LoadArguments$
             for (long i = 0; i < invokeCount; i++)
@@ -275,13 +293,16 @@
             }
         }
 
-        private void IdleSingleAction(long _)
+        private void IdleActionNoUnroll(long invokeCount)
         {
             $LoadArguments$
-            idleDelegate($PassArguments$);
+            for (long i = 0; i < invokeCount; i++)
+            {
+                idleDelegate($PassArguments$);
+            }
         }
         
-        private void MainMultiAction(long invokeCount)
+        private void MainActionUnroll(long invokeCount)
         {
             $LoadArguments$
             for (long i = 0; i < invokeCount; i++)
@@ -290,10 +311,13 @@
             }
         }
         
-        private void MainSingleAction(long _)
+        private void MainActionNoUnroll(long invokeCount)
         {
             $LoadArguments$
-            targetDelegate($PassArguments$);
+            for (long i = 0; i < invokeCount; i++)
+            {
+                targetDelegate($PassArguments$);
+            }
         }
 
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]

--- a/src/BenchmarkDotNet/Toolchains/InProcess/InProcessRunner.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/InProcessRunner.cs
@@ -125,13 +125,21 @@ namespace BenchmarkDotNet.Toolchains.InProcess
                 var engineParameters = new EngineParameters
                 {
                     Host = host,
-                    MainSingleAction = _ => mainAction.InvokeSingle(),
-                    MainMultiAction = mainAction.InvokeMultiple,
+                    MainActionNoUnroll = invocationCount =>
+                    {
+                        for (int i = 0; i < invocationCount; i++)
+                            mainAction.InvokeSingle();
+                    },
+                    MainActionUnroll = mainAction.InvokeMultiple,
                     Dummy1Action = dummy1.InvokeSingle,
                     Dummy2Action = dummy2.InvokeSingle,
                     Dummy3Action = dummy3.InvokeSingle,
-                    IdleSingleAction = _ => idleAction.InvokeSingle(),
-                    IdleMultiAction = idleAction.InvokeMultiple,
+                    IdleActionNoUnroll = invocationCount =>
+                    {
+                        for (int i = 0; i < invocationCount; i++)
+                            idleAction.InvokeSingle();
+                    },
+                    IdleActionUnroll = idleAction.InvokeMultiple,
                     GlobalSetupAction = globalSetupAction.InvokeSingle,
                     GlobalCleanupAction = globalCleanupAction.InvokeSingle,
                     IterationSetupAction = iterationSetupAction.InvokeSingle,

--- a/tests/BenchmarkDotNet.Tests/Engine/EngineFactoryTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Engine/EngineFactoryTests.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Threading;
 using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Engines;
-using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using Xunit;
@@ -143,7 +142,7 @@ namespace BenchmarkDotNet.Tests.Engine
         }
 
         [Fact]
-        public void RespectIterationTimeForBenchmarksWhichShouldBeInvokedLessThanDefaultUnrollFactorTimesPerIteration()
+        public void MediumTimeConsumingBenchmarksShouldStartPilotFrom2AndIcrementItWithEveryStep()
         {
             var unrollFactor = Job.Default.ResolveValue(RunMode.UnrollFactorCharacteristic, DefaultResolver);
 
@@ -180,8 +179,9 @@ namespace BenchmarkDotNet.Tests.Engine
             Assert.Equal(1, timesIterationCleanupCalled);
             Assert.Equal(0, timesGlobalCleanupCalled);
             
-            Assert.Equal(times, engine.TargetJob.Run.InvocationCount); // no need to run pilot!
+            Assert.False(engine.TargetJob.Run.HasValue(RunMode.InvocationCountCharacteristic)); // we need to run the pilot!
             Assert.Equal(1, engine.TargetJob.Run.UnrollFactor);  // no unroll factor!
+            Assert.Equal(2, engine.TargetJob.Accuracy.MinInvokeCount);  // we start from two (we know that 1 is not enough, the default is 4 so we need to override it)
             
             Assert.True(engine.TargetJob.Run.HasValue(AccuracyMode.EvaluateOverheadCharacteristic)); // is set to false in explicit way
             Assert.False(engine.TargetJob.Accuracy.EvaluateOverhead); // don't evaluate overhead in that case

--- a/tests/BenchmarkDotNet.Tests/Engine/EngineFactoryTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Engine/EngineFactoryTests.cs
@@ -33,11 +33,11 @@ namespace BenchmarkDotNet.Tests.Engine
             Thread.Sleep(IterationTime);
         }
         
-        void InstantSingle(long _) => timesBenchmarkCalled++;
-        void Instant16(long _) => timesBenchmarkCalled += 16;
+        void InstantNoUnroll(long invocationCount) => timesBenchmarkCalled += (int)invocationCount;
+        void InstantUnroll(long _) => timesBenchmarkCalled += 16;
         
-        void IdleSingle(long _) => timesIdleCalled++;
-        void Idle16(long _) => timesIdleCalled += 16;
+        void IdleNoUnroll(long invocationCount) => timesIdleCalled += (int)invocationCount;
+        void IdleUnroll(long _) => timesIdleCalled += 16;
 
         public static IEnumerable<object[]> JobsWhichDontRequireJitting()
         {
@@ -50,7 +50,7 @@ namespace BenchmarkDotNet.Tests.Engine
         [MemberData(nameof(JobsWhichDontRequireJitting))]
         public void ForJobsThatDontRequireJittingOnlyGlobalSetupIsCalled(Job job)
         {
-            var engineParameters = CreateEngineParameters(mainSingleAction: Throwing, mainMultiAction: Throwing, job: job);
+            var engineParameters = CreateEngineParameters(mainNoUnroll: Throwing, mainUnroll: Throwing, job: job);
 
             var engine = new EngineFactory().CreateReadyToRun(engineParameters);
 
@@ -69,7 +69,7 @@ namespace BenchmarkDotNet.Tests.Engine
         [Fact]
         public void ForDefaultSettingsVeryTimeConsumingBenchmarksAreExecutedOncePerIterationWithoutOverheadDeduction()
         {
-            var engineParameters = CreateEngineParameters(mainSingleAction: VeryTimeConsumingSingle, mainMultiAction: Throwing, job: Job.Default);
+            var engineParameters = CreateEngineParameters(mainNoUnroll: VeryTimeConsumingSingle, mainUnroll: Throwing, job: Job.Default);
 
             var engine = new EngineFactory().CreateReadyToRun(engineParameters);
 
@@ -101,7 +101,7 @@ namespace BenchmarkDotNet.Tests.Engine
 
         private void AssertGlobalSetupWasCalledAndMultiActionGotJitted(Job job)
         {
-            var engineParameters = CreateEngineParameters(mainSingleAction: Throwing, mainMultiAction: Instant16, job: job);
+            var engineParameters = CreateEngineParameters(mainNoUnroll: Throwing, mainUnroll: InstantUnroll, job: job);
 
             var engine = new EngineFactory().CreateReadyToRun(engineParameters);
 
@@ -122,7 +122,7 @@ namespace BenchmarkDotNet.Tests.Engine
         [Fact]
         public void NonVeryTimeConsumingBenchmarksAreExecutedMoreThanOncePerIterationWithUnrollFactorForDefaultSettings()
         {
-            var engineParameters = CreateEngineParameters(mainSingleAction: InstantSingle, mainMultiAction: Instant16, job: Job.Default);
+            var engineParameters = CreateEngineParameters(mainNoUnroll: InstantNoUnroll, mainUnroll: InstantUnroll, job: Job.Default);
 
             var engine = new EngineFactory().CreateReadyToRun(engineParameters);
 
@@ -143,19 +143,25 @@ namespace BenchmarkDotNet.Tests.Engine
         }
 
         [Fact]
-        public void DontRunThePilotIfThePilotRequirementIsMetDuringWarmup()
+        public void RespectIterationTimeForBenchmarksWhichShouldBeInvokedLessThanDefaultUnrollFactorTimesPerIteration()
         {
             var unrollFactor = Job.Default.ResolveValue(RunMode.UnrollFactorCharacteristic, DefaultResolver);
-            var mediumTime =  TimeSpan.FromMilliseconds((IterationTime.TotalMilliseconds / unrollFactor) * 2);
-            
-            void MediumSingle(long _)
-            {
-                timesBenchmarkCalled++;
 
-                Thread.Sleep(mediumTime);
+            const int times = 5; // how many times we should invoke the benchmark per iteration
+            
+            var mediumTime = TimeSpan.FromMilliseconds(IterationTime.TotalMilliseconds / times);
+            
+            void MediumNoUnroll(long invocationCount)
+            {
+                for (int i = 0; i < invocationCount; i++)
+                {
+                    timesBenchmarkCalled++;
+
+                    Thread.Sleep(mediumTime);
+                }
             }
         
-            void MediumMultiple(long _)
+            void MediumUnroll(long _)
             {
                 timesBenchmarkCalled += unrollFactor;
             
@@ -163,19 +169,19 @@ namespace BenchmarkDotNet.Tests.Engine
                     Thread.Sleep(mediumTime);
             }
             
-            var engineParameters = CreateEngineParameters(mainSingleAction: MediumSingle, mainMultiAction: MediumMultiple, job: Job.Default);
+            var engineParameters = CreateEngineParameters(mainNoUnroll: MediumNoUnroll, mainUnroll: MediumUnroll, job: Job.Default);
             
             var engine = new EngineFactory().CreateReadyToRun(engineParameters);
 
             Assert.Equal(1, timesGlobalSetupCalled);
-            Assert.Equal(1+1, timesIterationSetupCalled);
-            Assert.Equal(1 + unrollFactor, timesBenchmarkCalled);
-            Assert.Equal(1 + unrollFactor, timesIdleCalled);
-            Assert.Equal(1+1, timesIterationCleanupCalled);
+            Assert.Equal(1, timesIterationSetupCalled);
+            Assert.Equal(1, timesBenchmarkCalled); // we run it just once and we know how many times it should be invoked
+            Assert.Equal(1, timesIdleCalled);
+            Assert.Equal(1, timesIterationCleanupCalled);
             Assert.Equal(0, timesGlobalCleanupCalled);
             
-            Assert.Equal(unrollFactor, engine.TargetJob.Run.InvocationCount); // no need to run pilot!
-            Assert.Equal(unrollFactor, engine.TargetJob.Run.UnrollFactor);  // remains the same!
+            Assert.Equal(times, engine.TargetJob.Run.InvocationCount); // no need to run pilot!
+            Assert.Equal(1, engine.TargetJob.Run.UnrollFactor);  // no unroll factor!
             
             Assert.True(engine.TargetJob.Run.HasValue(AccuracyMode.EvaluateOverheadCharacteristic)); // is set to false in explicit way
             Assert.False(engine.TargetJob.Accuracy.EvaluateOverhead); // don't evaluate overhead in that case
@@ -185,7 +191,7 @@ namespace BenchmarkDotNet.Tests.Engine
             Assert.Equal(1, timesGlobalCleanupCalled);
         }
 
-        private EngineParameters CreateEngineParameters(Action<long> mainSingleAction, Action<long> mainMultiAction, Job job)
+        private EngineParameters CreateEngineParameters(Action<long> mainNoUnroll, Action<long> mainUnroll, Job job)
             => new EngineParameters
             {
                 Dummy1Action = () => { },
@@ -194,12 +200,12 @@ namespace BenchmarkDotNet.Tests.Engine
                 GlobalSetupAction = GlobalSetup,
                 GlobalCleanupAction = GlobalCleanup,
                 Host = new ConsoleHost(TextWriter.Null, TextReader.Null),
-                IdleMultiAction = Idle16,
-                IdleSingleAction = IdleSingle,
+                IdleActionUnroll = IdleUnroll,
+                IdleActionNoUnroll = IdleNoUnroll,
                 IterationCleanupAction = IterationCleanup,
                 IterationSetupAction = IterationSetup,
-                MainMultiAction = mainMultiAction,
-                MainSingleAction = mainSingleAction,
+                MainActionUnroll = mainUnroll,
+                MainActionNoUnroll = mainNoUnroll,
                 TargetJob = job
             };
     }


### PR DESCRIPTION
I am currently working on porting CoreCLR to BenchmarkDotNet.
CoreCLR contains a lot of "benchmark game" benchmarks. These are long-running benchmarks.

After #760 the time it takes to run the benchmarks has greatly improved (ML.NET benchmarks from 20 to 2 minutes). However, I have found two extra scenarios for improvement:

 1. The time to execute benchmark is slighly less than IterationTime. Let's say it's 0.4s when the IterationTime is 0.5s. In that case we invoke it 16 times per iteration (default unroll factor value). It's too much, we should invoke it just once.
2. The time to execute benchmark is just **few** times less than IterationTime. Let's say it's 0.1s when the IterationTime is 0.5s. In that case we invoke it 16 times per iteration (default unroll factor value). It's too much, we should invoke it few times to fit within IterationTime .

My changes are quite simple:

1. If the time to execute benchmark is slighly less than IterationTime, run it once per iteration. No Pilot needed.
2. If the time to execute benchmark is just **few** times less than IterationTime, start the Pilot with MinInvokeCount = 2 (we know 1 is not enough), and increment it with every pilot iteration (not double, it's typically too much for these benchmarks).

Example:

```cs
[Benchmark]
public void Sleep100() => Thread.Sleep(100);
```

```log
IdleJitting  1: 1 op, 803135.91 ns, 803.1359 us/op
MainJitting  1: 1 op, 100786001.20 ns, 100.7860 ms/op

Pilot        1: 2 op, 200567013.38 ns, 100.2835 ms/op
Pilot        2: 3 op, 301861923.92 ns, 100.6206 ms/op
Pilot        3: 4 op, 401721624.60 ns, 100.4304 ms/op
Pilot        4: 5 op, 503124019.07 ns, 100.6248 ms/op

MainWarmup   1: 5 op, 503016250.03 ns, 100.6033 ms/op
```