### PR TITLE
print benchmark process id to the output (better profiler user story)

### DIFF
--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -360,6 +360,11 @@ namespace BenchmarkDotNet.Running
                     useDiagnoser ? noOverheadCompositeDiagnoser : null,
                     ref success);
 
+                if (executeResult.ProcessId.HasValue)
+                {
+                    logger.WriteLineInfo($"// Benchmark Process {executeResult.ProcessId} has exited with code {executeResult.ExitCode}");
+                }
+
                 executeResults.Add(executeResult);
 
                 var errors = executeResults.SelectMany(r => r.Data)

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
@@ -31,7 +31,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                 foreach (var file in new DirectoryInfo(executeParameters.BuildResult.ArtifactsPaths.BinariesDirectoryPath).GetFiles("*.*"))
                     executeParameters.Logger.WriteLineError(file.Name);
                 
-                return new ExecuteResult(false, -1, Array.Empty<string>(), Array.Empty<string>());
+                return new ExecuteResult(false, -1, default, Array.Empty<string>(), Array.Empty<string>());
             }
 
             try
@@ -93,7 +93,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
                 if (process.ExitCode == 0)
                 {
-                    return new ExecuteResult(true, process.ExitCode, loggerWithDiagnoser.LinesWithResults, loggerWithDiagnoser.LinesWithExtraOutput);
+                    return new ExecuteResult(true, process.ExitCode, process.Id, loggerWithDiagnoser.LinesWithResults, loggerWithDiagnoser.LinesWithExtraOutput);
                 }
 
                 if (!string.IsNullOrEmpty(standardError))
@@ -101,7 +101,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                     logger.WriteError(standardError);
                 }
 
-                return new ExecuteResult(true, process.ExitCode, Array.Empty<string>(), Array.Empty<string>());
+                return new ExecuteResult(true, process.ExitCode, process.Id, Array.Empty<string>(), Array.Empty<string>());
             }
         }
     }

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -29,7 +29,7 @@ namespace BenchmarkDotNet.Toolchains
 
             if (!File.Exists(exePath))
             {
-                return new ExecuteResult(false, -1, Array.Empty<string>(), Array.Empty<string>());
+                return new ExecuteResult(false, -1, default, Array.Empty<string>(), Array.Empty<string>());
             }
 
             return Execute(executeParameters.BenchmarkCase, executeParameters.BenchmarkId, executeParameters.Logger, exePath, null, args, executeParameters.Diagnoser, executeParameters.Resolver);
@@ -73,13 +73,13 @@ namespace BenchmarkDotNet.Toolchains
 
             if (process.ExitCode == 0)
             {
-                return new ExecuteResult(true, process.ExitCode, loggerWithDiagnoser.LinesWithResults, loggerWithDiagnoser.LinesWithExtraOutput);
+                return new ExecuteResult(true, process.ExitCode, process.Id, loggerWithDiagnoser.LinesWithResults, loggerWithDiagnoser.LinesWithExtraOutput);
             }
 
             if (loggerWithDiagnoser.LinesWithResults.Any(line => line.Contains("BadImageFormatException")))
                 logger.WriteLineError("You are probably missing <PlatformTarget>AnyCPU</PlatformTarget> in your .csproj file.");
 
-            return new ExecuteResult(true, process.ExitCode, Array.Empty<string>(), Array.Empty<string>());
+            return new ExecuteResult(true, process.ExitCode, process.Id, Array.Empty<string>(), Array.Empty<string>());
         }
 
         private ProcessStartInfo CreateStartInfo(BenchmarkCase benchmarkCase, string exePath, string args, string workingDirectory, IResolver resolver)

--- a/src/BenchmarkDotNet/Toolchains/InProcess.Emit/InProcessEmitExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.Emit/InProcessEmitExecutor.cs
@@ -133,13 +133,13 @@ namespace BenchmarkDotNet.Toolchains.InProcess.Emit
         {
             if (exitCode != 0)
             {
-                return new ExecuteResult(true, exitCode, Array.Empty<string>(), Array.Empty<string>());
+                return new ExecuteResult(true, exitCode, default, Array.Empty<string>(), Array.Empty<string>());
             }
 
             var lines = runResults.GetMeasurements().Select(measurement => measurement.ToOutputLine()).ToList();
             lines.Add(runResults.GCStats.ToOutputLine());
 
-            return new ExecuteResult(true, 0, lines.ToArray(), Array.Empty<string>());
+            return new ExecuteResult(true, 0, default, lines.ToArray(), Array.Empty<string>());
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitExecutor.cs
@@ -123,13 +123,13 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
         {
             if (exitCode != 0)
             {
-                return new ExecuteResult(true, exitCode, Array.Empty<string>(), Array.Empty<string>());
+                return new ExecuteResult(true, exitCode, default, Array.Empty<string>(), Array.Empty<string>());
             }
 
             var lines = runResults.GetMeasurements().Select(measurement => measurement.ToOutputLine()).ToList();
             lines.Add(runResults.GCStats.ToOutputLine());
 
-            return new ExecuteResult(true, 0, lines.ToArray(), Array.Empty<string>());
+            return new ExecuteResult(true, 0, default, lines.ToArray(), Array.Empty<string>());
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/InProcess/InProcessExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/InProcessExecutor.cs
@@ -127,13 +127,13 @@ namespace BenchmarkDotNet.Toolchains.InProcess
         {
             if (exitCode != 0)
             {
-                return new ExecuteResult(true, exitCode, Array.Empty<string>(), Array.Empty<string>());
+                return new ExecuteResult(true, exitCode, default, Array.Empty<string>(), Array.Empty<string>());
             }
 
             var lines = runResults.GetMeasurements().Select(measurement => measurement.ToOutputLine()).ToList();
             lines.Add(runResults.GCStats.ToOutputLine());
 
-            return new ExecuteResult(true, 0, lines.ToArray(), Array.Empty<string>());
+            return new ExecuteResult(true, 0, default, lines.ToArray(), Array.Empty<string>());
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/Results/ExecuteResult.cs
+++ b/src/BenchmarkDotNet/Toolchains/Results/ExecuteResult.cs
@@ -6,13 +6,15 @@ namespace BenchmarkDotNet.Toolchains.Results
     {
         public bool FoundExecutable { get; }
         public int ExitCode { get; }
+        public int? ProcessId { get; }
         public IReadOnlyList<string> Data { get; }
         public IReadOnlyList<string> ExtraOutput { get; }
 
-        public ExecuteResult(bool foundExecutable, int exitCode, IReadOnlyList<string> data, IReadOnlyList<string> linesWithExtraOutput)
+        public ExecuteResult(bool foundExecutable, int exitCode, int? processId, IReadOnlyList<string> data, IReadOnlyList<string> linesWithExtraOutput)
         {
             FoundExecutable = foundExecutable;
             Data = data;
+            ProcessId = processId;
             ExitCode = exitCode;
             ExtraOutput = linesWithExtraOutput;
         }

--- a/tests/BenchmarkDotNet.IntegrationTests/ToolchainTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ToolchainTest.cs
@@ -49,7 +49,7 @@ namespace BenchmarkDotNet.IntegrationTests
             {
                 executeParameters.Logger.WriteLine("Executing");
                 Done = true;
-                return new ExecuteResult(true, 0, Array.Empty<string>(), Array.Empty<string>());
+                return new ExecuteResult(true, 0, default, Array.Empty<string>(), Array.Empty<string>());
             }
         }
 

--- a/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
+++ b/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
@@ -49,7 +49,7 @@ namespace BenchmarkDotNet.Tests.Mocks
         private static BenchmarkReport CreateReport(BenchmarkCase benchmarkCase, int n, double nanoseconds)
         {
             var buildResult = BuildResult.Success(GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>()));
-            var executeResult = new ExecuteResult(true, 0, Array.Empty<string>(), new[] { $"// Runtime=extra output line" });
+            var executeResult = new ExecuteResult(true, 0, default, Array.Empty<string>(), new[] { $"// Runtime=extra output line" });
             var measurements = Enumerable.Range(0, n)
                 .Select(index => new Measurement(1, IterationMode.Workload, IterationStage.Result, index + 1, 1, nanoseconds + index))
                 .ToList();

--- a/tests/BenchmarkDotNet.Tests/Reports/DefaultColumnProvidersTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/DefaultColumnProvidersTests.cs
@@ -90,7 +90,7 @@ namespace BenchmarkDotNet.Tests.Reports
         private static BenchmarkReport CreateReport(BenchmarkCase benchmarkCase, bool hugeSd, Metric[] metrics)
         {
             var buildResult = BuildResult.Success(GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>()));
-            var executeResult = new ExecuteResult(true, 0, Array.Empty<string>(), Array.Empty<string>());
+            var executeResult = new ExecuteResult(true, 0, default, Array.Empty<string>(), Array.Empty<string>());
             bool isFoo = benchmarkCase.Descriptor.WorkloadMethodDisplayInfo == "Foo";
             bool isBar = benchmarkCase.Descriptor.WorkloadMethodDisplayInfo == "Bar";            
             var measurements = new List<Measurement>

--- a/tests/BenchmarkDotNet.Tests/Reports/RatioPrecisionTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/RatioPrecisionTests.cs
@@ -80,7 +80,7 @@ namespace BenchmarkDotNet.Tests.Reports
         private static BenchmarkReport CreateReport(BenchmarkCase benchmarkCase, int measurementValue)
         {
             var buildResult = BuildResult.Success(GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>()));
-            var executeResult = new ExecuteResult(true, 0, Array.Empty<string>(), Array.Empty<string>());
+            var executeResult = new ExecuteResult(true, 0, default, Array.Empty<string>(), Array.Empty<string>());
             var measurements = new List<Measurement>
                 {
                     new Measurement(1, IterationMode.Workload, IterationStage.Result, 1, 1, measurementValue),


### PR DESCRIPTION
@tannergooding has pointed the fact that BDN does not print the benchmark process ID and it's hard to figure the PID when using some machine-wide profiler with BDN

this PR extends the logged output with one line. Example:

```log
// Benchmark Process 9868 has exited with code 0
```