### PR TITLE
Warn the user when benchmark baseline value is too close to zero and the columns derived from BaselineCustomColumn cannot be computed

### DIFF
--- a/src/BenchmarkDotNet/Analysers/BaselineCustomAnalyzer.cs
+++ b/src/BenchmarkDotNet/Analysers/BaselineCustomAnalyzer.cs
@@ -28,8 +28,8 @@ namespace BenchmarkDotNet.Analysers
                 if (BaselineCustomColumn.ResultsAreInvalid(summary, benchmarkCase, baseline) == false)
                     continue;
 
-                var message = "A question mark '?' symbol indicates that it was not possible " +
-                                $"to compute ({columNames}) because the baseline value is too close to zero.";
+                var message = "A question mark '?' symbol indicates that it was not possible to compute the " +
+                                $"({columNames}) column(s) because the baseline value is too close to zero.";
 
                 yield return Conclusion.CreateWarning(Id, message);
             }

--- a/src/BenchmarkDotNet/Analysers/BaselineCustomAnalyzer.cs
+++ b/src/BenchmarkDotNet/Analysers/BaselineCustomAnalyzer.cs
@@ -1,0 +1,44 @@
+﻿using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BenchmarkDotNet.Analysers
+{
+    public class BaselineCustomAnalyzer : AnalyserBase
+    {
+        public static readonly IAnalyser Default = new BaselineCustomAnalyzer();
+
+        public override string Id => nameof(BaselineCustomAnalyzer);
+
+        protected override IEnumerable<Conclusion> AnalyseSummary(Summary summary)
+        {
+            var columns = summary.GetColumns().Where(t => t.GetType().IsSubclassOf(typeof(BaselineCustomColumn)))
+                                              .Select(t => t.ColumnName)
+                                              .Distinct()
+                                              .ToArray();
+
+            var columNames = string.Join(",", columns);
+            foreach (var benchmarkCase in summary.BenchmarksCases.Where(c => ResultsAreInvalid(summary, c)))
+            {
+                string message = "A question mark '?' symbol indicates that it was not possible " +
+                                $"to compute ({columNames}) because the baseline value is too close to zero.";
+                yield return Conclusion.CreateWarning(Id, message);
+            }
+        }
+
+        private static bool ResultsAreInvalid(Summary summary, BenchmarkCase benchmarkCase)
+        {
+            var logicalGroupKey = summary.GetLogicalGroupKey(benchmarkCase);
+            var baseline = summary.GetBaseline(logicalGroupKey);
+
+            return baseline == null ||
+                   summary[baseline] == null ||
+                   summary[baseline].ResultStatistics == null ||
+                   !summary[baseline].ResultStatistics.CanBeInverted() ||
+                   summary[benchmarkCase] == null ||
+                   summary[benchmarkCase].ResultStatistics == null;
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Analysers/BaselineCustomAnalyzer.cs
+++ b/src/BenchmarkDotNet/Analysers/BaselineCustomAnalyzer.cs
@@ -19,26 +19,20 @@ namespace BenchmarkDotNet.Analysers
                                               .Distinct()
                                               .ToArray();
 
-            var columNames = string.Join(",", columns);
-            foreach (var benchmarkCase in summary.BenchmarksCases.Where(c => ResultsAreInvalid(summary, c)))
+            var columNames = string.Join(", ", columns);
+
+            foreach (var benchmarkCase in summary.BenchmarksCases)
             {
-                string message = "A question mark '?' symbol indicates that it was not possible " +
+                string logicalGroupKey = summary.GetLogicalGroupKey(benchmarkCase);
+                var baseline = summary.GetBaseline(logicalGroupKey);
+                if (BaselineCustomColumn.ResultsAreInvalid(summary, benchmarkCase, baseline) == false)
+                    continue;
+
+                var message = "A question mark '?' symbol indicates that it was not possible " +
                                 $"to compute ({columNames}) because the baseline value is too close to zero.";
+
                 yield return Conclusion.CreateWarning(Id, message);
             }
-        }
-
-        private static bool ResultsAreInvalid(Summary summary, BenchmarkCase benchmarkCase)
-        {
-            var logicalGroupKey = summary.GetLogicalGroupKey(benchmarkCase);
-            var baseline = summary.GetBaseline(logicalGroupKey);
-
-            return baseline == null ||
-                   summary[baseline] == null ||
-                   summary[baseline].ResultStatistics == null ||
-                   !summary[baseline].ResultStatistics.CanBeInverted() ||
-                   summary[benchmarkCase] == null ||
-                   summary[benchmarkCase].ResultStatistics == null;
         }
     }
 }

--- a/src/BenchmarkDotNet/Columns/BaselineCustomColumn.cs
+++ b/src/BenchmarkDotNet/Columns/BaselineCustomColumn.cs
@@ -14,14 +14,8 @@ namespace BenchmarkDotNet.Columns
             string logicalGroupKey = summary.GetLogicalGroupKey(benchmarkCase);
             var baseline = summary.GetBaseline(logicalGroupKey);
             bool isBaseline = summary.IsBaseline(benchmarkCase);
-            bool invalidResults = baseline == null ||
-                                 summary[baseline] == null ||
-                                 summary[baseline].ResultStatistics == null ||
-                                 !summary[baseline].ResultStatistics.CanBeInverted() ||
-                                 summary[benchmarkCase] == null ||
-                                 summary[benchmarkCase].ResultStatistics == null;
 
-            if (invalidResults)
+            if (ResultsAreInvalid(summary, benchmarkCase, baseline))
                 return "?";
 
             var baselineStat = summary[baseline].ResultStatistics;
@@ -42,5 +36,15 @@ namespace BenchmarkDotNet.Columns
         public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style) => GetValue(summary, benchmarkCase);
         public override string ToString() => ColumnName;
         public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
+
+        internal static bool ResultsAreInvalid(Summary summary, BenchmarkCase benchmarkCase, BenchmarkCase baseline)
+        {
+            return baseline == null ||
+                   summary[baseline] == null ||
+                   summary[baseline].ResultStatistics == null ||
+                   !summary[baseline].ResultStatistics.CanBeInverted() ||
+                   summary[benchmarkCase] == null ||
+                   summary[benchmarkCase].ResultStatistics == null;
+        }
     }
 }

--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -51,6 +51,7 @@ namespace BenchmarkDotNet.Configs
             yield return MultimodalDistributionAnalyzer.Default;
             yield return RuntimeErrorAnalyser.Default;
             yield return ZeroMeasurementAnalyser.Default;
+            yield return BaselineCustomAnalyzer.Default;
         }
 
         public IEnumerable<IValidator> GetValidators()


### PR DESCRIPTION
Fixes #600 

Sample Message:
```
// * Warnings *
BaselineCustomAnalyzer
  Summary -> A question mark '?' symbol indicates that it was not possible to compute 
  the (Ratio, RatioSD) column(s) because the baseline value is too close to zero.
```

Please note that the PR also adds the analyzer to the default configuration.