### PR TITLE
Constant Folding Analyzer

### DIFF
--- a/src/BenchmarkDotNet/Analysers/ConstantFoldingAnalyzer.cs
+++ b/src/BenchmarkDotNet/Analysers/ConstantFoldingAnalyzer.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Reports;
+
+namespace BenchmarkDotNet.Analysers
+{
+    public class ConstantFoldingAnalyzer: AnalyserBase
+    {
+        public override string Id => "ConstantFolding";
+        
+        public static readonly IAnalyser Default = new ConstantFoldingAnalyzer();
+
+        public override IEnumerable<Conclusion> AnalyseReport(BenchmarkReport report, Summary summary)
+        {
+            if (report.AllMeasurements.Any(x => x.IterationMode == IterationMode.Result && x.Nanoseconds == 0))
+                yield return CreateWarning($"It seems that in {report.Benchmark.Target.DisplayInfo} takes place constant folding, values were zeroed");
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -48,6 +48,7 @@ namespace BenchmarkDotNet.Configs
             yield return IterationSetupCleanupAnalyser.Default;
             yield return MultimodalDistributionAnalyzer.Default;
             yield return RuntimeErrorAnalyser.Default;
+            yield return ConstantFoldingAnalyzer.Default;
         }
 
         public IEnumerable<IValidator> GetValidators()

--- a/src/BenchmarkDotNet/Helpers/ConstantFoldingHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/ConstantFoldingHelper.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Reports;
+
+namespace BenchmarkDotNet.Helpers
+{
+    public static class ConstantFoldingHelper
+    {
+        private static readonly double threshold = 0.2d; //nanoseconds
+        
+        public static Measurement[] HandleConstantFolding(IEnumerable<Measurement> measurements)
+        {
+            var measurementList = measurements.ToArray();
+            
+            var maxIdle = measurementList.Where(x => x.IterationMode == IterationMode.IdleTarget).DefaultIfEmpty().Max();
+            var minTarget = measurementList.Where(x => x.IterationMode == IterationMode.MainTarget).DefaultIfEmpty().Min();
+            var meanNs = measurementList.Where(x => x.IterationMode == IterationMode.Result)
+                                        .Select(x => x.GetAverageNanoseconds())
+                                        .Average();
+
+            if (maxIdle.Nanoseconds > minTarget.Nanoseconds && meanNs <= threshold)
+                for (int i = 0; i < measurementList.Length; i++)
+                    if (measurementList[i].IterationMode == IterationMode.Result)
+                        measurementList[i] = new Measurement(measurementList[i]);
+
+            return measurementList;
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Helpers/ConstantFoldingHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/ConstantFoldingHelper.cs
@@ -17,6 +17,7 @@ namespace BenchmarkDotNet.Helpers
             var minTarget = measurementList.Where(x => x.IterationMode == IterationMode.MainTarget).DefaultIfEmpty().Min();
             var meanNs = measurementList.Where(x => x.IterationMode == IterationMode.Result)
                                         .Select(x => x.GetAverageNanoseconds())
+                                        .DefaultIfEmpty()
                                         .Average();
 
             if (maxIdle.Nanoseconds > minTarget.Nanoseconds && meanNs <= threshold)

--- a/src/BenchmarkDotNet/Reports/Measurement.cs
+++ b/src/BenchmarkDotNet/Reports/Measurement.cs
@@ -55,6 +55,20 @@ namespace BenchmarkDotNet.Reports
             IterationIndex = iterationIndex;
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="Measurement"/> based on specified measurement with zero time value.
+        /// </summary>
+        /// <param name="measurement"></param>
+        public Measurement(Measurement measurement)
+        {
+            Encoding = measurement.Encoding;
+            Operations = measurement.Operations;
+            Nanoseconds = 0d;
+            LaunchIndex = measurement.LaunchIndex;
+            IterationMode = measurement.IterationMode;
+            IterationIndex = measurement.IterationIndex;
+        }
+
         public string ToOutputLine()
         {
             string alignedIterationMode = IterationMode.ToString().PadRight(IterationModeNameMaxWidth, ' ');

--- a/src/BenchmarkDotNet/Running/BenchmarkRunner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunner.cs
@@ -343,7 +343,9 @@ namespace BenchmarkDotNet.Running
             for (int index = 0; index < executeResults.Count; index++)
             {
                 var executeResult = executeResults[index];
-                runs.AddRange(executeResult.Data.Select(line => Measurement.Parse(logger, line, index + 1)).Where(r => r.IterationMode != IterationMode.Unknown));
+                var measurements = ConstantFoldingHelper.HandleConstantFolding(executeResult.Data.Select(line => Measurement.Parse(logger, line, index + 1))
+                                                                                                 .Where(r => r.IterationMode != IterationMode.Unknown));
+                runs.AddRange(measurements);
             }
 
             return new BenchmarkReport(benchmark, buildResult, buildResult, executeResults, runs, gcStats);
@@ -410,7 +412,7 @@ namespace BenchmarkDotNet.Running
                     .Select(line => Measurement.Parse(logger, line, 0))
                     .Where(r => r.IterationMode != IterationMode.Unknown)
                     .ToArray();
-
+                
                 if (!measurements.Any())
                 {
                     // Something went wrong during the benchmark, don't bother doing more runs


### PR DESCRIPTION
This PR basically solves https://github.com/dotnet/BenchmarkDotNet/issues/731 and https://github.com/dotnet/BenchmarkDotNet/issues/601
It consists of two parts:
1) At first, there is some heuristics. We checks Result measurement just like described in https://github.com/dotnet/BenchmarkDotNet/issues/601#issuecomment-353104592. I chose threshold value = 0.2 ns that corresponding 5 GHz. It also checks for Measurement(Target) < Measurement(Idle) condition. If both of that is satisfied, we just zeroing value of appropriate measurement.
2) Second, introduced ConstantFoldingAnalyzer, that simply checks Result reports for 0 ns measurements and warning about possible constant folding.