### PR TITLE
Use invariant culture for csc messages

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/RoslynToolchainTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/RoslynToolchainTest.cs
@@ -1,0 +1,56 @@
+﻿using System.Globalization;
+using System.Threading;
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Tests.Loggers;
+using BenchmarkDotNet.Toolchains.Roslyn;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class RoslynToolchainTest : BenchmarkTestExecutor
+    {
+        public RoslynToolchainTest(ITestOutputHelper output) : base(output) { }
+
+        /// <summary>Prooftest for #1039.</summary>
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("fr-FR")]
+        [InlineData("ru-RU")]
+        [InlineData("ja-JP")]
+        public void CanExecuteWithNonDefaultUiCulture(string culture)
+        {
+            var originCulture = CultureInfo.CurrentCulture;
+            var originUiCulture = CultureInfo.CurrentUICulture;
+            try
+            {
+                var overrideCulture = CultureInfo.GetCultureInfo(culture);
+                Assert.NotNull(overrideCulture);
+                Assert.False(overrideCulture.IsNeutralCulture);
+                CultureInfo.CurrentCulture = overrideCulture;
+                CultureInfo.CurrentUICulture = overrideCulture;
+
+                var logger = new OutputLogger(Output);
+                var miniJob = Job.Dry.With(RoslynToolchain.Instance);
+                var config = CreateSimpleConfig(logger, miniJob);
+
+                CanExecute<SimpleBenchmarks>(config);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originCulture;
+                CultureInfo.CurrentUICulture = originUiCulture;
+            }
+        }
+
+        public class SimpleBenchmarks
+        {
+            [Benchmark]
+            public void Benchmark() => Thread.Sleep(5);
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.IntegrationTests/RoslynToolchainTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/RoslynToolchainTest.cs
@@ -17,7 +17,7 @@ namespace BenchmarkDotNet.IntegrationTests
         public RoslynToolchainTest(ITestOutputHelper output) : base(output) { }
 
         /// <summary>Prooftest for #1039.</summary>
-        [Theory]
+        [TheoryFullFrameworkOnly]
         [InlineData("en-US")]
         [InlineData("fr-FR")]
         [InlineData("ru-RU")]

--- a/tests/BenchmarkDotNet.IntegrationTests/RoslynToolchainTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/RoslynToolchainTest.cs
@@ -17,7 +17,7 @@ namespace BenchmarkDotNet.IntegrationTests
         public RoslynToolchainTest(ITestOutputHelper output) : base(output) { }
 
         /// <summary>Prooftest for #1039.</summary>
-        [TheoryFullFrameworkOnly]
+        [Tests.XUnit.TheoryFullFrameworkOnly("Roslyn toolchain does not support .NET Core")]
         [InlineData("en-US")]
         [InlineData("fr-FR")]
         [InlineData("ru-RU")]


### PR DESCRIPTION
Fixes culture-related errors mentioned in #1039.
Roslyn uses LocalizableString undercover; all methods that return human-readable messages should be called with specific culture passed as an arg.

I've added CanExecuteWithNonDefaultUiCulture test to prevent possible regressions.