### PR TITLE
More command line args

### DIFF
--- a/docs/articles/guides/console-args.md
+++ b/docs/articles/guides/console-args.md
@@ -43,12 +43,12 @@ You can also filter the benchmarks by categories:
 
 ## Runtimes
 
-The `--runtimes` or just `-r` allows you to run the benchmarks for selected Runtimes. Available options are: Clr, Mono, Core and CoreRT.
+The `--runtimes` or just `-r` allows you to run the benchmarks for selected Runtimes. Available options are: Mono, CoreRT, net46, net461, net462, net47, net471, net472, netcoreapp2.0, netcoreapp2.1, netcoreapp2.2, netcoreapp3.0.
 
-Example: run the benchmarks for .NET and .NET Core:
+Example: run the benchmarks for .NET 4.7.2 and .NET Core 2.1:
 
 ```log
-dotnet run -c Release -- --runtimes clr core
+dotnet run -c Release -- --runtimes net472 netcoreapp2.1
 ```
 
 ## More
@@ -61,4 +61,7 @@ dotnet run -c Release -- --runtimes clr core
 * `--affinity` Affinity mask to set for the benchmark process
 * `--allStats` (Default: false) Displays all statistics (min, max & more)
 * `--attribute` Run all methods with given attribute (applied to class or method)
+* `--monoPath` custom Path for Mono
+* `--cliPath` custom Path for dotnet cli
+* `--coreRt` path to ILCompiler for CoreRT
 

--- a/docs/articles/guides/console-args.md
+++ b/docs/articles/guides/console-args.md
@@ -51,6 +51,26 @@ Example: run the benchmarks for .NET 4.7.2 and .NET Core 2.1:
 dotnet run -c Release -- --runtimes net472 netcoreapp2.1
 ```
 
+## Number of invocations and iterations
+
+* `--launchCount` - how many times we should launch process with target benchmark. The default is 1.
+* `--warmupCount` - how many warmup iterations should be performed. If you set it, the minWarmupCount and maxWarmupCount are ignored. By default calculated by the heuristic.
+* `--minWarmupCount` - minimum count of warmup iterations that should be performed. The default is 6.
+* `--maxWarmupCount` - maximum count of warmup iterations that should be performed. The default is 50.
+* `--iterationTime` - desired time of execution of an iteration. Used by Pilot stage to estimate the number of invocations per iteration. 500ms by default.
+* `--iterationCount` - how many target iterations should be performed. By default calculated by the heuristic.
+* `--minIterationCount` - minimum number of iterations to run. The default is 15.
+* `--maxIterationCount` - maximum number of iterations to run. The default is 100.
+* `--invocationCount` - invocation count in a single iteration. By default calculated by the heuristic.
+* `--unrollFactor` - how many times the benchmark method will be invoked per one iteration of a generated loop. 16 by default
+* `--runOncePerIteration` - run the benchmark exactly once per iteration. False by default.
+
+Example: run single warmup iteration, from 9 to 12 actual workload iterations.
+
+```log
+dotnet run -c Release -- --warmupCount 1 --minIterationCount 9 --maxIterationCount 12
+```
+
 ## More
 
 * `-j`, `--job` (Default: Default) Dry/Short/Medium/Long or Default

--- a/docs/articles/guides/console-args.md
+++ b/docs/articles/guides/console-args.md
@@ -71,6 +71,31 @@ Example: run single warmup iteration, from 9 to 12 actual workload iterations.
 dotnet run -c Release -- --warmupCount 1 --minIterationCount 9 --maxIterationCount 12
 ```
 
+## Specifying custom default settings for console argument parser
+
+If you want to have a possibility to specify custom default Job settings programmatically and optionally overwrite it with console line arguments, then you should create a global config with single job marked as `.AsDefault` and pass it to `BenchmarkSwitcher` together with the console line arguments.
+
+Example: run single warmup iteration by default.
+
+```cs
+static void Main(string[] args)
+    => BenchmarkSwitcher
+        .FromAssembly(typeof(Program).Assembly)
+        .Run(args, GetGlobalConfig());
+
+static IConfig GetGlobalConfig()
+    => DefaultConfig.Instance
+        .With(Job.Default
+            .WithWarmupCount(1)
+            .AsDefault()); // the KEY to get it working
+```
+
+Now, the default settings are: `WarmupCount=1` but you might still overwrite it from console args like in the example below: 
+
+```log
+dotnet run -c Release -- --warmupCount 2
+```
+
 ## More
 
 * `-j`, `--job` (Default: Default) Dry/Short/Medium/Long or Default

--- a/src/BenchmarkDotNet/Configs/ConfigExtensions.cs
+++ b/src/BenchmarkDotNet/Configs/ConfigExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using BenchmarkDotNet.Analysers;
@@ -59,6 +60,38 @@ namespace BenchmarkDotNet.Configs
                 : new ReadOnlyConfig(config);
 
         public static bool HasMemoryDiagnoser(this IConfig config) => config.GetDiagnosers().Any(diagnoser => diagnoser is MemoryDiagnoser);
+
+        /// <summary>
+        /// returns a set of unique jobs that are ready to run
+        /// </summary>
+        public static IReadOnlyList<Job> GetRunnableJobs(this IConfig config)
+        {
+            var unique = config.GetJobs().Distinct().ToArray();
+            var result = new List<Job>();
+
+            foreach (var standardJob in unique.Where(job => !job.Meta.IsMutator && !job.Meta.IsDefault))
+                result.Add(standardJob);
+
+            var customDefaultJob = unique.SingleOrDefault(job => job.Meta.IsDefault);
+            var defaultJob = customDefaultJob ?? Job.Default;
+            
+            if (!result.Any())
+                result.Add(defaultJob);
+
+            foreach (var mutatorJob in unique.Where(job => job.Meta.IsMutator))
+            {
+                for (int i = 0; i < result.Count; i++)
+                {
+                    var copy = result[i].UnfreezeCopy();
+
+                    copy.Apply(mutatorJob);
+
+                    result[i] = copy.Freeze();
+                }
+            }
+
+            return result;
+        }
 
         private static IConfig With(this IConfig config, Action<ManualConfig> addAction)
         {

--- a/src/BenchmarkDotNet/Configs/ManualConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ManualConfig.cs
@@ -73,7 +73,7 @@ namespace BenchmarkDotNet.Configs
             loggers.AddRange(config.GetLoggers());
             diagnosers.AddRange(config.GetDiagnosers());
             analysers.AddRange(config.GetAnalysers());
-            AddJobs(config.GetJobs());
+            jobs.AddRange(config.GetJobs());
             validators.AddRange(config.GetValidators());
             hardwareCounters.AddRange(config.GetHardwareCounters());
             filters.AddRange(config.GetFilters());
@@ -160,30 +160,6 @@ namespace BenchmarkDotNet.Configs
                     throw new ArgumentOutOfRangeException();
             }
             return manualConfig;
-        }
-
-        private void AddJobs(IEnumerable<Job> toAdd)
-        {
-            var toAddList = toAdd.ToList();
-            foreach (var notMutator in toAddList.Where(job => !job.Meta.IsMutator))
-                jobs.Add(notMutator);
-            
-            var mutators = toAddList.Where(job => job.Meta.IsMutator).ToArray();
-            if (!mutators.Any())
-                return;
-            
-            if (!jobs.Any())
-                jobs.Add(Job.Default);
-
-            for (int i = 0; i < jobs.Count; i++)
-            {
-                var copy = jobs[i].UnfreezeCopy();
-
-                foreach (var mutator in mutators)
-                    copy.Apply(mutator);
-
-                jobs[i] = copy.Freeze();
-            }
         }
     }
 }

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -82,6 +82,39 @@ namespace BenchmarkDotNet.ConsoleArguments
 
         [Option("ilcPath", Required = false, HelpText = "Optional IlcPath which should be used to run with private CoreRT build.")]
         public DirectoryInfo CoreRtPath { get; set; }
+        
+        [Option("launchCount", Required = false, HelpText = "How many times we should launch process with target benchmark. The default is 1.")]
+        public int? LaunchCount { get; set; }
+            
+        [Option("warmupCount", Required = false, HelpText = "How many warmup iterations should be performed. If you set it, the minWarmupCount and maxWarmupCount are ignored. By default calculated by the heuristic.")]
+        public int? WarmupIterationCount { get; set; }
+        
+        [Option("minWarmupCount", Required = false, HelpText = "Minimum count of warmup iterations that should be performed. The default is 6.")]
+        public int? MinWarmupIterationCount { get; set; }
+        
+        [Option("maxWarmupCount", Required = false, HelpText = "Maximum count of warmup iterations that should be performed. The default is 50.")]
+        public int? MaxWarmupIterationCount { get; set; }
+        
+        [Option("iterationTime", Required = false, HelpText = "Desired time of execution of an iteration. Used by Pilot stage to estimate the number of invocations per iteration. 500ms by default")]
+        public int? IterationTimeInMiliseconds { get; set; }
+        
+        [Option("iterationCount", Required = false, HelpText = "How many target iterations should be performed. By default calculated by the heuristic.")]
+        public int? IterationCount { get; set; }
+        
+        [Option("minIterationCount", Required = false, HelpText = "Minimum number of iterations to run. The default is 15.")]
+        public int? MinIterationCount { get; set; }
+        
+        [Option("maxIterationCount", Required = false, HelpText = "Maximum number of iterations to run. The default is 100.")]
+        public int? MaxIterationCount { get; set; }
+        
+        [Option("invocationCount", Required = false, HelpText = "Invocation count in a single iteration. By default calculated by the heuristic.")]
+        public int? InvocationCount { get; set; }
+        
+        [Option("unrollFactor", Required = false, HelpText = "How many times the benchmark method will be invoked per one iteration of a generated loop. 16 by default")]
+        public int? UnrollFactor { get; set; }
+        
+        [Option("runOncePerIteration", Required = false, Default = false, HelpText = "Run the benchmark exactly once per iteration.")]
+        public bool RunOncePerIteration { get; set; }
 
         [Usage(ApplicationAlias = "")]
         [PublicAPI]
@@ -103,7 +136,10 @@ namespace BenchmarkDotNet.ConsoleArguments
                 yield return new Example("Run all benchmarks from System.Memory namespace", shortName, new CommandLineOptions { Filters = new[] { HandleWildcardsOnUnix("System.Memory*") } });
                 yield return new Example("Run all benchmarks from ClassA and ClassB using type names", shortName, new CommandLineOptions { Filters = new[] { "ClassA", "ClassB" } });
                 yield return new Example("Run all benchmarks from ClassA and ClassB using patterns", shortName, new CommandLineOptions { Filters = new[] { HandleWildcardsOnUnix("*.ClassA.*"), HandleWildcardsOnUnix("*.ClassB.*") } });
-                yield return new Example("Run all benchmarks called `BenchmarkName` and show the results in single summary", shortName, new CommandLineOptions { Join = true, Filters = new[] { HandleWildcardsOnUnix("*.BenchmarkName") } });
+                yield return new Example("Run all benchmarks called `BenchmarkName` and show the results in single summary", longName, new CommandLineOptions { Join = true, Filters = new[] { HandleWildcardsOnUnix("*.BenchmarkName") } });
+                yield return new Example("Run selected benchmarks once per iteration", longName, new CommandLineOptions { RunOncePerIteration = true });
+                yield return new Example("Run selected benchmarks 100 times per iteration. Perform single warmup iteration and 5 actual workload iterations", longName, new CommandLineOptions { InvocationCount = 100, WarmupIterationCount = 1, IterationCount = 5});
+                yield return new Example("Run selected benchmarks 250ms per iteration. Perform from 9 to 15 iterations", longName, new CommandLineOptions { IterationTimeInMiliseconds = 250, MinIterationCount = 9, MaxIterationCount = 15});
             }
         }
 

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -16,7 +16,7 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option('j', "job", Required = false, Default = "Default", HelpText = "Dry/Short/Medium/Long or Default")]
         public string BaseJob { get; set; }
 
-        [Option('r', "runtimes", Required = false, HelpText = "Clr/Core/Mono/CoreRt")]
+        [Option('r', "runtimes", Required = false, HelpText = "Full target framework moniker for .NET Core and .NET. For Mono just 'Mono', for CoreRT just 'CoreRT'. First one will be marked as baseline!")]
         public IEnumerable<string> Runtimes { get; set; }
 
         [Option('e', "exporters", Required = false, HelpText = "GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML")]
@@ -58,14 +58,26 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option("join", Required = false, Default = false, HelpText = "Prints single table with results for all benchmarks")]
         public bool Join { get; set; }
         
+        [Option("keepFiles", Required = false, Default = false, HelpText = "Determines if all auto-generated files should be kept or removed after running the benchmarks.")]
+        public bool KeepBenchmarkFiles { get; set; }
+        
         [Option("cli", Required = false, HelpText = "Path to dotnet cli (optional).")]
         public FileInfo CliPath { get; set; }
 
         [Option("coreRun", Required = false, HelpText = "Path to CoreRun (optional).")]
         public FileInfo CoreRunPath { get; set; }
+
+        [Option("monoPath", Required = false, HelpText = "Optional path to Mono which should be used for running benchmarks.")]
+        public FileInfo MonoPath { get; set; }
+
+        [Option("clrVersion", Required = false, HelpText = "Optional version of private CLR build used as the value of COMPLUS_Version env var.")]
+        public string ClrVersion { get; set; }
         
-        [Option("keepFiles", Required = false, Default = false, HelpText = "Determines if all auto-generated files should be kept or removed after running the benchmarks.")]
-        public bool KeepBenchmarkFiles { get; set; }
+        [Option("coreRtVersion", Required = false, HelpText = "Optional version of Microsoft.DotNet.ILCompiler which should be used to run with CoreRT. Example: \"1.0.0-alpha-26414-01\"")]
+        public string CoreRtVersion { get; set; }
+
+        [Option("ilcPath", Required = false, HelpText = "Optional IlcPath which should be used to run with private CoreRT build.")]
+        public DirectoryInfo CoreRtPath { get; set; }
 
         [Usage(ApplicationAlias = "")]
         [PublicAPI]
@@ -73,18 +85,20 @@ namespace BenchmarkDotNet.ConsoleArguments
         {
             get
             {
-                var style = new UnParserSettings { PreferShortName = true };
+                var shortName = new UnParserSettings { PreferShortName = true };
+                var longName = new UnParserSettings { PreferShortName = false };
 
-                yield return new Example("Use Job.ShortRun for running the benchmarks", style, new CommandLineOptions { BaseJob = "short" });
-                yield return new Example("Run benchmarks in process", style, new CommandLineOptions { RunInProcess = true });
-                yield return new Example("Run benchmarks for Clr, Core and Mono", style, new CommandLineOptions { Runtimes = new[] { "Clr", "Core", "Mono" } });
-                yield return new Example("Use MemoryDiagnoser to get GC stats", style, new CommandLineOptions { UseMemoryDiagnoser = true });
-                yield return new Example("Use DisassemblyDiagnoser to get disassembly", style, new CommandLineOptions { UseDisassemblyDiagnoser = true });
-                yield return new Example("Run all benchmarks exactly once", style, new CommandLineOptions { BaseJob = "Dry", Filters = new[] { HandleWildcardsOnUnix("*") } });
-                yield return new Example("Run all benchmarks from System.Memory namespace", style, new CommandLineOptions { Filters = new[] { HandleWildcardsOnUnix("System.Memory*") } });
-                yield return new Example("Run all benchmarks from ClassA and ClassB using type names", style, new CommandLineOptions { Filters = new[] { "ClassA", "ClassB" } });
-                yield return new Example("Run all benchmarks from ClassA and ClassB using patterns", style, new CommandLineOptions { Filters = new[] { HandleWildcardsOnUnix("*.ClassA.*"), HandleWildcardsOnUnix("*.ClassB.*") } });
-                yield return new Example("Run all benchmarks called `BenchmarkName` and show the results in single summary", style, new CommandLineOptions { Join = true, Filters = new[] { HandleWildcardsOnUnix("*.BenchmarkName") } });
+                yield return new Example("Use Job.ShortRun for running the benchmarks", shortName, new CommandLineOptions { BaseJob = "short" });
+                yield return new Example("Run benchmarks in process", shortName, new CommandLineOptions { RunInProcess = true });
+                yield return new Example("Run benchmarks for .NET 4.7.2, .NET Core 2.1 and Mono. .NET 4.7.2 will be baseline because it was first.", longName, new CommandLineOptions { Runtimes = new[] { "net472", "netcoreapp2.1", "Mono" } });
+                yield return new Example("Run benchmarks for .NET Core 2.0, .NET Core 2.1 and .NET Core 2.2. .NET Core 2.0 will be baseline because it was first.", longName, new CommandLineOptions { Runtimes = new[] { "netcoreapp2.0", "netcoreapp2.1", "netcoreapp2.2" } });
+                yield return new Example("Use MemoryDiagnoser to get GC stats", shortName, new CommandLineOptions { UseMemoryDiagnoser = true });
+                yield return new Example("Use DisassemblyDiagnoser to get disassembly", shortName, new CommandLineOptions { UseDisassemblyDiagnoser = true });
+                yield return new Example("Run all benchmarks exactly once", shortName, new CommandLineOptions { BaseJob = "Dry", Filters = new[] { HandleWildcardsOnUnix("*") } });
+                yield return new Example("Run all benchmarks from System.Memory namespace", shortName, new CommandLineOptions { Filters = new[] { HandleWildcardsOnUnix("System.Memory*") } });
+                yield return new Example("Run all benchmarks from ClassA and ClassB using type names", shortName, new CommandLineOptions { Filters = new[] { "ClassA", "ClassB" } });
+                yield return new Example("Run all benchmarks from ClassA and ClassB using patterns", shortName, new CommandLineOptions { Filters = new[] { HandleWildcardsOnUnix("*.ClassA.*"), HandleWildcardsOnUnix("*.ClassB.*") } });
+                yield return new Example("Run all benchmarks called `BenchmarkName` and show the results in single summary", shortName, new CommandLineOptions { Join = true, Filters = new[] { HandleWildcardsOnUnix("*.BenchmarkName") } });
             }
         }
 

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Mathematics;
 using BenchmarkDotNet.Portability;
 using CommandLine;
@@ -60,6 +61,9 @@ namespace BenchmarkDotNet.ConsoleArguments
         
         [Option("keepFiles", Required = false, Default = false, HelpText = "Determines if all auto-generated files should be kept or removed after running the benchmarks.")]
         public bool KeepBenchmarkFiles { get; set; }
+
+        [Option("counters", Required = false, HelpText = "Hardware Counters", Separator = '+')]
+        public IEnumerable<string> HardwareCounters { get; set; }
         
         [Option("cli", Required = false, HelpText = "Path to dotnet cli (optional).")]
         public FileInfo CliPath { get; set; }
@@ -94,6 +98,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 yield return new Example("Run benchmarks for .NET Core 2.0, .NET Core 2.1 and .NET Core 2.2. .NET Core 2.0 will be baseline because it was first.", longName, new CommandLineOptions { Runtimes = new[] { "netcoreapp2.0", "netcoreapp2.1", "netcoreapp2.2" } });
                 yield return new Example("Use MemoryDiagnoser to get GC stats", shortName, new CommandLineOptions { UseMemoryDiagnoser = true });
                 yield return new Example("Use DisassemblyDiagnoser to get disassembly", shortName, new CommandLineOptions { UseDisassemblyDiagnoser = true });
+                yield return new Example("Use HardwareCountersDiagnoser to get hardware coutner info", longName, new CommandLineOptions { HardwareCounters = new [] { nameof(HardwareCounter.CacheMisses), nameof(HardwareCounter.InstructionRetired) } });
                 yield return new Example("Run all benchmarks exactly once", shortName, new CommandLineOptions { BaseJob = "Dry", Filters = new[] { HandleWildcardsOnUnix("*") } });
                 yield return new Example("Run all benchmarks from System.Memory namespace", shortName, new CommandLineOptions { Filters = new[] { HandleWildcardsOnUnix("System.Memory*") } });
                 yield return new Example("Run all benchmarks from ClassA and ClassB using type names", shortName, new CommandLineOptions { Filters = new[] { "ClassA", "ClassB" } });

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -163,6 +163,11 @@ namespace BenchmarkDotNet.ConsoleArguments
                 config.Add(baseJob);
 
             config.Add(options.Exporters.SelectMany(exporter => AvailableExporters[exporter]).ToArray());
+            
+            config.Add(options.HardwareCounters
+                .Select(counterName => Enum.TryParse(counterName, ignoreCase: true, out HardwareCounter counter) ? counter : HardwareCounter.NotSet)
+                .Where(counter => counter != HardwareCounter.NotSet)
+                .ToArray());
 
             if (options.UseMemoryDiagnoser)
                 config.Add(MemoryDiagnoser.Default);

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -14,6 +14,7 @@ using BenchmarkDotNet.Exporters.Json;
 using BenchmarkDotNet.Exporters.Xml;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Filters;
+using BenchmarkDotNet.Horology;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Mathematics;
@@ -203,6 +204,29 @@ namespace BenchmarkDotNet.ConsoleArguments
             if (options.Affinity.HasValue)
                 baseJob = baseJob.WithAffinity((IntPtr) options.Affinity.Value);
 
+            if (options.LaunchCount.HasValue)
+                baseJob = baseJob.WithLaunchCount(options.LaunchCount.Value);
+            if (options.WarmupIterationCount.HasValue)
+                baseJob = baseJob.WithWarmupCount(options.WarmupIterationCount.Value);
+            if (options.MinWarmupIterationCount.HasValue)
+                baseJob = baseJob.WithMinWarmupCount(options.MinWarmupIterationCount.Value);
+            if (options.MaxWarmupIterationCount.HasValue)
+                baseJob = baseJob.WithMaxWarmupCount(options.MaxWarmupIterationCount.Value);
+            if (options.IterationTimeInMiliseconds.HasValue)
+                baseJob = baseJob.WithIterationTime(TimeInterval.FromMilliseconds(options.IterationTimeInMiliseconds.Value));
+            if (options.IterationCount.HasValue)
+                baseJob = baseJob.WithIterationCount(options.IterationCount.Value);
+            if (options.MinIterationCount.HasValue)
+                baseJob = baseJob.WithMinIterationCount(options.MinIterationCount.Value);
+            if (options.MaxIterationCount.HasValue)
+                baseJob = baseJob.WithMaxIterationCount(options.MaxIterationCount.Value);
+            if (options.InvocationCount.HasValue)
+                baseJob = baseJob.WithInvocationCount(options.InvocationCount.Value);
+            if (options.UnrollFactor.HasValue)
+                baseJob = baseJob.WithUnrollFactor(options.UnrollFactor.Value);
+            if (options.RunOncePerIteration)
+                baseJob = baseJob.RunOncePerIteration();
+            
             return baseJob;
         }
 
@@ -212,7 +236,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 yield return baseJob.With(InProcessToolchain.Instance);
 
             foreach (string runtime in options.Runtimes) // known runtimes
-                yield return CreateJob(baseJob, runtime.ToLowerInvariant(), options);
+                yield return CreateJobForGivenRuntime(baseJob, runtime.ToLowerInvariant(), options);
 
             if (options.CoreRunPath != null)
                 yield return CreateCoreRunJob(baseJob, options); // local CoreFX and CoreCLR builds
@@ -220,7 +244,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 yield return baseJob.With(new ClrRuntime(options.ClrVersion)); // local builds of .NET Runtime
         }
 
-        private static Job CreateJob(Job baseJob, string runtime, CommandLineOptions options)
+        private static Job CreateJobForGivenRuntime(Job baseJob, string runtime, CommandLineOptions options)
         {
             switch (runtime)
             {

--- a/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
@@ -123,5 +123,8 @@ namespace BenchmarkDotNet.Extensions
 
             return directoryPath;
         }
+
+        internal static bool IsNotNullButDoesNotExist(this FileSystemInfo fileInfo)
+            => fileInfo != null && !fileInfo.Exists;
     }
 }

--- a/src/BenchmarkDotNet/Jobs/JobExtensions.cs
+++ b/src/BenchmarkDotNet/Jobs/JobExtensions.cs
@@ -242,6 +242,11 @@ namespace BenchmarkDotNet.Jobs
         /// mutator job should not be added to the config, but instead applied to other jobs in given config
         /// </summary>
         public static Job AsMutator(this Job job) => job.WithCore(j => j.Meta.IsMutator = true);
+        
+        /// <summary>
+        /// use it if you want to specify custom default settings for default job used by console arguments parser
+        /// </summary>
+        public static Job AsDefault(this Job job, bool value = true) => job.WithCore(j => j.Meta.IsDefault = value);
 
         internal static Job MakeSettingsUserFriendly(this Job job, Descriptor descriptor)
         {

--- a/src/BenchmarkDotNet/Jobs/MetaMode.cs
+++ b/src/BenchmarkDotNet/Jobs/MetaMode.cs
@@ -7,6 +7,7 @@ namespace BenchmarkDotNet.Jobs
     {
         [PublicAPI] public static readonly Characteristic<bool> BaselineCharacteristic = CreateHiddenCharacteristic<bool>(nameof(Baseline));
         [PublicAPI] public static readonly Characteristic<bool> IsMutatorCharacteristic = CreateIgnoreOnApplyCharacteristic<bool>(nameof(IsMutator));
+        [PublicAPI] public static readonly Characteristic<bool> IsDefaultCharacteristic = CreateHiddenCharacteristic<bool>(nameof(IsDefault));
 
         public bool Baseline
         {
@@ -21,6 +22,15 @@ namespace BenchmarkDotNet.Jobs
         {
             get => IsMutatorCharacteristic[this];
             set => IsMutatorCharacteristic[this] = value;
+        }
+        
+        /// <summary>
+        /// set to true if you want to specify custom default settings for default job used by console arguments parser
+        /// </summary>
+        public bool IsDefault
+        {
+            get => IsDefaultCharacteristic[this];
+            set => IsDefaultCharacteristic[this] = value;
         }
     }
 }

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -50,10 +50,7 @@ namespace BenchmarkDotNet.Running
             var parameterDefinitions = GetParameterDefinitions(containingType);
             var parameterInstancesList = parameterDefinitions.Expand();
 
-            var rawJobs = fullConfig.GetJobs().ToArray();
-            if (rawJobs.IsEmpty())
-                rawJobs = new[] { Job.Default };
-            var jobs = rawJobs.Distinct().ToArray();
+            var jobs = fullConfig.GetRunnableJobs();
 
             var targets = GetTargets(targetMethods, containingType, globalSetupMethods, globalCleanupMethods, iterationSetupMethods, iterationCleanupMethods).ToArray();
 

--- a/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
@@ -61,7 +61,7 @@ namespace BenchmarkDotNet.Running
         {
             args = args ?? Array.Empty<string>();
 
-            (bool isParsingSuccess, var parsedConfig) = ConfigParser.Parse(args, ConsoleLogger.Default);
+            (bool isParsingSuccess, var parsedConfig) = ConfigParser.Parse(args, ConsoleLogger.Default, config);
             if (!isParsingSuccess)
                 return Enumerable.Empty<Summary>();
 

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/Publisher.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/Publisher.cs
@@ -14,8 +14,8 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
             UseCppCodeGenerator = useCppCodeGenerator;
             RuntimeIdentifier = runtimeIdentifier;
         }
-        
-        private string IlcPath { get; }
+
+        internal string IlcPath { get; }
         private bool UseCppCodeGenerator { get; }
         private string RuntimeIdentifier { get; }
 

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
@@ -27,7 +27,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
             CustomDotNetCliPath = customDotNetCliPath;
         }
 
-        private string CustomDotNetCliPath { get; }
+        internal string CustomDotNetCliPath { get; }
 
         [PublicAPI]
         public static IToolchain From(NetCoreAppSettings settings)

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliGenerator.cs
@@ -12,7 +12,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
     [PublicAPI]
     public abstract class DotNetCliGenerator : GeneratorBase
     {
-        protected string TargetFrameworkMoniker { get; }
+        internal string TargetFrameworkMoniker { get; }
 
         protected Func<Platform, string> PlatformProvider { get; }
 

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using BenchmarkDotNet.ConsoleArguments;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Exporters;
@@ -167,6 +168,16 @@ namespace BenchmarkDotNet.Tests
             Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is MonoRuntime));
             Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is CoreRtRuntime));
             Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is CoreRtRuntime));
+        }
+        
+        [Fact]
+        public void CanParseHardwareCounters()
+        {
+            var config = ConfigParser.Parse(new[] { "--counters", $"{nameof(HardwareCounter.CacheMisses)}+{nameof(HardwareCounter.InstructionRetired)}"}, new OutputLogger(Output)).config;
+
+            Assert.Equal(2, config.GetHardwareCounters().Count());
+            Assert.Single(config.GetHardwareCounters().Where(counter => counter == HardwareCounter.CacheMisses));
+            Assert.Single(config.GetHardwareCounters().Where(counter => counter == HardwareCounter.InstructionRetired));
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -2,12 +2,17 @@
 using System.IO;
 using System.Linq;
 using BenchmarkDotNet.ConsoleArguments;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Exporters.Csv;
 using BenchmarkDotNet.Tests.Loggers;
 using BenchmarkDotNet.Toolchains;
+using BenchmarkDotNet.Toolchains.CoreRt;
 using BenchmarkDotNet.Toolchains.CoreRun;
+using BenchmarkDotNet.Toolchains.CsProj;
+using BenchmarkDotNet.Toolchains.DotNetCli;
+using BenchmarkDotNet.Toolchains.Roslyn;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -74,7 +79,7 @@ namespace BenchmarkDotNet.Tests
         }
 
         [Fact]
-        public void CoreRunConfigParserCorrectly()
+        public void CoreRunConfigParsedCorrectly()
         {
             var fakeDotnetCliPath = typeof(object).Assembly.Location;
             var fakeCoreRunPath = typeof(ConfigParserTests).Assembly.Location;
@@ -85,6 +90,83 @@ namespace BenchmarkDotNet.Tests
             Assert.NotNull(toolchain);
             Assert.Equal(fakeCoreRunPath, toolchain.SourceCoreRun.FullName);
             Assert.Equal(fakeDotnetCliPath, toolchain.CustomDotNetCliPath.FullName);
+        }
+        
+        [Fact]
+        public void MonoPathParsedCorrectly()
+        {
+            var fakeMonoPath = typeof(object).Assembly.Location;
+            var config = ConfigParser.Parse(new[] { "-r", "mono", "--monoPath", fakeMonoPath }, new OutputLogger(Output)).config;
+
+            Assert.Single(config.GetJobs());
+            Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is MonoRuntime mono && mono.CustomPath == fakeMonoPath));
+        }
+        
+        [Fact]
+        public void ClrVersionParsedCorrectly()
+        {
+            const string clrVersion = "secret";
+            var config = ConfigParser.Parse(new[] { "--clrVersion", clrVersion }, new OutputLogger(Output)).config;
+
+            Assert.Single(config.GetJobs());
+            Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is ClrRuntime clr && clr.Version == clrVersion));
+        }
+        
+        [Fact]
+        public void CoreRtPathParsedCorrectly()
+        {
+            var fakeCoreRtPath =  new FileInfo(typeof(ConfigParserTests).Assembly.Location).Directory;
+            var config = ConfigParser.Parse(new[] { "-r", "corert", "--ilcPath", fakeCoreRtPath.FullName }, new OutputLogger(Output)).config;
+
+            Assert.Single(config.GetJobs());
+            CoreRtToolchain toolchain = config.GetJobs().Single().GetToolchain() as CoreRtToolchain;
+            Assert.NotNull(toolchain);
+            Assert.Equal(fakeCoreRtPath.FullName, ((Publisher)toolchain.Builder).IlcPath);
+        }
+        
+        [Theory]
+        [InlineData("netcoreapp2.0")]
+        [InlineData("netcoreapp2.1")]
+        [InlineData("netcoreapp2.2")]
+        [InlineData("netcoreapp3.0")]
+        public void DotNetCliParsedCorrectly(string tfm)
+        {
+            var fakeDotnetCliPath = typeof(object).Assembly.Location;
+            var config = ConfigParser.Parse(new[] { "-r", tfm, "--cli", fakeDotnetCliPath }, new OutputLogger(Output)).config;
+
+            Assert.Single(config.GetJobs());
+            CsProjCoreToolchain toolchain = config.GetJobs().Single().GetToolchain() as CsProjCoreToolchain;
+            Assert.NotNull(toolchain);
+            Assert.Equal(tfm, ((DotNetCliGenerator)toolchain.Generator).TargetFrameworkMoniker);
+            Assert.Equal(fakeDotnetCliPath, toolchain.CustomDotNetCliPath);
+        }
+        
+        [Theory]
+        [InlineData("net46")]
+        [InlineData("net461")]
+        [InlineData("net462")]
+        [InlineData("net47")]
+        [InlineData("net471")]
+        [InlineData("net472")]
+        public void NetFrameworkMonikerParsedCorrectly(string tfm)
+        {
+            var config = ConfigParser.Parse(new[] { "-r", tfm }, new OutputLogger(Output)).config;
+
+            Assert.Single(config.GetJobs());
+            CsProjClassicNetToolchain toolchain = config.GetJobs().Single().GetToolchain() as CsProjClassicNetToolchain;
+            Assert.NotNull(toolchain);
+            Assert.Equal(tfm, ((DotNetCliGenerator)toolchain.Generator).TargetFrameworkMoniker);
+        }
+        
+        [Fact]
+        public void CanCompreFewDifferentRuntimes()
+        {
+            var config = ConfigParser.Parse(new[] { "--runtimes", "net46", "MONO", "netcoreapp3.0", "CoreRT"}, new OutputLogger(Output)).config;
+
+            Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is ClrRuntime));
+            Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is MonoRuntime));
+            Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is CoreRtRuntime));
+            Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is CoreRtRuntime));
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.ConsoleArguments;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Environments;
@@ -214,6 +215,20 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(2, config.GetHardwareCounters().Count());
             Assert.Single(config.GetHardwareCounters().Where(counter => counter == HardwareCounter.CacheMisses));
             Assert.Single(config.GetHardwareCounters().Where(counter => counter == HardwareCounter.InstructionRetired));
+        }
+
+        [Fact]
+        public void UserCanSpecifyCustomDefaultJobAndOverwriteItsSettingsViaConsoleArgs()
+        {
+            var globalConfig = DefaultConfig.Instance
+                .With(Job.Default
+                    .WithWarmupCount(1)
+                    .AsDefault());
+            
+            var parserdConfig = ConfigParser.Parse(new[] { "--warmupCount", "2"}, new OutputLogger(Output), globalConfig).config;
+            
+            Assert.Equal(2, parserdConfig.GetJobs().Single().Run.WarmupCount);
+            Assert.Equal(false, parserdConfig.GetJobs().Single().Meta.IsDefault); // after the merge the job is not "default" anymore
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/GetRunnableJobsTests.cs
+++ b/tests/BenchmarkDotNet.Tests/GetRunnableJobsTests.cs
@@ -1,0 +1,99 @@
+﻿using System.Linq;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests
+{
+    public class GetRunnableJobsTests
+    {
+        [Fact]
+        public void WhenTwoConfigsAreAddedTheRegularJobsAreJustAdded()
+        {
+            var configWithClrJob = CreateConfigFromJobs(Job.Clr);
+            var cofingWithCoreJob = CreateConfigFromJobs(Job.Core);
+
+            foreach (var added in AddLeftToTheRightAndRightToTheLef(configWithClrJob, cofingWithCoreJob))
+            {
+                var runnableJobs = added.GetRunnableJobs();
+                
+                Assert.Equal(2, runnableJobs.Count);
+                Assert.Single(runnableJobs, job => job.Environment.Runtime is ClrRuntime);
+                Assert.Single(runnableJobs, job => job.Environment.Runtime is CoreRuntime);
+            }
+        }
+        
+        [Fact]
+        public void WhenTwoConfigsAreAddedTheMutatorJobsAreAppliedToAllOtherJobs()
+        {
+            const int warmupCount = 2;
+            var configWithMutatorJob = CreateConfigFromJobs(Job.Default.WithWarmupCount(warmupCount).AsMutator());
+            var configWithTwoStandardJobs = CreateConfigFromJobs(Job.Clr, Job.Core);
+
+            foreach (var added in AddLeftToTheRightAndRightToTheLef(configWithTwoStandardJobs, configWithMutatorJob))
+            {
+                var runnableJobs = added.GetRunnableJobs();
+                
+                Assert.Equal(2, runnableJobs.Count);
+                Assert.All(runnableJobs, job => Assert.Equal(warmupCount, job.Run.WarmupCount));
+                Assert.Single(runnableJobs, job => job.Environment.Runtime is ClrRuntime);
+                Assert.Single(runnableJobs, job => job.Environment.Runtime is CoreRuntime);
+            }
+        }
+        
+        [Fact]
+        public void WhenTwoConfigsAreAddedTheMutatorJobsAreAppliedToCustomDefaultJobIfPresent()
+        {
+            const int warmupCount = 2;
+            const int iterationsCount = 10;
+
+            var configWithCustomDefaultJob = CreateConfigFromJobs(Job.Default.WithIterationCount(iterationsCount).AsDefault());
+            var configWithMutatorJob = CreateConfigFromJobs(Job.Default.WithWarmupCount(warmupCount).AsMutator());
+
+            foreach (var added in AddLeftToTheRightAndRightToTheLef(configWithCustomDefaultJob, configWithMutatorJob))
+            {
+                var mergedJob = added.GetRunnableJobs().Single();
+                Assert.Equal(warmupCount, mergedJob.Run.WarmupCount);
+                Assert.Equal(iterationsCount, mergedJob.Run.IterationCount);
+                Assert.False(mergedJob.Meta.IsMutator); // after the merge the "child" job becomes a standard job
+            }
+        }
+        
+        [Fact]
+        public void WhenTwoConfigsAreAddedTheMutatorJobsAreAppliedToDefaultJobIfCustomDefaultJobIsNotPresent()
+        {
+            const int warmupCount = 2;
+            var configWithMutatorJob = CreateConfigFromJobs(Job.Default.WithWarmupCount(warmupCount).AsMutator());
+
+            foreach (var added in AddLeftToTheRightAndRightToTheLef(ManualConfig.CreateEmpty(), configWithMutatorJob))
+            {
+                var mergedJob = added.GetRunnableJobs().Single();
+                Assert.Equal(warmupCount, mergedJob.Run.WarmupCount);
+                Assert.False(mergedJob.Meta.IsDefault); // after the merge the "child" job becomes a standard job
+                Assert.False(mergedJob.Meta.IsMutator); // after the merge the "child" job becomes a standard job
+                Assert.Single(mergedJob.GetCharacteristicsWithValues(), changedCharacteristic => ReferenceEquals(changedCharacteristic, RunMode.WarmupCountCharacteristic));
+            }
+        }
+        
+        private static ManualConfig CreateConfigFromJobs(params Job[] jobs)
+        {
+            var config = ManualConfig.CreateEmpty();
+            
+            config.Add(jobs);
+
+            return config;
+        }
+        
+        private static ManualConfig[] AddLeftToTheRightAndRightToTheLef(ManualConfig left, ManualConfig right)
+        {
+            var rightAddedToLeft = ManualConfig.Create(left);
+            rightAddedToLeft.Add(right);
+            
+            var leftAddedToTheRight = ManualConfig.Create(right);
+            leftAddedToTheRight.Add(left);
+
+            return new []{ rightAddedToLeft, leftAddedToTheRight };
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.Tests/JobTests.cs
+++ b/tests/BenchmarkDotNet.Tests/JobTests.cs
@@ -415,7 +415,7 @@ namespace BenchmarkDotNet.IntegrationTests
             Assert.Equal("Id;Accuracy;AnalyzeLaunchVariance;EvaluateOverhead;" +
                 "MaxAbsoluteError;MaxRelativeError;MinInvokeCount;MinIterationTime;OutlierMode;Environment;Affinity;EnvironmentVariables;" +
                 "Jit;Platform;Runtime;Gc;AllowVeryLargeObjects;Concurrent;CpuGroups;Force;HeapAffinitizeMask;HeapCount;NoAffinitize;" +
-                "RetainVm;Server;Infrastructure;Arguments;BuildConfiguration;Clock;EngineFactory;Toolchain;Meta;Baseline;IsMutator;Run;InvocationCount;IterationCount;IterationTime;" +
+                "RetainVm;Server;Infrastructure;Arguments;BuildConfiguration;Clock;EngineFactory;Toolchain;Meta;Baseline;IsDefault;IsMutator;Run;InvocationCount;IterationCount;IterationTime;" +
                 "LaunchCount;MaxIterationCount;MaxWarmupIterationCount;MinIterationCount;MinWarmupIterationCount;RunStrategy;UnrollFactor;WarmupCount", string.Join(";", a));
         }
         


### PR DESCRIPTION
Recently I am using BDN on a large scale and in some scenarios I can't recompile the code, I need to be able to specify most of the settings from the command line. This PR adds most of the things to supported command line arguments.

## Runtimes

The `--runtimes` or just `-r` allows you to run the benchmarks for selected Runtimes. Available options are: Mono, CoreRT, net46, net461, net462, net47, net471, net472, netcoreapp2.0, netcoreapp2.1, netcoreapp2.2, netcoreapp3.0.

Example: run the benchmarks for .NET 4.7.2 and .NET Core 2.1:

```log
dotnet run -c Release -- --runtimes net472 netcoreapp2.1
```

## Number of invocations and iterations

* `--launchCount` - how many times we should launch process with target benchmark. The default is 1.
* `--warmupCount` - how many warmup iterations should be performed. If you set it, the minWarmupCount and maxWarmupCount are ignored. By default calculated by the heuristic.
* `--minWarmupCount` - minimum count of warmup iterations that should be performed. The default is 6.
* `--maxWarmupCount` - maximum count of warmup iterations that should be performed. The default is 50.
* `--iterationTime` - desired time of execution of an iteration. Used by Pilot stage to estimate the number of invocations per iteration. 500ms by default.
* `--iterationCount` - how many target iterations should be performed. By default calculated by the heuristic.
* `--minIterationCount` - minimum number of iterations to run. The default is 15.
* `--maxIterationCount` - maximum number of iterations to run. The default is 100.
* `--invocationCount` - invocation count in a single iteration. By default calculated by the heuristic.
* `--unrollFactor` - how many times the benchmark method will be invoked per one iteration of a generated loop. 16 by default
* `--runOncePerIteration` - run the benchmark exactly once per iteration. False by default.

Example: run single warmup iteration, from 9 to 12 actual workload iterations.

```log
dotnet run -c Release -- --warmupCount 1 --minIterationCount 9 --maxIterationCount 12
```

## Specifying custom default settings for console argument parser

If you want to have a possibility to specify custom default Job settings programmatically and optionally overwrite it with console line arguments, then you should create a global config with single job marked as `.AsDefault` and pass it to `BenchmarkSwitcher` together with the console line arguments.

Example: run single warmup iteration by default.

```cs
static void Main(string[] args)
    => BenchmarkSwitcher
        .FromAssembly(typeof(Program).Assembly)
        .Run(args, GetGlobalConfig());

static IConfig GetGlobalConfig()
    => DefaultConfig.Instance
        .With(Job.Default
            .WithWarmupCount(1)
            .AsDefault()); // the KEY to get it working
```

Now, the default settings are: `WarmupCount=1` but you might still overwrite it from console args like in the example below: 

```log
dotnet run -c Release -- --warmupCount 2
```

/cc @AndreyAkinshin @jorive