### PR TITLE
WIP for supporting testing between Nuget dependencies

### DIFF
--- a/samples/BenchmarkDotNet.Samples/IntroNuget.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroNuget.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Exporters.Csv;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Toolchains.CsProj;
+
+namespace BenchmarkDotNet.Samples
+
+    [Config(typeof(Config))]
+    public class IntroNuget
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                //TODO: So far only implemented with any toolchain using DotNetCliBuilder
+                Add(Job.MediumRun.With(CsProjCoreToolchain.Current.Value).WithNuget("Newtonsoft.Json", "11.0.1").WithId("11.0.1"));
+                Add(Job.MediumRun.With(CsProjCoreToolchain.Current.Value).WithNuget("Newtonsoft.Json", "10.0.3").WithId("10.0.3"));
+                Add(Job.MediumRun.With(CsProjCoreToolchain.Current.Value).WithNuget("Newtonsoft.Json", "9.0.1").WithId("9.0.1"));
+                Add(Job.MediumRun.With(CsProjCoreToolchain.Current.Value).WithNuget("Newtonsoft.Json", "8.0.1").WithId("8.0.1"));
+                Add(Job.MediumRun.With(CsProjCoreToolchain.Current.Value).WithNuget("Newtonsoft.Json", "7.0.1").WithId("7.0.1"));
+                Add(Job.MediumRun.With(CsProjCoreToolchain.Current.Value).WithNuget("Newtonsoft.Json", "6.0.1").WithId("6.0.1"));
+                Add(DefaultConfig.Instance.GetColumnProviders().ToArray());
+                Add(DefaultConfig.Instance.GetLoggers().ToArray());
+                Add(CsvExporter.Default);
+            }
+        }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var jsonConvertMethod = Assembly.Load("Newtonsoft.Json").GetType("Newtonsoft.Json.JsonConvert")
+                .GetMethods().Where(x => x.Name == "SerializeObject" && x.GetParameters().Length == 1)
+                .First();
+
+            Serializer = s => (string)jsonConvertMethod.Invoke(null, new object[] { s });
+        }
+
+        public Func<object, string> Serializer { get; private set; }
+
+        [Benchmark]
+        public void SerializeAnonymousObject() => Serializer(new { hello = "world", price = 1.99, now = DateTime.UtcNow });
+    }
+}

--- a/src/BenchmarkDotNet/Environments/InfrastructureResolver.cs
+++ b/src/BenchmarkDotNet/Environments/InfrastructureResolver.cs
@@ -17,7 +17,8 @@ namespace BenchmarkDotNet.Environments
             Register(InfrastructureMode.EngineFactoryCharacteristic, () => new EngineFactory());
             Register(InfrastructureMode.BuildConfigurationCharacteristic, () => InfrastructureMode.ReleaseConfigurationName);
 
-            Register(InfrastructureMode.ArgumentsCharacteristic, Array.Empty<Argument>);            
+            Register(InfrastructureMode.ArgumentsCharacteristic, Array.Empty<Argument>);
+            Register(InfrastructureMode.NugetReferencesCharacteristic, Array.Empty<NugetReference>);
         }
     }
 }

--- a/src/BenchmarkDotNet/Jobs/InfrastructureMode.cs
+++ b/src/BenchmarkDotNet/Jobs/InfrastructureMode.cs
@@ -16,6 +16,7 @@ namespace BenchmarkDotNet.Jobs
         public static readonly Characteristic<IEngineFactory> EngineFactoryCharacteristic = CreateCharacteristic<IEngineFactory>(nameof(EngineFactory));
         public static readonly Characteristic<string> BuildConfigurationCharacteristic = CreateCharacteristic<string>(nameof(BuildConfiguration));        
         public static readonly Characteristic<IReadOnlyList<Argument>> ArgumentsCharacteristic = CreateCharacteristic<IReadOnlyList<Argument>>(nameof(Arguments));
+        public static readonly Characteristic<IReadOnlyList<NugetReference>> NugetReferencesCharacteristic = CreateCharacteristic<IReadOnlyList<NugetReference>>(nameof(NugetReferences));
 
         public static readonly InfrastructureMode InProcess = new InfrastructureMode(InProcessToolchain.Instance);
         public static readonly InfrastructureMode InProcessDontLogOutput = new InfrastructureMode(InProcessToolchain.DontLogOutput);
@@ -59,6 +60,12 @@ namespace BenchmarkDotNet.Jobs
         {
             get => ArgumentsCharacteristic[this];
             set => ArgumentsCharacteristic[this] = value;
+        }
+
+        public IReadOnlyList<NugetReference> NugetReferences
+        {
+            get => NugetReferencesCharacteristic[this];
+            set => NugetReferencesCharacteristic[this] = value;
         }
     }
 }

--- a/src/BenchmarkDotNet/Jobs/JobExtensions.cs
+++ b/src/BenchmarkDotNet/Jobs/JobExtensions.cs
@@ -159,8 +159,33 @@ namespace BenchmarkDotNet.Jobs
         public static Job WithCustomBuildConfiguration(this Job job, string buildConfiguration) => job.WithCore(j => j.Infrastructure.BuildConfiguration = buildConfiguration);
         public static Job With(this Job job, IReadOnlyList<EnvironmentVariable> environmentVariables) => job.WithCore(j => j.Environment.EnvironmentVariables = environmentVariables);
         public static Job With(this Job job, IReadOnlyList<Argument> arguments) => job.WithCore(j => j.Infrastructure.Arguments = arguments);
+        
+        /// <summary>
+        /// Runs the job with a specific Nuget dependency which will be resolved during the Job build process
+        /// </summary>
+        /// <param name="job"></param>
+        /// <param name="packageName">The Nuget package name</param>
+        /// <param name="packageVersion">The Nuget package version</param>
+        /// <returns></returns>
+        public static Job WithNuget(this Job job, string packageName, string packageVersion) => job.WithCore(j => j.Infrastructure.NugetReferences = new List<NugetReference> { new NugetReference(packageName, packageVersion) });
 
-    // Accuracy
+        /// <summary>
+        /// Runs the job with a specific Nuget dependency which will be resolved during the Job build process
+        /// </summary>
+        /// <param name="job"></param>
+        /// <param name="packageName">The Nuget package name, the latest version will be resolved</param>
+        /// <returns></returns>
+        public static Job WithNuget(this Job job, string packageName) => job.WithCore(j => j.Infrastructure.NugetReferences = new List<NugetReference> { new NugetReference(packageName, string.Empty) });
+
+        /// <summary>
+        /// Runs the job with a specific Nuget dependencies which will be resolved during the Job build process
+        /// </summary>
+        /// <param name="job"></param>
+        /// <param name="nugetReferences">A collection of Nuget dependencies</param>
+        /// <returns></returns>
+        public static Job WithNuget(this Job job, IReadOnlyList<NugetReference> nugetReferences) => job.WithCore(j => j.Infrastructure.NugetReferences = nugetReferences);
+
+        // Accuracy
         /// <summary>
         /// Maximum acceptable error for a benchmark (by default, BenchmarkDotNet continue iterations until the actual error is less than the specified error).
         /// The default value is 0.02.

--- a/src/BenchmarkDotNet/Jobs/NugetReference.cs
+++ b/src/BenchmarkDotNet/Jobs/NugetReference.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace BenchmarkDotNet.Jobs
+{
+    public class NugetReference
+    {
+        public NugetReference(string packageName, string packageVersion)
+        {
+            if (string.IsNullOrWhiteSpace(packageName))
+                throw new ArgumentException("message", nameof(packageName));
+
+            PackageName = packageName;
+            PackageVersion = packageVersion;
+            if (!string.IsNullOrWhiteSpace(PackageVersion) && !Version.TryParse(PackageVersion, out var version))
+                throw new InvalidOperationException($"Invalid version specified: {packageVersion}");
+        }
+
+        public string PackageName { get; }
+        public string PackageVersion { get; }
+
+        public override string ToString()
+        {
+            return $"{PackageName}{(string.IsNullOrWhiteSpace(PackageVersion) ? string.Empty : $" {PackageVersion}")}";
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
@@ -47,9 +47,9 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
         internal static CommandResult ExecuteCommand(
             string customDotNetCliPath, string commandWithArguments, string workingDirectory, ILogger logger, 
-            IReadOnlyList<EnvironmentVariable> environmentVariables = null, bool useSharedCompilation = false)
+            IReadOnlyList<EnvironmentVariable> environmentVariables = null, bool? useSharedCompilation = false)
         {
-            commandWithArguments = $"{commandWithArguments} /p:UseSharedCompilation={useSharedCompilation.ToString().ToLowerInvariant()}";
+            commandWithArguments = $"{commandWithArguments}{(useSharedCompilation.HasValue ? $" /p:UseSharedCompilation={useSharedCompilation.ToString().ToLowerInvariant()}" : string.Empty)}";
 
             using (var process = new Process { StartInfo = BuildStartInfo(customDotNetCliPath, workingDirectory, commandWithArguments, environmentVariables) })
             {


### PR DESCRIPTION
This is a WIP to resolve the task https://github.com/dotnet/BenchmarkDotNet/issues/290

I've got this working with the `CsProjCoreToolchain` and have added a sample showing the syntax and how it works. During development i noticed that the `BuildScriptFilePath` doesn't ever seem to be used so raised a question/issue about that here https://github.com/dotnet/BenchmarkDotNet/issues/804

What I need help understanding at this stage is how to get this working with the RoslynToolchain. I can see that the Roslyn Generator calls into `csc` and there's a `/references` switch so I assume I'd need to find a way to go fetch the nuget packages and get these wired up but I'm not sure if there's some sort of automated way like with the dotnet cli that can be used.  Any ideas on this one?

Please provide any feedback you might have. Hopefully i haven't done something too odd, there's a bit of a learning curve involved in this codebase :)
