### PR TITLE
Fix NRE in MetricColumn (#986)

### DIFF
--- a/src/BenchmarkDotNet/Columns/DefaultColumnProvider.cs
+++ b/src/BenchmarkDotNet/Columns/DefaultColumnProvider.cs
@@ -84,7 +84,6 @@ namespace BenchmarkDotNet.Columns
         {
             public IEnumerable<IColumn> GetColumns(Summary summary) => summary
                 .Reports
-                .Where(report => report.Metrics != null)
                 .SelectMany(report => report.Metrics.Values.Select(metric => metric.Descriptor))
                 .Distinct(MetricDescriptorEqualityComparer.Instance)
                 .Select(descriptor => new MetricColumn(descriptor));

--- a/src/BenchmarkDotNet/Columns/MetricColumn.cs
+++ b/src/BenchmarkDotNet/Columns/MetricColumn.cs
@@ -22,13 +22,17 @@ namespace BenchmarkDotNet.Columns
 
         public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
 
-        public bool IsAvailable(Summary summary) => summary.Reports.Any(report => report.Metrics.ContainsKey(descriptor.Id));
+        public bool IsAvailable(Summary summary) => summary.Reports.Any(report => report.Metrics?.ContainsKey(descriptor.Id) ?? false);
 
         public string GetValue(Summary summary, BenchmarkCase benchmarkCase) => GetValue(summary, benchmarkCase, SummaryStyle.Default);
         
         public string GetValue(Summary summary, BenchmarkCase benchmarkCase, ISummaryStyle style) 
         {
-            if (!summary.HasReport(benchmarkCase) || !summary[benchmarkCase].Metrics.TryGetValue(descriptor.Id, out Metric metric) || metric.Value == 0.0)
+            if (!summary.HasReport(benchmarkCase))
+                return "-";
+
+            BenchmarkReport report = summary[benchmarkCase];
+            if (report.Metrics == null || !report.Metrics.TryGetValue(descriptor.Id, out Metric metric) || metric.Value == 0.0)
                 return "-";
 
             if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Size)

--- a/src/BenchmarkDotNet/Columns/MetricColumn.cs
+++ b/src/BenchmarkDotNet/Columns/MetricColumn.cs
@@ -22,17 +22,13 @@ namespace BenchmarkDotNet.Columns
 
         public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
 
-        public bool IsAvailable(Summary summary) => summary.Reports.Any(report => report.Metrics?.ContainsKey(descriptor.Id) ?? false);
+        public bool IsAvailable(Summary summary) => summary.Reports.Any(report => report.Metrics.ContainsKey(descriptor.Id));
 
         public string GetValue(Summary summary, BenchmarkCase benchmarkCase) => GetValue(summary, benchmarkCase, SummaryStyle.Default);
         
         public string GetValue(Summary summary, BenchmarkCase benchmarkCase, ISummaryStyle style) 
         {
-            if (!summary.HasReport(benchmarkCase))
-                return "-";
-
-            BenchmarkReport report = summary[benchmarkCase];
-            if (report.Metrics == null || !report.Metrics.TryGetValue(descriptor.Id, out Metric metric) || metric.Value == 0.0)
+            if (!summary.HasReport(benchmarkCase) || !summary[benchmarkCase].Metrics.TryGetValue(descriptor.Id, out Metric metric) || metric.Value == 0.0)
                 return "-";
 
             if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Size)

--- a/src/BenchmarkDotNet/Reports/BenchmarkReport.cs
+++ b/src/BenchmarkDotNet/Reports/BenchmarkReport.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Mathematics;
@@ -46,7 +47,8 @@ namespace BenchmarkDotNet.Reports
             ExecuteResults = executeResults ?? Array.Empty<ExecuteResult>();
             AllMeasurements = allMeasurements ?? Array.Empty<Measurement>();
             GcStats = gcStats;
-            Metrics = metrics?.ToDictionary(metric => metric.Descriptor.Id);
+            Metrics = metrics?.ToDictionary(metric => metric.Descriptor.Id)
+                ?? (IReadOnlyDictionary<string, Metric>)ImmutableDictionary<string, Metric>.Empty;
         }
 
         public override string ToString() => $"{BenchmarkCase.DisplayInfo}, {AllMeasurements.Count} runs";

--- a/tests/BenchmarkDotNet.Tests/Reports/SummaryTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/SummaryTests.cs
@@ -81,7 +81,6 @@ namespace BenchmarkDotNet.Tests.Reports
 
         public class MockBenchmarkClass
         {
-            // Looks like this attribute is significant here. The issue does not reproduce if it is omitted.
             [Benchmark(Baseline = true)]
             public void Foo() { }
         }

--- a/tests/BenchmarkDotNet.Tests/Reports/SummaryTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/SummaryTests.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Tests.Builders;
@@ -11,6 +13,7 @@ using BenchmarkDotNet.Toolchains;
 using BenchmarkDotNet.Toolchains.Results;
 using BenchmarkDotNet.Validators;
 using Xunit;
+using RunMode = BenchmarkDotNet.Jobs.RunMode;
 
 namespace BenchmarkDotNet.Tests.Reports
 {
@@ -21,15 +24,53 @@ namespace BenchmarkDotNet.Tests.Reports
         /// See also: <see href="https://github.com/dotnet/BenchmarkDotNet/issues/986" />
         /// </summary>
         [Fact]
-        public void FailureWithDefaultMetricsDoesNotThrowNre()
+        public void SummaryWithFailureReportDoesNotThrowNre()
         {
             // Arrange:
-            IConfig config = DefaultConfig.Instance;
-            IEnumerable<BenchmarkCase> benchmarks = CreateBenchmarks(config);
-            IList<BenchmarkReport> reports = benchmarks.Select(CreateReportWithDefaultMetrics).ToArray();
+            IConfig config = CreateConfig();
+            IList<BenchmarkReport> reports = CreateReports(config);
 
             // Act:
             Summary _ = CreateSummary(reports, config);
+        }
+
+        private static IConfig CreateConfig()
+        {
+            // We use runtime as selector later. It is chosen as selector just to be close to initial issue. Nothing particularly special about it.
+            Job coreJob = new Job(Job.Default).With(Runtime.Core).ApplyAndFreeze(RunMode.Dry);
+            Job clrJob = new Job(Job.Default).With(Runtime.Clr).ApplyAndFreeze(RunMode.Dry);
+            return ManualConfig.Create(DefaultConfig.Instance).With(coreJob).With(clrJob);
+        }
+
+        private static BenchmarkReport[] CreateReports(IConfig config)
+        {
+            BenchmarkRunInfo benchmarkRunInfo = BenchmarkConverter.TypeToBenchmarks(typeof(MockBenchmarkClass), config);
+            return benchmarkRunInfo.BenchmarksCases.Select(CreateReport).ToArray();
+        }
+
+        private static BenchmarkReport CreateReport(BenchmarkCase benchmark)
+        {
+            return benchmark.Job.Environment.Runtime.Equals(Runtime.Clr)
+                ? CreateFailureReport(benchmark)
+                : CreateSuccessReport(benchmark);
+        }
+
+        private static BenchmarkReport CreateFailureReport(BenchmarkCase benchmark)
+        {
+            GenerateResult generateResult = GenerateResult.Failure(ArtifactsPaths.Empty, Array.Empty<string>());
+            BuildResult buildResult = BuildResult.Failure(generateResult);
+            // Null may be legitimately passed as metrics to BenchmarkReport ctor here:
+            // https://github.com/dotnet/BenchmarkDotNet/blob/89255c9fceb1b27c475a93d08c152349be4199e9/src/BenchmarkDotNet/Running/BenchmarkRunner.cs#L197
+            return new BenchmarkReport(false, benchmark, generateResult, buildResult, default, default, default, default);
+        }
+
+        private static BenchmarkReport CreateSuccessReport(BenchmarkCase benchmark)
+        {
+            GenerateResult generateResult = GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>());
+            BuildResult buildResult = BuildResult.Success(generateResult);
+            var metrics = new[] { new Metric(new FakeMetricDescriptor(), Math.E) };
+            return new BenchmarkReport(true, benchmark, generateResult, buildResult,
+                Array.Empty<ExecuteResult>(), Array.Empty<Measurement>(), default, metrics);
         }
 
         private static Summary CreateSummary(IList<BenchmarkReport> reports, IConfig config)
@@ -38,29 +79,22 @@ namespace BenchmarkDotNet.Tests.Reports
             return new Summary("MockSummary", reports, hostEnvironmentInfo, config, string.Empty, TimeSpan.FromMinutes(1.0), Array.Empty<ValidationError>());
         }
 
-        private static BenchmarkCase[] CreateBenchmarks(IConfig config)
-        {
-            BenchmarkRunInfo benchmarkRunInfo = BenchmarkConverter.TypeToBenchmarks(typeof(MockBenchmarkClass), config);
-            return benchmarkRunInfo.BenchmarksCases;
-        }
-
-        private static BenchmarkReport CreateReportWithDefaultMetrics(BenchmarkCase benchmark)
-        {
-            GenerateResult generateResult = GenerateResult.Failure(ArtifactsPaths.Empty, Array.Empty<string>());
-            BuildResult buildResult = BuildResult.Failure(generateResult);
-            // We want to match this call:
-            // https://github.com/dotnet/BenchmarkDotNet/blob/89255c9fceb1b27c475a93d08c152349be4199e9/src/BenchmarkDotNet/Running/BenchmarkRunner.cs#L197
-            return new BenchmarkReport(false, benchmark, generateResult, buildResult, default, default, default, default);
-        }
-
-        [ShortRunJob]
         public class MockBenchmarkClass
         {
+            // Looks like this attribute is significant here. The issue does not reproduce if it is omitted.
             [Benchmark(Baseline = true)]
             public void Foo() { }
+        }
 
-            [Benchmark]
-            public void Bar() { }
+        private sealed class FakeMetricDescriptor : IMetricDescriptor
+        {
+            public string Id { get; } = nameof(Id);
+            public string DisplayName { get; } = nameof(DisplayName);
+            public string Legend { get; } = nameof(Legend);
+            public string NumberFormat { get; } = "N";
+            public UnitType UnitType { get; }
+            public string Unit { get; } = nameof(Unit);
+            public bool TheGreaterTheBetter { get; }
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/Reports/SummaryTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/SummaryTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Tests.Builders;
+using BenchmarkDotNet.Toolchains;
+using BenchmarkDotNet.Toolchains.Results;
+using BenchmarkDotNet.Validators;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.Reports
+{
+    public class SummaryTests
+    {
+        /// <summary>
+        /// Ensures that passing null metrics to BenchmarkReport ctor does not result in NullReferenceException later in Summary ctor.
+        /// See also: <see href="https://github.com/dotnet/BenchmarkDotNet/issues/986" />
+        /// </summary>
+        [Fact]
+        public void FailureWithDefaultMetricsDoesNotThrowNre()
+        {
+            // Arrange:
+            IConfig config = DefaultConfig.Instance;
+            IEnumerable<BenchmarkCase> benchmarks = CreateBenchmarks(config);
+            IList<BenchmarkReport> reports = benchmarks.Select(CreateReportWithDefaultMetrics).ToArray();
+
+            // Act:
+            Summary _ = CreateSummary(reports, config);
+        }
+
+        private static Summary CreateSummary(IList<BenchmarkReport> reports, IConfig config)
+        {
+            HostEnvironmentInfo hostEnvironmentInfo = new HostEnvironmentInfoBuilder().Build();
+            return new Summary("MockSummary", reports, hostEnvironmentInfo, config, string.Empty, TimeSpan.FromMinutes(1.0), Array.Empty<ValidationError>());
+        }
+
+        private static BenchmarkCase[] CreateBenchmarks(IConfig config)
+        {
+            BenchmarkRunInfo benchmarkRunInfo = BenchmarkConverter.TypeToBenchmarks(typeof(MockBenchmarkClass), config);
+            return benchmarkRunInfo.BenchmarksCases;
+        }
+
+        private static BenchmarkReport CreateReportWithDefaultMetrics(BenchmarkCase benchmark)
+        {
+            GenerateResult generateResult = GenerateResult.Failure(ArtifactsPaths.Empty, Array.Empty<string>());
+            BuildResult buildResult = BuildResult.Failure(generateResult);
+            // We want to match this call:
+            // https://github.com/dotnet/BenchmarkDotNet/blob/89255c9fceb1b27c475a93d08c152349be4199e9/src/BenchmarkDotNet/Running/BenchmarkRunner.cs#L197
+            return new BenchmarkReport(false, benchmark, generateResult, buildResult, default, default, default, default);
+        }
+
+        [ShortRunJob]
+        public class MockBenchmarkClass
+        {
+            [Benchmark(Baseline = true)]
+            public void Foo() { }
+
+            [Benchmark]
+            public void Bar() { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes NRE after unchecked access to `BenchmarkReport.Metrics` property.