### PR TITLE
Enhance rscript location

### DIFF
--- a/docs/articles/configs/exporters.md
+++ b/docs/articles/configs/exporters.md
@@ -20,7 +20,7 @@ By default, files with results will be located in
 
 ## Plots
 
-You can install [R](https://www.r-project.org/) to automatically get nice plots of your benchmark results.
+[You can install R](https://www.r-project.org/) to automatically get nice plots of your benchmark results.
 First, make sure `Rscript.exe` or `Rscript` is in your path,
   or define an R_HOME environment variable pointing to the R installation directory (containing the `bin` directory).
 Use `RPlotExporter.Default` and `CsvMeasurementsExporter.Default` in your config,

--- a/docs/articles/configs/exporters.md
+++ b/docs/articles/configs/exporters.md
@@ -22,7 +22,8 @@ By default, files with results will be located in
 
 [You can install R](https://www.r-project.org/) to automatically get nice plots of your benchmark results.
 First, make sure `Rscript.exe` or `Rscript` is in your path,
-  or define an R_HOME environment variable pointing to the R installation directory (containing the `bin` directory).
+  or define an R_HOME environment variable pointing to the R installation directory.  
+_eg: If `Rscript` is located in `/path/to/R/R-1.2.3/bin/Rscript`, then `R_HOME` must point to `/path/to/R/R-1.2.3/`, it **should not** point to `/path/to/R/R-1.2.3/bin`_  
 Use `RPlotExporter.Default` and `CsvMeasurementsExporter.Default` in your config,
   and the `BuildPlots.R` script in your bin directory will take care of the rest.
 

--- a/src/BenchmarkDotNet/Exporters/RPlotExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/RPlotExporter.cs
@@ -88,7 +88,6 @@ namespace BenchmarkDotNet.Exporters
                 }
 
                 consoleLogger.WriteLineError($"RPlotExporter requires R_HOME to point to the parent directory of the existing '{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}{rscriptExecutable} (currently points to {rHome})");
-                rscriptPath = null;
             }
 
             // No R_HOME, or R_HOME points to a wrong folder, try the path

--- a/src/BenchmarkDotNet/Exporters/RPlotExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/RPlotExporter.cs
@@ -74,7 +74,7 @@ namespace BenchmarkDotNet.Exporters
             throw new NotSupportedException();
         }
 
-        public static bool TryFindRScript(ILogger consoleLogger, out string rscriptPath)
+        private static bool TryFindRScript(ILogger consoleLogger, out string rscriptPath)
         {
             string rscriptExecutable = RuntimeInformation.IsWindows() ? "Rscript.exe" : "Rscript";
             rscriptPath = null;


### PR DESCRIPTION
Hello,

As long with #1220, few Docs changes has been proposed in #1221,
This one try to "extends" `RScript` detection if `R_HOME` value is wrong, so that it also look in the `PATH`

This branch is on purpose on top of the existing #1221 so that is would be easy to directly pick it up