### PR TITLE
Fix typo in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ using BenchmarkDotNet.Running;
 
 namespace MyBenchmarks
 {
-    [ClrJob(isBaseline: true), CoreJob, MonoJob, CoreRtJob]
+    [ClrJob(baseline: true), CoreJob, MonoJob, CoreRtJob]
     [RPlotExporter, RankColumn]
     public class Md5VsSha256
     {


### PR DESCRIPTION
The example code in [README.md](https://github.com/dotnet/BenchmarkDotNet/blob/master/README.md) doesn't compile. 

This change in this PR fixes the issue!