### PR TITLE
Enabled GcModeTests.CanEnableServerGcMode

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/GcModeTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/GcModeTests.cs
@@ -24,7 +24,7 @@ namespace BenchmarkDotNet.IntegrationTests
             CanExecute<WorkstationGcOnly>(config);
         }
 
-        [Fact(Skip = "It fails on appveyor")]
+        [Fact]
         public void CanEnableServerGcMode()
         {
             var config = CreateConfig(new GcMode { Server = true });


### PR DESCRIPTION
In #221 there was a request to investigate why CanEnableServerGcMode failed on AppVeyor. I enabled this and ran a build on my own AppVeyor account to check if this still happened and it looks like this is fixed.

This PR enables the unit test and that would mean we could close issue #221.