### PR TITLE
Documentation: Fix some typos in the documentation

### DIFF
--- a/docs/articles/contributing/disassembler.md
+++ b/docs/articles/contributing/disassembler.md
@@ -12,18 +12,18 @@ We have 3 disassemblers:
 
 The MonoDisassembler is very simple: it spawns Mono with the right arguments to get the asm, Mono prints the output to the console and we just parse it. Single class does the job: `MonoDisassembler`.
 
-When it comes to Windows disassemblers it's not so easy. To obtain the disassm we are using ClrMD. ClrMD can attach only to the process of same bitness (architecture). 
+When it comes to Windows disassemblers it's not so easy. To obtain the disassm we are using ClrMD. ClrMD can attach only to the process of same bitness (architecture).
 This is why we have two dissasemblers: x64 and x86. The code is the same (single class, linked in two projects) but compiled for two different architectures.
 
-Unfortunatelly ClrMD is not a signed dll. This is why, we keep both diassemblers in the resources of the BenchmarkDotNet.dll. 
+Unfortunately ClrMD is not a signed dll. This is why, we keep both diassemblers in the resources of the BenchmarkDotNet.dll.
 When we need the disassembler, we search for it in the resources, copy it to the disk and run (it's an exe).
 
 ### How to debug the disassembler
 
-You need to create a new project which executes the code that you would like to disassemble. It can be a simple console app. 
+You need to create a new project which executes the code that you would like to disassemble. It can be a simple console app.
 In this app, you need to run the desired code (to get it jitted) and just don't exit. Before you exit, you have to attach with Disassembler to given process.
 
-Disassembler requires some arguments to run: id of the process to attach, full type name of the type which contains desired method, name of desired method and what should be disassembled: asm, IL, C#, prolog & epilog.  
+Disassembler requires some arguments to run: id of the process to attach, full type name of the type which contains desired method, name of desired method and what should be disassembled: asm, IL, C#, prolog & epilog.
 
 Personally I use following code to run the console app and print arguments that are required to attach to it:
 
@@ -74,12 +74,12 @@ namespace Sample
 }
 ```
 
-**Important**: Please remember that every new classic .NET project in VS compiles as 32 bit. If you want to check the asm produced for x64 you need to go to the properites of the console app (Alt+Enter) and uncheck "Prefer 32 bit" in the "Build" tab.
+**Important**: Please remember that every new classic .NET project in VS compiles as 32 bit. If you want to check the asm produced for x64 you need to go to the properties of the console app (Alt+Enter) and uncheck "Prefer 32 bit" in the "Build" tab.
 
 Once you configure your app, you should run it. It will give you an output similar to this:
 
 `13672 ConsoleApp1.RandomSort ArraySort True True True True 7 C:\Users\adsitnik\AppData\Local\Temp\tmpDCB9.tmp.xml`
 
-Now you go to BenchmarkDotNet solution, select desired Disassembler project in the Solution Explorer and Set it as Startup project. After this you go to the project's properties and in the Debug tab copy-paste the arguments for the disassembler. Now when you start debugging, your IDE will spawn new process of the disassembler with the right arguments to attach to the desired exe. You should be able to debug it like any othe app.
+Now you go to BenchmarkDotNet solution, select desired Disassembler project in the Solution Explorer and Set it as Startup project. After this you go to the project's properties and in the Debug tab copy-paste the arguments for the disassembler. Now when you start debugging, your IDE will spawn new process of the disassembler with the right arguments to attach to the desired exe. You should be able to debug it like any other app.
 
 Please keep in mind that you should always use the disassembler for the correct processor architecture. If you fail to debug it, you are most probably using the wrong one.

--- a/docs/articles/features/etwprofiler.md
+++ b/docs/articles/features/etwprofiler.md
@@ -21,7 +21,7 @@ What we have today comes with following limitations:
 
 * EtwProfiler works only on Windows (one day we might implement similar thing for Unix using EventPipe)
 * Requires to run as Admin (to create ETW Kernel Session)
-* No `InProcessToolchain` support 
+* No `InProcessToolchain` support
 * To get the best possible managed code symbols you should configure your project in following way:
 
 ```xml
@@ -47,7 +47,7 @@ public class TheClassThatContainsBenchmarks { /* benchmarks go here */ }
 ```cs
 class Program
 {
-    static void Main(string[] args) 
+    static void Main(string[] args)
         => BenchmarkSwitcher
             .FromAssembly(typeof(Program).Assembly)
             .Run(args,
@@ -65,7 +65,7 @@ To configure the new diagnoser you need to create an instance of `EtwProfilerCon
 
 * `performExtraBenchmarksRun` - if set to true, benchmarks will be executed one more time with the profiler attached. If set to false, there will be no extra run but the results will contain overhead. True by default.
 * `bufferSizeInMb` - ETW session buffer size, in MB. 256 by default.
-* `intervalSelectors` - interval per harwdare counter, if not provided then default values will be used.
+* `intervalSelectors` - interval per hardware counter, if not provided then default values will be used.
 * `kernelKeywords` - kernel session keywords, ImageLoad (for native stack frames) and Profile (for CPU Stacks) are the defaults.
 * `providers` - providers that should be enabled, if not provided then default values will be used.
 

--- a/docs/articles/samples/IntroArguments.md
+++ b/docs/articles/samples/IntroArguments.md
@@ -6,11 +6,11 @@ uid: BenchmarkDotNet.Samples.IntroArguments
 
 As an alternative to using [`[Params]`](xref:BenchmarkDotNet.Attributes.ParamsAttribute),
   you can specify arguments for your benchmarks.
-There are several ways to do it (described below). 
+There are several ways to do it (described below).
 
 
 The [`[Arguments]`](xref:BenchmarkDotNet.Attributes.ArgumentsAttribute) allows you to provide a set of values.
-Every value must be a compile-time constant (it's C# lanugage limitation for attributes in general).
+Every value must be a compile-time constant (it's C# language limitation for attributes in general).
 You can also combine
   [`[Arguments]`](xref:BenchmarkDotNet.Attributes.ArgumentsAttribute) with
   [`[Params]`](xref:BenchmarkDotNet.Attributes.ParamsAttribute).
@@ -32,7 +32,7 @@ As a result, you will get results for each combination of params values.
 | Benchmark |                 True | 100 | 10 | 115.3 ms | 0.1375 ms | 0.1286 ms |
 | Benchmark |                 True | 100 | 20 | 125.3 ms | 0.1212 ms | 0.1134 ms |
 | Benchmark |                 True | 200 | 10 | 215.4 ms | 0.0779 ms | 0.0691 ms |
-| Benchmark |                 True | 200 | 20 | 225.4 ms | 0.0775 ms | 0.0725 ms | 
+| Benchmark |                 True | 200 | 20 | 225.4 ms | 0.0775 ms | 0.0725 ms |
 ```
 
 ### Links

--- a/docs/articles/samples/IntroEncoding.md
+++ b/docs/articles/samples/IntroEncoding.md
@@ -5,8 +5,8 @@ uid: BenchmarkDotNet.Samples.IntroEncoding
 ## Sample: IntroEncoding
 
 BenchmarkDotNet currently supports two encodings for output - `ASCII` and `Unicode`.
-By default `ASCII` is setted.
-`Unicode` allows to use special characters, like `μ` and `±`. 
+By default `ASCII` is set.
+`Unicode` allows to use special characters, like `μ` and `±`.
 *Encoding* allows you to set encoding in your benchmark.
 
 > [!WARNING]

--- a/docs/articles/samples/IntroInProcess.md
+++ b/docs/articles/samples/IntroInProcess.md
@@ -6,7 +6,7 @@ uid: BenchmarkDotNet.Samples.IntroInProcess
 
 InProcessEmitToolchain is our toolchain which does not generate any new executable.
 It emits IL on the fly and runs it from within the process itself.
-It can be usefull if want to run the benchmarks very fast or if you want to run them for framework which we don't support.
+It can be useful if want to run the benchmarks very fast or if you want to run them for framework which we don't support.
 An example could be a local build of CoreCLR.
 
 ### Usage

--- a/docs/articles/samples/IntroStopOnFirstError.md
+++ b/docs/articles/samples/IntroStopOnFirstError.md
@@ -4,7 +4,7 @@ uid: BenchmarkDotNet.Samples.IntroStopOnFirstError
 
 ## Sample: IntroStopOnFirstError
 
-BenchmarkDotNet can be configured to stop on first error. You just have to add `StopOnFirstError` attrubute to your class or use `--stopOnfirstError` command line argument.
+BenchmarkDotNet can be configured to stop on first error. You just have to add `StopOnFirstError` attribute to your class or use `--stopOnFirstError` command line argument.
 
 ### Source code
 


### PR DESCRIPTION
Mostly due to my editor settings it also removed trailing whitespace. If that's not desired let me know and I'll add them.