### PR TITLE
Added support for async GlobalSetup.

### DIFF
--- a/src/BenchmarkDotNet/Code/DeclarationsProvider.cs
+++ b/src/BenchmarkDotNet/Code/DeclarationsProvider.cs
@@ -70,12 +70,16 @@ namespace BenchmarkDotNet.Code
                 return EmptyAction;
             }
 
-            if (method.ReturnType != typeof(Task))
+            if (method.ReturnType == typeof(Task) ||
+                method.ReturnType == typeof(ValueTask) ||
+                (method.ReturnType.IsGenericType &&
+                    (method.ReturnType.GetGenericTypeDefinition() == typeof(Task<>) ||
+                     method.ReturnType.GetGenericTypeDefinition() == typeof(ValueTask<>))))
             {
-                return method.Name;
+                return $"() => {method.Name}().GetAwaiter().GetResult()";
             }
 
-            return $"() => {method.Name}().GetAwaiter().GetResult()";
+            return method.Name;
         }
     }
 

--- a/src/BenchmarkDotNet/Code/DeclarationsProvider.cs
+++ b/src/BenchmarkDotNet/Code/DeclarationsProvider.cs
@@ -28,7 +28,7 @@ namespace BenchmarkDotNet.Code
 
         public string WorkloadTypeName => Descriptor.Type.GetCorrectCSharpTypeName();
 
-        public string GlobalSetupMethodName => Descriptor.GlobalSetupMethod?.Name ?? EmptyAction;
+        public string GlobalSetupMethodName => GetMethodName(Descriptor.GlobalSetupMethod);
 
         public string GlobalCleanupMethodName => Descriptor.GlobalCleanupMethod?.Name ?? EmptyAction;
 
@@ -62,6 +62,21 @@ namespace BenchmarkDotNet.Code
             => Descriptor.WorkloadMethod.GetParameters()
                 .Where(arg => !string.IsNullOrEmpty(arg.ParameterType.Namespace))
                 .Select(arg => $"using {arg.ParameterType.Namespace};");
+
+        private string GetMethodName(MethodInfo method)
+        {
+            if (method == null)
+            {
+                return EmptyAction;
+            }
+
+            if (method.ReturnType != typeof(Task))
+            {
+                return method.Name;
+            }
+
+            return $"() => {method.Name}().GetAwaiter().GetResult()";
+        }
     }
 
     internal class VoidDeclarationsProvider : DeclarationsProvider
@@ -81,10 +96,10 @@ namespace BenchmarkDotNet.Code
     {
         public NonVoidDeclarationsProvider(Descriptor descriptor) : base(descriptor) { }
 
-        public override string WorkloadMethodReturnTypeNamespace 
+        public override string WorkloadMethodReturnTypeNamespace
             => WorkloadMethodReturnType.Namespace == "System" // As "using System;" is always included in the template, don't emit it again
-                || string.IsNullOrWhiteSpace(WorkloadMethodReturnType.Namespace) 
-                    ? string.Empty 
+                || string.IsNullOrWhiteSpace(WorkloadMethodReturnType.Namespace)
+                    ? string.Empty
                     : $"using {WorkloadMethodReturnType.Namespace};";
 
         public override string ConsumeField
@@ -110,7 +125,7 @@ namespace BenchmarkDotNet.Code
                 else if (type.GetTypeInfo().IsClass || type.GetTypeInfo().IsInterface)
                     value = "null";
                 else
-                    value = SourceCodeHelper.ToSourceCode(Activator.CreateInstance(type)) + ";";                                    
+                    value = SourceCodeHelper.ToSourceCode(Activator.CreateInstance(type)) + ";";
                 return $"return {value};";
             }
         }

--- a/src/BenchmarkDotNet/Validators/ExecutionValidatorBase.cs
+++ b/src/BenchmarkDotNet/Validators/ExecutionValidatorBase.cs
@@ -2,11 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Running;
 
-namespace BenchmarkDotNet.Validators 
+namespace BenchmarkDotNet.Validators
 {
     public abstract class ExecutionValidatorBase : IValidator
     {
@@ -92,7 +93,12 @@ namespace BenchmarkDotNet.Validators
 
             try
             {
-                globalSetupMethods.First().Invoke(benchmarkTypeInstance, null);
+                var result = globalSetupMethods.First().Invoke(benchmarkTypeInstance, null);
+
+                if (result is Task task)
+                {
+                    task.GetAwaiter().GetResult();
+                }
             }
             catch (Exception ex)
             {

--- a/tests/BenchmarkDotNet.IntegrationTests/AllSetupAndCleanupTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/AllSetupAndCleanupTest.cs
@@ -59,36 +59,6 @@ namespace BenchmarkDotNet.IntegrationTests
             Assert.Equal(expectedLogLines, actualLogLines);
         }
 
-        [Fact]
-        public void AllSetupAndCleanupMethodRunsAsyncTest()
-        {
-            var logger = new OutputLogger(Output);
-            var miniJob = Job.Default.With(RunStrategy.Monitoring).WithWarmupCount(2).WithIterationCount(3).WithInvocationCount(1).WithUnrollFactor(1).WithId("MiniJob");
-            var config = CreateSimpleConfig(logger, miniJob);
-
-            CanExecute<AllSetupAndCleanupAttributeBenchmarksAsync>(config);
-
-            var actualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(Prefix)).ToArray();
-            foreach (string line in actualLogLines)
-                Output.WriteLine(line);
-            Assert.Equal(expectedLogLines, actualLogLines);
-        }
-
-        [Fact]
-        public void AllSetupAndCleanupMethodRunsAsyncSetupTest()
-        {
-            var logger = new OutputLogger(Output);
-            var miniJob = Job.Default.With(RunStrategy.Monitoring).WithWarmupCount(2).WithIterationCount(3).WithInvocationCount(1).WithUnrollFactor(1).WithId("MiniJob");
-            var config = CreateSimpleConfig(logger, miniJob);
-
-            CanExecute<AllSetupAndCleanupAttributeBenchmarksAsyncSetup>(config);
-
-            var actualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(Prefix)).ToArray();
-            foreach (string line in actualLogLines)
-                Output.WriteLine(line);
-            Assert.Equal(expectedLogLines, actualLogLines);
-        }
-
         public class AllSetupAndCleanupAttributeBenchmarks
         {
             private int setupCounter;
@@ -108,6 +78,21 @@ namespace BenchmarkDotNet.IntegrationTests
 
             [Benchmark]
             public void Benchmark() => Console.WriteLine(BenchmarkCalled);
+        }
+
+        [Fact]
+        public void AllSetupAndCleanupMethodRunsAsyncTest()
+        {
+            var logger = new OutputLogger(Output);
+            var miniJob = Job.Default.With(RunStrategy.Monitoring).WithWarmupCount(2).WithIterationCount(3).WithInvocationCount(1).WithUnrollFactor(1).WithId("MiniJob");
+            var config = CreateSimpleConfig(logger, miniJob);
+
+            CanExecute<AllSetupAndCleanupAttributeBenchmarksAsync>(config);
+
+            var actualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(Prefix)).ToArray();
+            foreach (string line in actualLogLines)
+                Output.WriteLine(line);
+            Assert.Equal(expectedLogLines, actualLogLines);
         }
 
         public class AllSetupAndCleanupAttributeBenchmarksAsync
@@ -131,7 +116,22 @@ namespace BenchmarkDotNet.IntegrationTests
             public Task Benchmark() => Console.Out.WriteLineAsync(BenchmarkCalled);
         }
 
-        public class AllSetupAndCleanupAttributeBenchmarksAsyncSetup
+        [Fact]
+        public void AllSetupAndCleanupMethodRunsAsyncTaskSetupTest()
+        {
+            var logger = new OutputLogger(Output);
+            var miniJob = Job.Default.With(RunStrategy.Monitoring).WithWarmupCount(2).WithIterationCount(3).WithInvocationCount(1).WithUnrollFactor(1).WithId("MiniJob");
+            var config = CreateSimpleConfig(logger, miniJob);
+
+            CanExecute<AllSetupAndCleanupAttributeBenchmarksAsyncTaskSetup>(config);
+
+            var actualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(Prefix)).ToArray();
+            foreach (string line in actualLogLines)
+                Output.WriteLine(line);
+            Assert.Equal(expectedLogLines, actualLogLines);
+        }
+
+        public class AllSetupAndCleanupAttributeBenchmarksAsyncTaskSetup
         {
             private int setupCounter;
             private int cleanupCounter;
@@ -144,6 +144,124 @@ namespace BenchmarkDotNet.IntegrationTests
 
             [GlobalSetup]
             public Task GlobalSetup() => Console.Out.WriteLineAsync(GlobalSetupCalled);
+
+            [GlobalCleanup]
+            public void GlobalCleanup() => Console.WriteLine(GlobalCleanupCalled);
+
+            [Benchmark]
+            public void Benchmark() => Console.WriteLine(BenchmarkCalled);
+        }
+
+        [Fact]
+        public void AllSetupAndCleanupMethodRunsAsyncGenericTaskSetupTest()
+        {
+            var logger = new OutputLogger(Output);
+            var miniJob = Job.Default.With(RunStrategy.Monitoring).WithWarmupCount(2).WithIterationCount(3).WithInvocationCount(1).WithUnrollFactor(1).WithId("MiniJob");
+            var config = CreateSimpleConfig(logger, miniJob);
+
+            CanExecute<AllSetupAndCleanupAttributeBenchmarksAsyncGenericTaskSetup>(config);
+
+            var actualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(Prefix)).ToArray();
+            foreach (string line in actualLogLines)
+                Output.WriteLine(line);
+            Assert.Equal(expectedLogLines, actualLogLines);
+        }
+
+        public class AllSetupAndCleanupAttributeBenchmarksAsyncGenericTaskSetup
+        {
+            private int setupCounter;
+            private int cleanupCounter;
+
+            [IterationSetup]
+            public void IterationSetup() => Console.WriteLine(IterationSetupCalled + " (" + ++setupCounter + ")");
+
+            [IterationCleanup]
+            public void IterationCleanup() => Console.WriteLine(IterationCleanupCalled + " (" + ++cleanupCounter + ")");
+
+            [GlobalSetup]
+            public async Task<int> GlobalSetup()
+            {
+                await Console.Out.WriteLineAsync(GlobalSetupCalled);
+
+                return 42;
+            }
+
+            [GlobalCleanup]
+            public void GlobalCleanup() => Console.WriteLine(GlobalCleanupCalled);
+
+            [Benchmark]
+            public void Benchmark() => Console.WriteLine(BenchmarkCalled);
+        }
+
+        [Fact]
+        public void AllSetupAndCleanupMethodRunsAsyncValueTaskSetupTest()
+        {
+            var logger = new OutputLogger(Output);
+            var miniJob = Job.Default.With(RunStrategy.Monitoring).WithWarmupCount(2).WithIterationCount(3).WithInvocationCount(1).WithUnrollFactor(1).WithId("MiniJob");
+            var config = CreateSimpleConfig(logger, miniJob);
+
+            CanExecute<AllSetupAndCleanupAttributeBenchmarksAsyncValueTaskSetup>(config);
+
+            var actualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(Prefix)).ToArray();
+            foreach (string line in actualLogLines)
+                Output.WriteLine(line);
+            Assert.Equal(expectedLogLines, actualLogLines);
+        }
+
+        public class AllSetupAndCleanupAttributeBenchmarksAsyncValueTaskSetup
+        {
+            private int setupCounter;
+            private int cleanupCounter;
+
+            [IterationSetup]
+            public void IterationSetup() => Console.WriteLine(IterationSetupCalled + " (" + ++setupCounter + ")");
+
+            [IterationCleanup]
+            public void IterationCleanup() => Console.WriteLine(IterationCleanupCalled + " (" + ++cleanupCounter + ")");
+
+            [GlobalSetup]
+            public ValueTask GlobalSetup() => new ValueTask(Console.Out.WriteLineAsync(GlobalSetupCalled));
+
+            [GlobalCleanup]
+            public void GlobalCleanup() => Console.WriteLine(GlobalCleanupCalled);
+
+            [Benchmark]
+            public void Benchmark() => Console.WriteLine(BenchmarkCalled);
+        }
+
+        [Fact]
+        public void AllSetupAndCleanupMethodRunsAsyncGenericValueTaskSetupTest()
+        {
+            var logger = new OutputLogger(Output);
+            var miniJob = Job.Default.With(RunStrategy.Monitoring).WithWarmupCount(2).WithIterationCount(3).WithInvocationCount(1).WithUnrollFactor(1).WithId("MiniJob");
+            var config = CreateSimpleConfig(logger, miniJob);
+
+            CanExecute<AllSetupAndCleanupAttributeBenchmarksAsyncGenericValueTaskSetup>(config);
+
+            var actualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(Prefix)).ToArray();
+            foreach (string line in actualLogLines)
+                Output.WriteLine(line);
+            Assert.Equal(expectedLogLines, actualLogLines);
+        }
+
+        public class AllSetupAndCleanupAttributeBenchmarksAsyncGenericValueTaskSetup
+        {
+            private int setupCounter;
+            private int cleanupCounter;
+
+            [IterationSetup]
+            public void IterationSetup() => Console.WriteLine(IterationSetupCalled + " (" + ++setupCounter + ")");
+
+            [IterationCleanup]
+            public void IterationCleanup() => Console.WriteLine(IterationCleanupCalled + " (" + ++cleanupCounter + ")");
+
+            [GlobalSetup]
+            public async ValueTask<int> GlobalSetup()
+            {
+                await Console.Out.WriteLineAsync(GlobalSetupCalled);
+
+                return 42;
+            }
 
             [GlobalCleanup]
             public void GlobalCleanup() => Console.WriteLine(GlobalCleanupCalled);

--- a/tests/BenchmarkDotNet.IntegrationTests/AllSetupAndCleanupTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/AllSetupAndCleanupTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Jobs;
@@ -62,6 +63,42 @@ namespace BenchmarkDotNet.IntegrationTests
             Assert.Equal(expectedLogLines, actualLogLines);
         }
 
+        [Fact]
+        public void AllSetupAndCleanupMethodRunsAsyncTest()
+        {
+            var logger = new OutputLogger(Output);
+            var miniJob = Job.Default.With(RunStrategy.Monitoring).WithWarmupCount(2).WithIterationCount(3).WithInvocationCount(1).WithUnrollFactor(1).WithId("MiniJob");
+            var config = CreateSimpleConfig(logger, miniJob);
+
+            CanExecute<AllSetupAndCleanupAttributeBenchmarksAsync>(config);
+            Output.WriteLine(OutputDelimeter);
+            Output.WriteLine(OutputDelimeter);
+            Output.WriteLine(OutputDelimeter);
+
+            var actualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(Prefix)).ToArray();
+            foreach (string line in actualLogLines)
+                Output.WriteLine(line);
+            Assert.Equal(expectedLogLines, actualLogLines);
+        }
+
+        [Fact]
+        public void AllSetupAndCleanupMethodRunsAsyncSetupTest()
+        {
+            var logger = new OutputLogger(Output);
+            var miniJob = Job.Default.With(RunStrategy.Monitoring).WithWarmupCount(2).WithIterationCount(3).WithInvocationCount(1).WithUnrollFactor(1).WithId("MiniJob");
+            var config = CreateSimpleConfig(logger, miniJob);
+
+            CanExecute<AllSetupAndCleanupAttributeBenchmarksAsyncSetup>(config);
+            Output.WriteLine(OutputDelimeter);
+            Output.WriteLine(OutputDelimeter);
+            Output.WriteLine(OutputDelimeter);
+
+            var actualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(Prefix)).ToArray();
+            foreach (string line in actualLogLines)
+                Output.WriteLine(line);
+            Assert.Equal(expectedLogLines, actualLogLines);
+        }
+
         public class AllSetupAndCleanupAttributeBenchmarks
         {
             private int setupCounter;
@@ -75,6 +112,48 @@ namespace BenchmarkDotNet.IntegrationTests
 
             [GlobalSetup]
             public void GlobalSetup() => Console.WriteLine(GlobalSetupCalled);
+
+            [GlobalCleanup]
+            public void GlobalCleanup() => Console.WriteLine(GlobalCleanupCalled);
+
+            [Benchmark]
+            public void Benchmark() => Console.WriteLine(BenchmarkCalled);
+        }
+
+        public class AllSetupAndCleanupAttributeBenchmarksAsync
+        {
+            private int setupCounter;
+            private int cleanupCounter;
+
+            [IterationSetup]
+            public void IterationSetup() => Console.WriteLine(IterationSetupCalled + " (" + ++setupCounter + ")");
+
+            [IterationCleanup]
+            public void IterationCleanup() => Console.WriteLine(IterationCleanupCalled + " (" + ++cleanupCounter + ")");
+
+            [GlobalSetup]
+            public Task GlobalSetup() => Console.Out.WriteLineAsync(GlobalSetupCalled);
+
+            [GlobalCleanup]
+            public void GlobalCleanup() => Console.WriteLine(GlobalCleanupCalled);
+
+            [Benchmark]
+            public Task Benchmark() => Console.Out.WriteLineAsync(BenchmarkCalled);
+        }
+
+        public class AllSetupAndCleanupAttributeBenchmarksAsyncSetup
+        {
+            private int setupCounter;
+            private int cleanupCounter;
+
+            [IterationSetup]
+            public void IterationSetup() => Console.WriteLine(IterationSetupCalled + " (" + ++setupCounter + ")");
+
+            [IterationCleanup]
+            public void IterationCleanup() => Console.WriteLine(IterationCleanupCalled + " (" + ++cleanupCounter + ")");
+
+            [GlobalSetup]
+            public Task GlobalSetup() => Console.Out.WriteLineAsync(GlobalSetupCalled);
 
             [GlobalCleanup]
             public void GlobalCleanup() => Console.WriteLine(GlobalCleanupCalled);

--- a/tests/BenchmarkDotNet.IntegrationTests/AllSetupAndCleanupTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/AllSetupAndCleanupTest.cs
@@ -18,7 +18,6 @@ namespace BenchmarkDotNet.IntegrationTests
         private const string IterationSetupCalled = Prefix + "IterationSetup";
         private const string IterationCleanupCalled = Prefix + "IterationCleanup";
         private const string BenchmarkCalled = Prefix + "Benchmark";
-        private const string OutputDelimeter = "===========================================================";
 
         private readonly string[] expectedLogLines = {
             "// ### Called: GlobalSetup",
@@ -53,9 +52,6 @@ namespace BenchmarkDotNet.IntegrationTests
             var config = CreateSimpleConfig(logger, miniJob);
 
             CanExecute<AllSetupAndCleanupAttributeBenchmarks>(config);
-            Output.WriteLine(OutputDelimeter);
-            Output.WriteLine(OutputDelimeter);
-            Output.WriteLine(OutputDelimeter);
             
             var actualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(Prefix)).ToArray();
             foreach (string line in actualLogLines)
@@ -71,9 +67,6 @@ namespace BenchmarkDotNet.IntegrationTests
             var config = CreateSimpleConfig(logger, miniJob);
 
             CanExecute<AllSetupAndCleanupAttributeBenchmarksAsync>(config);
-            Output.WriteLine(OutputDelimeter);
-            Output.WriteLine(OutputDelimeter);
-            Output.WriteLine(OutputDelimeter);
 
             var actualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(Prefix)).ToArray();
             foreach (string line in actualLogLines)
@@ -89,9 +82,6 @@ namespace BenchmarkDotNet.IntegrationTests
             var config = CreateSimpleConfig(logger, miniJob);
 
             CanExecute<AllSetupAndCleanupAttributeBenchmarksAsyncSetup>(config);
-            Output.WriteLine(OutputDelimeter);
-            Output.WriteLine(OutputDelimeter);
-            Output.WriteLine(OutputDelimeter);
 
             var actualLogLines = logger.GetLog().Split('\r', '\n').Where(line => line.StartsWith(Prefix)).ToArray();
             foreach (string line in actualLogLines)

--- a/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Validators;
@@ -280,6 +281,31 @@ namespace BenchmarkDotNet.Tests.Validators
 
             [GlobalSetup]
             public void Single() { }
+
+            [Benchmark]
+            public void NonThrowing() { }
+        }
+
+        [Fact]
+        public void AsyncGlobalSetupIsExecuted()
+        {
+            var validationErrors = ExecutionValidator.FailOnError.Validate(BenchmarkConverter.TypeToBenchmarks(typeof(AsyncGlobalSetup))).ToList();
+
+            Assert.True(AsyncGlobalSetup.WasCalled);
+            Assert.Empty(validationErrors);
+        }
+
+        public class AsyncGlobalSetup
+        {
+            public static bool WasCalled;
+
+            [GlobalSetup]
+            public async Task GlobalSetup()
+            {
+                await Task.Delay(1);
+
+                WasCalled = true;
+            }
 
             [Benchmark]
             public void NonThrowing() { }

--- a/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
@@ -287,15 +287,15 @@ namespace BenchmarkDotNet.Tests.Validators
         }
 
         [Fact]
-        public void AsyncGlobalSetupIsExecuted()
+        public void AsyncTaskGlobalSetupIsExecuted()
         {
-            var validationErrors = ExecutionValidator.FailOnError.Validate(BenchmarkConverter.TypeToBenchmarks(typeof(AsyncGlobalSetup))).ToList();
+            var validationErrors = ExecutionValidator.FailOnError.Validate(BenchmarkConverter.TypeToBenchmarks(typeof(AsyncTaskGlobalSetup))).ToList();
 
-            Assert.True(AsyncGlobalSetup.WasCalled);
+            Assert.True(AsyncTaskGlobalSetup.WasCalled);
             Assert.Empty(validationErrors);
         }
 
-        public class AsyncGlobalSetup
+        public class AsyncTaskGlobalSetup
         {
             public static bool WasCalled;
 
@@ -305,6 +305,85 @@ namespace BenchmarkDotNet.Tests.Validators
                 await Task.Delay(1);
 
                 WasCalled = true;
+            }
+
+            [Benchmark]
+            public void NonThrowing() { }
+        }
+
+        [Fact]
+        public void AsyncGenericTaskGlobalSetupIsExecuted()
+        {
+            var validationErrors = ExecutionValidator.FailOnError.Validate(BenchmarkConverter.TypeToBenchmarks(typeof(AsyncGenericTaskGlobalSetup))).ToList();
+
+            Assert.True(AsyncGenericTaskGlobalSetup.WasCalled);
+            Assert.Empty(validationErrors);
+        }
+
+        public class AsyncGenericTaskGlobalSetup
+        {
+            public static bool WasCalled;
+
+            [GlobalSetup]
+            public async Task<int> GlobalSetup()
+            {
+                await Task.Delay(1);
+
+                WasCalled = true;
+
+                return 42;
+            }
+
+            [Benchmark]
+            public void NonThrowing() { }
+        }
+
+        [Fact]
+        public void AsyncValueTaskGlobalSetupIsExecuted()
+        {
+            var validationErrors = ExecutionValidator.FailOnError.Validate(BenchmarkConverter.TypeToBenchmarks(typeof(AsyncValueTaskGlobalSetup))).ToList();
+
+            Assert.True(AsyncValueTaskGlobalSetup.WasCalled);
+            Assert.Empty(validationErrors);
+        }
+
+        public class AsyncValueTaskGlobalSetup
+        {
+            public static bool WasCalled;
+
+            [GlobalSetup]
+            public async ValueTask GlobalSetup()
+            {
+                await Task.Delay(1);
+
+                WasCalled = true;
+            }
+
+            [Benchmark]
+            public void NonThrowing() { }
+        }
+
+        [Fact]
+        public void AsyncGenericValueTaskGlobalSetupIsExecuted()
+        {
+            var validationErrors = ExecutionValidator.FailOnError.Validate(BenchmarkConverter.TypeToBenchmarks(typeof(AsyncGenericValueTaskGlobalSetup))).ToList();
+
+            Assert.True(AsyncGenericValueTaskGlobalSetup.WasCalled);
+            Assert.Empty(validationErrors);
+        }
+
+        public class AsyncGenericValueTaskGlobalSetup
+        {
+            public static bool WasCalled;
+
+            [GlobalSetup]
+            public async ValueTask<int> GlobalSetup()
+            {
+                await Task.Delay(1);
+
+                WasCalled = true;
+
+                return 42;
             }
 
             [Benchmark]


### PR DESCRIPTION
This PR adds support for an `async` `GlobalSetup` as requested in #521. I am also planning to add support for `async` `GlobalCleanup.` I can add this to the same PR if that is preferred or I could open a separate PR for that.