### PR TITLE
Improve global tool

### DIFF
--- a/src/BenchmarkDotNet.Tool/AssemblyResolver.cs
+++ b/src/BenchmarkDotNet.Tool/AssemblyResolver.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.Extensions.DependencyModel.Resolution;
+
+namespace BenchmarkDotNet.Tool
+{
+    // https://www.codeproject.com/Articles/1194332/Resolving-Assemblies-in-NET-Core
+    internal sealed class AssemblyResolver : IDisposable
+    {
+        private readonly ICompilationAssemblyResolver assemblyResolver;
+        private readonly DependencyContext dependencyContext;
+        private readonly AssemblyLoadContext loadContext;
+
+        public AssemblyResolver(string path)
+        {
+            this.Assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+            this.dependencyContext = DependencyContext.Load(this.Assembly);
+
+            this.assemblyResolver = new CompositeCompilationAssemblyResolver
+            (new ICompilationAssemblyResolver[]
+            {
+                new AppBaseCompilationAssemblyResolver(Path.GetDirectoryName(path)),
+                new ReferenceAssemblyPathResolver(),
+                new PackageCompilationAssemblyResolver()
+            });
+
+            this.loadContext = AssemblyLoadContext.GetLoadContext(this.Assembly);
+            this.loadContext.Resolving += OnResolving;
+        }
+
+        public Assembly Assembly { get; }
+
+        public void Dispose()
+        {
+            this.loadContext.Resolving -= this.OnResolving;
+        }
+
+        private Assembly OnResolving(AssemblyLoadContext context, AssemblyName name)
+        {
+            bool NamesMatch(RuntimeLibrary runtime)
+            {
+                return string.Equals(runtime.Name, name.Name, StringComparison.OrdinalIgnoreCase);
+            }
+
+            RuntimeLibrary library =
+                this.dependencyContext.RuntimeLibraries.FirstOrDefault(NamesMatch);
+            if (library != null)
+            {
+                var wrapper = new CompilationLibrary(
+                    library.Type,
+                    library.Name,
+                    library.Version,
+                    library.Hash,
+                    library.RuntimeAssemblyGroups.SelectMany(g => g.AssetPaths),
+                    library.Dependencies,
+                    library.Serviceable);
+
+                var assemblies = new List<string>();
+                this.assemblyResolver.TryResolveAssemblyPaths(wrapper, assemblies);
+                if (assemblies.Count > 0)
+                {
+                    return this.loadContext.LoadFromAssemblyPath(assemblies[0]);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/BenchmarkDotNet.Tool/BenchmarkDotNet.Tool.csproj
+++ b/src/BenchmarkDotNet.Tool/BenchmarkDotNet.Tool.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <ToolCommandName>dotnet-BenchmarkDotNet</ToolCommandName>
+    <ToolCommandName>dotnet-benchmark</ToolCommandName>
     <Description>A dotnet tool to execute BenchmarkDotNet benchmarks.</Description>
     <PackageTags>benchmark;benchmarking;performance;tool</PackageTags>
     <PackageId>BenchmarkDotNetTool</PackageId>
@@ -13,6 +13,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BenchmarkDotNet\BenchmarkDotNet.csproj" />
+    <ProjectReference Include="..\BenchmarkDotNet.Diagnostics.Windows\BenchmarkDotNet.Diagnostics.Windows.csproj" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarkDotNet.Tool/Program.cs
+++ b/src/BenchmarkDotNet.Tool/Program.cs
@@ -39,20 +39,28 @@ namespace BenchmarkDotNet.Tool
 
         public int OnExecute()
         {
-            Assembly assembly;
             try
             {
-                assembly = Assembly.LoadFrom(AssemblyFile);
+                using (var dynamicContext = new AssemblyResolver(Path.GetFullPath(AssemblyFile)))
+                {
+
+                    BenchmarkSwitcher benchmarkSwitcher = BenchmarkSwitcher.FromAssembly(dynamicContext.Assembly);
+                    benchmarkSwitcher.Run(RemainingArguments);
+                }
             }
-            catch (Exception ex)
+            catch (FileLoadException ex)
             {
                 Console.Error.WriteLine($"Couldn't load the assembly {AssemblyFile}.");
                 Console.Error.WriteLine(ex.ToString());
                 return 1;
             }
+            catch (BadImageFormatException ex)
+            {
+                Console.Error.WriteLine($"The assembly {AssemblyFile} is not a valid assembly.");
+                Console.Error.WriteLine(ex.ToString());
+                return 1;
+            }
 
-            BenchmarkSwitcher benchmarkSwitcher = BenchmarkSwitcher.FromAssembly(assembly);
-            benchmarkSwitcher.Run(RemainingArguments);
             return 0;
         }
 


### PR DESCRIPTION
In this PR:
1. change name of global tool:
```
dotnet benchmark MyLib.dll --filter *ABC*
```
2. Add reference to `BenchmarkDotNet.Diagnostics.Windows`
3. I've used `AssemblyResolver` to load dll using `*.deps.json` from assembly location. 

**But I know about one more problem in my solution and in previous solution**
When I compile my global tool in release:
```
c:\Work\BDN_master\src\BenchmarkDotNet.Tool
dotnet pack -c Release
```
Then I install this tool:
```
dotnet tool install --global --add-source .\bin\Release --version 0.11.3-develop BenchmarkDotNetTool
```

Then when I run dll that was compiled in Debug configuration I got exception. E.g.:
```
cd  c:\Work\BDN_master\samples\BenchmarkDotNet.Samples\bin\Debug\netcoreapp2.1
dotnet benchmark BenchmarkDotNet.Samples.dll --filter *Dry*
Unhandled Exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.MethodAccessException: Attempt by method 'BenchmarkDotNet.Samples.IntroInProcessWrongEnv+Config..ctor()' to access method 'BenchmarkDotNet.Portability.RuntimeInformation.Is64BitPlatform()' failed.
   at BenchmarkDotNet.Samples.IntroInProcessWrongEnv.Config..ctor() in c:\Work\BDN_master\samples\BenchmarkDotNet.Samples\IntroInProcessWrongEnv.cs:line 21
   --- End of inner exception stack trace ---
   at System.RuntimeTypeHandle.CreateInstance(RuntimeType type, Boolean publicOnly, Boolean wrapExceptions, Boolean& canBeCached, RuntimeMethodHandleInternal& ctor)
   at System.RuntimeType.CreateInstanceSlow(Boolean publicOnly, Boolean wrapExceptions, Boolean skipCheckThis, Boolean fillCache)
   at System.Activator.CreateInstance(Type type, Boolean nonPublic, Boolean wrapExceptions)
   at BenchmarkDotNet.Attributes.ConfigAttribute..ctor(Type type) in c:\Work\BDN_master\src\BenchmarkDotNet\Attributes\ConfigAttribute.cs:line 11
   at System.Reflection.CustomAttribute._CreateCaObject(RuntimeModule pModule, IRuntimeMethodInfo pCtor, Byte** ppBlob, Byte* pEndBlob, Int32* pcNamedArgs)
   at System.Reflection.CustomAttribute.CreateCaObject(RuntimeModule module, IRuntimeMethodInfo ctor, IntPtr& blob, IntPtr blobEnd, Int32& namedArgs)
   at System.Reflection.CustomAttribute.GetCustomAttributes(RuntimeModule decoratedModule, Int32 decoratedMetadataToken, Int32 pcaCount, RuntimeType attributeFilterType, Boolean mustBeInheritable, IList derivedAttributes)
   at System.Reflection.CustomAttribute.GetCustomAttributes(RuntimeType type, RuntimeType caType, Boolean inherit)
   at BenchmarkDotNet.Helpers.GenericBenchmarksBuilder.BuildGenericsIfNeeded(Type type) in c:\Work\BDN_master\src\BenchmarkDotNet\Helpers\GenericBenchmarksBuilder.cs:line 20
   at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.MoveNext()
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.ToArray()
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at BenchmarkDotNet.Running.TypeFilter.GetTypesWithRunnableBenchmarks(IEnumerable`1 types, IEnumerable`1 assemblies, ILogger logger) in c:\Work\BDN_master\src\BenchmarkDotNet\Running\TypeFilter.cs:line 34
   at BenchmarkDotNet.Running.BenchmarkSwitcher.RunWithDirtyAssemblyResolveHelper(String[] args, IConfig config) in c:\Work\BDN_master\src\BenchmarkDotNet\Running\BenchmarkSwitcher.cs:line 84
   at BenchmarkDotNet.Running.BenchmarkSwitcher.Run(String[] args, IConfig config) in c:\Work\BDN_master\src\BenchmarkDotNet\Running\BenchmarkSwitcher.cs:line 65
   at BenchmarkDotNet.Tool.Program.OnExecute() in c:\Work\BDN_master\src\BenchmarkDotNet.Tool\Program.cs:line 46
--- End of stack trace from previous location where exception was thrown ---
   at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.Invoke(MethodInfo method, Object instance, Object[] arguments)
   at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.OnExecute(ConventionContext context)
   at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.<>c__DisplayClass0_0.<<Apply>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.<>c__DisplayClass138_0.<OnExecute>b__0()
   at BenchmarkDotNet.Tool.Program.Main(String[] args) in c:\Work\BDN_master\src\BenchmarkDotNet.Tool\Program.cs:line 26
```
But I have:
```
λ dotnet --version
3.0.100-preview-010184
```