### PR TITLE
Add support for fully synchronous mode for WebAssembly

### DIFF
--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using BenchmarkDotNet.Analysers;
 using BenchmarkDotNet.Columns;
@@ -87,5 +88,11 @@ namespace BenchmarkDotNet.Configs
         public IEnumerable<HardwareCounter> GetHardwareCounters() => Array.Empty<HardwareCounter>();
 
         public IEnumerable<IFilter> GetFilters() => Array.Empty<IFilter>();
+
+        /// <summary>
+        /// Determines if the current runtime supports threading.
+        /// </summary>
+        /// <remarks>This property returns <c>false</c> when running under WebAssembly, otherwise <c>true</c>.</remarks>
+        public static bool SupportsThreading { get; } = !RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY"));
     }
 }

--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -88,11 +88,5 @@ namespace BenchmarkDotNet.Configs
         public IEnumerable<HardwareCounter> GetHardwareCounters() => Array.Empty<HardwareCounter>();
 
         public IEnumerable<IFilter> GetFilters() => Array.Empty<IFilter>();
-
-        /// <summary>
-        /// Determines if the current runtime supports threading.
-        /// </summary>
-        /// <remarks>This property returns <c>false</c> when running under WebAssembly, otherwise <c>true</c>.</remarks>
-        public static bool SupportsThreading { get; } = !RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY"));
     }
 }

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -351,22 +351,37 @@ namespace BenchmarkDotNet.Portability
             {
                 try
                 {
-                    using (var searcher = new ManagementObjectSearcher("Select * from Win32_ComputerSystem"))
-                    {
-                        using (var items = searcher.Get())
-                        {
-                            foreach (var item in items)
-                            {
-                                string manufacturer = item["Manufacturer"]?.ToString();
-                                string model = item["Model"]?.ToString();
-                                return hypervisors.FirstOrDefault(x => x.IsVirtualMachine(manufacturer, model));
-                            }
-                        }
-                    }
+                    return GetVirtualMachineHypervisor(hypervisors);
                 }
                 catch
                 {
                     // Never mind
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the hypervisors from WMI
+        /// </summary>
+        /// <remarks>
+        /// This method is separated from <see cref="GetVirtualMachineHypervisor()"/> in case 
+        /// the runtime assemblies for System.Management are not available, such as in WebAssembly.
+        /// </remarks>
+
+        private static VirtualMachineHypervisor GetVirtualMachineHypervisor(VirtualMachineHypervisor[] hypervisors)
+        {
+            using (var searcher = new ManagementObjectSearcher("Select * from Win32_ComputerSystem"))
+            {
+                using (var items = searcher.Get())
+                {
+                    foreach (var item in items)
+                    {
+                        string manufacturer = item["Manufacturer"]?.ToString();
+                        string model = item["Model"]?.ToString();
+                        return hypervisors.FirstOrDefault(x => x.IsVirtualMachine(manufacturer, model));
+                    }
                 }
             }
 

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -216,6 +216,13 @@ namespace BenchmarkDotNet.Portability
 
         public static bool Is64BitPlatform() => IntPtr.Size == 8;
 
+        /// <summary>
+        /// Determines if the current runtime supports threading.
+        /// </summary>
+        /// <remarks>This property returns <c>false</c> when running under WebAssembly, otherwise <c>true</c>.</remarks>
+        internal static bool SupportsThreading() => !System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY"));
+
+
         private static IEnumerable<JitModule> GetJitModules()
         {
             return

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -252,8 +252,11 @@ namespace BenchmarkDotNet.Running
 
             var buildLogger = buildPartitions.Length == 1 ? logger : NullLogger.Instance; // when we have just one partition we can print to std out
 
-            var buildResults = buildPartitions
-                .AsParallel()
+            var partitionQuery = DefaultConfig.SupportsThreading
+                ? buildPartitions.AsParallel()
+                : buildPartitions.AsEnumerable();
+
+            var buildResults = partitionQuery
                 .Select(buildPartition => (buildPartition, buildResult: Build(buildPartition, rootArtifactsFolderPath, buildLogger)))
                 .ToDictionary(result => result.buildPartition, result => result.buildResult);
 

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -16,6 +16,7 @@ using BenchmarkDotNet.Horology;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Mathematics;
+using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Toolchains;
 using BenchmarkDotNet.Toolchains.Parameters;
@@ -252,7 +253,7 @@ namespace BenchmarkDotNet.Running
 
             var buildLogger = buildPartitions.Length == 1 ? logger : NullLogger.Instance; // when we have just one partition we can print to std out
 
-            var partitionQuery = DefaultConfig.SupportsThreading
+            var partitionQuery = RuntimeInformation.SupportsThreading()
                 ? buildPartitions.AsParallel()
                 : buildPartitions.AsEnumerable();
 

--- a/src/BenchmarkDotNet/Toolchains/InProcess/InProcessToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/InProcessToolchain.cs
@@ -19,6 +19,13 @@ namespace BenchmarkDotNet.Toolchains.InProcess
         /// <summary>The toolchain instance without output logging.</summary>
         public static readonly IToolchain DontLogOutput = new InProcessToolchain(false);
 
+        /// <summary>The default toolchain instance.</summary>
+        public static readonly IToolchain Synchronous = new InProcessToolchain(
+            InProcessExecutor.DefaultTimeout,
+            BenchmarkActionCodegen.ReflectionEmit,
+            true, 
+            true);
+
         /// <summary>Initializes a new instance of the <see cref="InProcessToolchain" /> class.</summary>
         /// <param name="logOutput"><c>true</c> if the output should be logged.</param>
         public InProcessToolchain(bool logOutput) : this(
@@ -32,11 +39,21 @@ namespace BenchmarkDotNet.Toolchains.InProcess
         /// <param name="timeout">Timeout for the run.</param>
         /// <param name="codegenMode">Describes how benchmark action code is generated.</param>
         /// <param name="logOutput"><c>true</c> if the output should be logged.</param>
-        public InProcessToolchain(TimeSpan timeout, BenchmarkActionCodegen codegenMode, bool logOutput)
+        public InProcessToolchain(TimeSpan timeout, BenchmarkActionCodegen codegenMode, bool logOutput) 
+            : this(timeout, codegenMode, logOutput, false)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="InProcessToolchain" /> class.</summary>
+        /// <param name="timeout">Timeout for the run.</param>
+        /// <param name="codegenMode">Describes how benchmark action code is generated.</param>
+        /// <param name="logOutput"><c>true</c> if the output should be logged.</param>
+        /// <param name="synchronous"><c>true</c> if the benchmarks should run synchronously.</param>
+        public InProcessToolchain(TimeSpan timeout, BenchmarkActionCodegen codegenMode, bool logOutput, bool synchronous)
         {
             Generator = new InProcessGenerator();
             Builder = new InProcessBuilder();
-            Executor = new InProcessExecutor(timeout, codegenMode, logOutput);
+            Executor = new InProcessExecutor(timeout, codegenMode, logOutput, synchronous);
         }
 
         /// <summary>Determines whether the specified benchmark is supported.</summary>


### PR DESCRIPTION
- `DefaultConfig.SupportsThreading` indicates if the current runtime supports threading. Returns false on current WebAssembly environments.
- `InProcessExecutor` and `InProcessToolchain` have an optional `synchronous` parameter to disable any use of threads.
- Expand the fallback catch in `GetVirtualMachineHypervisor` to ensure that a missing runtime assembly won't fail the report generation