### PR TITLE
Improve diff disassembly

### DIFF
--- a/src/BenchmarkDotNet/Exporters/PrettyGithubMarkdownDiffDisassemblyExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/PrettyGithubMarkdownDiffDisassemblyExporter.cs
@@ -56,7 +56,7 @@ namespace BenchmarkDotNet.Exporters
                     logger.WriteLine($"{GetImportantInfo(summary[secondBenchmarkCase])}");
 
                     logger.WriteLine("```diff");
-                    logger.WriteLine(builder.ToString());
+                    logger.WriteLine(builder.ToString().Trim());
                     logger.WriteLine("```");
                 }
                 finally
@@ -88,7 +88,7 @@ namespace BenchmarkDotNet.Exporters
         {
             try
             {
-                (int exitCode, IReadOnlyList<string> output) = ProcessHelper.RunAndReadOutputLineByLine("git", $"diff --no-index --no-color --text {firstFile} {secondFile}");
+                (int exitCode, IReadOnlyList<string> output) = ProcessHelper.RunAndReadOutputLineByLine("git", $"diff --no-index --no-color --text --function-context {firstFile} {secondFile}");
 
                 bool canRead = false;
 


### PR DESCRIPTION
Currently when you generate diff two disassembly, the result file looks like:

## BenchmarkDotNet.Samples.IntroDisassemblyCode
**Diff for LoweringTESTtoBT method between:**
.NET Core 2.0.9 (CoreCLR 4.6.26614.01, CoreFX 4.6.26614.01), 64bit RyuJIT
.NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT
```diff
        xor     edx,edx
        jmp     M00_L01
 M00_L00:
-       mov     ecx,eax
-       and     ecx,1Fh
-       mov     edx,1
-       shl     edx,cl
-       mov     ecx,dword ptr [rsp+4]
-       test    edx,ecx
+       bt      ecx,eax
        mov     edx,ecx
-       jne     M00_L01
+       jb      M00_L01
        inc     eax
 M00_L01:
        lea     ecx,[rdx+1]
-       mov     dword ptr [rsp+4],ecx
        cmp     edx,989680h
        jl      M00_L00
-       add     rsp,8
-; Total bytes of code 49
+       ret
+; Total bytes of code 27
 


```

After changes: 
## BenchmarkDotNet.Samples.IntroDisassemblyCode
**Diff for LoweringTESTtoBT method between:**
.NET Core 2.0.9 (CoreCLR 4.6.26614.01, CoreFX 4.6.26614.01), 64bit RyuJIT
.NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT
```diff
; BenchmarkDotNet.Samples.IntroDisassemblyCode.LoweringTESTtoBT()
        xor     eax,eax
        xor     edx,edx
        jmp     M00_L01
 M00_L00:
-       mov     ecx,eax
-       and     ecx,1Fh
-       mov     edx,1
-       shl     edx,cl
-       mov     ecx,dword ptr [rsp+4]
-       test    edx,ecx
+       bt      ecx,eax
        mov     edx,ecx
-       jne     M00_L01
+       jb      M00_L01
        inc     eax
 M00_L01:
        lea     ecx,[rdx+1]
-       mov     dword ptr [rsp+4],ecx
        cmp     edx,989680h
        jl      M00_L00
-       add     rsp,8
-; Total bytes of code 49
+       ret
+; Total bytes of code 27
```