### PR TITLE
Make it so that the code analysis settings are disabled.

### DIFF
--- a/src/BenchmarkDotNet/Templates/CsProj.txt
+++ b/src/BenchmarkDotNet/Templates/CsProj.txt
@@ -14,6 +14,7 @@
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <UseSharedCompilation>false</UseSharedCompilation>
+    <CodeAnalysisRuleSet></CodeAnalysisRuleSet>
     $COPIEDSETTINGS$
   </PropertyGroup>
 


### PR DESCRIPTION
If there is a CodeAnalysisRuleSet set by the Directory.Build.Props, the project will fail if there isn't a subsequent one in the benchmarks project folder.

This just forces them to be turned off since we don't care about the analysis.