### PR TITLE
CoreRT toolchain update

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -325,7 +325,9 @@ namespace BenchmarkDotNet.ConsoleArguments
 
                     if (options.CliPath != null)
                         builder.DotNetCli(options.CliPath.FullName);
-                    
+                    if (options.RestorePath != null)
+                        builder.PackagesRestorePath(options.RestorePath.FullName);
+
                     if (options.CoreRtPath != null)
                         builder.UseCoreRtLocal(options.CoreRtPath.FullName);
                     else if (!string.IsNullOrEmpty(options.CoreRtVersion))

--- a/src/BenchmarkDotNet/Templates/CsProj.txt
+++ b/src/BenchmarkDotNet/Templates/CsProj.txt
@@ -17,6 +17,7 @@
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
+    <UseSharedCompilation>false</UseSharedCompilation>
     $COPIEDSETTINGS$
   </PropertyGroup>
 

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
@@ -15,11 +15,11 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
         internal CoreRtToolchain(string displayName, 
             string coreRtVersion, string ilcPath, bool useCppCodeGenerator,
             string runtimeFrameworkVersion, string targetFrameworkMoniker, string runtimeIdentifier,
-            string customDotNetCliPath,
+            string customDotNetCliPath, string packagesRestorePath,
             Dictionary<string, string> feeds, bool useNuGetClearTag, bool useTempFolderForRestore,
             TimeSpan timeout)
             : base(displayName,
-                new Generator(coreRtVersion, useCppCodeGenerator, runtimeFrameworkVersion, targetFrameworkMoniker, customDotNetCliPath, runtimeIdentifier, feeds, useNuGetClearTag, useTempFolderForRestore),
+                new Generator(coreRtVersion, useCppCodeGenerator, runtimeFrameworkVersion, targetFrameworkMoniker, customDotNetCliPath, runtimeIdentifier, feeds, useNuGetClearTag, useTempFolderForRestore, packagesRestorePath),
                 new DotNetCliPublisher(customDotNetCliPath, GetExtraArguments(useCppCodeGenerator, runtimeIdentifier), GetEnvironmentVariables(ilcPath), timeout), 
                 new Executor())
         {

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchainBuilder.cs
@@ -11,7 +11,8 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
         private string coreRtVersion;
         private string ilcPath;
         private bool useCppCodeGenerator;
-        
+        private string packagesRestorePath;
+
         private bool isCoreRtConfigured;
 
         /// <summary>
@@ -62,6 +63,17 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
             return this;
         }
 
+        /// <summary>
+        /// The directory to restore packages to (optional).
+        /// </summary>
+        /// <returns></returns>
+        public CoreRtToolchainBuilder PackagesRestorePath(string packagesRestorePath)
+        {
+            this.packagesRestorePath = packagesRestorePath;
+
+            return this;
+        }
+
         public override IToolchain ToToolchain()
         {
             if (!isCoreRtConfigured)
@@ -76,6 +88,7 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
                 targetFrameworkMoniker: GetTargetFrameworkMoniker(),
                 runtimeIdentifier: runtimeIdentifier ?? GetPortableRuntimeIdentifier(),
                 customDotNetCliPath: customDotNetCliPath,
+                packagesRestorePath: packagesRestorePath,
                 feeds: Feeds,
                 useNuGetClearTag: useNuGetClearTag,
                 useTempFolderForRestore: useTempFolderForRestore,

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchainBuilder.cs
@@ -73,7 +73,7 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
                 ilcPath: ilcPath,
                 useCppCodeGenerator: useCppCodeGenerator,
                 runtimeFrameworkVersion: runtimeFrameworkVersion,
-                targetFrameworkMoniker: targetFrameworkMoniker,
+                targetFrameworkMoniker: GetTargetFrameworkMoniker(),
                 runtimeIdentifier: runtimeIdentifier ?? GetPortableRuntimeIdentifier(),
                 customDotNetCliPath: customDotNetCliPath,
                 feeds: Feeds,

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
@@ -106,7 +106,14 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                         : GenerateProjectForLocalBuild(buildPartition, artifactsPaths, logger));
 
         private string GenerateProjectForNuGetBuild(BuildPartition buildPartition, ArtifactsPaths artifactsPaths, ILogger logger) => $@"
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project ToolsVersion=""15.0"">
+  <PropertyGroup>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  </PropertyGroup>
+
+  <Import Project=""Sdk.props"" Sdk=""Microsoft.NET.Sdk"" />
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>{TargetFrameworkMoniker}</TargetFramework>
@@ -127,6 +134,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <PackageReference Include=""Microsoft.DotNet.ILCompiler"" Version=""{coreRtVersion}"" />
     <ProjectReference Include=""{GetProjectFilePath(buildPartition.RepresentativeBenchmarkCase.Descriptor.Type, logger).FullName}"" />
   </ItemGroup>
+  <Import Project=""Sdk.targets"" Sdk=""Microsoft.NET.Sdk"" />
 </Project>";
 
         private string GenerateProjectForLocalBuild(BuildPartition buildPartition, ArtifactsPaths artifactsPaths, ILogger logger) => $@"

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
@@ -23,8 +23,9 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
 
         internal Generator(string coreRtVersion, bool useCppCodeGenerator,
             string runtimeFrameworkVersion, string targetFrameworkMoniker, string cliPath,
-            string runtimeIdentifier, IReadOnlyDictionary<string, string> feeds, bool useNuGetClearTag, bool useTempFolderForRestore)
-            : base(targetFrameworkMoniker, cliPath, GetPackagesDirectoryPath(useTempFolderForRestore), runtimeFrameworkVersion)
+            string runtimeIdentifier, IReadOnlyDictionary<string, string> feeds, bool useNuGetClearTag, 
+            bool useTempFolderForRestore, string packagesRestorePath)
+            : base(targetFrameworkMoniker, cliPath, GetPackagesDirectoryPath(useTempFolderForRestore, packagesRestorePath), runtimeFrameworkVersion)
         {
             this.coreRtVersion = coreRtVersion;
             this.useCppCodeGenerator = useCppCodeGenerator;
@@ -72,10 +73,8 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
         // to avoid this https://github.com/dotnet/coreclr/blob/master/Documentation/workflow/UsingDotNetCli.md#update-coreclr-using-runtime-nuget-package
         // some of the packages are going to contain source code, so they can not be in the subfolder of current solution
         // otherwise they would be compiled too (new .csproj include all .cs files from subfolders by default
-        private static string GetPackagesDirectoryPath(bool useTempFolderForRestore)
-            => useTempFolderForRestore
-                ? Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
-                : null;
+        private static string GetPackagesDirectoryPath(bool useTempFolderForRestore, string packagesRestorePath)
+            => packagesRestorePath ?? (useTempFolderForRestore ? Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()) : null);
 
         protected override string[] GetArtifactsToCleanup(ArtifactsPaths artifactsPaths)
             => useTempFolderForRestore

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
@@ -125,6 +125,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
   {GetRuntimeSettings(buildPartition.RepresentativeBenchmarkCase.Job.Environment.Gc, buildPartition.Resolver)}
   <ItemGroup>
@@ -151,6 +152,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
   <Import Project=""$(MSBuildSDKsPath)\Microsoft.NET.Sdk\Sdk\Sdk.targets"" />
   <Import Project=""$(IlcPath)\build\Microsoft.NETCore.Native.targets"" />

--- a/src/BenchmarkDotNet/Toolchains/CustomCoreClr/CustomCoreClrToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/CustomCoreClr/CustomCoreClrToolchainBuilder.cs
@@ -118,7 +118,7 @@ namespace BenchmarkDotNet.Toolchains.CustomCoreClr
                 coreClrVersion: coreClrVersion,
                 coreFxVersion: coreFxVersion,
                 runtimeFrameworkVersion: runtimeFrameworkVersion,
-                targetFrameworkMoniker: targetFrameworkMoniker,
+                targetFrameworkMoniker: GetTargetFrameworkMoniker(),
                 runtimeIdentifier: runtimeIdentifier ?? GetPortableRuntimeIdentifier(),
                 customDotNetCliPath: customDotNetCliPath,
                 feeds: Feeds,

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/CustomDotNetCliToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/CustomDotNetCliToolchainBuilder.cs
@@ -13,11 +13,12 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         protected readonly Dictionary<string, string> Feeds = new Dictionary<string, string>();
 
         protected string runtimeIdentifier, customDotNetCliPath;
-        protected string targetFrameworkMoniker = "netcoreapp2.1", displayName;
+        protected string displayName;
         protected string runtimeFrameworkVersion;
 
         protected bool useNuGetClearTag, useTempFolderForRestore;
         protected TimeSpan? timeout;
+        private string targetFrameworkMoniker;
 
         public abstract IToolchain ToToolchain();
 
@@ -53,6 +54,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
             return this;
         }
+
+        protected string GetTargetFrameworkMoniker() => targetFrameworkMoniker ?? NetCoreAppSettings.Current.Value.TargetFrameworkMoniker;
 
         /// <param name="newCustomDotNetCliPath">if not provided, the one from PATH will be used</param>
         [PublicAPI]

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliGenerator.cs
@@ -72,10 +72,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             }
         }
 
-        protected override string GetPackagesDirectoryPath(string buildArtifactsDirectoryPath)
-            => string.IsNullOrEmpty(PackagesPath)
-                ? base.GetPackagesDirectoryPath(buildArtifactsDirectoryPath)
-                : PackagesPath;
+        protected override string GetPackagesDirectoryPath(string buildArtifactsDirectoryPath) => PackagesPath;
 
         protected override void GenerateBuildScript(BuildPartition buildPartition, ArtifactsPaths artifactsPaths)
         {

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
@@ -10,7 +10,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
     [PublicAPI]
     public class NetCoreAppSettings
     {
-        public static readonly TimeSpan DefaultBuildTimeout = TimeSpan.FromMinutes(1); // it should always be few seconds, but some ppl might have a bad internet connection
+        public static readonly TimeSpan DefaultBuildTimeout = TimeSpan.FromMinutes(1); // it should always be a few seconds, but some users might have a bad internet connection
 
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp20 = new NetCoreAppSettings("netcoreapp2.0", null, ".NET Core 2.0");
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp21 = new NetCoreAppSettings("netcoreapp2.1", null, ".NET Core 2.1");


### PR DESCRIPTION
1. port #854 PR to CoreRT toolchain as well so the output file path doe not get overwritten by .props files
2. take the current TFM as default, not netcoreapp2.1 for CoreRT
3. if we fail to do the standard publish, let's try with --no-build
4. CoreRT toolchain must respect `--packages`