### PR TITLE
Invalid arg passing in StreamLogger constructor

### DIFF
--- a/src/BenchmarkDotNet/Loggers/StreamLogger.cs
+++ b/src/BenchmarkDotNet/Loggers/StreamLogger.cs
@@ -13,7 +13,7 @@ namespace BenchmarkDotNet.Loggers
         public void Dispose() => writer.Dispose();
 
         [PublicAPI]
-        public StreamLogger(string filePath, bool append = false) => writer = new StreamWriter(filePath, append: false);
+        public StreamLogger(string filePath, bool append = false) => writer = new StreamWriter(filePath, append);
 
         public void Write(LogKind logKind, string text) => writer.Write(text);
 


### PR DESCRIPTION
The `append` arg should be passed to the `StreamWriter` .ctor.