### PR TITLE
Read StandardOutput in a smart way to avoid infinite loops

### DIFF
--- a/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
+++ b/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
@@ -39,29 +39,26 @@ namespace BenchmarkDotNet.Loggers
         {
             string line;
 
-            // ReadLine() can return string.Empty/null as values.
-            while (!process.StandardOutput.EndOfStream)
+            // Peek -1 or 0 can indicate internal error.
+            while (!process.StandardOutput.EndOfStream && process.StandardOutput.Peek() > 0)
             {
-                if (process.StandardOutput.Peek() > 0) // 0 or -1 can indicate internal error.
+                // ReadLine() can actually return string.Empty and null as valid values.
+                line = process.StandardOutput.ReadLine();
+
+                if (!string.IsNullOrEmpty(line)) // Skip bad data.
                 {
-                    line = process.StandardOutput.ReadLine();
+                    logger.WriteLine(LogKind.Default, line);
 
-                    if (!string.IsNullOrEmpty(line)) // Skip bad data.
+                    if (!line.StartsWith("//"))
+                    { LinesWithResults.Add(line); }
+                    else if (Engine.Signals.TryGetSignal(line, out var signal))
                     {
-                        logger.WriteLine(LogKind.Default, line);
-
-                        if (!line.StartsWith("//"))
-                        { LinesWithResults.Add(line); }
-                        else if (Engine.Signals.TryGetSignal(line, out var signal))
-                        {
-                            diagnoser?.Handle(signal, diagnoserActionParameters);
-                            process.StandardInput.WriteLine(Engine.Signals.Acknowledgment);
-                        }
-                        else
-                        { LinesWithExtraOutput.Add(line); }
+                        diagnoser?.Handle(signal, diagnoserActionParameters);
+                        process.StandardInput.WriteLine(Engine.Signals.Acknowledgment);
                     }
+                    else
+                    { LinesWithExtraOutput.Add(line); }
                 }
-                else { break; } // No more 'characters' can be read.
             }
         }
     }

--- a/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
+++ b/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
@@ -37,8 +37,6 @@ namespace BenchmarkDotNet.Loggers
 
         internal void ProcessInput()
         {
-            process.StandardOutput.BaseStream.ReadTimeout = 5000;
-
             string line;
             // ReadLine() can return string.Empty/null as values.
             while (!process.StandardOutput.EndOfStream)

--- a/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
+++ b/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
@@ -37,8 +37,9 @@ namespace BenchmarkDotNet.Loggers
 
         internal void ProcessInput()
         {
-            string line;
+            process.StandardOutput.BaseStream.ReadTimeout = 5000;
 
+            string line;
             // ReadLine() can return string.Empty/null as values.
             while (!process.StandardOutput.EndOfStream)
             {

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -69,11 +69,7 @@ namespace BenchmarkDotNet.Toolchains
 
             loggerWithDiagnoser.ProcessInput();
 
-            // Timeout Added. Freeze detected.
-            if (!process.WaitForExit(30000)) 
-            {
-                process.Kill();
-            }
+            process.WaitForExit(); // should we add timeout here?
 
             if (process.ExitCode == 0)
             {

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -69,7 +69,11 @@ namespace BenchmarkDotNet.Toolchains
 
             loggerWithDiagnoser.ProcessInput();
 
-            process.WaitForExit(); // should we add timeout here?
+            // Timeout Added. Freeze detected.
+            if (!process.WaitForExit(30000)) 
+            {
+                process.Kill();
+            }
 
             if (process.ExitCode == 0)
             {


### PR DESCRIPTION
Potential fix for SynchronousProcessOutputLoggerWithDiagnoser infinite loop.
Related to my issue in #828 . Detected an abnormal streamread lock/loop. After some investigation, it looks to be potentially an infinite loop at the StreamReader.ReadLine(). It is capable of returning `string.Empty` and `null` as valid values.  The loop proceeds to continue when `string.IsNullOrEmpty`.

If EndOfStream is never achieved/reached, then a break or timeout will need to be added.

Ran the unit test that calls Execute and found that it froze during WaitForExit. I saw the comment should we add a Timeout and proceeded to do so.

Added timeout in Execute, detected freeze during UnitTest.
`ToolchainTests.CustomToolchainsAreSupported()`

* The infinite loop won't be fixed if the stream never ends.
* The infinite loop won't be fixed if the StreamReader can't read the underlying file (OS lock contention).
   * Wanted to have added a 5 second timeout to read the line to assist with this issue, but the underlying stream doesn't support timeouts.

The Execute timeout probably needs to be reviewed and debated about, I have chosen an arbitrary 30 seconds on a WaitForExit().

Commit 2/3, attempted to add timeouts then undo them.

Commit 4 attempted enhancement utilizing StreamReader peek() to see if it can bypass a ReadLine timeout.

Similar Stackoverflow Examples:
https://stackoverflow.com/questions/35318588/streamreader-readline-will-hang-in-an-infinite-loop
https://stackoverflow.com/questions/286533/filestream-streamreader-problem-in-c-sharp
https://stackoverflow.com/questions/13705209/check-if-a-streamreader-can-read-another-line
