### PR TITLE
Remove obsolete info from the docs

### DIFF
--- a/docs/articles/guides/nuget.md
+++ b/docs/articles/guides/nuget.md
@@ -9,7 +9,7 @@ name: Installing NuGet packages
 
 We have the following set of NuGet packages (you can install it directly from `nuget.org`):
 
-* `BenchmarkDotNet`: Basic BenchmarkDotNet infrastructure and logic. Doesn't have any dependencies. This is all you need to run benchmarks.
+* `BenchmarkDotNet`: Basic BenchmarkDotNet infrastructure and logic. This is all you need to run benchmarks.
 * `BenchmarkDotNet.Diagnostics.Windows`: an additional optional package that provides a set of Windows diagnosers.
 
 ## Versioning system and feeds


### PR DESCRIPTION
`BenchmarkDotNet` `Doesn't have any dependencies` - is no longer true.