### PR TITLE
Remove InternalsVisibleTo for Samples application

### DIFF
--- a/samples/BenchmarkDotNet.Samples/IntroInProcessWrongEnv.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroInProcessWrongEnv.cs
@@ -1,10 +1,10 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Order;
-using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Toolchains.InProcess;
 
 namespace BenchmarkDotNet.Samples
@@ -18,7 +18,7 @@ namespace BenchmarkDotNet.Samples
         {
             public Config()
             {
-                var wrongPlatform = RuntimeInformation.Is64BitPlatform()
+                var wrongPlatform = Environment.Is64BitProcess
                     ? Platform.X64
                     : Platform.X86;
 

--- a/src/BenchmarkDotNet/Properties/AssemblyInfo.cs
+++ b/src/BenchmarkDotNet/Properties/AssemblyInfo.cs
@@ -12,11 +12,9 @@ using BenchmarkDotNet.Properties;
 #if RELEASE
 [assembly: InternalsVisibleTo("BenchmarkDotNet.Tests,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]
 [assembly: InternalsVisibleTo("BenchmarkDotNet.IntegrationTests,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]
-[assembly: InternalsVisibleTo("BenchmarkDotNet.Samples,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]
 [assembly: InternalsVisibleTo("BenchmarkDotNet.Diagnostics.Windows,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]
 #else
 [assembly: InternalsVisibleTo("BenchmarkDotNet.Tests")]
 [assembly: InternalsVisibleTo("BenchmarkDotNet.IntegrationTests")]
-[assembly: InternalsVisibleTo("BenchmarkDotNet.Samples")]
 [assembly: InternalsVisibleTo("BenchmarkDotNet.Diagnostics.Windows")]
 #endif


### PR DESCRIPTION
Sample application shouldn't use internal class. Instead of `RuntimeInformation.Is64BitPlatform()` I've used `Environment.Is64BitProcess`

https://github.com/dotnet/corefx/blob/94e9d02ad70b2224d012ac4a66eaa1f913ae4f29/src/Common/src/CoreLib/System/Environment.cs#L111

Now global tool works well.