### PR TITLE
possible fix for MosCpu Info Provider

### DIFF
--- a/src/BenchmarkDotNet/Portability/Cpu/MosCpuInfoProvider.cs
+++ b/src/BenchmarkDotNet/Portability/Cpu/MosCpuInfoProvider.cs
@@ -34,8 +34,11 @@ namespace BenchmarkDotNet.Portability.Cpu
                     physicalCoreCount += (uint) moProcessor[WmicCpuInfoKeyNames.NumberOfCores];
                     logicalCoreCount += (uint) moProcessor[WmicCpuInfoKeyNames.NumberOfLogicalProcessors];
                     maxClockSpeed = (uint) moProcessor[WmicCpuInfoKeyNames.MaxClockSpeed];
-                }
+                    nominalClockSpeed = (uint) moProcessor[WmicCpuInfoKeyNames.CurrentClockSpeed];
+				}
             }
+
+            minClockSpeed = Math.Min(nominalClockSpeed, maxClockSpeed);
 
             return new CpuInfo(
                 processorModelNames.Count > 0 ? string.Join(", ", processorModelNames) : null,

--- a/src/BenchmarkDotNet/Portability/Cpu/WmicCpuInfoKeyNames.cs
+++ b/src/BenchmarkDotNet/Portability/Cpu/WmicCpuInfoKeyNames.cs
@@ -6,5 +6,6 @@
         internal const string NumberOfCores = "NumberOfCores";
         internal const string Name = "Name";
         internal const string MaxClockSpeed = "MaxClockSpeed";
+        internal const string CurrentClockSpeed = "CurrentClockSpeed";
     }
 }


### PR DESCRIPTION
Hi,
I have run some static code analysis tools other this project and found that `nominalClockSpeed`  was not updated .
I computed  `nominalClockSpeed` as minimum between current and maximum clock speed.

Comments and suggestions are more than welcome.
Hopefully it will help.

Best regards,
Ion Dormenco