### PR TITLE
Simplify AMD Ryzen CPU brand info

### DIFF
--- a/src/BenchmarkDotNet/Environments/ProcessorBrandStringHelper.cs
+++ b/src/BenchmarkDotNet/Environments/ProcessorBrandStringHelper.cs
@@ -33,7 +33,11 @@ namespace BenchmarkDotNet.Environments
 
             string frequencyString = GetBrandStyledActualFrequency(cpuInfo.NominalFrequency);
             if (includeMaxFrequency && frequencyString != null && !processorName.Contains(frequencyString))
-                processorName = $"{processorName} (Max: {frequencyString})";
+            {
+                // show Max only if there's already a frequency name to differentiate the two
+                string maxFrequency = processorName.Contains("Hz") ? $"(Max: {frequencyString})" : frequencyString;
+                processorName = $"{processorName} {maxFrequency}";
+            }
             
             // Remove double spaces
             processorName = Regex.Replace(processorName.Trim(), @"\s+", " ");

--- a/src/BenchmarkDotNet/Environments/ProcessorBrandStringHelper.cs
+++ b/src/BenchmarkDotNet/Environments/ProcessorBrandStringHelper.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Horology;
+using BenchmarkDotNet.Portability.Cpu;
 using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Environments
@@ -12,17 +13,26 @@ namespace BenchmarkDotNet.Environments
         /// <summary>
         /// Transform a processor brand string to a nice form for summary.
         /// </summary>
-        /// <param name="processorName">Original processor brand string</param>
-        /// <param name="maxFrequency">processor actual frequency</param>
+        /// <param name="cpuInfo">The CPU information</param>
+        /// <param name="includeMaxFrequency">Whether to include determined max frequency information</param>
         /// <returns>Prettified version</returns>
         [NotNull]
-        public static string Prettify([NotNull] string processorName, Frequency? maxFrequency = null)
+        public static string Prettify(CpuInfo cpuInfo, bool includeMaxFrequency = false)
         {
-            // Remove parts which don't provide any useful information for user
-            processorName = processorName.Replace("@", "").Replace("(R)", "").Replace("(TM)", "");
+            if (cpuInfo == null)
+            {
+                return "";
+            }
 
-            string frequencyString = GetBrandStyledActualFrequency(maxFrequency);
-            if (frequencyString != null && !processorName.Contains(frequencyString))
+            // Remove parts which don't provide any useful information for user
+            var processorName = cpuInfo.ProcessorName.Replace("@", "").Replace("(R)", "").Replace("(TM)", "");
+            
+            // If we have found physical core(s), we can safely assume we can drop extra info from brand
+            if (cpuInfo.PhysicalCoreCount > 0)
+                processorName = Regex.Replace(processorName, @"(\w+?-Core Processor)", "").Trim();
+
+            string frequencyString = GetBrandStyledActualFrequency(cpuInfo.NominalFrequency);
+            if (includeMaxFrequency && frequencyString != null && !processorName.Contains(frequencyString))
                 processorName = $"{processorName} (Max: {frequencyString})";
             
             // Remove double spaces

--- a/src/BenchmarkDotNet/Exporters/Json/JsonExporterBase.cs
+++ b/src/BenchmarkDotNet/Exporters/Json/JsonExporterBase.cs
@@ -30,7 +30,7 @@ namespace BenchmarkDotNet.Exporters.Json
                 HostEnvironmentInfo.BenchmarkDotNetCaption,
                 summary.HostEnvironmentInfo.BenchmarkDotNetVersion,
                 OsVersion = summary.HostEnvironmentInfo.OsVersion.Value,
-                ProcessorName = ProcessorBrandStringHelper.Prettify(summary.HostEnvironmentInfo.CpuInfo.Value?.ProcessorName ?? ""),
+                ProcessorName = ProcessorBrandStringHelper.Prettify(summary.HostEnvironmentInfo.CpuInfo.Value),
                 summary.HostEnvironmentInfo.CpuInfo.Value?.PhysicalProcessorCount,
                 summary.HostEnvironmentInfo.CpuInfo.Value?.PhysicalCoreCount,
                 summary.HostEnvironmentInfo.CpuInfo.Value?.LogicalCoreCount,

--- a/src/BenchmarkDotNet/Exporters/Xml/SummaryDto.cs
+++ b/src/BenchmarkDotNet/Exporters/Xml/SummaryDto.cs
@@ -36,7 +36,7 @@ namespace BenchmarkDotNet.Exporters.Xml
         public string BenchmarkDotNetCaption => HostEnvironmentInfo.BenchmarkDotNetCaption;
         public string BenchmarkDotNetVersion => hei.BenchmarkDotNetVersion;
         public string OsVersion => hei.OsVersion.Value;
-        public string ProcessorName => ProcessorBrandStringHelper.Prettify(hei.CpuInfo.Value?.ProcessorName ?? "");
+        public string ProcessorName => ProcessorBrandStringHelper.Prettify(hei.CpuInfo.Value);
         public string PhysicalProcessorCount => hei.CpuInfo.Value?.PhysicalProcessorCount?.ToString();
         public string PhysicalCoreCount => hei.CpuInfo.Value?.PhysicalCoreCount?.ToString();
         public string LogicalCoreCount => hei.CpuInfo.Value?.LogicalCoreCount?.ToString();

--- a/src/BenchmarkDotNet/Portability/Cpu/CpuInfo.cs
+++ b/src/BenchmarkDotNet/Portability/Cpu/CpuInfo.cs
@@ -10,8 +10,13 @@ namespace BenchmarkDotNet.Portability.Cpu
         public int? LogicalCoreCount { get; }
         public Frequency? NominalFrequency { get; }
         public Frequency? MinFrequency { get; }
-        public Frequency? MaxFrequency { get; }        
+        public Frequency? MaxFrequency { get; }
 
+        internal CpuInfo(string processorName, Frequency? nominalFrequency)
+            : this(processorName, null, null, null, nominalFrequency, null, null)
+        {
+        }
+        
         public CpuInfo(string processorName,
                        int? physicalProcessorCount,
                        int? physicalCoreCount,

--- a/src/BenchmarkDotNet/Portability/Cpu/CpuInfoFormatter.cs
+++ b/src/BenchmarkDotNet/Portability/Cpu/CpuInfoFormatter.cs
@@ -6,34 +6,37 @@ namespace BenchmarkDotNet.Portability.Cpu
     public static class CpuInfoFormatter
     {
         public static string Format(CpuInfo cpuInfo)
-            => Format(cpuInfo?.ProcessorName, cpuInfo?.PhysicalProcessorCount, cpuInfo?.PhysicalCoreCount, cpuInfo?.LogicalCoreCount, cpuInfo?.NominalFrequency);
-
-        private static string Format(string processorName, int? physicalProcessorCount, int? physicalCoreCount, int? logicalCoreCount, double? processorFreq)
         {
+            if (cpuInfo == null)
+            {
+                return "Unknown processor";
+            }
+            
             var parts = new List<string>
             {
-                !string.IsNullOrWhiteSpace(processorName)
-                    ? ProcessorBrandStringHelper.Prettify(processorName, processorFreq)
+                !string.IsNullOrWhiteSpace(cpuInfo.ProcessorName)
+                    ? ProcessorBrandStringHelper.Prettify(cpuInfo, includeMaxFrequency: true)
                     : "Unknown processor"
             };
 
-            if (physicalProcessorCount > 0)
-                parts.Add($", {physicalProcessorCount} CPU");
+            if (cpuInfo.PhysicalProcessorCount > 0)
+                parts.Add($", {cpuInfo.PhysicalProcessorCount} CPU");
 
-            if (logicalCoreCount == 1)
+            if (cpuInfo.LogicalCoreCount == 1)
                 parts.Add(", 1 logical core");
-            if (logicalCoreCount > 1)
-                parts.Add($", {logicalCoreCount} logical cores");
 
-            if (logicalCoreCount > 0 && physicalCoreCount > 0)
+            if (cpuInfo.LogicalCoreCount > 1)
+                parts.Add($", {cpuInfo.LogicalCoreCount} logical cores");
+
+            if (cpuInfo.LogicalCoreCount > 0 && cpuInfo.PhysicalCoreCount > 0)
                 parts.Add(" and ");
-            else if (physicalCoreCount > 0)
+            else if (cpuInfo.PhysicalCoreCount > 0)
                 parts.Add(", ");
 
-            if (physicalCoreCount == 1)
+            if (cpuInfo.PhysicalCoreCount == 1)
                 parts.Add("1 physical core");
-            if (physicalCoreCount > 1)
-                parts.Add($"{physicalCoreCount} physical cores");
+            if (cpuInfo.PhysicalCoreCount > 1)
+                parts.Add($"{cpuInfo.PhysicalCoreCount} physical cores");
             
             string result = string.Join("", parts);
             // The line with ProcessorBrandString is one of the longest lines in the summary.

--- a/tests/BenchmarkDotNet.Tests/Environments/ProcessorBrandStringTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Environments/ProcessorBrandStringTests.cs
@@ -35,8 +35,8 @@ namespace BenchmarkDotNet.Tests.Environments
         }
         
         [Theory]
-        [InlineData("AMD Ryzen 7 2700X Eight-Core Processor", "AMD Ryzen 7 2700X (Max: 4.10GHz)", 4.1, 8, 16)]
-        [InlineData("AMD Ryzen 7 2700X Eight-Core Processor", "AMD Ryzen 7 2700X Eight-Core Processor (Max: 4.10GHz)", 4.1, null, null)]
+        [InlineData("AMD Ryzen 7 2700X Eight-Core Processor", "AMD Ryzen 7 2700X 4.10GHz", 4.1, 8, 16)]
+        [InlineData("AMD Ryzen 7 2700X Eight-Core Processor", "AMD Ryzen 7 2700X Eight-Core Processor 4.10GHz", 4.1, null, null)]
         public void AmdIsPrettifiedWithDiffFrequencies(string originalName, string prettifiedName, double actualFrequency, int? physicalCoreCount, int? logicalCoreCount)
         {
             var cpuInfo = new CpuInfo(
@@ -44,7 +44,7 @@ namespace BenchmarkDotNet.Tests.Environments
                 physicalProcessorCount: null,
                 physicalCoreCount, 
                 logicalCoreCount, 
-                Frequency.FromGHz(actualFrequency), 
+                Frequency.FromGHz(actualFrequency),
                 minFrequency: null, 
                 maxFrequency: null);
 

--- a/tests/BenchmarkDotNet.Tests/Environments/ProcessorBrandStringTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Environments/ProcessorBrandStringTests.cs
@@ -1,5 +1,6 @@
 ﻿using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Horology;
+using BenchmarkDotNet.Portability.Cpu;
 using Xunit;
 
 namespace BenchmarkDotNet.Tests.Environments
@@ -19,7 +20,7 @@ namespace BenchmarkDotNet.Tests.Environments
         [InlineData("Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz ", "Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R)")]
         [InlineData("Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz", "Intel Core i7-8700K CPU 3.70GHz (Coffee Lake)")]
         public void IntroCoreIsPrettified(string originalName, string prettifiedName) =>
-            Assert.Equal(prettifiedName, ProcessorBrandStringHelper.Prettify(originalName));
+            Assert.Equal(prettifiedName, ProcessorBrandStringHelper.Prettify(new CpuInfo(originalName, nominalFrequency: null)));
 
         [Theory]
         [InlineData("Intel(R) Pentium(TM) G4560 CPU @ 3.50GHz", "Intel Pentium G4560 CPU 3.50GHz (Max: 3.70GHz)", 3.7)]
@@ -30,7 +31,24 @@ namespace BenchmarkDotNet.Tests.Environments
         [InlineData("Intel(R) Core(TM) i7-5775R CPU @ 3.30GHz", "Intel Core i7-5775R CPU 3.30GHz (Max: 3.40GHz) (Broadwell)", 3.4)]
         public void CoreIsPrettifiedWithDiffFrequencies(string originalName, string prettifiedName, double actualFrequency)
         {
-            Assert.Equal(prettifiedName, ProcessorBrandStringHelper.Prettify(originalName, Frequency.FromGHz(actualFrequency)));
+            Assert.Equal(prettifiedName, ProcessorBrandStringHelper.Prettify(new CpuInfo(originalName, nominalFrequency: Frequency.FromGHz(actualFrequency)), includeMaxFrequency: true));
+        }
+        
+        [Theory]
+        [InlineData("AMD Ryzen 7 2700X Eight-Core Processor", "AMD Ryzen 7 2700X (Max: 4.10GHz)", 4.1, 8, 16)]
+        [InlineData("AMD Ryzen 7 2700X Eight-Core Processor", "AMD Ryzen 7 2700X Eight-Core Processor (Max: 4.10GHz)", 4.1, null, null)]
+        public void AmdIsPrettifiedWithDiffFrequencies(string originalName, string prettifiedName, double actualFrequency, int? physicalCoreCount, int? logicalCoreCount)
+        {
+            var cpuInfo = new CpuInfo(
+                originalName, 
+                physicalProcessorCount: null,
+                physicalCoreCount, 
+                logicalCoreCount, 
+                Frequency.FromGHz(actualFrequency), 
+                minFrequency: null, 
+                maxFrequency: null);
+
+            Assert.Equal(prettifiedName, ProcessorBrandStringHelper.Prettify(cpuInfo, includeMaxFrequency: true));
         }
     }
 }


### PR DESCRIPTION
I changed prettifier API to take whole CpuInfo so more logic can be used to determine whether we can safely remove the core count information. Hope that is OK, calling code also was a bit simplified because CpuInfo instance was already there. 