### PR TITLE
Fixed typo in IntroTagColumn sample

### DIFF
--- a/samples/BenchmarkDotNet.Samples/IntroTagColumn.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroTagColumn.cs
@@ -15,7 +15,7 @@ namespace BenchmarkDotNet.Samples
             public Config()
             {
                 Add(Job.Dry);
-                Add(new TagColumn("Foo or Bar", name => name.Substring(0, 3)));
+                Add(new TagColumn("Kind", name => name.Substring(0, 3)));
                 Add(new TagColumn("Number", name => name.Substring(3)));
             }
         }


### PR DESCRIPTION
the sample read:
```csharp
Add(new TagColumn("Foo or Bar", name => name.Substring(0, 3)));
```
instead of
```csharp
Add(new TagColumn("Kind", name => name.Substring(0, 3)));
```