### PR TITLE
Disable batch mode and explicitly enable build trigger for master branch

### DIFF
--- a/azure-pipelines.Ubuntu.yml
+++ b/azure-pipelines.Ubuntu.yml
@@ -1,6 +1,7 @@
 trigger:
-  batch: true
   branches:
+    include:
+    - master
     exclude:
     - gh-pages
 

--- a/azure-pipelines.Windows.yml
+++ b/azure-pipelines.Windows.yml
@@ -1,6 +1,7 @@
 trigger:
-  batch: true
   branches:
+    include:
+    - master
     exclude:
     - gh-pages
 

--- a/azure-pipelines.macOS.yml
+++ b/azure-pipelines.macOS.yml
@@ -1,6 +1,7 @@
 trigger:
-  batch: true
   branches:
+    include:
+    - master
     exclude:
     - gh-pages
 


### PR DESCRIPTION
It seems to me that we have to define branch for master builds explicitly.