### PR TITLE
Improve restore, build and publish projects - Fix for #1002

### DIFF
--- a/samples/BenchmarkDotNet.Samples/Properties/launchSettings.json
+++ b/samples/BenchmarkDotNet.Samples/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "BenchmarkDotNet.Samples": {
-      "commandName": "Project",
-      "commandLineArgs": "--filter *IntroColdCpuCache*"
-    }
-  }
-}

--- a/samples/BenchmarkDotNet.Samples/Properties/launchSettings.json
+++ b/samples/BenchmarkDotNet.Samples/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "BenchmarkDotNet.Samples": {
+      "commandName": "Project",
+      "commandLineArgs": "--filter *IntroColdCpuCache*"
+    }
+  }
+}

--- a/src/BenchmarkDotNet/Toolchains/CoreRun/CoreRunGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRun/CoreRunGenerator.cs
@@ -19,8 +19,8 @@ namespace BenchmarkDotNet.Toolchains.CoreRun
 
         private bool NeedsCopy => SourceCoreRun != CopyCoreRun;
 
-        protected override string GetPackagesDirectoryPath(string buildArtifactsDirectoryPath) 
-            => null; // we don't want to restore to a dedicated folder
+        protected override string GetPackagesDirectoryPath(string buildArtifactsDirectoryPath)
+            => base.PackagesPath;
 
         protected override string GetBinariesDirectoryPath(string buildArtifactsDirectoryPath, string configuration)
             => Path.Combine(buildArtifactsDirectoryPath, "bin", configuration, TargetFrameworkMoniker, "publish");

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
@@ -88,8 +88,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
             var publishResult = Publish();
             
-            if (!publishResult.IsSuccess) // if we failed to do the standard publish, let's try with --no-build
-                publishResult = PublishNoBuild();
+//            if (!publishResult.IsSuccess) // if we failed to do the standard publish, let's try with --no-build
+//                publishResult = PublishNoBuild();
 
             return publishResult.ToBuildResult(GenerateResult);
         }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
@@ -57,10 +57,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             if (!restoreResult.IsSuccess)
                 return BuildResult.Failure(GenerateResult, new Exception(restoreResult.AllInformation));
 
-            var buildResult = Build().ToBuildResult(GenerateResult);
-            
-            if (!buildResult.IsBuildSuccess) // if we failed to do the full build, let's try with --no-dependencies
-                buildResult = BuildNoDependencies().ToBuildResult(GenerateResult);
+            var buildResult = BuildNoRestore().ToBuildResult(GenerateResult);
 
             return buildResult;
         }
@@ -78,18 +75,12 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             if (!restoreResult.IsSuccess)
                 return BuildResult.Failure(GenerateResult, new Exception(restoreResult.AllInformation));
 
-            var buildResult = Build();
+            var buildResult = BuildNoRestore();
 
-            if (!buildResult.IsSuccess) // if we failed to do the full build, let's try with --no-dependencies
-                buildResult = BuildNoDependencies();
-            
             if (!buildResult.IsSuccess)
                 return BuildResult.Failure(GenerateResult, new Exception(buildResult.AllInformation));
 
-            var publishResult = Publish();
-            
-//            if (!publishResult.IsSuccess) // if we failed to do the standard publish, let's try with --no-build
-//                publishResult = PublishNoBuild();
+            var publishResult = PublishNoBuildAndNoRestore();    
 
             return publishResult.ToBuildResult(GenerateResult);
         }
@@ -112,21 +103,14 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             => DotNetCliCommandExecutor.Execute(WithArguments(
                 GetRestoreCommand(GenerateResult.ArtifactsPaths, BuildPartition, Arguments)));
         
-        public DotNetCliCommandResult Build()
+        public DotNetCliCommandResult BuildNoRestore()
             => DotNetCliCommandExecutor.Execute(WithArguments(
-                GetBuildCommand(BuildPartition, Arguments)));
-        
-        public DotNetCliCommandResult BuildNoDependencies()
-            => DotNetCliCommandExecutor.Execute(WithArguments(
-                GetBuildCommand(BuildPartition, $"{Arguments} --no-dependencies")));
-        
-        public DotNetCliCommandResult Publish()
-            => DotNetCliCommandExecutor.Execute(WithArguments(
-                GetPublishCommand(BuildPartition, Arguments)));
+                GetBuildCommand(BuildPartition, $"{Arguments} --no-restore")));
+                
 
-        public DotNetCliCommandResult PublishNoBuild()
+        public DotNetCliCommandResult PublishNoBuildAndNoRestore()
             => DotNetCliCommandExecutor.Execute(WithArguments(
-                GetPublishCommand(BuildPartition, $"{Arguments} --no-build")));
+                GetPublishCommand(BuildPartition, $"{Arguments} --no-build --no-restore")));
 
         internal static IEnumerable<string> GetAddPackagesCommands(BuildPartition buildPartition)
             => GetNuGetAddPackageCommands(buildPartition.RepresentativeBenchmarkCase, buildPartition.Resolver);


### PR DESCRIPTION
After this changes `benchmarks_ci.py` works good.:

```ini
[2019/01/11 14:16:15][INFO] $ pushd "C:\Work\performance\src\benchmarks\micro"
[2019/01/11 14:16:15][INFO] $ dotnet run --project MicroBenchmarks.csproj --configuration Release --framework netcoreapp3.0 --no-restore --no-build -- --coreRun C:\Work\corefx\artifacts\bin\testhost\netcoreapp-Windows_NT-Debug-x64\shared\Microsoft.NETCore.App\9.9.9\CoreRun.exe --filter *.Perf_Dictionary.* --join --packages C:\Work\performance\artifacts\packages --runtimes netcoreapp3.0
[2019/01/11 14:16:24][INFO] // Validating benchmarks:
[2019/01/11 14:16:25][INFO] // ***** BenchmarkRunner: Start   *****
[2019/01/11 14:16:25][INFO] // ***** Building 1 exe(s) in Parallel: Start   *****
[2019/01/11 14:16:29][INFO] // start dotnet restore --packages "C:\Work\performance\artifacts\packages"  /p:UseSharedCompilation=false in C:\Work\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp3.0\3148b284-3041-4f20-a315-4811137f804d
[2019/01/11 14:16:33][INFO] // command took 3.68s and exited with 0
[2019/01/11 14:16:33][INFO] // start dotnet build -c Release  --no-restore /p:UseSharedCompilation=false in C:\Work\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp3.0\3148b284-3041-4f20-a315-4811137f804d
[2019/01/11 14:16:39][INFO] // command took 6.18s and exited with 0
[2019/01/11 14:16:39][INFO] // start dotnet publish -c Release  --no-build --no-restore /p:UseSharedCompilation=false in C:\Work\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp3.0\3148b284-3041-4f20-a315-4811137f804d
[2019/01/11 14:16:41][INFO] // command took 2.73s and exited with 0
```

In this PR I've changed:
1. CoreRunGenerator didn't support custom package directory from `--packages` parameter.
2. Now BND compile project like `benchmarks_ci.py` script in steps:
   * dotnet restore Project.csproj --packages ABC (package is add when ABC is not null)
   * dotnet build Project.csproj --no-restore (project was built in step above)
   * dotnet publish Project.csproj --no-build --no-restore (project was built and restored in steps above)