### PR TITLE
[WIP] Proposal: centralize full config creation logic

### DIFF
--- a/src/BenchmarkDotNet/Validators/CompositeValidator.cs
+++ b/src/BenchmarkDotNet/Validators/CompositeValidator.cs
@@ -3,31 +3,13 @@ using System.Linq;
 
 namespace BenchmarkDotNet.Validators
 {
-    internal class CompositeValidator : IValidator
+    public class CompositeValidator : IValidator
     {
-        private static readonly IValidator[] MandatoryValidators = 
-        {
-            BaselineValidator.FailOnError,
-            SetupCleanupValidator.FailOnError,
-            RunModeValidator.FailOnError,
-            DiagnosersValidator.Default,
-            CompilationValidator.Default,
-            ConfigValidator.Default,
-            ShadowCopyValidator.Default,
-            JitOptimizationsValidator.DontFailOnError,
-            DeferredExecutionValidator.DontFailOnError
-        };
-
         internal readonly IValidator[] Validators;
 
         public CompositeValidator(IValidator[] configuredValidators)
         {
-            Validators = configuredValidators
-                .Concat(MandatoryValidators)
-                .GroupBy(validator => validator.GetType())
-                .Select(groupedByType => groupedByType.FirstOrDefault(validator => validator.TreatsWarningsAsErrors) ?? groupedByType.First())
-                .Distinct()
-                .ToArray();
+            Validators = configuredValidators;
         }
 
         /// <summary>

--- a/tests/BenchmarkDotNet.Tests/Validators/CompositeValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/CompositeValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
-using System.Linq;
+
 using BenchmarkDotNet.Validators;
+
 using Xunit;
 
 namespace BenchmarkDotNet.Tests.Validators
@@ -8,36 +9,24 @@ namespace BenchmarkDotNet.Tests.Validators
     public class CompositeValidatorTests
     {
         [Fact]
-        public void ThreatWarningsAsErrorsOverridesDefaultBehaviour()
+        public void ValidatorsAreNotAltered()
         {
-            var compositeValidator = new CompositeValidator(
-                new IValidator[]
-                {
-                    ExecutionValidator.DontFailOnError,
-                    ExecutionValidator.FailOnError
-                });
+            var validators = new IValidator[]
+            {
+                ExecutionValidator.DontFailOnError,
+                ExecutionValidator.FailOnError
+            };
+            var compositeValidator = new CompositeValidator(validators);
 
-            Assert.True(compositeValidator.TreatsWarningsAsErrors);
-            Assert.Contains(ExecutionValidator.FailOnError, compositeValidator.Validators);
-            Assert.DoesNotContain(ExecutionValidator.DontFailOnError, compositeValidator.Validators);
+            Assert.Equal(validators, compositeValidator.Validators);
         }
 
         [Fact]
-        public void BaseLineValidatorIsMandatory()
+        public void NoMandatoryValidatorsAdded()
         {
             var compositeValidator = new CompositeValidator(Array.Empty<IValidator>());
 
-            Assert.Contains(BaselineValidator.FailOnError, compositeValidator.Validators);
-        }
-
-        [Fact]
-        public void DuplicatesAreEliminated()
-        {
-            var compositeValidator = new CompositeValidator(Enumerable.Repeat(JitOptimizationsValidator.DontFailOnError, 3).ToArray());
-
-            Assert.Single(
-                compositeValidator.Validators,
-                validator => ReferenceEquals(validator, JitOptimizationsValidator.DontFailOnError));
+            Assert.Empty(compositeValidator.Validators);
         }
     }
 }


### PR DESCRIPTION
Originally proposed in #988. Previous issue was closed as no-gain thing (code becomes too complex with no profit for end users). I was going to agree but after looking at the code I discovered that 99.9% job is done already and decide to suggest a fix that does not alter BDN behavior and actually simplifies the code.

What I'm talking about: there is a long-standing task to make BDN configuration simpler, keep config creation logic centralized and do not spread it over entire BDN codebase. Personally, I've did a #565 that introduces `BenchmarkRunInfo` and `ReadOnlyConfig` types. This part works well but entire config creation pipeline was not exposed as a public API and there were no way to pass config as is.

The second half of the problem was, there were no single point of config creation. As example, the `CompositeValidator` always adds some mandatory validators and this was a big surprise for my code and tests:)

Proposed fix covers both issues. Here is how it works now:
1. `BenchmarkRunInfo` instances store **final** config description (including a final config) that will not be modified during benchmark runs. There are public api methods, `BenchmarkConverter.TypeToBenchmarksWithFullConfig()` and `BenchmarkConverter.MethodsToBenchmarksWithFullConfig` that allow to bypass `MakeFullConfig` call and leave custom config untouched.
1. The `BenchmarkConverter.GetFullConfig()` logic now includes two additional steps: mandatory config setup and config cleanup (duplicates removal, ordering and so on), implemented as `ManualConfig.UnionWithMandatory` and `ManualConfig.Cleanup` methods.
1. Custom logic from the `CompositeValidator` was moved into corresponding methods of the `ManualConfig`

**Things to improve**
* Current mandatory setup/cleanup implementation does not alter anything but the validators. I'd prefer to start with a small step as complete solution takes too mach time to review (yep, I'm looking at you, #921!)

* I'm not happy with placing the `GetMandatoryValidators()` into `ManualConfig`. Should I create a new `MandatoryConfig` that will contain all mandatory things?
