### PR TITLE
docs: multiversion combobox

### DIFF
--- a/docs/template/styles/main.js
+++ b/docs/template/styles/main.js
@@ -1,0 +1,23 @@
+$(function () {
+    function updateVersions() {
+        if( $('#navbar-versions').length == 0)
+        {
+            $('#navbar ul').append('<li id="navbar-versions" class="dropdown">\n' +
+                '  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Version: master <span class="caret"></span></a>\n' +
+                '  <ul class="dropdown-menu">\n' +
+                '    <li><a href="/">master</a></li>\n' +
+                '    <li><a href="/v0.10.14/">v0.10.14</a></li>\n' +
+                '    <li><a href="/v0.10.13/">v0.10.13</a></li>\n' +
+                '    <li><a href="/v0.10.12/">v0.10.12</a></li>\n' +
+                '  </ul>\n' +
+                '</li>');
+        }
+    }
+    updateVersions();
+    $('#navbar').bind("DOMSubtreeModified", updateVersions);
+    $('#breadcrumb').bind("DOMSubtreeModified", function () {
+        if ($('#breadcrumb ul a').length > 0 && $('#breadcrumb ul a').html().startsWith("Version")) {
+            $('#breadcrumb').html('');
+        }
+    });
+});


### PR DESCRIPTION
Preview: https://andreyakinshin.github.io/bdn-docs-wip/
![image](https://user-images.githubusercontent.com/2259237/41365767-f4fbab4a-6f42-11e8-84f1-0ae986a6dc62.png)

Benefits:
* We can keep the old version of documentation on `https:/benchmarkdotnet.org/vNUMBER/`
* We can deploy documentation for the master branch on `https://benchmarkdotnet.org/`
* The implementation of this combobox is pretty simple and doesn't change the template.

Current problems:
* We still need a set of scripts for build & deploy, but it sounds solvable.