### PR TITLE
sort enum parameters by value instead of name

### DIFF
--- a/docs/articles/samples/IntroParamsAllValues.md
+++ b/docs/articles/samples/IntroParamsAllValues.md
@@ -17,17 +17,17 @@ If you want to use all possible values of an `enum` or another type with a small
 ### Output
 
 ```markdown
-    Method |   E |     B |     Mean | Error |
----------- |---- |------ |---------:|------:|
- Benchmark |   A |     ? | 101.9 ms |    NA |
- Benchmark |   A | False | 111.9 ms |    NA |
- Benchmark |   A |  True | 122.3 ms |    NA |
- Benchmark |  BB |     ? | 201.5 ms |    NA |
- Benchmark |  BB | False | 211.8 ms |    NA |
- Benchmark |  BB |  True | 221.4 ms |    NA |
- Benchmark | CCC |     ? | 301.8 ms |    NA |
- Benchmark | CCC | False | 312.3 ms |    NA |
- Benchmark | CCC |  True | 322.2 ms |    NA |
+    Method |     E |     B |     Mean | Error |
+---------- |------ |------ |---------:|------:|
+ Benchmark |   One |     ? | 101.4 ms |    NA |
+ Benchmark |   One | False | 111.1 ms |    NA |
+ Benchmark |   One |  True | 122.0 ms |    NA |
+ Benchmark |   Two |     ? | 201.3 ms |    NA |
+ Benchmark |   Two | False | 212.1 ms |    NA |
+ Benchmark |   Two |  True | 221.3 ms |    NA |
+ Benchmark | Three |     ? | 301.4 ms |    NA |
+ Benchmark | Three | False | 311.5 ms |    NA |
+ Benchmark | Three |  True | 320.8 ms |    NA |
 
 // * Legends *
   E     : Value of the 'E' parameter

--- a/samples/BenchmarkDotNet.Samples/IntroParamsAllValues.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroParamsAllValues.cs
@@ -1,5 +1,5 @@
-﻿using System.Threading;
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
+using System.Threading;
 
 namespace BenchmarkDotNet.Samples
 {
@@ -8,9 +8,9 @@ namespace BenchmarkDotNet.Samples
     {
         public enum CustomEnum
         {
-            A,
-            BB,
-            CCC
+            One = 1,
+            Two,
+            Three
         }
 
         [ParamsAllValues]
@@ -23,7 +23,7 @@ namespace BenchmarkDotNet.Samples
         public void Benchmark()
         {
             Thread.Sleep(
-                E.ToString().Length * 100 +
+                (int)E * 100 +
                 (B == true ? 20 : B == false ? 10 : 0));
         }
     }

--- a/src/BenchmarkDotNet/Parameters/ParameterComparer.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterComparer.cs
@@ -38,18 +38,21 @@ namespace BenchmarkDotNet.Parameters
 
             public Comparer Add<T>(Func<T, T, int> compareFunc)
             {
-                comparers.Add(typeof(T), (x, y) => compareFunc((T) x, (T) y));
+                comparers.Add(typeof(T), (x, y) => compareFunc((T)x, (T)y));
                 return this;
             }
 
             public int CompareTo(object x, object y)
             {
-                return x != null && y != null && x.GetType() == y.GetType() && HasComparer(x)
-                    ? comparers[x.GetType()](x, y)
+                return x != null && y != null && x.GetType() == y.GetType() && comparers.TryGetValue(GetComparisonType(x), out var comparer)
+                    ? comparer(x, y)
                     : string.CompareOrdinal(x?.ToString(), y?.ToString());
             }
 
-            private bool HasComparer(object x) => comparers.ContainsKey(x.GetType());
+            private static Type GetComparisonType(object x) =>
+                x.GetType().IsEnum
+                ? x.GetType().GetEnumUnderlyingType()
+                : x.GetType();
         }
     }
 }


### PR DESCRIPTION
This addresses some of the feedback from #660 that Enums should default to ordering by value instead of by name.