### PR TITLE
Add Timeout for dotnet cli build commands to our toolchains

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -103,7 +103,7 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option("maxWarmupCount", Required = false, HelpText = "Maximum count of warmup iterations that should be performed. The default is 50.")]
         public int? MaxWarmupIterationCount { get; set; }
         
-        [Option("iterationTime", Required = false, HelpText = "Desired time of execution of an iteration. Used by Pilot stage to estimate the number of invocations per iteration. 500ms by default")]
+        [Option("iterationTime", Required = false, HelpText = "Desired time of execution of an iteration in miliseconds. Used by Pilot stage to estimate the number of invocations per iteration. 500ms by default")]
         public int? IterationTimeInMiliseconds { get; set; }
         
         [Option("iterationCount", Required = false, HelpText = "How many target iterations should be performed. By default calculated by the heuristic.")]
@@ -132,6 +132,9 @@ namespace BenchmarkDotNet.ConsoleArguments
         
         [Option("disasmDepth", Required = false, Default = 1, HelpText = "Sets the recursive depth for the disassembler.")]
         public int DisassemblerRecursiveDepth { get; set; }
+
+        [Option("buildTimeout", Required = false, HelpText = "Build timeout in seconds.")]
+        public int? TimeOutInSeconds { get; set; }
 
         internal bool UserProvidedFilters => Filters.Any() || AttributeNames.Any() || AllCategories.Any() || AnyCategories.Any(); 
 

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
@@ -16,10 +16,11 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
             string coreRtVersion, string ilcPath, bool useCppCodeGenerator,
             string runtimeFrameworkVersion, string targetFrameworkMoniker, string runtimeIdentifier,
             string customDotNetCliPath,
-            Dictionary<string, string> feeds, bool useNuGetClearTag, bool useTempFolderForRestore)
+            Dictionary<string, string> feeds, bool useNuGetClearTag, bool useTempFolderForRestore,
+            TimeSpan timeout)
             : base(displayName,
                 new Generator(coreRtVersion, useCppCodeGenerator, runtimeFrameworkVersion, targetFrameworkMoniker, customDotNetCliPath, runtimeIdentifier, feeds, useNuGetClearTag, useTempFolderForRestore),
-                new DotNetCliPublisher(customDotNetCliPath, GetExtraArguments(useCppCodeGenerator, runtimeIdentifier), GetEnvironmentVariables(ilcPath)), 
+                new DotNetCliPublisher(customDotNetCliPath, GetExtraArguments(useCppCodeGenerator, runtimeIdentifier), GetEnvironmentVariables(ilcPath), timeout), 
                 new Executor())
         {
             IlcPath = ilcPath;

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchainBuilder.cs
@@ -78,7 +78,8 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
                 customDotNetCliPath: customDotNetCliPath,
                 feeds: Feeds,
                 useNuGetClearTag: useNuGetClearTag,
-                useTempFolderForRestore: useTempFolderForRestore);
+                useTempFolderForRestore: useTempFolderForRestore,
+                timeout: timeout ?? TimeSpan.FromMinutes(5)); // downloading all CoreRT dependencies can take a LOT of time
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/CoreRun/CoreRunPublisher.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRun/CoreRunPublisher.cs
@@ -11,10 +11,10 @@ namespace BenchmarkDotNet.Toolchains.CoreRun
 {
     public class CoreRunPublisher : IBuilder
     {
-        public CoreRunPublisher(FileInfo coreRun, FileInfo customDotNetCliPath = null)
+        public CoreRunPublisher(FileInfo coreRun, FileInfo customDotNetCliPath = null, TimeSpan? timeout = null)
         {
             CoreRun = coreRun;
-            DotNetCliPublisher = new DotNetCliPublisher(customDotNetCliPath?.FullName);
+            DotNetCliPublisher = new DotNetCliPublisher(customDotNetCliPath?.FullName, timeout: timeout);
         }
 
         private FileInfo CoreRun { get; }

--- a/src/BenchmarkDotNet/Toolchains/CoreRun/CoreRunToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRun/CoreRunToolchain.cs
@@ -20,10 +20,12 @@ namespace BenchmarkDotNet.Toolchains.CoreRun
         /// <param name="customDotNetCliPath">path to dotnet cli, if not provided the one from PATH will be used</param>
         /// <param name="displayName">display name, CoreRun is the default value</param>
         /// <param name="restorePath">the directory to restore packages to</param>
+        /// <param name="timeout">the timeout for building the benchmarks</param>
         public CoreRunToolchain(FileInfo coreRun, bool createCopy = true,
             string targetFrameworkMoniker = "netcoreapp2.1", 
             FileInfo customDotNetCliPath = null, DirectoryInfo restorePath = null,
-            string displayName = "CoreRun") 
+            string displayName = "CoreRun",
+            TimeSpan? timeout = null) 
         {
             if (coreRun == null) throw new ArgumentNullException(nameof(coreRun));
             if (!coreRun.Exists) throw new FileNotFoundException("Provided CoreRun path does not exist");
@@ -35,7 +37,7 @@ namespace BenchmarkDotNet.Toolchains.CoreRun
 
             Name = displayName;
             Generator = new CoreRunGenerator(SourceCoreRun, CopyCoreRun, targetFrameworkMoniker, customDotNetCliPath?.FullName, restorePath?.FullName);
-            Builder = new CoreRunPublisher(CopyCoreRun, customDotNetCliPath);
+            Builder = new CoreRunPublisher(CopyCoreRun, customDotNetCliPath, timeout);
             Executor = new DotNetCliExecutor(customDotNetCliPath: CopyCoreRun.FullName); // instead of executing "dotnet $pathToDll" we do "CoreRun $pathToDll" 
         }
 

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
@@ -42,17 +42,17 @@ namespace BenchmarkDotNet.Toolchains.CsProj
 
         private string targetFrameworkMoniker;
 
-        private CsProjClassicNetToolchain(string targetFrameworkMoniker, string packagesPath = null)
+        private CsProjClassicNetToolchain(string targetFrameworkMoniker, string packagesPath = null, TimeSpan? timeout = null)
             : base(targetFrameworkMoniker,
                 new CsProjGenerator(targetFrameworkMoniker, cliPath: null, packagesPath: packagesPath, runtimeFrameworkVersion: null),
-                new DotNetCliBuilder(targetFrameworkMoniker, customDotNetCliPath: null),
+                new DotNetCliBuilder(targetFrameworkMoniker, customDotNetCliPath: null, timeout: timeout),
                 new Executor())
         {
             this.targetFrameworkMoniker = targetFrameworkMoniker;
         }
 
-        public static IToolchain From(string targetFrameworkMoniker, string packagesPath = null)
-            => new CsProjClassicNetToolchain(targetFrameworkMoniker, packagesPath);
+        public static IToolchain From(string targetFrameworkMoniker, string packagesPath = null, TimeSpan? timeout = null)
+            => new CsProjClassicNetToolchain(targetFrameworkMoniker, packagesPath, timeout);
 
         public override bool IsSupported(BenchmarkCase benchmarkCase, ILogger logger, IResolver resolver)
         {

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
@@ -33,7 +33,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         public static IToolchain From(NetCoreAppSettings settings)
             => new CsProjCoreToolchain(settings.Name,
                 new CsProjGenerator(settings.TargetFrameworkMoniker, settings.CustomDotNetCliPath, settings.PackagesPath, settings.RuntimeFrameworkVersion), 
-                new DotNetCliBuilder(settings.TargetFrameworkMoniker, settings.CustomDotNetCliPath), 
+                new DotNetCliBuilder(settings.TargetFrameworkMoniker, settings.CustomDotNetCliPath, settings.Timeout), 
                 new DotNetCliExecutor(settings.CustomDotNetCliPath),
                 settings.CustomDotNetCliPath);
 

--- a/src/BenchmarkDotNet/Toolchains/CustomCoreClr/CustomCoreClrToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CustomCoreClr/CustomCoreClrToolchain.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using BenchmarkDotNet.Toolchains.DotNetCli;
 
 namespace BenchmarkDotNet.Toolchains.CustomCoreClr
@@ -8,10 +9,11 @@ namespace BenchmarkDotNet.Toolchains.CustomCoreClr
         internal CustomCoreClrToolchain(string displayName, string coreClrVersion, string coreFxVersion, string runtimeFrameworkVersion,
             string targetFrameworkMoniker, string runtimeIdentifier, 
             string customDotNetCliPath, 
-            Dictionary<string, string> feeds, bool useNuGetClearTag, bool useTempFolderForRestore)
+            Dictionary<string, string> feeds, bool useNuGetClearTag, bool useTempFolderForRestore,
+            TimeSpan timeout)
             : base(displayName,
                 new Generator(coreClrVersion, coreFxVersion, runtimeFrameworkVersion, targetFrameworkMoniker, runtimeIdentifier, customDotNetCliPath, feeds, useNuGetClearTag, useTempFolderForRestore),
-                new DotNetCliPublisher(customDotNetCliPath),
+                new DotNetCliPublisher(customDotNetCliPath: customDotNetCliPath, timeout: timeout),
                 new Executor())
         {
         }

--- a/src/BenchmarkDotNet/Toolchains/CustomCoreClr/CustomCoreClrToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/CustomCoreClr/CustomCoreClrToolchainBuilder.cs
@@ -123,7 +123,8 @@ namespace BenchmarkDotNet.Toolchains.CustomCoreClr
                 customDotNetCliPath: customDotNetCliPath,
                 feeds: Feeds,
                 useNuGetClearTag: useNuGetClearTag,
-                useTempFolderForRestore: useTempFolderForRestore);
+                useTempFolderForRestore: useTempFolderForRestore,
+                timeout: timeout ?? TimeSpan.FromMinutes(3)); // downloading entire Runtime for this toolchain might take a while!
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/CustomDotNetCliToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/CustomDotNetCliToolchainBuilder.cs
@@ -10,12 +10,14 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public abstract class CustomDotNetCliToolchainBuilder
     {
+        protected readonly Dictionary<string, string> Feeds = new Dictionary<string, string>();
+
         protected string runtimeIdentifier, customDotNetCliPath;
         protected string targetFrameworkMoniker = "netcoreapp2.1", displayName;
         protected string runtimeFrameworkVersion;
 
         protected bool useNuGetClearTag, useTempFolderForRestore;
-        protected readonly Dictionary<string, string> Feeds = new Dictionary<string, string>();
+        protected TimeSpan? timeout;
 
         public abstract IToolchain ToToolchain();
 
@@ -101,6 +103,17 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         public CustomDotNetCliToolchainBuilder UseTempFolderForRestore(bool value)
         {
             useTempFolderForRestore = value;
+
+            return this;
+        }
+
+        /// <summary>
+        /// sets provided timeout for build
+        /// </summary>
+        [PublicAPI]
+        public CustomDotNetCliToolchainBuilder Timeout(TimeSpan timeout)
+        {
+            this.timeout = timeout;
 
             return this;
         }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
@@ -10,15 +10,18 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
     [PublicAPI]
     public class DotNetCliBuilder : IBuilder
     {
+        internal TimeSpan Timeout { get; }
+
         private string TargetFrameworkMoniker { get; }
 
         private string CustomDotNetCliPath { get; }
 
         [PublicAPI]
-        public DotNetCliBuilder(string targetFrameworkMoniker, string customDotNetCliPath = null)
+        public DotNetCliBuilder(string targetFrameworkMoniker, string customDotNetCliPath = null, TimeSpan? timeout = null)
         {
             TargetFrameworkMoniker = targetFrameworkMoniker;
             CustomDotNetCliPath = customDotNetCliPath;
+            Timeout = timeout ?? NetCoreAppSettings.DefaultBuildTimeout;
         }
 
         public BuildResult Build(GenerateResult generateResult, BuildPartition buildPartition, ILogger logger)
@@ -28,7 +31,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                     generateResult,
                     logger,
                     buildPartition,
-                    Array.Empty<EnvironmentVariable>())
+                    Array.Empty<EnvironmentVariable>(),
+                    Timeout)
                 .RestoreThenBuild();
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
@@ -26,9 +26,11 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         [PublicAPI] public BuildPartition BuildPartition { get; }
 
         [PublicAPI] public IReadOnlyList<EnvironmentVariable> EnvironmentVariables { get; }
-            
+        
+        [PublicAPI] public TimeSpan Timeout { get; }
+
         public DotNetCliCommand(string cliPath, string arguments, GenerateResult generateResult, ILogger logger, 
-            BuildPartition buildPartition, IReadOnlyList<EnvironmentVariable> environmentVariables)
+            BuildPartition buildPartition, IReadOnlyList<EnvironmentVariable> environmentVariables, TimeSpan timeout)
         {
             CliPath = cliPath;
             Arguments = arguments;
@@ -36,10 +38,11 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             Logger = logger;
             BuildPartition = buildPartition;
             EnvironmentVariables = environmentVariables;
+            Timeout = timeout;
         }
             
         public DotNetCliCommand WithArguments(string arguments)
-            => new DotNetCliCommand(CliPath, arguments, GenerateResult, Logger, BuildPartition, EnvironmentVariables);
+            => new DotNetCliCommand(CliPath, arguments, GenerateResult, Logger, BuildPartition, EnvironmentVariables, Timeout);
 
         [PublicAPI]
         public BuildResult RestoreThenBuild()

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
@@ -50,12 +50,12 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             var packagesResult = AddPackages();
 
             if (!packagesResult.IsSuccess)
-                return BuildResult.Failure(GenerateResult, new Exception(packagesResult.ProblemDescription));
+                return BuildResult.Failure(GenerateResult, new Exception(packagesResult.AllInformation));
 
             var restoreResult = Restore();
 
             if (!restoreResult.IsSuccess)
-                return BuildResult.Failure(GenerateResult, new Exception(restoreResult.ProblemDescription));
+                return BuildResult.Failure(GenerateResult, new Exception(restoreResult.AllInformation));
 
             var buildResult = Build().ToBuildResult(GenerateResult);
             
@@ -71,12 +71,12 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             var packagesResult = AddPackages();
 
             if (!packagesResult.IsSuccess)
-                return BuildResult.Failure(GenerateResult, new Exception(packagesResult.ProblemDescription));
+                return BuildResult.Failure(GenerateResult, new Exception(packagesResult.AllInformation));
 
             var restoreResult = Restore();
 
             if (!restoreResult.IsSuccess)
-                return BuildResult.Failure(GenerateResult, new Exception(restoreResult.ProblemDescription));
+                return BuildResult.Failure(GenerateResult, new Exception(restoreResult.AllInformation));
 
             var buildResult = Build();
 
@@ -84,7 +84,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                 buildResult = BuildNoDependencies();
             
             if (!buildResult.IsSuccess)
-                return BuildResult.Failure(GenerateResult, new Exception(buildResult.ProblemDescription));
+                return BuildResult.Failure(GenerateResult, new Exception(buildResult.AllInformation));
 
             return Publish().ToBuildResult(GenerateResult);
         }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandResult.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandResult.cs
@@ -15,12 +15,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
         [PublicAPI] public string StandardError { get; }
 
-        /// <summary>
-        /// in theory, all errors should be reported to standard error, 
-        /// but sometimes they are not so we can at least return 
-        /// standard output which hopefully will contain some useful information
-        /// </summary>
-        public string ProblemDescription => HasNonEmptyErrorMessage ? StandardError : StandardOutput;
+        public string AllInformation => $"Standard output: {Environment.NewLine} {StandardOutput} {Environment.NewLine} Standard error: {Environment.NewLine} {StandardError}";
 
         [PublicAPI] public bool HasNonEmptyErrorMessage => !string.IsNullOrEmpty(StandardError);
 
@@ -42,6 +37,6 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         public BuildResult ToBuildResult(GenerateResult generateResult)
             => IsSuccess || File.Exists(generateResult.ArtifactsPaths.ExecutablePath) // dotnet cli could have successfully built the program, but returned 1 as exit code because it had some warnings
                 ? BuildResult.Success(generateResult)
-                : BuildResult.Failure(generateResult, new Exception(ProblemDescription));
+                : BuildResult.Failure(generateResult, new Exception(AllInformation));
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliPublisher.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliPublisher.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
@@ -8,11 +9,12 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 {
     public class DotNetCliPublisher : IBuilder
     {
-        public DotNetCliPublisher(string customDotNetCliPath = null, string extraArguments = null, IReadOnlyList<EnvironmentVariable> environmentVariables = null)
+        public DotNetCliPublisher(string customDotNetCliPath = null, string extraArguments = null, IReadOnlyList<EnvironmentVariable> environmentVariables = null, TimeSpan? timeout = null)
         {
             CustomDotNetCliPath = customDotNetCliPath;
             ExtraArguments = extraArguments;
             EnvironmentVariables = environmentVariables;
+            Timeout = timeout ?? NetCoreAppSettings.DefaultBuildTimeout;
         }
 
         private string CustomDotNetCliPath { get; }
@@ -21,6 +23,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
         private IReadOnlyList<EnvironmentVariable> EnvironmentVariables { get; }
 
+        private TimeSpan Timeout { get; }
+
         public BuildResult Build(GenerateResult generateResult, BuildPartition buildPartition, ILogger logger) 
             => new DotNetCliCommand(
                     CustomDotNetCliPath, 
@@ -28,7 +32,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                     generateResult, 
                     logger, 
                     buildPartition,
-                    EnvironmentVariables)
+                    EnvironmentVariables,
+                    Timeout)
                 .RestoreThenBuildThenPublish();
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
@@ -10,6 +10,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
     [PublicAPI]
     public class NetCoreAppSettings
     {
+        public static readonly TimeSpan DefaultBuildTimeout = TimeSpan.FromMinutes(1); // it should always be few seconds, but some ppl might have a bad internet connection
+
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp20 = new NetCoreAppSettings("netcoreapp2.0", null, ".NET Core 2.0");
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp21 = new NetCoreAppSettings("netcoreapp2.1", null, ".NET Core 2.1");
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp22 = new NetCoreAppSettings("netcoreapp2.2", null, ".NET Core 2.2");
@@ -40,6 +42,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         /// simply ignored if null
         /// </param>
         /// <param name="packagesPath">the directory to restore packages to</param>
+        /// <param name="timeout">timeout to build the benchmark</param>
         /// </summary>
         [PublicAPI]
         public NetCoreAppSettings(
@@ -47,13 +50,15 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             string runtimeFrameworkVersion, 
             string name,
             string customDotNetCliPath = null,
-            string packagesPath = null)
+            string packagesPath = null,
+            TimeSpan? timeout = null)
         {
             TargetFrameworkMoniker = targetFrameworkMoniker;
             RuntimeFrameworkVersion = runtimeFrameworkVersion;
             Name = name;
             CustomDotNetCliPath = customDotNetCliPath;
             PackagesPath = packagesPath;
+            Timeout = timeout ?? DefaultBuildTimeout;
         }
 
         /// <summary>
@@ -75,11 +80,19 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         /// </summary>
         public string PackagesPath { get; }
 
+        /// <summary>
+        /// timeout to build the benchmark
+        /// </summary>
+        public TimeSpan Timeout { get; }
+
         public NetCoreAppSettings WithCustomDotNetCliPath(string customDotNetCliPath, string displayName = null)
-            => new NetCoreAppSettings(TargetFrameworkMoniker, RuntimeFrameworkVersion, displayName ?? Name, customDotNetCliPath, PackagesPath);
+            => new NetCoreAppSettings(TargetFrameworkMoniker, RuntimeFrameworkVersion, displayName ?? Name, customDotNetCliPath, PackagesPath, Timeout);
         
         public NetCoreAppSettings WithCustomPackagesRestorePath(string packagesPath, string displayName = null)
-            => new NetCoreAppSettings(TargetFrameworkMoniker, RuntimeFrameworkVersion, displayName ?? Name, CustomDotNetCliPath, packagesPath);
+            => new NetCoreAppSettings(TargetFrameworkMoniker, RuntimeFrameworkVersion, displayName ?? Name, CustomDotNetCliPath, packagesPath, Timeout);
+        
+        public NetCoreAppSettings WithTimeout(TimeSpan? timeOut)
+            => new NetCoreAppSettings(TargetFrameworkMoniker, RuntimeFrameworkVersion, Name, CustomDotNetCliPath, PackagesPath, timeOut ?? Timeout);
 
         internal static NetCoreAppSettings GetCurrentVersion()
         {

--- a/tests/BenchmarkDotNet.IntegrationTests/BuildTimeoutTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/BuildTimeoutTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Portability;
+using BenchmarkDotNet.Toolchains.CoreRt;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class BuildTimeoutTests: BenchmarkTestExecutor
+    {
+        public BuildTimeoutTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
+
+        [Fact]
+        public void WhenBuildTakesMoreTimeThanTheTimeoutTheEntireProcessTreeIsKilled()
+        {
+            if (RuntimeInformation.GetCurrentPlatform() == Platform.X86) // CoreRT does not support 32bit yet
+                return;
+            
+            // we use CoreRT on purpose because it takes a LOT of time to build it
+            // so we can be sure that timeout = 1s should fail!
+            var timeout = TimeSpan.FromSeconds(1);
+            
+            var config = ManualConfig.CreateEmpty()
+                .With(Job.Dry
+                    .With(Runtime.CoreRT)
+                    .With(CoreRtToolchain.CreateBuilder()
+                        .UseCoreRtNuGet(microsoftDotNetILCompilerVersion: "1.0.0-alpha-26414-01") // we test against specific version to keep this test stable
+                        .Timeout(timeout)
+                        .ToToolchain()));
+
+            var processesBefore = Process.GetProcesses();
+            var summary = CanExecute<CoreRtBenchmark>(config, fullValidation: false);
+            var processesAfter = Process.GetProcesses();
+
+            Assert.All(summary.Reports, report => Assert.False(report.BuildResult.IsBuildSuccess));
+            Assert.All(summary.Reports, report => Assert.Contains("The configured timeout", report.BuildResult.BuildException.Message));
+            Assert.True(processesAfter.Length <= processesBefore.Length); // CI or the VM could have spawn something in the meantime, but let's hope for the best. Remove in the case the test is not stable 
+        }
+    }
+
+    public class Impossible
+    {
+        [Benchmark]
+        public void Check() => Environment.FailFast("This benchmark should have been never executed because 1s is not enough to build CoreRT benchmark!");
+    }
+}

--- a/tests/BenchmarkDotNet.IntegrationTests/BuildTimeoutTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/BuildTimeoutTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
@@ -39,8 +40,13 @@ namespace BenchmarkDotNet.IntegrationTests
 
             Assert.All(summary.Reports, report => Assert.False(report.BuildResult.IsBuildSuccess));
             Assert.All(summary.Reports, report => Assert.Contains("The configured timeout", report.BuildResult.BuildException.Message));
-            Assert.True(processesAfter.Length <= processesBefore.Length); // CI or the VM could have spawn something in the meantime, but let's hope for the best. Remove in the case the test is not stable 
+            Assert.True(CountOfProcessesWeCareAbout(processesAfter) <= CountOfProcessesWeCareAbout(processesBefore)); // CI or the VM could have spawn something in the meantime, but let's hope for the best. Remove in the case the test is not stable 
         }
+
+        private static int CountOfProcessesWeCareAbout(Process[] processes)
+            => processes.Count(process =>
+                process.ProcessName.StartsWith("dotnet", StringComparison.InvariantCultureIgnoreCase) ||
+                process.ProcessName.StartsWith("msbuild", StringComparison.InvariantCultureIgnoreCase));
     }
 
     public class Impossible

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -226,6 +226,29 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(fakeRestoreDirectory, ((DotNetCliGenerator)toolchain.Generator).PackagesPath);
         }
         
+        [Fact]
+        public void UserCanSpecifyBuildTimeout()
+        {
+            const int timeoutInSeconds = 10;
+            var config = ConfigParser.Parse(new[] { "-r", "netcoreapp3.0", "--buildTimeout", timeoutInSeconds.ToString() }, new OutputLogger(Output)).config;
+
+            Assert.Single(config.GetJobs());
+            CsProjCoreToolchain toolchain = config.GetJobs().Single().GetToolchain() as CsProjCoreToolchain;
+            Assert.NotNull(toolchain);
+            Assert.Equal(timeoutInSeconds, ((DotNetCliBuilder)toolchain.Builder).Timeout.TotalSeconds);
+        }
+        
+        [Fact]
+        public void WhenUserDoesNotSpecifyTimeoutTheDefaultValueIsUsed()
+        {
+            var config = ConfigParser.Parse(new[] { "-r", "netcoreapp3.0" }, new OutputLogger(Output)).config;
+
+            Assert.Single(config.GetJobs());
+            CsProjCoreToolchain toolchain = config.GetJobs().Single().GetToolchain() as CsProjCoreToolchain;
+            Assert.NotNull(toolchain);
+            Assert.Equal(NetCoreAppSettings.DefaultBuildTimeout, ((DotNetCliBuilder)toolchain.Builder).Timeout);
+        }
+        
         [Theory]
         [InlineData("net46")]
         [InlineData("net461")]


### PR DESCRIPTION
I need to run .NET Core 2.1 vs 2.2 for the official .NET Core preview release and I can't because I need a feature (the new disasm diff) from our CI which is red because of the hanging build #933 

This PR is very simple: add default timeout to the build commands we run with dotnet cli. If dotnet cli times out, kill the entire process tree. Moreover, if something fails: print all info we have.