### PR TITLE
Fix example code (isBaseline -> baseline)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ using BenchmarkDotNet.Running;
 
 namespace MyBenchmarks
 {
-    [ClrJob(isBaseline: true), CoreJob, MonoJob, CoreRtJob]
+    [ClrJob(baseline: true), CoreJob, MonoJob, CoreRtJob]
     [RPlotExporter, RankColumn]
     public class Md5VsSha256
     {


### PR DESCRIPTION
#787 changed the parameter name on job attributes, but the example code on the landing page still used the old name. I grepped the docs folder and this appears to be the only example that had this issue.