### PR TITLE
Detect .NET Core benchmark failures from LINQPad

### DIFF
--- a/src/BenchmarkDotNet/Running/BenchmarkRunner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunner.cs
@@ -197,7 +197,19 @@ namespace BenchmarkDotNet.Running
                     reports.Add(new BenchmarkReport(false, benchmark, buildResult, buildResult, default, default, default, default));
 
                     if (buildResult.GenerateException != null)
+                    {
                         logger.WriteLineError($"// Generate Exception: {buildResult.GenerateException.Message}");
+
+                        if (benchmark.Job.Environment == EnvironmentMode.Core)
+                        {
+                            var assembly = benchmark.Descriptor.Type.GetTypeInfo().Assembly;
+                            if (assembly.FullName.ToUpper().Contains("LINQPAD"))
+                            {
+                                logger.WriteLineError("// .NET Core benchmarks are not possible with LINQPad. See BenchmarkDotNet issue #975 on GitHub.");
+                            }
+                        }
+                    }
+
                     if (buildResult.BuildException != null)
                         logger.WriteLineError($"// Build Exception: {buildResult.BuildException.Message}");
 

--- a/src/BenchmarkDotNet/Running/BenchmarkRunner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunner.cs
@@ -197,19 +197,7 @@ namespace BenchmarkDotNet.Running
                     reports.Add(new BenchmarkReport(false, benchmark, buildResult, buildResult, default, default, default, default));
 
                     if (buildResult.GenerateException != null)
-                    {
                         logger.WriteLineError($"// Generate Exception: {buildResult.GenerateException.Message}");
-
-                        if (benchmark.Job.Environment == EnvironmentMode.Core)
-                        {
-                            var assembly = benchmark.Descriptor.Type.GetTypeInfo().Assembly;
-                            if (assembly.FullName.ToUpper().Contains("LINQPAD"))
-                            {
-                                logger.WriteLineError("// .NET Core benchmarks are not possible with LINQPad. See BenchmarkDotNet issue #975 on GitHub.");
-                            }
-                        }
-                    }
-
                     if (buildResult.BuildException != null)
                         logger.WriteLineError($"// Build Exception: {buildResult.BuildException.Message}");
 

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Reflection;
 using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Extensions;
@@ -58,6 +59,13 @@ namespace BenchmarkDotNet.Toolchains.CsProj
             if (benchmarkCase.Job.ResolveValue(GcMode.AllowVeryLargeObjectsCharacteristic, resolver))
             {
                 logger.WriteLineError($"Currently project.json does not support gcAllowVeryLargeObjects (app.config does), benchmark '{benchmarkCase.DisplayInfo}' will not be executed");
+                return false;
+            }
+
+            var benchmarkAssembly = benchmarkCase.Descriptor.Type.GetTypeInfo().Assembly;
+            if (benchmarkAssembly.FullName.ToUpper().Contains("LINQPAD"))
+            {
+                logger.WriteLineError($"Currently LINQPad does not support .NET Core benchmarks (see dotnet/BenchmarkDotNet#975), benchmark '{benchmarkCase.DisplayInfo}' will not be executed");
                 return false;
             }
 


### PR DESCRIPTION
When running a .NET Core benchmark job from LINQPad, you will encounter an error like the following:
> // Generate Exception: Unable to find LINQPadQuery in C:\Program Files (x86)\LINQPad5 and its subfolders. Most probably the name of output exe is different than the name of the .(c/f)sproj

As noted in [this comment](https://github.com/dotnet/BenchmarkDotNet/issues/975#issuecomment-443297722), this is because to run a .NET Core job requires the benchmarks to be in .NET Core (LINQPad does not provide this).

This change detects that a .NET Core benchmark job was run from LINQPad and provides an additional error message stating this fact.

Detection of LINQPad is the same implementation used in [`JitOptimizationsValidator`](https://github.com/dotnet/BenchmarkDotNet/blob/master/src/BenchmarkDotNet/Validators/JitOptimizationsValidator.cs) which uses the assembly name.