### PR TITLE
print full architecture name

### DIFF
--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -47,7 +47,7 @@ namespace BenchmarkDotNet.Portability
 
         internal static string ScriptFileExtension => IsWindows() ? ".bat" : ".sh";
 
-        internal static string GetArchitecture() => Is64BitPlatform() ? "64bit" : "32bit";
+        internal static string GetArchitecture() => GetCurrentPlatform().ToString();
 
         private static string DockerSdkVersion => Environment.GetEnvironmentVariable("DOTNET_VERSION");
 


### PR DESCRIPTION
@AndreyAkinshin I've recently been running a lot of benchmarks for x64, x86, ARM and ARM64. The reported results always contained "64bit" or "32bit" which does not tell if it's ARM or not. I think that we should use full architecture name.

Before:

```log
BenchmarkDotNet=v0.11.5.20190727-develop, OS=Windows 10.0.18362
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.3815.0), 64bit RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.3815.0), 64bit RyuJIT
```

After:

```log
BenchmarkDotNet=v0.11.5.20190727-develop, OS=Windows 10.0.18362
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.3815.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.3815.0), X64 RyuJIT
```