### PR TITLE
Partition benchmark run info based on added nuget packages

### DIFF
--- a/src/BenchmarkDotNet/Jobs/JobExtensions.cs
+++ b/src/BenchmarkDotNet/Jobs/JobExtensions.cs
@@ -192,7 +192,7 @@ namespace BenchmarkDotNet.Jobs
         /// <param name="packageName">The Nuget package name</param>
         /// <param name="packageVersion">The Nuget package version</param>
         /// <returns></returns>
-        public static Job WithNuget(this Job job, string packageName, string packageVersion) => job.WithCore(j => j.Infrastructure.NugetReferences = new HashSet<NugetReference>(j.Infrastructure.NugetReferences ?? Array.Empty<NugetReference>()) { new NugetReference(packageName, packageVersion) });
+        public static Job WithNuget(this Job job, string packageName, string packageVersion) => job.WithCore(j => j.Infrastructure.NugetReferences = new NugetReferenceList(j.Infrastructure.NugetReferences ?? Array.Empty<NugetReference>()) { new NugetReference(packageName, packageVersion) });
 
         /// <summary>
         /// Runs the job with a specific Nuget dependency which will be resolved during the Job build process
@@ -200,7 +200,7 @@ namespace BenchmarkDotNet.Jobs
         /// <param name="job"></param>
         /// <param name="packageName">The Nuget package name, the latest version will be resolved</param>
         /// <returns></returns>
-        public static Job WithNuget(this Job job, string packageName) => job.WithCore(j => j.Infrastructure.NugetReferences = new HashSet<NugetReference>(j.Infrastructure.NugetReferences ?? Array.Empty<NugetReference>()) { new NugetReference(packageName, string.Empty) });
+        public static Job WithNuget(this Job job, string packageName) => job.WithNuget(packageName, string.Empty);
 
         /// <summary>
         /// Runs the job with a specific Nuget dependencies which will be resolved during the Job build process

--- a/src/BenchmarkDotNet/Jobs/NugetReference.cs
+++ b/src/BenchmarkDotNet/Jobs/NugetReference.cs
@@ -29,22 +29,20 @@ namespace BenchmarkDotNet.Jobs
         }
 
         /// <summary>
-        /// Object is equals when the package name is the same
+        /// Object is equals when the package name and version are the same
         /// </summary>
         /// <param name="other"></param>
         /// <returns></returns>
-        /// <remarks>
-        /// There can only be one package reference of the same name regardless of version
-        /// </remarks>
         public bool Equals(NugetReference other)
         {
             return other != null &&
-                   PackageName == other.PackageName;
+                   PackageName == other.PackageName &&
+                   PackageVersion == other.PackageVersion;
         }
 
         public override int GetHashCode()
         {
-            return 557888800 + EqualityComparer<string>.Default.GetHashCode(PackageName);
+            return 557888800 + EqualityComparer<string>.Default.GetHashCode(PackageName) + EqualityComparer<string>.Default.GetHashCode(PackageVersion).GetHashCode();
         }
 
         public override string ToString() => $"{PackageName}{(string.IsNullOrWhiteSpace(PackageVersion) ? string.Empty : $" {PackageVersion}")}";

--- a/src/BenchmarkDotNet/Jobs/NugetReferenceList.cs
+++ b/src/BenchmarkDotNet/Jobs/NugetReferenceList.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace BenchmarkDotNet.Jobs
+{
+    /// <summary>
+    /// An ordered list of Nuget references. Does not allow duplicate references with the same PackageName.
+    /// </summary>
+    internal class NugetReferenceList : IReadOnlyCollection<NugetReference>
+    {
+        private readonly List<NugetReference> references = new List<NugetReference>();
+
+        public NugetReferenceList(IReadOnlyCollection<NugetReference> readOnlyCollection)
+        {
+            foreach (var nugetReference in readOnlyCollection)
+            {
+                Add(nugetReference);
+            }
+        }
+
+        public int Count => references.Count;
+
+        public IEnumerator<NugetReference> GetEnumerator() => references.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Add(NugetReference reference)
+        {
+            if (reference == null)
+                throw new ArgumentNullException(nameof(reference));
+
+            var insertionIndex = references.BinarySearch(reference, PackageNameComparer.Default);
+            if (0 <= insertionIndex && insertionIndex < Count)
+                throw new ArgumentException($"Nuget package {reference.PackageName} was already added", nameof(reference));
+
+            references.Insert(~insertionIndex, reference);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != GetType())
+                return false;
+
+            var otherList = (NugetReferenceList)obj;
+            if (Count != otherList.Count)
+                return false;
+
+            for (int i = 0; i < Count; i++)
+            {
+                if (!references[i].Equals(otherList.references[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = 0;
+                foreach (var nugetReference in references)
+                {
+                    hashCode = hashCode * 397 + nugetReference.GetHashCode();
+                }
+
+                return hashCode;
+            }
+        }
+
+        private class PackageNameComparer : IComparer<NugetReference>
+        {
+            private PackageNameComparer() { }
+
+            public static PackageNameComparer Default { get; } = new PackageNameComparer();
+
+            public int Compare(NugetReference x, NugetReference y) => Comparer<string>.Default.Compare(x.PackageName, y.PackageName);
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Jobs/NugetReferenceList.cs
+++ b/src/BenchmarkDotNet/Jobs/NugetReferenceList.cs
@@ -7,9 +7,13 @@ namespace BenchmarkDotNet.Jobs
     /// <summary>
     /// An ordered list of Nuget references. Does not allow duplicate references with the same PackageName.
     /// </summary>
-    internal class NugetReferenceList : IReadOnlyCollection<NugetReference>
+    public class NugetReferenceList : IReadOnlyCollection<NugetReference>
     {
         private readonly List<NugetReference> references = new List<NugetReference>();
+
+        public NugetReferenceList()
+        {
+        }
 
         public NugetReferenceList(IReadOnlyCollection<NugetReference> readOnlyCollection)
         {

--- a/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
@@ -45,6 +45,8 @@ namespace BenchmarkDotNet.Running
                     return false;
                 if (AreDifferent(jobX.Infrastructure.Arguments, jobY.Infrastructure.Arguments)) // arguments can be anything (Mono runtime settings or MsBuild parameters)
                     return false;
+                if (AreDifferent(jobX.Infrastructure.NugetReferences, jobY.Infrastructure.NugetReferences))
+                    return false;
                 if (!jobX.Environment.Gc.Equals(jobY.Environment.Gc)) // GC settings are per .config/.csproj
                     return false;
 
@@ -78,6 +80,8 @@ namespace BenchmarkDotNet.Running
                     hashCode ^= job.Infrastructure.BuildConfiguration.GetHashCode();
                 if (job.Infrastructure.Arguments != null && job.Infrastructure.Arguments.Any())
                     hashCode ^= job.Infrastructure.Arguments.GetHashCode();
+                if (job.Infrastructure.NugetReferences != null)
+                    hashCode ^= job.Infrastructure.GetHashCode();
                 if (!string.IsNullOrEmpty(obj.Descriptor.AdditionalLogic))
                     hashCode ^= obj.Descriptor.AdditionalLogic.GetHashCode();
 

--- a/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
@@ -81,7 +81,7 @@ namespace BenchmarkDotNet.Running
                 if (job.Infrastructure.Arguments != null && job.Infrastructure.Arguments.Any())
                     hashCode ^= job.Infrastructure.Arguments.GetHashCode();
                 if (job.Infrastructure.NugetReferences != null)
-                    hashCode ^= job.Infrastructure.GetHashCode();
+                    hashCode ^= job.Infrastructure.NugetReferences.GetHashCode();
                 if (!string.IsNullOrEmpty(obj.Descriptor.AdditionalLogic))
                     hashCode ^= obj.Descriptor.AdditionalLogic.GetHashCode();
 

--- a/tests/BenchmarkDotNet.Tests/Running/JobRuntimePropertiesComparerTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Running/JobRuntimePropertiesComparerTests.cs
@@ -84,6 +84,29 @@ namespace BenchmarkDotNet.Tests.Running
         }
 
         [Fact]
+        public void CustomNugetJobsWithSamePackageVersionAreGroupedTogether()
+        {
+            var job1 = Job.Default.WithNuget("AutoMapper", "7.0.1");
+            var job2 = Job.Default.WithNuget("AutoMapper", "7.0.1");
+
+            var config = ManualConfig.Create(DefaultConfig.Instance)
+                .With(job1)
+                .With(job2);
+            
+            var benchmarks1 = BenchmarkConverter.TypeToBenchmarks(typeof(Plain1), config);
+            var benchmarks2 = BenchmarkConverter.TypeToBenchmarks(typeof(Plain2), config);
+
+            var grouped = benchmarks1.BenchmarksCases.Union(benchmarks2.BenchmarksCases)
+                .GroupBy(benchmark => benchmark, new BenchmarkPartitioner.BenchmarkRuntimePropertiesComparer())
+                .ToArray();
+
+            Assert.Single(grouped); // 7.0.1
+
+            foreach (var grouping in grouped)
+                Assert.Equal(2 * 3 * 2, grouping.Count()); // ((job1 + job2) * (M1 + M2 + M3) * (Plain1 + Plain2)
+        }
+
+        [Fact]
         public void CustomNugetJobsAreGroupedByPackageVersion()
         {
             var config = ManualConfig.Create(DefaultConfig.Instance)


### PR DESCRIPTION
Fixes #931. Related to #922.

I tried to follow the local coding style, but my have failed. In particular, I saw no consistent method for calculating hashes. I'm happy to make any changes to conform.

The partitioner needs an implementation where package references are considered different if either name or version differ, so I amended `Equals` and `GetHashCode`. then `HashSet` wouldn't recognize duplicate packages, so I replaced it with a custom collection. I had it throw when the nuget reference's package name is a duplicate, since configuring different package versions of the same package for one job is an error, and it seems better to fail fast rather than run with perhaps an unintended version.

Thanks for considering this. Again, I'm happy to make any changes at all.
