### PR TITLE
async GlobalCleanup support

### DIFF
--- a/src/BenchmarkDotNet/Validators/ExecutionValidatorBase.cs
+++ b/src/BenchmarkDotNet/Validators/ExecutionValidatorBase.cs
@@ -44,7 +44,14 @@ namespace BenchmarkDotNet.Validators
                     continue;
                 }
 
+                int errorCount = errors.Count;
+
                 ExecuteBenchmarks(benchmarkTypeInstance, typeGroup, errors);
+
+                if (errorCount == errors.Count)
+                {
+                    TryToCallGlobalCleanup(benchmarkTypeInstance, errors);
+                }
             }
 
             return errors;
@@ -71,29 +78,39 @@ namespace BenchmarkDotNet.Validators
 
         private bool TryToCallGlobalSetup(object benchmarkTypeInstance, List<ValidationError> errors)
         {
-            var globalSetupMethods = benchmarkTypeInstance
+            return TryToCallGlobalMethod<GlobalSetupAttribute>(benchmarkTypeInstance, errors);
+        }
+
+        private void TryToCallGlobalCleanup(object benchmarkTypeInstance, List<ValidationError> errors)
+        {
+            TryToCallGlobalMethod<GlobalCleanupAttribute>(benchmarkTypeInstance, errors);
+        }
+
+        private bool TryToCallGlobalMethod<T>(object benchmarkTypeInstance, List<ValidationError> errors)
+        {
+            var methods = benchmarkTypeInstance
                 .GetType()
                 .GetAllMethods()
-                .Where(methodInfo => methodInfo.GetCustomAttributes(false).OfType<GlobalSetupAttribute>().Any())
+                .Where(methodInfo => methodInfo.GetCustomAttributes(false).OfType<T>().Any())
                 .ToArray();
 
-            if (!globalSetupMethods.Any())
+            if (!methods.Any())
             {
                 return true;
             }
 
-            if (globalSetupMethods.Count(methodInfo => !methodInfo.IsVirtual) > 1)
+            if (methods.Count(methodInfo => !methodInfo.IsVirtual) > 1)
             {
                 errors.Add(new ValidationError(
                     TreatsWarningsAsErrors,
-                    $"Only single [GlobalSetup] method is allowed per type, type {benchmarkTypeInstance.GetType().Name} has few"));
+                    $"Only single [{GetAttributeName(typeof(T))}] method is allowed per type, type {benchmarkTypeInstance.GetType().Name} has few"));
 
                 return false;
             }
 
             try
             {
-                var result = globalSetupMethods.First().Invoke(benchmarkTypeInstance, null);
+                var result = methods.First().Invoke(benchmarkTypeInstance, null);
 
                 TryToGetTaskResult(result);
             }
@@ -101,13 +118,15 @@ namespace BenchmarkDotNet.Validators
             {
                 errors.Add(new ValidationError(
                     TreatsWarningsAsErrors,
-                    $"Failed to execute [GlobalSetup] for {benchmarkTypeInstance.GetType().Name}, exception was {GetDisplayExceptionMessage(ex)}"));
+                    $"Failed to execute [{GetAttributeName(typeof(T))}] for {benchmarkTypeInstance.GetType().Name}, exception was {GetDisplayExceptionMessage(ex)}"));
 
                 return false;
             }
 
             return true;
         }
+
+        private string GetAttributeName(Type type) => type.Name.Replace("Attribute", string.Empty);
 
         private void TryToGetTaskResult(object result)
         {

--- a/src/BenchmarkDotNet/Validators/ExecutionValidatorBase.cs
+++ b/src/BenchmarkDotNet/Validators/ExecutionValidatorBase.cs
@@ -44,14 +44,9 @@ namespace BenchmarkDotNet.Validators
                     continue;
                 }
 
-                int errorCount = errors.Count;
-
                 ExecuteBenchmarks(benchmarkTypeInstance, typeGroup, errors);
 
-                if (errorCount == errors.Count)
-                {
-                    TryToCallGlobalCleanup(benchmarkTypeInstance, errors);
-                }
+                TryToCallGlobalCleanup(benchmarkTypeInstance, errors);
             }
 
             return errors;

--- a/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
@@ -23,10 +23,7 @@ namespace BenchmarkDotNet.Tests.Validators
 
         public class FailingConstructor
         {
-            public FailingConstructor()
-            {
-                throw new Exception("This one fails");
-            }
+            public FailingConstructor() => throw new Exception("This one fails");
 
             [Benchmark]
             public void NonThrowing() { }
@@ -45,10 +42,7 @@ namespace BenchmarkDotNet.Tests.Validators
         public class FailingGlobalSetup
         {
             [GlobalSetup]
-            public void Failing()
-            {
-                throw new Exception("This one fails");
-            }
+            public void Failing() => throw new Exception("This one fails");
 
             [Benchmark]
             public void NonThrowing() { }
@@ -67,10 +61,7 @@ namespace BenchmarkDotNet.Tests.Validators
         public class FailingGlobalCleanup
         {
             [GlobalCleanup]
-            public void Failing()
-            {
-                throw new Exception("This one fails");
-            }
+            public void Failing() => throw new Exception("This one fails");
 
             [Benchmark]
             public void NonThrowing() { }
@@ -131,10 +122,7 @@ namespace BenchmarkDotNet.Tests.Validators
         public class BaseClassWithThrowingGlobalSetup
         {
             [GlobalSetup]
-            public virtual void GlobalSetup()
-            {
-                throw new Exception("Should not be executed when overridden");
-            }
+            public virtual void GlobalSetup() => throw new Exception("Should not be executed when overridden");
 
             [Benchmark]
             public void NonThrowing() { }
@@ -145,10 +133,7 @@ namespace BenchmarkDotNet.Tests.Validators
             public static bool WasCalled;
 
             [GlobalSetup]
-            public override void GlobalSetup()
-            {
-                WasCalled = true;
-            }
+            public override void GlobalSetup() => WasCalled = true;
         }
 
         [Fact]
@@ -164,10 +149,7 @@ namespace BenchmarkDotNet.Tests.Validators
         public class BaseClassWithThrowingGlobalCleanup
         {
             [GlobalCleanup]
-            public virtual void GlobalCleanup()
-            {
-                throw new Exception("Should not be executed when overridden");
-            }
+            public virtual void GlobalCleanup() => throw new Exception("Should not be executed when overridden");
 
             [Benchmark]
             public void NonThrowing() { }
@@ -178,10 +160,7 @@ namespace BenchmarkDotNet.Tests.Validators
             public static bool WasCalled;
 
             [GlobalCleanup]
-            public override void GlobalCleanup()
-            {
-                WasCalled = true;
-            }
+            public override void GlobalCleanup() => WasCalled = true;
         }
 
         [Fact]
@@ -387,10 +366,7 @@ namespace BenchmarkDotNet.Tests.Validators
         public class FailingBenchmark
         {
             [Benchmark]
-            public void Throwing()
-            {
-                throw new Exception("This benchmark throws");
-            }
+            public void Throwing() => throw new Exception("This benchmark throws");
         }
 
         [Fact]


### PR DESCRIPTION
The `GlobalCleanup` attribute is not checked inside the `ExecutionValidatorBase` class. This patch adds support for that. 

The check inside the `Validate` method checks the count of the errors before and after executing `ExecuteBenchmarks`. And other option would be having `ExecuteBenchmarks` return a boolean but that would be a breaking change.