### PR TITLE
Fix #1068 - Copy value of CopyLocalLockFileAssemblies

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -23,7 +23,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         private const string DefaultSdkName = "Microsoft.NET.Sdk";
 
         private static readonly ImmutableArray<string> SettingsWeWantToCopy =
-            new[] { "NetCoreAppImplicitPackageVersion", "RuntimeFrameworkVersion", "PackageTargetFallback", "LangVersion", "UseWpf", "UseWindowsForms" }.ToImmutableArray();
+            new[] { "NetCoreAppImplicitPackageVersion", "RuntimeFrameworkVersion", "PackageTargetFallback", "LangVersion", "UseWpf", "UseWindowsForms", "CopyLocalLockFileAssemblies" }.ToImmutableArray();
 
         public string RuntimeFrameworkVersion { get; }
 


### PR DESCRIPTION
Fix for #1068 - Copy value of `CopyLocalLockFileAssemblies` to `BenchmarkDotNet.Autogenerated.csproj`