### PR TITLE
Exclude Directory.Build.props/targets from generated csproj files

### DIFF
--- a/src/BenchmarkDotNet/Templates/CsProj.txt
+++ b/src/BenchmarkDotNet/Templates/CsProj.txt
@@ -1,4 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project ToolsVersion="15.0">
+  <PropertyGroup>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
   <PropertyGroup>
     <AssemblyTitle>$PROGRAMNAME$</AssemblyTitle>
     <TargetFramework>$TFM$</TargetFramework>
@@ -21,4 +28,6 @@
     <ProjectReference Include="$CSPROJPATH$" />
   </ItemGroup>
   $RUNTIMESETTINGS$
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
Unless explicitly excluded, MSBuild will walk up the directory tree looking for
Directory.Build.props and Directory.Build.targets files. This is problematic for
one of the most common uses of Directory.Build.* files: redirecting output
directories. The rest of the benchmarking infrastructure has strong expectations
of where files will be produced, so things will often go wrong if they are redirected.