### PR TITLE
Fix GlobalCleanupAttributeTest.GlobalCleanupMethodRunsTest

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/GlobalCleanupAttributeTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/GlobalCleanupAttributeTest.cs
@@ -24,8 +24,8 @@ namespace BenchmarkDotNet.IntegrationTests
             string log = logger.GetLog();
             Assert.Contains(BenchmarkCalled + System.Environment.NewLine, log);
             Assert.True(
-                log.IndexOf(GlobalCleanupCalled + System.Environment.NewLine) >
-                log.IndexOf(BenchmarkCalled + System.Environment.NewLine));
+                log.IndexOf(BenchmarkCalled + System.Environment.NewLine) <
+                log.IndexOf(GlobalCleanupCalled + System.Environment.NewLine));
         }
 
         public class GlobalCleanupAttributeBenchmarks

--- a/tests/BenchmarkDotNet.IntegrationTests/GlobalCleanupAttributeTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/GlobalCleanupAttributeTest.cs
@@ -22,7 +22,7 @@ namespace BenchmarkDotNet.IntegrationTests
             CanExecute<GlobalCleanupAttributeBenchmarks>(config);
 
             string log = logger.GetLog();
-            Assert.Contains(GlobalCleanupCalled + System.Environment.NewLine, log);
+            Assert.Contains(BenchmarkCalled + System.Environment.NewLine, log);
             Assert.True(
                 log.IndexOf(GlobalCleanupCalled + System.Environment.NewLine) >
                 log.IndexOf(BenchmarkCalled + System.Environment.NewLine));


### PR DESCRIPTION
This PR fixes corrects the tests because this test will also pass when
```C#
[Benchmark]
public void Benchmark()
{
    Console.WriteLine(BenchmarkCalled);
}
```

is changed to

```C#
[Benchmark]
public void Benchmark()
{
    //Console.WriteLine(BenchmarkCalled);
}
```

This is happening because there is a check if log contains `GlobalCleanupCalled` instead `BenchmarkCalled`. When the log only contains `GlobalCleanupCalled` this will happen:

```C#
string log = logger.GetLog();
Assert.Contains(GlobalCleanupCalled + System.Environment.NewLine, log);
// True
Assert.True(
    log.IndexOf(GlobalCleanupCalled + System.Environment.NewLine) >
    log.IndexOf(BenchmarkCalled + System.Environment.NewLine));
// 0 > -1 == true
```