### PR TITLE
Rephrase Notes section and fix markdown

### DIFF
--- a/docs/articles/contributing/documentation.md
+++ b/docs/articles/contributing/documentation.md
@@ -15,37 +15,37 @@ BenchmarkDotNet uses [DocFX](https://dotnet.github.io/docfx/) as a documentation
     
 ## Notes
 
-DocFX uses the following syntax for different types of notes:
+DocFX uses the [following syntax](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html?tabs=tabid-1%2Ctabid-a#note-warningtipimportant) inside block quote for different types of notes:
 
 ```markdown
 > [!NOTE]
-> <note content>
+> note content
 > [!TIP]
-> <note content>
+> tip content
 > [!WARNING]
-> <warning content>
+> warning content
 > [!IMPORTANT]
-> <important content>
+> important content
 > [!Caution]
-> <caution content>
+> caution content
 ```
 
 It will be transformed to:
 
 > [!NOTE]
-> <note content>
+> note content
 
 > [!TIP]
-> <note content>
+> tip content
 
 > [!WARNING]
-> <warning content>
+> warning content
 
 > [!IMPORTANT]
-> <important content>
+> important content
 
 > [!Caution]
-> <caution content>
+> caution content
 
 ## Building documentation locally
 


### PR DESCRIPTION
The sample markdown as it was - was broken and misleading.
I guess it is https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html?tabs=tabid-1%2Ctabid-a#note-warningtipimportant to blame for abstract self-contradictory samples with copy-paste artifacts.