### PR TITLE
[WIP] Mono AOT mode

### DIFF
--- a/src/BenchmarkDotNet/Attributes/Jobs/MonoJobAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/Jobs/MonoJobAttribute.cs
@@ -15,5 +15,10 @@ namespace BenchmarkDotNet.Attributes
             : base(new Job(name, new EnvironmentMode(new MonoRuntime(name, path)).Freeze()).WithBaseline(baseline).Freeze())
         {
         }
+
+        public MonoJobAttribute(string name, string path, bool aot, string aotParameters, bool baseline = false)
+            : base(new Job(name, new EnvironmentMode(new MonoRuntime(name, path) { Aot = aot, AotParameters = aotParameters }).Freeze()).WithBaseline(baseline).Freeze())
+        {
+        }
     }
 }

--- a/src/BenchmarkDotNet/Environments/Runtime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtime.cs
@@ -78,6 +78,10 @@ namespace BenchmarkDotNet.Environments
     {
         public string CustomPath { get; }
 
+        public bool Aot { get; set; }
+
+        public string AotParameters { get; set; }
+
         public MonoRuntime() : base("Mono")
         {
         }


### PR DESCRIPTION
This Work-in-progrss PR introduces AOT flag for Mono.
Examples:
`mono --aot Program.cs && mono Program.exe`
`mono --aot=interp Program.cs && mono Program.exe`
`mono --aot=llvm Program.cs && mono Program.exe`
`mono --aot=llvm,llvmopts="-O3 xxx",llvmllc="-O3 xxx" Program.cs && mono Program.exe`

I am not really familiar with BDN inner architecture yet, could you point me to a place where I could insert an additional Process.Start (ProcessHelper.RunAndReadOutput?)?