### PR TITLE
Detect correct version of .NET Core in Docker

### DIFF
--- a/src/BenchmarkDotNet/Environments/BenchmarkEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet/Environments/BenchmarkEnvironmentInfo.cs
@@ -25,6 +25,7 @@ namespace BenchmarkDotNet.Environments
         [PublicAPI] public bool IsServerGC { get; protected set; }
         [PublicAPI] public bool IsConcurrentGC { get; protected set; }
         [PublicAPI] public long GCAllocationQuantum { get; protected set; }
+        [PublicAPI] public bool InDocker { get; protected set; }
 
         protected BenchmarkEnvironmentInfo()
         {
@@ -37,6 +38,7 @@ namespace BenchmarkDotNet.Environments
             IsConcurrentGC = GCSettings.LatencyMode != GCLatencyMode.Batch;
             HasAttachedDebugger = Debugger.IsAttached;
             GCAllocationQuantum = GcStats.AllocationQuantum;
+            InDocker = RuntimeInformation.InDocker;
         }
 
         public static BenchmarkEnvironmentInfo GetCurrent() => new BenchmarkEnvironmentInfo();

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -59,18 +59,17 @@ namespace BenchmarkDotNet.Portability
                 && string.IsNullOrEmpty(typeof(object).Assembly.Location); // but it's merged to a single .exe and .Location returns null here ;)
 #endif
 
-        public static bool IsInDocker => string.Equals(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), "true");
-        
-        internal static string DockerSdkVersion => Environment.GetEnvironmentVariable("DOTNET_VERSION");
-        
-        internal static string DockerAspnetSdkVersion => Environment.GetEnvironmentVariable("ASPNETCORE_VERSION");
-        
+        public static bool InDocker => string.Equals(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), "true");
+                
         internal static string ExecutableExtension => IsWindows() ? ".exe" : string.Empty;
 
         internal static string ScriptFileExtension => IsWindows() ? ".bat" : ".sh";
 
         internal static string GetArchitecture() => GetCurrentPlatform() == Platform.X86 ? "32bit" : "64bit";
 
+        private static string DockerSdkVersion => Environment.GetEnvironmentVariable("DOTNET_VERSION");
+        private static string DockerAspnetSdkVersion => Environment.GetEnvironmentVariable("ASPNETCORE_VERSION");
+        
         internal static bool IsWindows()
         {
 #if CLASSIC
@@ -161,7 +160,7 @@ namespace BenchmarkDotNet.Portability
             return null;
         }
 
-        internal static string GetNetCoreVersion() => IsInDocker ? GetDockerNetCoreVersion() : GetBaseNetCoreVersion();
+        internal static string GetNetCoreVersion() => InDocker ? GetDockerNetCoreVersion() : GetBaseNetCoreVersion();
 
         private static string GetDockerNetCoreVersion() => string.IsNullOrEmpty(DockerSdkVersion) ? DockerAspnetSdkVersion : DockerSdkVersion;
 


### PR DESCRIPTION
For https://github.com/dotnet/BenchmarkDotNet/issues/788 . Uses environment variables, provided by runtime to detect version.