### PR TITLE
Fix duplicate example in RunStrategy guide

### DIFF
--- a/docs/articles/guides/choosing-run-strategy.md
+++ b/docs/articles/guides/choosing-run-strategy.md
@@ -28,4 +28,4 @@ public class MyBenchmarkClass
 
 [!include[IntroColdStart](../samples/IntroColdStart.md)]
 
-[!include[IntroColdStart](../samples/IntroColdStart.md)]
+[!include[IntroMonitoring](../samples/IntroMonitoring.md)]


### PR DESCRIPTION
The `RunStrategy` guide currently shows 2 identical `ColdStart` examples. I'm assuming we want to show `Monitoring` as the second one, instead.