### PR TITLE
Use new .NET Core 3.0 API to get the total number of allocated bytes for all threads

### DIFF
--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -13,7 +13,7 @@ namespace BenchmarkDotNet.Engines
         public static readonly long AllocationQuantum = CalculateAllocationQuantumSize();
 
         private static readonly Func<long> GetAllocatedBytesForCurrentThreadDelegate = CreateGetAllocatedBytesForCurrentThreadDelegate();
-        private static readonly Func<bool, long> GetGetTotalAllocatedBytesDelegate = CreateGetGetTotalAllocatedBytesDelegate();
+        private static readonly Func<bool, long> GetTotalAllocatedBytesDelegate = CreateGetTotalAllocatedBytesDelegate();
 
         public static readonly GcStats Empty = new GcStats(0, 0, 0, 0, 0);
 
@@ -144,8 +144,8 @@ namespace BenchmarkDotNet.Engines
             if (RuntimeInformation.IsFullFramework) // it can be a .NET app consuming our .NET Standard package
                 return AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize;
 
-            if (GetGetTotalAllocatedBytesDelegate != null) // it's .NET Core 3.0 with the new API available
-                return GetGetTotalAllocatedBytesDelegate.Invoke(true); // true for the "precise" argument
+            if (GetTotalAllocatedBytesDelegate != null) // it's .NET Core 3.0 with the new API available
+                return GetTotalAllocatedBytesDelegate.Invoke(true); // true for the "precise" argument
 
             // https://apisof.net/catalog/System.GC.GetAllocatedBytesForCurrentThread() is not part of the .NET Standard, so we use reflection to call it..
             return GetAllocatedBytesForCurrentThreadDelegate.Invoke();
@@ -160,7 +160,7 @@ namespace BenchmarkDotNet.Engines
             return method != null ? (Func<long>)method.CreateDelegate(typeof(Func<long>)) : null;
         }
 
-        private static Func<bool, long> CreateGetGetTotalAllocatedBytesDelegate()
+        private static Func<bool, long> CreateGetTotalAllocatedBytesDelegate()
         {
             // this method is not a part of .NET Standard so we need to use reflection
             var method = typeof(GC).GetTypeInfo().GetMethod("GetTotalAllocatedBytes", BindingFlags.Public | BindingFlags.Static);

--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -12,7 +12,8 @@ namespace BenchmarkDotNet.Engines
 
         public static readonly long AllocationQuantum = CalculateAllocationQuantumSize();
 
-        private static readonly Func<long> GetAllocatedBytesForCurrentThreadDelegate = GetAllocatedBytesForCurrentThread();
+        private static readonly Func<long> GetAllocatedBytesForCurrentThreadDelegate = CreateGetAllocatedBytesForCurrentThreadDelegate();
+        private static readonly Func<bool, long> GetGetTotalAllocatedBytesDelegate = CreateGetGetTotalAllocatedBytesDelegate();
 
         public static readonly GcStats Empty = new GcStats(0, 0, 0, 0, 0);
 
@@ -143,11 +144,14 @@ namespace BenchmarkDotNet.Engines
             if (RuntimeInformation.IsFullFramework) // it can be a .NET app consuming our .NET Standard package
                 return AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize;
 
+            if (GetGetTotalAllocatedBytesDelegate != null) // it's .NET Core 3.0 with the new API available
+                return GetGetTotalAllocatedBytesDelegate.Invoke(true); // true for the "precise" argument
+
             // https://apisof.net/catalog/System.GC.GetAllocatedBytesForCurrentThread() is not part of the .NET Standard, so we use reflection to call it..
             return GetAllocatedBytesForCurrentThreadDelegate.Invoke();
         }
 
-        private static Func<long> GetAllocatedBytesForCurrentThread()
+        private static Func<long> CreateGetAllocatedBytesForCurrentThreadDelegate()
         {
             // this method is not a part of .NET Standard so we need to use reflection
             var method = typeof(GC).GetTypeInfo().GetMethod("GetAllocatedBytesForCurrentThread", BindingFlags.Public | BindingFlags.Static);
@@ -155,7 +159,16 @@ namespace BenchmarkDotNet.Engines
             // we create delegate to avoid boxing, IMPORTANT!
             return method != null ? (Func<long>)method.CreateDelegate(typeof(Func<long>)) : null;
         }
-  
+
+        private static Func<bool, long> CreateGetGetTotalAllocatedBytesDelegate()
+        {
+            // this method is not a part of .NET Standard so we need to use reflection
+            var method = typeof(GC).GetTypeInfo().GetMethod("GetTotalAllocatedBytes", BindingFlags.Public | BindingFlags.Static);
+
+            // we create delegate to avoid boxing, IMPORTANT!
+            return method != null ? (Func<bool, long>)method.CreateDelegate(typeof(Func<bool, long>)) : null;
+        }
+
         public string ToOutputLine() 
             => $"{ResultsLinePrefix} {Gen0Collections} {Gen1Collections} {Gen2Collections} {AllocatedBytes} {TotalOperations}";
 

--- a/tests/BenchmarkDotNet.Tests/XUnit/TheoryNetCore30Attribute.cs
+++ b/tests/BenchmarkDotNet.Tests/XUnit/TheoryNetCore30Attribute.cs
@@ -1,0 +1,15 @@
+﻿using BenchmarkDotNet.Toolchains.DotNetCli;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.XUnit
+{
+    public class TheoryNetCore30Attribute : TheoryAttribute
+    {
+        // ReSharper disable once VirtualMemberCallInConstructor
+        public TheoryNetCore30Attribute(string skipReason)
+        {
+            if (NetCoreAppSettings.GetCurrentVersion() != NetCoreAppSettings.NetCoreApp30)
+                Skip = skipReason;
+        }
+    }
+}


### PR DESCRIPTION
preview6 of .NET Core 3.0 exposes a new method that allows to get the number of allocated bytes for all threads. By using it we can fix #1153 and #723


Sample:

```cs
public class MultiThreadedAllocation
{
    public const int Size = 1_000_000;
    public const int ThreadsCount = 10;

    private Thread[] threads;

    [IterationSetup]
    public void SetupIteration()
    {
        threads = Enumerable.Range(0, ThreadsCount)
            .Select(_ => new Thread(() => GC.KeepAlive(new byte[Size])))
            .ToArray();
    }

    [Benchmark]
    public void Allocate()
    {
        foreach (var thread in threads)
        {
            thread.Start();
            thread.Join();
        }
    }
}
```

```cmd
dotnet run -c Release -f netcoreapp2.1 --filter *MultiThreadedAllocation* --runtimes netcoreapp3.0 netcoreapp2.1 net461 --memory 
```

|   Method | Runtime |     Toolchain |     Gen 0 |     Gen 1 |     Gen 2 |  Allocated |
|--------- |-------- |-------------- |----------:|----------:|----------:|-----------:|
| Allocate |     Clr |        net461 | 2000.0000 | 2000.0000 | 2000.0000 | 10024816 B |
| Allocate |    Core | netcoreapp2.1 | 2000.0000 | 2000.0000 | 2000.0000 |          - |
| Allocate |    Core | netcoreapp3.0 | 2000.0000 | 2000.0000 | 2000.0000 | 10001360 B |