### PR TITLE
Add printDiff in DisassemblyDiagnoserAttribute

### DIFF
--- a/src/BenchmarkDotNet/Attributes/DisassemblyDiagnoserAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/DisassemblyDiagnoserAttribute.cs
@@ -11,11 +11,12 @@ namespace BenchmarkDotNet.Attributes
         /// <param name="printSource">C# source code will be printed. False by default.</param>
         /// <param name="printPrologAndEpilog">ASM for prolog and epilog will be printed. False by default.</param>
         /// <param name="recursiveDepth">Includes called methods to given level. 1 by default, indexed from 1. To print just benchmark set to 0</param>
-        public DisassemblyDiagnoserAttribute(bool printAsm = true, bool printIL = false, bool printSource = false, bool printPrologAndEpilog = false, int recursiveDepth = 1)
+        /// <param name="printDiff">Diff will be printed. False by default.</param>
+        public DisassemblyDiagnoserAttribute(bool printAsm = true, bool printIL = false, bool printSource = false, bool printPrologAndEpilog = false, int recursiveDepth = 1, bool printDiff = false)
         {
             Config = ManualConfig.CreateEmpty().With(
                 DisassemblyDiagnoser.Create(
-                    new DisassemblyDiagnoserConfig(printAsm, printIL, printSource, printPrologAndEpilog, recursiveDepth)));
+                    new DisassemblyDiagnoserConfig(printAsm, printIL, printSource, printPrologAndEpilog, recursiveDepth, printDiff)));
         }
 
         public IConfig Config { get; }


### PR DESCRIPTION
In last PR #937 I forgot to add `printDiff` to `DisassemblyDiagnoserAttribute`.