### PR TITLE
Update RExporter documentation (link visibility / R_HOME value)

### DIFF
--- a/docs/articles/configs/exporters.md
+++ b/docs/articles/configs/exporters.md
@@ -20,7 +20,7 @@ By default, files with results will be located in
 
 ## Plots
 
-You can install [R](https://www.r-project.org/) to automatically get nice plots of your benchmark results.
+[You can install R](https://www.r-project.org/) to automatically get nice plots of your benchmark results.
 First, make sure `Rscript.exe` or `Rscript` is in your path,
   or define an R_HOME environment variable pointing to the R installation directory (containing the `bin` directory).
 Use `RPlotExporter.Default` and `CsvMeasurementsExporter.Default` in your config,

--- a/docs/articles/configs/exporters.md
+++ b/docs/articles/configs/exporters.md
@@ -22,7 +22,8 @@ By default, files with results will be located in
 
 [You can install R](https://www.r-project.org/) to automatically get nice plots of your benchmark results.
 First, make sure `Rscript.exe` or `Rscript` is in your path,
-  or define an R_HOME environment variable pointing to the R installation directory (containing the `bin` directory).
+  or define an R_HOME environment variable pointing to the R installation directory.  
+_eg: If `Rscript` is located in `/path/to/R/R-1.2.3/bin/Rscript`, then `R_HOME` must point to `/path/to/R/R-1.2.3/`, it **should not** point to `/path/to/R/R-1.2.3/bin`_  
 Use `RPlotExporter.Default` and `CsvMeasurementsExporter.Default` in your config,
   and the `BuildPlots.R` script in your bin directory will take care of the rest.
 


### PR DESCRIPTION
As i tried, and managed to use `RExporter`, i had 2 minor issues listed here : #1220 

Here is a proposal of doc changes that attempt to help others developers trying ot use `RExporter`.
I'm not sure about the `R_HOME` part to be honest.


#### Side note
Even with `RScript.exe` in the `PATH`, it seems that if `R_HOME` exist and points to a wrong path (i initially tried `C:\Program Files\R\R-3.6.1\bin`) it won't try to check in the `PATH`.
If a run takes few hours, the error appears latter :

* Should the Rscript detection fallback to the `PATH` is `R_HOME` seems wrong ?
* Could the `RExporter` be detected before the `Benchmark` start
  * Should it output an error / warning
  * Should it prompt the User to continue or not ?
  * What to do on the CI ? (would waste ~xxx Min on the CI to fail at the end)

I could attempt to add few of these additional changes to this PR