### PR TITLE
Allow reflecting on DebuggableAttribute on CoreRT

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
@@ -175,7 +175,8 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 </Project>";
 
         /// <summary>
-        /// mandatory to make it possible ot call GC.GetAllocatedBytesForCurrentThread() using reflection (not part of .NET Standard)
+        /// mandatory to make it possible to call GC.GetAllocatedBytesForCurrentThread() using reflection (not part of .NET Standard)
+        /// and 
         /// </summary>
         private void GenerateReflectionFile(ArtifactsPaths artifactsPaths)
         {
@@ -184,6 +185,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <Application>
         <Assembly Name=""System.Runtime"">
             <Type Name=""System.GC"" Dynamic=""Required All"" />
+            <Type Name=""System.Diagnostics.DebuggableAttribute"" Dynamic=""Required All"" />
         </Assembly>
     </Application>
 </Directives>

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
@@ -176,7 +176,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
         /// <summary>
         /// mandatory to make it possible to call GC.GetAllocatedBytesForCurrentThread() using reflection (not part of .NET Standard)
-        /// and 
+        /// and DebuggableAttribute.
         /// </summary>
         private void GenerateReflectionFile(ArtifactsPaths artifactsPaths)
         {


### PR DESCRIPTION
See https://github.com/dotnet/corert/pull/6955#discussion_r254766270.

BenchmakeDotNet reflects on this attribute here:

https://github.com/dotnet/BenchmarkDotNet/blob/a76f438a81e3e0235a2e9b1249a5280038189689/src/BenchmarkDotNet/Extensions/AssemblyExtensions.cs#L28-L38