### PR TITLE
Give a warning when the [Benchmark] method is static

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/InProcessTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/InProcessTest.cs
@@ -54,24 +54,6 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void BenchmarkActionValueTaskOfTSupported() => TestInvoke(x => x.InvokeOnceValueTaskOfT(), UnrollFactor, DecimalResult);
 
-        [Fact]
-        public void BenchmarkActionStaticVoidSupported() => TestInvoke(x => BenchmarkAllCases.InvokeOnceStaticVoid(), UnrollFactor);
-
-        [Fact]
-        public void BenchmarkActionStaticTaskSupported() => TestInvoke(x => BenchmarkAllCases.InvokeOnceStaticTaskAsync(), UnrollFactor, null);
-
-        [Fact]
-        public void BenchmarkActionStaticRefTypeSupported() => TestInvoke(x => BenchmarkAllCases.InvokeOnceStaticRefType(), UnrollFactor, StringResult);
-
-        [Fact]
-        public void BenchmarkActionStaticValueTypeSupported() => TestInvoke(x => BenchmarkAllCases.InvokeOnceStaticValueType(), UnrollFactor, DecimalResult);
-
-        [Fact]
-        public void BenchmarkActionStaticTaskOfTSupported() => TestInvoke(x => BenchmarkAllCases.InvokeOnceStaticTaskOfTAsync(), UnrollFactor, StringResult);
-
-        [Fact]
-        public void BenchmarkActionStaticValueTaskOfTSupported() => TestInvoke(x => BenchmarkAllCases.InvokeOnceStaticValueTaskOfT(), UnrollFactor, DecimalResult);
-
         [AssertionMethod]
         private void TestInvoke(Expression<Action<BenchmarkAllCases>> methodCall, int unrollFactor)
         {
@@ -296,48 +278,6 @@ namespace BenchmarkDotNet.IntegrationTests
 
             [Benchmark]
             public ValueTask<decimal> InvokeOnceValueTaskOfT()
-            {
-                Interlocked.Increment(ref Counter);
-                return new ValueTask<decimal>(DecimalResult);
-            }
-
-            [Benchmark]
-            public static void InvokeOnceStaticVoid()
-            {
-                Interlocked.Increment(ref Counter);
-            }
-
-            [Benchmark]
-            public static async Task InvokeOnceStaticTaskAsync()
-            {
-                await Task.Yield();
-                Interlocked.Increment(ref Counter);
-            }
-
-            [Benchmark]
-            public static string InvokeOnceStaticRefType()
-            {
-                Interlocked.Increment(ref Counter);
-                return StringResult;
-            }
-
-            [Benchmark]
-            public static decimal InvokeOnceStaticValueType()
-            {
-                Interlocked.Increment(ref Counter);
-                return DecimalResult;
-            }
-
-            [Benchmark]
-            public static async Task<string> InvokeOnceStaticTaskOfTAsync()
-            {
-                await Task.Yield();
-                Interlocked.Increment(ref Counter);
-                return StringResult;
-            }
-
-            [Benchmark]
-            public static ValueTask<decimal> InvokeOnceStaticValueTaskOfT()
             {
                 Interlocked.Increment(ref Counter);
                 return new ValueTask<decimal>(DecimalResult);

--- a/tests/BenchmarkDotNet.IntegrationTests/ParamsAttributeStaticTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ParamsAttributeStaticTest.cs
@@ -106,7 +106,7 @@ namespace BenchmarkDotNet.IntegrationTests
             private static HashSet<int> collectedParams = new HashSet<int>();
 
             [Benchmark]
-            public static void Benchmark()
+            public void Benchmark()
             {
                 if (collectedParams.Contains(StaticParamField) == false)
                 {
@@ -135,7 +135,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
 #pragma warning disable xUnit1013 // Public method should be marked as test
         [Benchmark]
-        public static void Benchmark()
+        public void Benchmark()
         {
             if (collectedParams.Contains(StaticParamField) == false)
             {

--- a/tests/BenchmarkDotNet.Tests/Validators/CompilationValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/CompilationValidatorTests.cs
@@ -70,7 +70,7 @@ namespace BenchmarkDotNet.Tests.Validators
                                                                .ToList();
             
             // Assert
-            Assert.Equal(validationErrors.Any(), hasErrors);
+            Assert.Equal(hasErrors, validationErrors.Any());
         }
       
         private static Delegate BuildDummyMethod<T>(string name)

--- a/tests/BenchmarkDotNet.Tests/Validators/CompilationValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/CompilationValidatorTests.cs
@@ -46,7 +46,7 @@ namespace BenchmarkDotNet.Tests.Validators
                                                                .ToList();
             
             // Assert
-            Assert.Equal(validationErrors.Any(), hasErrors);
+            Assert.Equal(hasErrors, validationErrors.Any());
         }
         
         [Theory]

--- a/tests/BenchmarkDotNet.Tests/Validators/CompilationValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/CompilationValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Emit;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
@@ -28,12 +29,25 @@ namespace BenchmarkDotNet.Tests.Validators
                         null)
                 }, new ManualConfig());
 
-            var errors = CompilationValidator.Default.Validate(parameters);
+            var errors = CompilationValidator.Default.Validate(parameters).Select(e => e.Message);
 
-            Assert.Equal("Benchmarked method `Has Some Whitespaces` contains illegal character(s). Please use `[<Benchmark(Description = \"Custom name\")>]` to set custom display name.", 
-                errors.Single().Message);
+            Assert.Contains(errors,
+                s => s.Equals(
+                    "Benchmarked method `Has Some Whitespaces` contains illegal character(s). Please use `[<Benchmark(Description = \"Custom name\")>]` to set custom display name."));
         }
 
+        [Theory]
+        [InlineData(typeof(BenchmarkClassWithStaticMethod), true)]
+        [InlineData(typeof(BenchmarkClass<PublicClass>), false)]
+        public void Benchmark_Class_Methods_Must_Be_Non_Static(Type type, bool hasErrors)
+        {
+            // Act
+            var validationErrors = CompilationValidator.Default.Validate(BenchmarkConverter.TypeToBenchmarks(type))
+                                                               .ToList();
+            
+            // Assert
+            Assert.Equal(validationErrors.Any(), hasErrors);
+        }
         
         [Theory]
         [InlineData(typeof(PublicClass), false)]
@@ -81,6 +95,12 @@ namespace BenchmarkDotNet.Tests.Validators
         {
             protected internal class ProtectedInternalNestedClass { }
         }
+    }
+    
+    public class BenchmarkClassWithStaticMethod
+    {
+        [Benchmark]
+        public static void StaticMethod() { }
     }
     
     public class BenchmarkClass<T> where T : new()


### PR DESCRIPTION
For https://github.com/dotnet/BenchmarkDotNet/issues/983