### PR TITLE
Use a monospaced font for LINQPad logging output

### DIFF
--- a/src/BenchmarkDotNet/Loggers/LinqPadLogger.cs
+++ b/src/BenchmarkDotNet/Loggers/LinqPadLogger.cs
@@ -57,7 +57,7 @@ namespace BenchmarkDotNet.Loggers
         public void WriteLine(LogKind logKind, string text) => Write(logKind, Console.WriteLine, text);
 
         private void Write(LogKind logKind, Action<object> write, string text) =>
-            write(WithStyle(text, "color:" + GetColor(logKind)));
+            write(WithStyle(text, "color:" + GetColor(logKind) + ";font-family:Consolas,'Lucida Console','Courier New',monospace"));
 
         private object WithStyle(object data, string htmlStyle) =>
             withStyle.Invoke(null, new[] { data, htmlStyle });


### PR DESCRIPTION
From https://github.com/dotnet/BenchmarkDotNet/pull/903#issuecomment-429616305.

>  it would be nice to enable a monospaced font for `LinqPadLogger` by default.

This change specifies a variety of monospaced fonts commonly installed on Windows systems and suitable for summary chart output.