### PR TITLE
make InProcessEmitToolchain the default one

### DIFF
--- a/docs/articles/samples/IntroInProcess.md
+++ b/docs/articles/samples/IntroInProcess.md
@@ -4,10 +4,9 @@ uid: BenchmarkDotNet.Samples.IntroInProcess
 
 ## Sample: IntroInProcess
 
-InProcessToolchain is our toolchain which does not generate any new executable.
+InProcessEmitToolchain is our toolchain which does not generate any new executable.
 It emits IL on the fly and runs it from within the process itself.
-It can be usefull if want to run the benchmarks very fast or
-  if you want to run them for framework which we don't support.
+It can be usefull if want to run the benchmarks very fast or if you want to run them for framework which we don't support.
 An example could be a local build of CoreCLR.
 
 ### Usage

--- a/samples/BenchmarkDotNet.Samples/IntroInProcess.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroInProcess.cs
@@ -3,7 +3,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Order;
-using BenchmarkDotNet.Toolchains.InProcess;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
 
 namespace BenchmarkDotNet.Samples
 {
@@ -22,7 +22,7 @@ namespace BenchmarkDotNet.Samples
 
                 Add(Job.MediumRun
                     .WithLaunchCount(1)
-                    .With(InProcessToolchain.Instance)
+                    .With(InProcessEmitToolchain.Instance)
                     .WithId("InProcess"));
             }
         }

--- a/samples/BenchmarkDotNet.Samples/IntroInProcessWrongEnv.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroInProcessWrongEnv.cs
@@ -6,6 +6,7 @@ using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Toolchains.InProcess;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
 
 namespace BenchmarkDotNet.Samples
 {
@@ -25,7 +26,7 @@ namespace BenchmarkDotNet.Samples
                 Add(Job.MediumRun
                     .WithLaunchCount(1)
                     .With(wrongPlatform)
-                    .With(InProcessToolchain.Instance)
+                    .With(InProcessEmitToolchain.Instance)
                     .WithId("InProcess"));
 
                 Add(InProcessValidator.DontFailOnError);

--- a/src/BenchmarkDotNet.Diagnostics.Windows/HardwareCounters.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/HardwareCounters.cs
@@ -5,6 +5,7 @@ using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Toolchains.InProcess;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using BenchmarkDotNet.Validators;
 using Microsoft.Diagnostics.Tracing.Session;
 
@@ -61,7 +62,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
             foreach (var benchmark in validationParameters.Benchmarks)
             {
                 if (benchmark.Job.Infrastructure.HasValue(InfrastructureMode.ToolchainCharacteristic)
-                    && benchmark.Job.Infrastructure.Toolchain is InProcessToolchain)
+                    && (benchmark.Job.Infrastructure.Toolchain is InProcessToolchain || benchmark.Job.Infrastructure.Toolchain is InProcessEmitToolchain))
                 {
                     yield return new ValidationError(true, "Hardware Counters are not supported for InProcessToolchain.", benchmark);
                 }

--- a/src/BenchmarkDotNet/Jobs/InfrastructureMode.cs
+++ b/src/BenchmarkDotNet/Jobs/InfrastructureMode.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Horology;
 using BenchmarkDotNet.Toolchains;
-using BenchmarkDotNet.Toolchains.InProcess;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
 
 namespace BenchmarkDotNet.Jobs
 {
@@ -20,8 +20,8 @@ namespace BenchmarkDotNet.Jobs
         public static readonly Characteristic<IReadOnlyList<Argument>> ArgumentsCharacteristic = CreateCharacteristic<IReadOnlyList<Argument>>(nameof(Arguments));
         public static readonly Characteristic<IReadOnlyCollection<NuGetReference>> NuGetReferencesCharacteristic = CreateCharacteristic<IReadOnlyCollection<NuGetReference>>(nameof(NuGetReferences));
 
-        public static readonly InfrastructureMode InProcess = new InfrastructureMode(InProcessToolchain.Instance);
-        public static readonly InfrastructureMode InProcessDontLogOutput = new InfrastructureMode(InProcessToolchain.DontLogOutput);
+        public static readonly InfrastructureMode InProcess = new InfrastructureMode(InProcessEmitToolchain.Instance);
+        public static readonly InfrastructureMode InProcessDontLogOutput = new InfrastructureMode(InProcessEmitToolchain.DontLogOutput);
 
         public InfrastructureMode() { }
 


### PR DESCRIPTION
Today I saw some people using `[InProcessAttribute]` and I realized that it's still using the old one.

I think that we should switch by default to the new one.