### PR TITLE
feature: add msbuild.sdk.extra builds for more platforms

### DIFF
--- a/src/BenchmarkDotNet/Templates/MsBuildSdkExtrasCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/MsBuildSdkExtrasCsProj.txt
@@ -1,0 +1,27 @@
+﻿<Project Sdk="MSBuild.Sdk.Extras/1.6.65">
+  <PropertyGroup>
+    <AssemblyTitle>$PROGRAMNAME$</AssemblyTitle>
+    <TargetFramework>$TFM$</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PlatformTarget>$PLATFORM$</PlatformTarget>
+    <AssemblyName>$PROGRAMNAME$</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <OutputPath>bin\$CONFIGURATIONNAME$</OutputPath>
+    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <CodeAnalysisRuleSet></CodeAnalysisRuleSet>
+    $COPIEDSETTINGS$
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$CODEFILENAME$" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$CSPROJPATH$" />
+  </ItemGroup>
+
+  $RUNTIMESETTINGS$
+</Project>

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
@@ -22,7 +22,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
 
         [PublicAPI] public static readonly Lazy<IToolchain> Current = new Lazy<IToolchain>(() => From(NetCoreAppSettings.GetCurrentVersion()));
 
-        private CsProjCoreToolchain(string name, IGenerator generator, IBuilder builder, IExecutor executor, string customDotNetCliPath) 
+        protected CsProjCoreToolchain(string name, IGenerator generator, IBuilder builder, IExecutor executor, string customDotNetCliPath) 
             : base(name, generator, builder, executor)
         {
             CustomDotNetCliPath = customDotNetCliPath;

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -22,6 +22,8 @@ namespace BenchmarkDotNet.Toolchains.CsProj
     {
         public string RuntimeFrameworkVersion { get; }
 
+        protected virtual string TemplateName => "CsProj.txt";
+
         public CsProjGenerator(string targetFrameworkMoniker, string cliPath, string packagesPath, string runtimeFrameworkVersion)
             : base(targetFrameworkMoniker, cliPath, packagesPath)
         {
@@ -44,7 +46,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
         protected override void GenerateProject(BuildPartition buildPartition, ArtifactsPaths artifactsPaths, ILogger logger)
         {
-            string template = ResourceHelper.LoadTemplate("CsProj.txt");
+            string template = ResourceHelper.LoadTemplate(TemplateName);
             var benchmark = buildPartition.RepresentativeBenchmarkCase;
             var projectFile = GetProjectFilePath(benchmark.Descriptor.Type, logger);
 

--- a/src/BenchmarkDotNet/Toolchains/MsBuildSdkExtras/MsBuildSdkExtrasGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MsBuildSdkExtras/MsBuildSdkExtrasGenerator.cs
@@ -1,0 +1,25 @@
+﻿using BenchmarkDotNet.Toolchains.CsProj;
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BenchmarkDotNet.Toolchains.MsBuildSdkExtras
+{
+    /// <summary>
+    /// A csproj generator that will generate projects compatible with the MsBuild.Sdk.Extra format
+    /// that will allow additional TargetFramework's to be targeted.
+    /// </summary>
+    [PublicAPI]
+    public class MsBuildSdkExtrasGenerator : CsProjGenerator
+    {
+        public MsBuildSdkExtrasGenerator(string targetFrameworkMoniker, string cliPath, string packagesPath, string runtimeFrameworkVersion)
+            : base(targetFrameworkMoniker, cliPath, packagesPath, runtimeFrameworkVersion)
+        {
+        }
+
+        protected override string TemplateName => "MsBuildSdkExtrasCsProj.txt";
+    }
+}

--- a/src/BenchmarkDotNet/Toolchains/MsBuildSdkExtras/MsBuildSdkExtrasToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/MsBuildSdkExtras/MsBuildSdkExtrasToolchain.cs
@@ -1,0 +1,56 @@
+﻿using BenchmarkDotNet.Toolchains.CsProj;
+using BenchmarkDotNet.Toolchains.DotNetCli;
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BenchmarkDotNet.Toolchains.MsBuildSdkExtras
+{
+    /// <summary>
+    /// A tool chain which uses the MSBuild.Sdk.Extras SDK to allow for greater frameworks including Xamarin.
+    /// </summary>
+    [PublicAPI]
+    public class MsBuildSdkExtrasToolchain : CsProjCoreToolchain
+    {
+        [PublicAPI] public static readonly IToolchain XamarinIOS10 = From(new NetCoreAppSettings("Xamarin.iOS10", null, "Xamarin iOS 1.0"));
+        [PublicAPI] public static readonly IToolchain XamarinMac20 = From(new NetCoreAppSettings("Xamarin.Mac20", null, "Xamarin Mac 2.0"));
+        [PublicAPI] public static readonly IToolchain XamarinTVOS10 = From(new NetCoreAppSettings("Xamarin.TVOS10", null, "Xamarin TV OS 1.0"));
+        [PublicAPI] public static readonly IToolchain XamarinWatchOS10 = From(new NetCoreAppSettings("Xamarin.WatchOS10", null, "Xamarin Watch OS 1.0"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid10 = From(new NetCoreAppSettings("MonoAndroid10", null, "Xamarin Mono Android 1.0"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid23 = From(new NetCoreAppSettings("MonoAndroid23", null, "Xamarin Mono Android 2.3"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid403 = From(new NetCoreAppSettings("MonoAndroid403", null, "Xamarin Mono Android 4.0.3"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid41 = From(new NetCoreAppSettings("MonoAndroid41", null, "Xamarin Mono Android 4.1"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid42 = From(new NetCoreAppSettings("MonoAndroid42", null, "Xamarin Mono Android 4.2"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid43 = From(new NetCoreAppSettings("MonoAndroid43", null, "Xamarin Mono Android 4.3"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid44 = From(new NetCoreAppSettings("MonoAndroid44", null, "Xamarin Mono Android 4.4"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid4487 = From(new NetCoreAppSettings("MonoAndroid4487", null, "Xamarin Mono Android 4.4.87"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid50 = From(new NetCoreAppSettings("MonoAndroid50", null, "Xamarin Mono Android 5.0"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid51 = From(new NetCoreAppSettings("MonoAndroid51", null, "Xamarin Mono Android 5.1"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid60 = From(new NetCoreAppSettings("MonoAndroid60", null, "Xamarin Mono Android 6.0"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid70 = From(new NetCoreAppSettings("MonoAndroid70", null, "Xamarin Mono Android 7.0"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid71 = From(new NetCoreAppSettings("MonoAndroid71", null, "Xamarin Mono Android 7.1"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid80 = From(new NetCoreAppSettings("MonoAndroid80", null, "Xamarin Mono Android 8.0"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid81 = From(new NetCoreAppSettings("MonoAndroid81", null, "Xamarin Mono Android 8.1"));
+        [PublicAPI] public static readonly IToolchain XamarinMonoAndroid90 = From(new NetCoreAppSettings("MonoAndroid90", null, "Xamarin Mono Android 9.0"));
+        [PublicAPI] public static readonly IToolchain XamarinTouch10 = From(new NetCoreAppSettings("MonoTouch10", null, "Xamarin Mono Touch 1.0"));
+        [PublicAPI] public static readonly IToolchain Tizen40 = From(new NetCoreAppSettings("Tizen40", null, "Tizen 4.0"));
+        [PublicAPI] public static readonly IToolchain Tizen50 = From(new NetCoreAppSettings("Tizen50", null, "Tizen 5.0"));
+
+        protected MsBuildSdkExtrasToolchain(string name, IGenerator generator, IBuilder builder, IExecutor executor, string customDotNetCliPath)
+            : base(name, generator, builder, executor, customDotNetCliPath)
+        {
+        }
+
+        [PublicAPI]
+        public new static IToolchain From(NetCoreAppSettings settings)
+            => new MsBuildSdkExtrasToolchain(settings.Name,
+                new MsBuildSdkExtrasGenerator(settings.TargetFrameworkMoniker, settings.CustomDotNetCliPath, settings.PackagesPath, settings.RuntimeFrameworkVersion),
+                new DotNetCliBuilder(settings.TargetFrameworkMoniker, settings.CustomDotNetCliPath, settings.Timeout),
+                new DotNetCliExecutor(settings.CustomDotNetCliPath),
+                settings.CustomDotNetCliPath);
+
+    }
+}


### PR DESCRIPTION
This is the start on starting support for Xamarin targets.

MSBuild.Sdk.Extras is a library by Oren Novotny https://github.com/onovotny/MSBuildSdkExtras that allows you to use the new csproj format with more TargetFramework's.

This allows me to build executables in those various platforms.

The next step is build something similar to https://github.com/xunit/devices.xunit which I am halfway through which will allow the benchmarks to run on device/emulator.

This also fixes an issue with my project (https://github.com/reactiveui/reactiveui) where was unable to benchmark due to Tizen TargetFramework in my project.