### PR TITLE
Support of --profiler NativeMemory command line argument

### DIFF
--- a/docs/articles/configs/diagnosers.md
+++ b/docs/articles/configs/diagnosers.md
@@ -28,7 +28,7 @@ The current Diagnosers are:
   It allows you to not only benchmark, but also profile the code. It's using TraceEvent, which internally uses ETW and exports all the information to a trace file. The trace file contains all of the stack traces captured by the profiler, PDBs to resolve symbols for both native and managed code and captured GC, JIT and CLR events. Please use one of the free tools: PerfView or Windows Performance Analyzer to analyze and visualize the data from trace file. You can find this diagnoser in a separate package with diagnosers for Windows (`BenchmarkDotNet.Diagnostics.Windows`): [![NuGet](https://img.shields.io/nuget/v/BenchmarkDotNet.svg)](https://www.nuget.org/packages/BenchmarkDotNet.Diagnostics.Windows/)
 - Concurrency Visualizer Profiler (`ConcurrencyVisualizerProfiler`)
   It uses `EtwProfiler` to profile the code using ETW and create not only `.etl` file but also a CVTrace file which can be opened by Concurrency Visualizer plugin from Visual Studio.
-- Native Memory Diagnoser (`NativeMemoryDiagnoser`)
+- Native Memory Profiler (`NativeMemoryProfiler`)
   It uses `EtwProfiler` to profile the code using ETW and adds the extra columns `Allocated native memory` and `Native memory leak`.
 
 ## Usage
@@ -62,7 +62,7 @@ You can also use one of the following attributes (apply it on a class that conta
 [TailCallDiagnoser]
 [EtwProfiler]
 [ConcurrencyVisualizerProfiler]
-[NativeMemoryDiagnoser]
+[NativeMemoryProfiler]
 ```
 
 In BenchmarkDotNet, 1kB = 1024B, 1MB = 1024kB, and so on. The column Gen X means number of GC collections per 1000 operations for that generation.
@@ -79,7 +79,7 @@ In BenchmarkDotNet, 1kB = 1024B, 1MB = 1024kB, and so on. The column Gen X means
     * No Hyper-V (Virtualization) support
     * Requires running as Admin (ETW Kernel Session)
     * No `InProcessToolchain` support ([#394](https://github.com/dotnet/BenchmarkDotNet/issues/394))
-* EtwProfiler, ConcurrencyVisualizerProfiler and NativeMemoryDiagnoser:
+* EtwProfiler, ConcurrencyVisualizerProfiler and NativeMemoryProfiler:
     * Windows only
     * Requires running as Admin (ETW Kernel Session)
     * No `InProcessToolchain` support ([#394](https://github.com/dotnet/BenchmarkDotNet/issues/394))

--- a/docs/articles/samples/IntroNativeMemory.md
+++ b/docs/articles/samples/IntroNativeMemory.md
@@ -4,7 +4,7 @@ uid: BenchmarkDotNet.Samples.IntroNativeMemory
 
 ## Sample: IntroNativeMemory
 
-The `NativeMemoryDiagnoser` diagnoser uses `EtwProfiler` to profile the code using ETW and adds the extra columns `Allocated native memory` and `Native memory leak` to the benchmark results table.
+The `NativeMemoryProfiler` uses `EtwProfiler` to profile the code using ETW and adds the extra columns `Allocated native memory` and `Native memory leak` to the benchmark results table.
 
 ### Source code
 

--- a/samples/BenchmarkDotNet.Samples/IntroNativeMemory.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroNativeMemory.cs
@@ -8,7 +8,7 @@ using BenchmarkDotNet.Diagnostics.Windows.Configs;
 namespace BenchmarkDotNet.Samples
 {
     [ShortRunJob]
-    [NativeMemoryDiagnoser]
+    [NativeMemoryProfiler]
     [MemoryDiagnoser]
     public class IntroNativeMemory
     {

--- a/src/BenchmarkDotNet.Diagnostics.Windows/Configs/NativeMemoryProfilerAttribute.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/Configs/NativeMemoryProfilerAttribute.cs
@@ -6,11 +6,11 @@ namespace BenchmarkDotNet.Diagnostics.Windows.Configs
 {
     [PublicAPI]
     [AttributeUsage(AttributeTargets.Class)]
-    public class NativeMemoryDiagnoserAttribute : Attribute, IConfigSource
+    public class NativeMemoryProfilerAttribute : Attribute, IConfigSource
     {
-        public NativeMemoryDiagnoserAttribute()
+        public NativeMemoryProfilerAttribute()
         {
-            Config = ManualConfig.CreateEmpty().With(new NativeMemoryDiagnoser());
+            Config = ManualConfig.CreateEmpty().With(new NativeMemoryProfiler());
         }
 
         public IConfig Config { get; }

--- a/src/BenchmarkDotNet.Diagnostics.Windows/EtwProfilerConfig.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/EtwProfilerConfig.cs
@@ -33,7 +33,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
         /// <param name="intervalSelectors">interval per hardware counter, if not provided then default values will be used.</param>
         /// <param name="kernelKeywords">kernel session keywords, ImageLoad (for native stack frames) and Profile (for CPU Stacks) are the defaults</param>
         /// <param name="providers">providers that should be enabled, if not provided then default values will be used</param>
-        /// <param name="createHeapSession">value indicating whether to create heap session. False by default, used internally by NativeMemoryDiagnoser.</param>
+        /// <param name="createHeapSession">value indicating whether to create heap session. False by default, used internally by NativeMemoryProfiler.</param>
         public EtwProfilerConfig(
             bool performExtraBenchmarksRun = true,
             int bufferSizeInMb = 256,

--- a/src/BenchmarkDotNet.Diagnostics.Windows/NativeMemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/NativeMemoryDiagnoser.cs
@@ -17,13 +17,15 @@ using Microsoft.Diagnostics.Tracing.Session;
 
 namespace BenchmarkDotNet.Diagnostics.Windows
 {
-    public class NativeMemoryDiagnoser : IDiagnoser
+    public class NativeMemoryDiagnoser : IProfiler
     {
         private static readonly string LogSeparator = new string('-', 20);
 
         private readonly LogCapture logger = new LogCapture();
 
         private readonly EtwProfiler etwProfiler;
+
+        public string ShortName => "NativeMemory";
 
         [PublicAPI] // parameterless ctor required by DiagnosersLoader to support creating this profiler via console line args
         public NativeMemoryDiagnoser() => etwProfiler = new EtwProfiler(CreateDefaultConfig());
@@ -37,7 +39,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
         public void DisplayResults(ILogger resultLogger)
         {
             resultLogger.WriteLineHeader(LogSeparator);
-            foreach (var line in this.logger.CapturedOutput)
+            foreach (var line in logger.CapturedOutput)
                 resultLogger.Write(line.Kind, line.Text);
         }
 

--- a/src/BenchmarkDotNet.Diagnostics.Windows/NativeMemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/NativeMemoryDiagnoser.cs
@@ -38,7 +38,12 @@ namespace BenchmarkDotNet.Diagnostics.Windows
 
         public void DisplayResults(ILogger resultLogger)
         {
-            resultLogger.WriteLineHeader(LogSeparator);
+            if (!etwProfiler.BenchmarkToEtlFile.Any())
+            {
+                resultLogger.WriteLineInfo($"Exported {etwProfiler.BenchmarkToEtlFile.Count} trace file(s). Example:");
+                resultLogger.WriteLineInfo(etwProfiler.BenchmarkToEtlFile.Values.First());
+            }
+
             foreach (var line in logger.CapturedOutput)
                 resultLogger.Write(line.Kind, line.Text);
         }

--- a/src/BenchmarkDotNet.Diagnostics.Windows/NativeMemoryProfiler.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/NativeMemoryProfiler.cs
@@ -36,7 +36,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
 
         public void DisplayResults(ILogger resultLogger)
         {
-            if (!etwProfiler.BenchmarkToEtlFile.Any())
+            if (etwProfiler.BenchmarkToEtlFile.Any())
             {
                 resultLogger.WriteLineInfo($"Exported {etwProfiler.BenchmarkToEtlFile.Count} trace file(s). Example:");
                 resultLogger.WriteLineInfo(etwProfiler.BenchmarkToEtlFile.Values.First());

--- a/src/BenchmarkDotNet.Diagnostics.Windows/NativeMemoryProfiler.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/NativeMemoryProfiler.cs
@@ -17,10 +17,8 @@ using Microsoft.Diagnostics.Tracing.Session;
 
 namespace BenchmarkDotNet.Diagnostics.Windows
 {
-    public class NativeMemoryDiagnoser : IProfiler
+    public class NativeMemoryProfiler : IProfiler
     {
-        private static readonly string LogSeparator = new string('-', 20);
-
         private readonly LogCapture logger = new LogCapture();
 
         private readonly EtwProfiler etwProfiler;
@@ -28,9 +26,9 @@ namespace BenchmarkDotNet.Diagnostics.Windows
         public string ShortName => "NativeMemory";
 
         [PublicAPI] // parameterless ctor required by DiagnosersLoader to support creating this profiler via console line args
-        public NativeMemoryDiagnoser() => etwProfiler = new EtwProfiler(CreateDefaultConfig());
+        public NativeMemoryProfiler() => etwProfiler = new EtwProfiler(CreateDefaultConfig());
 
-        public IEnumerable<string> Ids => new[] { nameof(NativeMemoryDiagnoser) };
+        public IEnumerable<string> Ids => new[] { nameof(NativeMemoryProfiler) };
 
         public IEnumerable<IExporter> Exporters => Array.Empty<IExporter>();
 

--- a/src/BenchmarkDotNet/Diagnosers/DiagnosersLoader.cs
+++ b/src/BenchmarkDotNet/Diagnosers/DiagnosersLoader.cs
@@ -80,7 +80,7 @@ namespace BenchmarkDotNet.Diagnosers
                         CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.PmcDiagnoser"),
                         CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.EtwProfiler"),
                         CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.ConcurrencyVisualizerProfiler"),
-                        CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.NativeMemoryDiagnoser")
+                        CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.NativeMemoryProfiler")
                     };
                 }
             }

--- a/src/BenchmarkDotNet/Diagnosers/DiagnosersLoader.cs
+++ b/src/BenchmarkDotNet/Diagnosers/DiagnosersLoader.cs
@@ -15,14 +15,14 @@ namespace BenchmarkDotNet.Diagnosers
         private const string DiagnosticAssemblyName = "BenchmarkDotNet.Diagnostics.Windows";
 
         // Make the Diagnosers lazy-loaded, so they are only instantiated if needed
-        private static readonly Lazy<IDiagnoser[]> LazyLoadedDiagnosers 
+        private static readonly Lazy<IDiagnoser[]> LazyLoadedDiagnosers
             = new Lazy<IDiagnoser[]>(LoadDiagnosers, LazyThreadSafetyMode.ExecutionAndPublication);
 
         internal static IDiagnoser GetImplementation<TDiagnoser>() where TDiagnoser : IDiagnoser
             => LazyLoadedDiagnosers.Value
                     .FirstOrDefault(diagnoser => diagnoser is TDiagnoser) // few diagnosers can implement same interface, order matters
                 ?? GetUnresolvedDiagnoser<TDiagnoser>();
-        
+
         internal static IDiagnoser GetImplementation<TDiagnoser>(Predicate<TDiagnoser> filter) where TDiagnoser : IDiagnoser
             => LazyLoadedDiagnosers.Value
                     .FirstOrDefault(diagnoser => diagnoser is TDiagnoser typed && filter(typed)) // few diagnosers can implement same interface, order matters
@@ -46,13 +46,13 @@ namespace BenchmarkDotNet.Diagnosers
 
         private static IDiagnoser[] LoadCore() => new IDiagnoser[] { MemoryDiagnoser.Default };
 
-        private static IDiagnoser[] LoadMono() 
+        private static IDiagnoser[] LoadMono()
             => new IDiagnoser[]
             {
                 // this method should return a IHardwareCountersDiagnoser when we implement Hardware Counters for Unix
                 MemoryDiagnoser.Default,
-                DisassemblyDiagnoser.Create(new DisassemblyDiagnoserConfig()) 
-            }; 
+                DisassemblyDiagnoser.Create(new DisassemblyDiagnoserConfig())
+            };
 
         private static IDiagnoser[] LoadClassic()
         {
@@ -79,7 +79,8 @@ namespace BenchmarkDotNet.Diagnosers
                         CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.InliningDiagnoser"),
                         CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.PmcDiagnoser"),
                         CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.EtwProfiler"),
-                        CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.ConcurrencyVisualizerProfiler")
+                        CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.ConcurrencyVisualizerProfiler"),
+                        CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.NativeMemoryDiagnoser")
                     };
                 }
             }


### PR DESCRIPTION
In this PR I support command line argument:
```
--profiler NativeMemory
```

@adamsitnik I wonder if `NativeMemoryDiagnoser` shouldn't be named `NativeMemoryProfiler`?
We have `MemoryDiagnoser` but there is also `EtwProfiler` and `ConcurrencyVisualizerProfiler`.