### PR TITLE
Change the name of the global tool

### DIFF
--- a/docs/articles/guides/global-dotnet-tool.md
+++ b/docs/articles/guides/global-dotnet-tool.md
@@ -12,13 +12,19 @@ BenchmarkDotNet is also available as a global dotnet tool and provides a conveni
 Download and install the [.NET Core 2.1 SDK](https://www.microsoft.com/net/download) or newer. Once installed, run the following command:
 
 ```log
-dotnet tool install BenchmarkDotNet.Tool -g
+dotnet tool install -g BenchmarkDotNet.Tool
 ```
 
 If you already have a previous version of installed, you can upgrade to the latest version using the following command:
 
 ```log
-dotnet tool update BenchmarkDotNet.Tool -g
+dotnet tool update -g BenchmarkDotNet.Tool
+```
+
+If you want to remove the tool:
+
+```log
+dotnet tool uninstall -g BenchmarkDotNet.Tool
 ```
 
 ## Usage
@@ -26,7 +32,7 @@ dotnet tool update BenchmarkDotNet.Tool -g
 The basic usage syntax is:
 
 ```log
-dotnet benchmarkdotnet [arguments] [options]
+dotnet benchmark [arguments] [options]
 ```
 
 ### Arguments
@@ -42,7 +48,7 @@ dotnet benchmarkdotnet [arguments] [options]
 |-?, -h or --help|Show help information|
 
 ```log
-dotnet benchmarkdotnet -?
+dotnet benchmark -?
 ```
 
 **Note**: This shows also all valid arguments for `BenchmarkSwitcher`.
@@ -52,13 +58,13 @@ dotnet benchmarkdotnet -?
 The following example scans the `MyAssemblyWithBenchmarks.dll` for benchmarks and lets you select which benchmark(s) to execute: 
 
 ```log
-dotnet benchmarkdotnet MyAssemblyWithBenchmarks.dll
+dotnet benchmark MyAssemblyWithBenchmarks.dll
 ```
 
 To execute all benchmarks use `--filter *`:
 
 ```log
-dotnet benchmarkdotnet MyAssemblyWithBenchmarks.dll --filter *
+dotnet benchmark MyAssemblyWithBenchmarks.dll --filter *
 ```
 
 **Note**: For further arguments for the `BenchmarkSwticher` see also [Console Arguments](console-args.md).

--- a/docs/articles/guides/how-to-run.md
+++ b/docs/articles/guides/how-to-run.md
@@ -11,12 +11,14 @@ var summary = BenchmarkRunner.Run(typeof(MyBenchmarkClass));
 
 ## Global dotnet tool
 
+You can also run a banchmark using `BenchmarkDotNet.Tool`.
+
 ```log
-dotnet tool install BenchmarkDotNet.Tool -g
+dotnet tool install -g BenchmarkDotNet.Tool
 ```
 
 ```log
-dotnet benchmarkdotnet MyAssemblyWithBenchmarks.dll --filter *
+dotnet benchmark MyAssemblyWithBenchmarks.dll --filter *
 ```
 
 ## Url

--- a/src/BenchmarkDotNet.Tool/BenchmarkDotNet.Tool.csproj
+++ b/src/BenchmarkDotNet.Tool/BenchmarkDotNet.Tool.csproj
@@ -8,7 +8,7 @@
     <ToolCommandName>dotnet-benchmark</ToolCommandName>
     <Description>A dotnet tool to execute BenchmarkDotNet benchmarks.</Description>
     <PackageTags>benchmark;benchmarking;performance;tool</PackageTags>
-    <PackageId>BenchmarkDotNetTool</PackageId>
+    <PackageId>BenchmarkDotNet.Tool</PackageId>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>

--- a/src/BenchmarkDotNet.Tool/Program.cs
+++ b/src/BenchmarkDotNet.Tool/Program.cs
@@ -11,7 +11,7 @@ using System.Text;
 namespace BenchmarkDotNet.Tool
 {
     [Command(
-        Name = "BenchmarkDotNet",
+        Name = "benchmark",
         Description = "A dotnet tool to execute benchmarks built with BenchmarkDotNet.")]
     [HelpOption()]
     [VersionOptionFromMember(MemberName = nameof(GetVersion))]


### PR DESCRIPTION
In this PR I've changed name of nuget pacgage from BenchmarkDotNetTool to BenchmarkDotNet.Tool. And I've updated documentation.