### PR TITLE
Shortify MemoryDiagnoser column titles

### DIFF
--- a/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
@@ -44,7 +44,7 @@ namespace BenchmarkDotNet.Diagnosers
             internal static readonly IMetricDescriptor Instance = new AllocatedMemoryMetricDescriptor();
             
             public string Id => "Allocated Memory";
-            public string DisplayName => "Allocated Memory/Op";
+            public string DisplayName => "Allocated";
             public string Legend => "Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)";
             public string NumberFormat => "N0";
             public UnitType UnitType => UnitType.Size;
@@ -61,8 +61,8 @@ namespace BenchmarkDotNet.Diagnosers
             private GarbageCollectionsMetricDescriptor(int generationId)
             {
                 Id = $"Gen{generationId}Collects";
-                DisplayName = $"Gen {generationId}/1k Op";
-                Legend = $"GC Generation {generationId} collects per 1k Operations";
+                DisplayName = $"Gen {generationId}";
+                Legend = $"GC Generation {generationId} collects per 1000 operations";
             }
 
             public string Id { get; }


### PR DESCRIPTION
Current titles of the MemoryDiagnoser columns contain too many chars.
Because of that, the summary table is too wide when MemoryDiagnoser is
enabled. Since we have a legend for each column below the summary table,
we can use shorter titles for these columns.