### PR TITLE
Support Nuget symbol server

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,4 +38,4 @@ test: off
 deploy: off
 
 artifacts:
-  - path: '**\BenchmarkDotNet.*.nupkg' # find all NuGet packages recursively
+  - path: '**\BenchmarkDotNet.*.*nupkg' # find all NuGet packages recursively

--- a/build.cake
+++ b/build.cake
@@ -151,7 +151,9 @@ Task("Pack")
         var settings = new DotNetCorePackSettings
         {
             Configuration = configuration,
-            OutputDirectory = artifactsDirectory
+            OutputDirectory = artifactsDirectory,
+			ArgumentCustomization = args=>args.Append("--include-symbols").Append("-p:SymbolPackageFormat=s
+")
         };
 
         var projects = GetFiles("./src/**/*.csproj");

--- a/build.cake
+++ b/build.cake
@@ -152,8 +152,7 @@ Task("Pack")
         {
             Configuration = configuration,
             OutputDirectory = artifactsDirectory,
-			ArgumentCustomization = args=>args.Append("--include-symbols").Append("-p:SymbolPackageFormat=s
-")
+			ArgumentCustomization = args=>args.Append("--include-symbols").Append("-p:SymbolPackageFormat=snupkg")
         };
 
         var projects = GetFiles("./src/**/*.csproj");

--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,7 @@ Param(
 )
 
 $CakeVersion = "0.30.0"
-$DotNetVersion = "2.1.403";
+$DotNetVersion = "2.1.500";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
   mkdir "$SCRIPT_DIR/.dotnet"
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://dot.net/v1/dotnet-install.sh
-sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 2.1.403 --install-dir .dotnet --no-path
+sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 2.1.500 --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/build/build-and-pack.cmd
+++ b/build/build-and-pack.cmd
@@ -8,4 +8,4 @@ dotnet pack .\src\BenchmarkDotNet\BenchmarkDotNet.csproj -c Release
 dotnet pack .\src\BenchmarkDotNet.Diagnostics.Windows\BenchmarkDotNet.Diagnostics.Windows.csproj  -c Release
 rmdir artifacts /s /q
 mkdir artifacts
-for /R %%x in (BenchmarkDotNet*.nupkg) do copy "%%x" "artifacts/" /Y
+for /R %%x in (BenchmarkDotNet*.*nupkg) do copy "%%x" "artifacts/" /Y

--- a/build/common.props
+++ b/build/common.props
@@ -8,7 +8,7 @@
     <PackageTags>benchmark;benchmarking;performance</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/dotnet/BenchmarkDotNet/master/docs/guide/logo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/dotnet/BenchmarkDotNet</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/dotnet/BenchmarkDotNet/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dotnet/BenchmarkDotNet</RepositoryUrl>
 

--- a/build/pack.bat
+++ b/build/pack.bat
@@ -2,4 +2,4 @@ dotnet pack .\src\BenchmarkDotNet\BenchmarkDotNet.csproj -c Release
 dotnet pack .\src\BenchmarkDotNet.Diagnostics.Windows\BenchmarkDotNet.Diagnostics.Windows.csproj  -c Release
 rmdir artifacts /s /q
 mkdir artifacts
-for /R %%x in (BenchmarkDotNet*.nupkg) do copy "%%x" "artifacts/" /Y
+for /R %%x in (BenchmarkDotNet*.*nupkg) do copy "%%x" "artifacts/" /Y

--- a/docs/_changelog/ChangeLogBuilder/.gitignore
+++ b/docs/_changelog/ChangeLogBuilder/.gitignore
@@ -160,6 +160,8 @@ PublishScripts/
 
 # NuGet Packages
 *.nupkg
+*.snupkg
+
 # The packages folder can be ignored because of Package Restore
 **/packages/*
 # except build/, which is used as an MSBuild target.


### PR DESCRIPTION
Fix for #967 

* I had to update .net to 2.1.500 version because this version support new snupkg symbol packages. There is information about it https://blog.nuget.org/20181116/Improved-debugging-experience-with-the-NuGet-org-symbol-server-and-snupkg.html 
* I had to change PackageLicenseUrl because it is deprecated. Without this change I got message: 
  ```
  warning NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead.
  ```
  More information: https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg. 

* I had to use 'ArgumentCustomization' in build.cake because Cake doesn't support new snupkg symbol packages. https://github.com/cake-build/cake/issues/2362 

Now after build project:
```
build.bat -Target Pack
```

You will see:
![image](https://user-images.githubusercontent.com/17333903/48840039-c836b400-ed8d-11e8-843e-782f47fac45c.png)

I don't know how you upload nupkg to Nuget. Perhaps uploading snupkg to NuGet may require more settings. 