### PR TITLE
Easier introduction of new benchmarks

### DIFF
--- a/docs/articles/overview.md
+++ b/docs/articles/overview.md
@@ -51,7 +51,7 @@ namespace MyBenchmarks
     {
         public static void Main(string[] args)
         {
-            var summary = BenchmarkRunner.Run<Md5VsSha256>();
+            var summary = BenchmarkRunner.Run(typeof(Program).Assembly);
         }
     }
 }


### PR DESCRIPTION
This PR changes the default `hello world` of BenchmarkDotNet in a way, that it enables to adding new benchmarks without diving into the selection mechanism. IMO it's make it easier to just copy it and add new benchmarks without thinking why they are not run.