### PR TITLE
RPlotExporter: use https to download dependencies

### DIFF
--- a/src/BenchmarkDotNet/Templates/BuildPlots.R
+++ b/src/BenchmarkDotNet/Templates/BuildPlots.R
@@ -2,7 +2,7 @@ BenchmarkDotNetVersion <- "$BenchmarkDotNetVersion$ "
 dir.create(Sys.getenv("R_LIBS_USER"), recursive = TRUE, showWarnings = FALSE)
 list.of.packages <- c("ggplot2", "dplyr", "gdata", "tidyr", "grid", "gridExtra", "Rcpp")
 new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
-if(length(new.packages)) install.packages(new.packages, lib = Sys.getenv("R_LIBS_USER"), repos = "http://cran.rstudio.com/")
+if(length(new.packages)) install.packages(new.packages, lib = Sys.getenv("R_LIBS_USER"), repos = "https://cran.rstudio.com/")
 library(ggplot2)
 library(dplyr)
 library(gdata)


### PR DESCRIPTION
Using a secure https connection should be preferred over http.

Download over http can be blocked by some corporate firewalls/proxy.