### PR TITLE
Threading Diagnoser

### DIFF
--- a/docs/_changelog/header/v0.11.6.md
+++ b/docs/_changelog/header/v0.11.6.md
@@ -10,6 +10,9 @@
     [#1214](https://github.com/dotnet/BenchmarkDotNet/pull/1214),
     [#1218](https://github.com/dotnet/BenchmarkDotNet/pull/1218),
     [#1219](https://github.com/dotnet/BenchmarkDotNet/pull/1219)
+  * **ThreadingDiagnoser** - it uses [new APIs](https://github.com/dotnet/corefx/issues/35500) exposed in .NET Core 3.0 to report `Completed Work Items` and `Lock Contentions`.
+    [#1154](https://github.com/dotnet/BenchmarkDotNet/issues/1154),
+    [#1227](https://github.com/dotnet/BenchmarkDotNet/pull/1227)
   * MemoryDiagnoser includes memory allocated by **all Threads** that were live during benchmark execution: a new GC API was exposed in .NET Core 3.0 preview6+. It allows to get the number of allocated bytes for all threads.
     [#1155](https://github.com/dotnet/BenchmarkDotNet/pull/1155),
     [#1153](https://github.com/dotnet/BenchmarkDotNet/issues/1153),
@@ -121,6 +124,23 @@ You should redesign your benchmark and remove the side-effects. You can use `Ope
 ```
 
 In this case, you should try to reduce the number of invocation, by adding `[ShortRunJob]` attribute or using `Job.Short` for custom configuration.
+
+## ThreadingDiagnoser
+
+The `ThreadingDiagnoser` uses [new APIs](https://github.com/dotnet/corefx/issues/35500) exposed in .NET Core 3.0 to report:
+
+* Completed Work Items: The number of work items that have been processed in ThreadPool (per single operation)
+* Lock Contentions: The number of times there **was contention** upon trying to take a Monitor's lock (per single operation)
+
+### Source code
+
+[!code-csharp[IntroThreadingDiagnoser.cs](../../../samples/BenchmarkDotNet.Samples/IntroThreadingDiagnoser.cs)]
+
+### Output
+
+|              Method |          Mean |     StdDev |        Median | Completed Work Items | Lock Contentions |
+|-------------------- |--------------:|-----------:|--------------:|---------------------:|-----------------:|
+| CompleteOneWorkItem | 8,073.5519 ns | 69.7261 ns | 8,111.6074 ns |               1.0000 |                - |
 
 ## Multiple frameworks support
 

--- a/docs/articles/configs/diagnosers.md
+++ b/docs/articles/configs/diagnosers.md
@@ -33,6 +33,7 @@ The current Diagnosers are:
 - Native Memory Profiler (`NativeMemoryProfiler`)
   It uses `EtwProfiler` to profile the code using ETW and adds the extra columns `Allocated native memory` and `Native memory leak`.
   Please see Wojciech Nagórski's [blog post](https://wojciechnagorski.com/2019/08/analyzing-native-memory-allocation-with-benchmarkdotnet/) for all the details.
+- Threading Diagnoser (`ThreadingDiagnoser`) - .NET Core 3.0+ diagnoser that reports some Threading statistics.
 
 ## Usage
 
@@ -54,6 +55,7 @@ private class Config : ManualConfig
         Add(MemoryDiagnoser.Default);
         Add(new InliningDiagnoser());
         Add(new EtwProfiler());
+        Add(ThreadingDiagnoser.Default);
     }
 }
 ```
@@ -66,6 +68,7 @@ You can also use one of the following attributes (apply it on a class that conta
 [EtwProfiler]
 [ConcurrencyVisualizerProfiler]
 [NativeMemoryProfiler]
+[ThreadingDiagnoser]
 ```
 
 In BenchmarkDotNet, 1kB = 1024B, 1MB = 1024kB, and so on. The column Gen X means number of GC collections per 1000 operations for that generation.
@@ -77,6 +80,8 @@ In BenchmarkDotNet, 1kB = 1024B, 1MB = 1024kB, and so on. The column Gen X means
 	* Mono currently [does not](http://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-in-mono) expose any api to get the number of allocated bytes. That's why our Mono users will get `?` in Allocated column.
 	* In order to get the number of allocated bytes in cross platform way we are using `GC.GetAllocatedBytesForCurrentThread` which recently got [exposed](https://github.com/dotnet/corefx/pull/12489) for netcoreapp1.1. That's why BenchmarkDotNet does not support netcoreapp1.0 from version 0.10.1.
 	* MemoryDiagnoser is `99.5%` accurate about allocated memory when using default settings or Job.ShortRun (or any longer job than it).
+* Threading Diagnoser:
+    * Works only for .NET Core 3.0+
 * HardwareCounters:
 	* Windows 8+ only (we plan to add Unix support in the future)
     * No Hyper-V (Virtualization) support
@@ -113,3 +118,5 @@ In BenchmarkDotNet, 1kB = 1024B, 1MB = 1024kB, and so on. The column Gen X means
 [!include[IntroTailcall](../samples/IntroTailcall.md)]
 
 [!include[IntroNativeMemory](../samples/IntroNativeMemory.md)]
+
+[!include[IntroThreadingDiagnoser](../samples/ThreadingDiagnoser.md)]

--- a/docs/articles/samples/IntroThreadingDiagnoser.md
+++ b/docs/articles/samples/IntroThreadingDiagnoser.md
@@ -1,0 +1,27 @@
+---
+uid: BenchmarkDotNet.Samples.IntroThreadingDiagnoser
+---
+
+## Sample: IntroThreadingDiagnoser
+
+The `ThreadingDiagnoser` uses new APIs [exposed](https://github.com/dotnet/corefx/issues/35500) in .NET Core 3.0 to report:
+
+* Completed Work Items: The number of work items that have been processed in ThreadPool (per single operation)
+* Lock Contentions: The number of times there **was contention** upon trying to take a Monitor's lock (per single operation)
+
+### Source code
+
+[!code-csharp[IntroThreadingDiagnoser.cs](../../../samples/BenchmarkDotNet.Samples/IntroThreadingDiagnoser.cs)]
+
+### Output
+
+|              Method |          Mean |     StdDev |        Median | Completed Work Items | Lock Contentions |
+|-------------------- |--------------:|-----------:|--------------:|---------------------:|-----------------:|
+| CompleteOneWorkItem | 8,073.5519 ns | 69.7261 ns | 8,111.6074 ns |               1.0000 |                - |
+
+### Links
+
+* @docs.diagnosers
+* The permanent link to this sample: @BenchmarkDotNet.Samples.IntroThreadingDiagnoser
+
+---

--- a/samples/BenchmarkDotNet.Samples/IntroThreadingDiagnoser.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroThreadingDiagnoser.cs
@@ -1,0 +1,19 @@
+﻿using BenchmarkDotNet.Attributes;
+using System.Threading;
+
+namespace BenchmarkDotNet.Samples
+{
+    [ThreadingDiagnoser] // ENABLE the diagnoser
+    public class IntroThreadingDiagnoser
+    {
+        [Benchmark]
+        public void CompleteOneWorkItem()
+        {
+            ManualResetEvent done = new ManualResetEvent(initialState: false);
+
+            ThreadPool.QueueUserWorkItem(m => (m as ManualResetEvent).Set(), done);
+
+            done.WaitOne();
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Attributes/ThreadingDiagnoserAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/ThreadingDiagnoserAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+namespace BenchmarkDotNet.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ThreadingDiagnoserAttribute : Attribute, IConfigSource
+    {
+        public IConfig Config { get; }
+
+        public ThreadingDiagnoserAttribute() => Config = ManualConfig.CreateEmpty().With(ThreadingDiagnoser.Default);
+    }
+}

--- a/src/BenchmarkDotNet/Code/CodeGenerator.cs
+++ b/src/BenchmarkDotNet/Code/CodeGenerator.cs
@@ -63,7 +63,7 @@ namespace BenchmarkDotNet.Code
                     .Replace("$PassArguments$", passArguments)
                     .Replace("$EngineFactoryType$", GetEngineFactoryTypeName(benchmark))
                     .Replace("$Ref$", provider.UseRefKeyword ? "ref" : null)
-                    .Replace("$MeasureGcStats$", buildInfo.Config.HasMemoryDiagnoser() ? "true" : "false")
+                    .Replace("$MeasureExtraStats$", buildInfo.Config.HasExtraStatsDiagnoser() ? "true" : "false")
                     .Replace("$Encoding$", buildInfo.Config.Encoding.ToTemplateString())
                     .Replace("$DisassemblerEntryMethodName$", DisassemblerConstants.DisassemblerEntryMethodName)
                     .Replace("$WorkloadMethodCall$", provider.GetWorkloadMethodCall(passArguments)).ToString();

--- a/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
@@ -93,6 +93,9 @@ namespace BenchmarkDotNet.Configs
         public IDiagnoser GetCompositeDiagnoser() => new CompositeDiagnoser(diagnosers);
 
         public bool HasMemoryDiagnoser() => diagnosers.Contains(MemoryDiagnoser.Default);
+        public bool HasThreadingDiagnoser() => diagnosers.Contains(ThreadingDiagnoser.Default);
+
+        public bool HasExtraStatsDiagnoser() => HasMemoryDiagnoser() || HasThreadingDiagnoser();
 
         public IDiagnoser GetCompositeDiagnoser(BenchmarkCase benchmarkCase, RunMode runMode)
         {

--- a/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
@@ -93,6 +93,7 @@ namespace BenchmarkDotNet.Configs
         public IDiagnoser GetCompositeDiagnoser() => new CompositeDiagnoser(diagnosers);
 
         public bool HasMemoryDiagnoser() => diagnosers.Contains(MemoryDiagnoser.Default);
+
         public bool HasThreadingDiagnoser() => diagnosers.Contains(ThreadingDiagnoser.Default);
 
         public bool HasExtraStatsDiagnoser() => HasMemoryDiagnoser() || HasThreadingDiagnoser();

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -29,6 +29,9 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option('m', "memory", Required = false, Default = false, HelpText = "Prints memory statistics")]
         public bool UseMemoryDiagnoser { get; set; }
 
+        [Option('t', "threading", Required = false, Default = false, HelpText = "Prints threding statistics")]
+        public bool UseThreadingDiagnoser { get; set; }
+
         [Option('d', "disasm", Required = false, Default = false, HelpText = "Gets disassembly of benchmarked code")]
         public bool UseDisassemblyDiagnoser { get; set; }
         

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -29,7 +29,7 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option('m', "memory", Required = false, Default = false, HelpText = "Prints memory statistics")]
         public bool UseMemoryDiagnoser { get; set; }
 
-        [Option('t', "threading", Required = false, Default = false, HelpText = "Prints threding statistics")]
+        [Option('t', "threading", Required = false, Default = false, HelpText = "Prints threading statistics")]
         public bool UseThreadingDiagnoser { get; set; }
 
         [Option('d', "disasm", Required = false, Default = false, HelpText = "Gets disassembly of benchmarked code")]

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -187,6 +187,8 @@ namespace BenchmarkDotNet.ConsoleArguments
 
             if (options.UseMemoryDiagnoser)
                 config.Add(MemoryDiagnoser.Default);
+            if (options.UseThreadingDiagnoser)
+                config.Add(ThreadingDiagnoser.Default);
             if (options.UseDisassemblyDiagnoser)
                 config.Add(DisassemblyDiagnoser.Create(new DisassemblyDiagnoserConfig(recursiveDepth: options.DisassemblerRecursiveDepth, printPrologAndEpilog: true, printDiff: options.DisassemblerDiff)));
             if (!string.IsNullOrEmpty(options.Profiler))

--- a/src/BenchmarkDotNet/Diagnosers/DiagnoserResults.cs
+++ b/src/BenchmarkDotNet/Diagnosers/DiagnoserResults.cs
@@ -5,11 +5,12 @@ namespace BenchmarkDotNet.Diagnosers
 {
     public class DiagnoserResults
     {
-        public DiagnoserResults(BenchmarkCase benchmarkCase, long totalOperations, GcStats gcStats)
+        public DiagnoserResults(BenchmarkCase benchmarkCase, long totalOperations, GcStats gcStats, ThreadingStats threadingStats)
         {
             BenchmarkCase = benchmarkCase;
             TotalOperations = totalOperations;
             GcStats = gcStats;
+            ThreadingStats = threadingStats;
         }
 
         public BenchmarkCase BenchmarkCase { get; }
@@ -17,5 +18,7 @@ namespace BenchmarkDotNet.Diagnosers
         public long TotalOperations { get; }
 
         public GcStats GcStats { get; }
+
+        public ThreadingStats ThreadingStats { get; }
     }
 }

--- a/src/BenchmarkDotNet/Diagnosers/ThreadingDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/ThreadingDiagnoser.cs
@@ -42,7 +42,7 @@ namespace BenchmarkDotNet.Diagnosers
         {
             if (!RuntimeInformation.IsNetCore || NetCoreAppSettings.Current.Value.IsOlderThan(TargetFrameworkMoniker.NetCoreApp30))
             {
-                yield return new ValidationError(true, "ThreadingDiagnoser supports only .NET Core 3.0+");
+                yield return new ValidationError(false, "ThreadingDiagnoser supports only .NET Core 3.0+");
             }
         }
 

--- a/src/BenchmarkDotNet/Diagnosers/ThreadingDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/ThreadingDiagnoser.cs
@@ -1,0 +1,9 @@
+﻿namespace BenchmarkDotNet.Diagnosers
+{
+    public class ThreadingDiagnoser : IDiagnoser
+    {
+        public static readonly ThreadingDiagnoser Default = new ThreadingDiagnoser();
+
+        private ThreadingDiagnoser() { }
+    }
+}

--- a/src/BenchmarkDotNet/Diagnosers/ThreadingDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/ThreadingDiagnoser.cs
@@ -42,7 +42,7 @@ namespace BenchmarkDotNet.Diagnosers
         {
             if (!RuntimeInformation.IsNetCore || NetCoreAppSettings.Current.Value.IsOlderThan(TargetFrameworkMoniker.NetCoreApp30))
             {
-                yield return new ValidationError(false, "ThreadingDiagnoser supports only .NET Core 3.0+");
+                yield return new ValidationError(false, $"{nameof(ThreadingDiagnoser)} supports only .NET Core 3.0+");
             }
         }
 

--- a/src/BenchmarkDotNet/Diagnosers/ThreadingDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/ThreadingDiagnoser.cs
@@ -1,9 +1,75 @@
-﻿namespace BenchmarkDotNet.Diagnosers
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Portability;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.DotNetCli;
+using BenchmarkDotNet.Validators;
+
+namespace BenchmarkDotNet.Diagnosers
 {
     public class ThreadingDiagnoser : IDiagnoser
     {
         public static readonly ThreadingDiagnoser Default = new ThreadingDiagnoser();
 
         private ThreadingDiagnoser() { }
+
+        public IEnumerable<string> Ids => new[] { nameof(ThreadingDiagnoser) };
+
+        public IEnumerable<IExporter> Exporters => Array.Empty<IExporter>();
+
+        public IEnumerable<IAnalyser> Analysers => Array.Empty<IAnalyser>();
+
+        public void DisplayResults(ILogger logger) { }
+
+        public RunMode GetRunMode(BenchmarkCase benchmarkCase) => RunMode.NoOverhead;
+
+        public void Handle(HostSignal signal, DiagnoserActionParameters parameters) { }
+
+        public IEnumerable<Metric> ProcessResults(DiagnoserResults results)
+        {
+            yield return new Metric(CompletedWorkItemCountMetricDescriptor.Instance, results.ThreadingStats.CompletedWorkItemCount / (double)results.ThreadingStats.TotalOperations);
+            yield return new Metric(LockContentionCountMetricDescriptor.Instance, results.ThreadingStats.LockContentionCount / (double)results.ThreadingStats.TotalOperations);
+        }
+
+        public IEnumerable<ValidationError> Validate(ValidationParameters validationParameters)
+        {
+            if (!RuntimeInformation.IsNetCore || NetCoreAppSettings.Current.Value.IsOlderThan(TargetFrameworkMoniker.NetCoreApp30))
+            {
+                yield return new ValidationError(true, "ThreadingDiagnoser supports only .NET Core 3.0+");
+            }
+        }
+
+        private class CompletedWorkItemCountMetricDescriptor : IMetricDescriptor
+        {
+            internal static readonly IMetricDescriptor Instance = new CompletedWorkItemCountMetricDescriptor();
+
+            public string Id => "CompletedWorkItemCount";
+            public string DisplayName => "Completed Work Items";
+            public string Legend => "The number of work items that have been processed in ThreadPool (per single operation)";
+            public string NumberFormat => "#0.0000";
+            public UnitType UnitType => UnitType.Dimensionless;
+            public string Unit => "Count";
+            public bool TheGreaterTheBetter => false;
+        }
+
+        private class LockContentionCountMetricDescriptor : IMetricDescriptor
+        {
+            internal static readonly IMetricDescriptor Instance = new LockContentionCountMetricDescriptor();
+
+            public string Id => "LockContentionCount";
+            public string DisplayName => "Lock Contentions";
+            public string Legend => "The number of times there was contention upon trying to take a Monitor's lock (per single operation)";
+            public string NumberFormat => "#0.0000";
+            public UnitType UnitType => UnitType.Dimensionless;
+            public string Unit => "Count";
+            public bool TheGreaterTheBetter => false;
+        }
     }
 }

--- a/src/BenchmarkDotNet/Engines/Engine.cs
+++ b/src/BenchmarkDotNet/Engines/Engine.cs
@@ -42,14 +42,14 @@ namespace BenchmarkDotNet.Engines
         private readonly EnginePilotStage pilotStage;
         private readonly EngineWarmupStage warmupStage;
         private readonly EngineActualStage actualStage;
-        private readonly bool includeMemoryStats;
+        private readonly bool includeExtraStats;
 
         internal Engine(
             IHost host,
             IResolver resolver,
             Action dummy1Action, Action dummy2Action, Action dummy3Action, Action<long> overheadAction, Action<long> workloadAction, Job targetJob,
             Action globalSetupAction, Action globalCleanupAction, Action iterationSetupAction, Action iterationCleanupAction, long operationsPerInvoke,
-            bool includeMemoryStats, Encoding encoding, string benchmarkName)
+            bool includeExtraStats, Encoding encoding, string benchmarkName)
         {
             
             Host = host;
@@ -64,7 +64,7 @@ namespace BenchmarkDotNet.Engines
             IterationSetupAction = iterationSetupAction;
             IterationCleanupAction = iterationCleanupAction;
             OperationsPerInvoke = operationsPerInvoke;
-            this.includeMemoryStats = includeMemoryStats;
+            this.includeExtraStats = includeExtraStats;
             BenchmarkName = benchmarkName;
 
             Resolver = resolver;
@@ -128,16 +128,16 @@ namespace BenchmarkDotNet.Engines
 
             Host.AfterMainRun();
 
-            var workGcHasDone = includeMemoryStats 
-                ? MeasureGcStats(new IterationData(IterationMode.Workload, IterationStage.Actual, 0, invokeCount, UnrollFactor)) 
-                : GcStats.Empty;
+            (GcStats workGcHasDone, ThreadingStats threadingStats) = includeExtraStats 
+                ? GetExtraStats(new IterationData(IterationMode.Workload, IterationStage.Actual, 0, invokeCount, UnrollFactor))
+                : (GcStats.Empty, ThreadingStats.Empty);
             
             if (EngineEventSource.Log.IsEnabled())
                 EngineEventSource.Log.BenchmarkStop(BenchmarkName);
 
             var outlierMode = TargetJob.ResolveValue(AccuracyMode.OutlierModeCharacteristic, Resolver);
 
-            return new RunResults(idle, main, outlierMode, workGcHasDone, Encoding);
+            return new RunResults(idle, main, outlierMode, workGcHasDone, threadingStats, Encoding);
         }
 
         public Measurement RunIteration(IterationData data)
@@ -177,7 +177,7 @@ namespace BenchmarkDotNet.Engines
             return measurement;
         }
 
-        private GcStats MeasureGcStats(IterationData data)
+        private (GcStats, ThreadingStats) GetExtraStats(IterationData data)
         {
             // we enable monitoring after main target run, for this single iteration which is executed at the end
             // so even if we enable AppDomain monitoring in separate process
@@ -187,14 +187,19 @@ namespace BenchmarkDotNet.Engines
             IterationSetupAction(); // we run iteration setup first, so even if it allocates, it is not included in the results
 
             var initialGcStats = GcStats.ReadInitial();
+            var initialThreadingStats = ThreadingStats.Read(); // this method does not allocate
 
             WorkloadAction(data.InvokeCount / data.UnrollFactor);
 
+            var finalThreadingStats = ThreadingStats.Read();
             var finalGcStats = GcStats.ReadFinal();
 
             IterationCleanupAction(); // we run iteration cleanup after collecting GC stats 
 
-            return (finalGcStats - initialGcStats).WithTotalOperations(data.InvokeCount * OperationsPerInvoke);
+            GcStats gcStats = (finalGcStats - initialGcStats).WithTotalOperations(data.InvokeCount * OperationsPerInvoke);
+            ThreadingStats threadingStats = (finalThreadingStats - initialThreadingStats).WithTotalOperations(data.InvokeCount * OperationsPerInvoke);
+
+            return (gcStats, threadingStats);
         }
 
         private void GcCollect()

--- a/src/BenchmarkDotNet/Engines/Engine.cs
+++ b/src/BenchmarkDotNet/Engines/Engine.cs
@@ -186,13 +186,13 @@ namespace BenchmarkDotNet.Engines
 
             IterationSetupAction(); // we run iteration setup first, so even if it allocates, it is not included in the results
 
+            var initialThreadingStats = ThreadingStats.ReadInitial(); // this method might allocate
             var initialGcStats = GcStats.ReadInitial();
-            var initialThreadingStats = ThreadingStats.Read(); // this method does not allocate
 
             WorkloadAction(data.InvokeCount / data.UnrollFactor);
 
-            var finalThreadingStats = ThreadingStats.Read();
             var finalGcStats = GcStats.ReadFinal();
+            var finalThreadingStats = ThreadingStats.ReadFinal();
 
             IterationCleanupAction(); // we run iteration cleanup after collecting GC stats 
 

--- a/src/BenchmarkDotNet/Engines/EngineFactory.cs
+++ b/src/BenchmarkDotNet/Engines/EngineFactory.cs
@@ -118,7 +118,7 @@ namespace BenchmarkDotNet.Engines
                 engineParameters.IterationSetupAction,
                 engineParameters.IterationCleanupAction,
                 engineParameters.OperationsPerInvoke,
-                engineParameters.MeasureGcStats,
+                engineParameters.MeasureExtraStats,
                 engineParameters.Encoding,
                 engineParameters.BenchmarkName);
     }

--- a/src/BenchmarkDotNet/Engines/EngineParameters.cs
+++ b/src/BenchmarkDotNet/Engines/EngineParameters.cs
@@ -26,7 +26,7 @@ namespace BenchmarkDotNet.Engines
         public Action GlobalCleanupAction { get; set; }
         public Action IterationSetupAction { get; set; }
         public Action IterationCleanupAction { get; set; }
-        public bool MeasureGcStats { get; set; }
+        public bool MeasureExtraStats { get; set; }
         
         [PublicAPI] public Encoding Encoding { get; set; }
         

--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -7,12 +7,6 @@ using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Engines
 {
-    public struct ThreadingStats
-    {
-        public long CompletedWorkItemCount { get; }
-        public long LockContentionCount { get; }
-    }
-
     public struct GcStats
     {
         internal const string ResultsLinePrefix = "GC: ";

--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -7,6 +7,12 @@ using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Engines
 {
+    public struct ThreadingStats
+    {
+        public long CompletedWorkItemCount { get; }
+        public long LockContentionCount { get; }
+    }
+
     public struct GcStats
     {
         internal const string ResultsLinePrefix = "GC: ";

--- a/src/BenchmarkDotNet/Engines/RunResults.cs
+++ b/src/BenchmarkDotNet/Engines/RunResults.cs
@@ -22,10 +22,13 @@ namespace BenchmarkDotNet.Engines
 
         public GcStats GCStats { get; }
 
+        public ThreadingStats ThreadingStats { get; }
+
         public RunResults([CanBeNull] IReadOnlyList<Measurement> overhead,
                           [NotNull] IReadOnlyList<Measurement> workload,
                           OutlierMode outlierMode,
                           GcStats gcStats,
+                          ThreadingStats threadingStats,
                           Encoding encoding)
         {
             this.outlierMode = outlierMode;
@@ -33,6 +36,7 @@ namespace BenchmarkDotNet.Engines
             Overhead = overhead;
             Workload = workload;
             GCStats = gcStats;
+            ThreadingStats = threadingStats;
         }
 
         public IEnumerable<Measurement> GetMeasurements()
@@ -65,6 +69,7 @@ namespace BenchmarkDotNet.Engines
                 outWriter.WriteLine(measurement.ToOutputLine());
 
             outWriter.WriteLine(GCStats.ToOutputLine());
+            outWriter.WriteLine(ThreadingStats.ToOutputLine());
             outWriter.WriteLine();
         }
 

--- a/src/BenchmarkDotNet/Engines/ThreadingStats.cs
+++ b/src/BenchmarkDotNet/Engines/ThreadingStats.cs
@@ -7,7 +7,7 @@ namespace BenchmarkDotNet.Engines
     {
         internal const string ResultsLinePrefix = "Threading: ";
 
-        // BDN targets .NET Standard 2.0, these properties are not part of it
+        // BDN targets .NET Standard 2.0, these properties are not part of .NET Standard 2.0, were added in .NET Core 3.0
         private static readonly Func<long> GetCompletedWorkItemCountDelegate = CreateGetterDelegate(typeof(ThreadPool), "CompletedWorkItemCount");
         private static readonly Func<long> GetLockContentionCountDelegate = CreateGetterDelegate(typeof(Monitor), "LockContentionCount");
 

--- a/src/BenchmarkDotNet/Engines/ThreadingStats.cs
+++ b/src/BenchmarkDotNet/Engines/ThreadingStats.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Threading;
+
+namespace BenchmarkDotNet.Engines
+{
+    public struct ThreadingStats
+    {
+        internal const string ResultsLinePrefix = "Threading: ";
+
+        private static readonly Func<long> GetCompletedWorkItemCountDelegate = CreateGetCompletedWorkItemCountDelegate();
+        private static readonly Func<long> GetLockContentionCountDelegate = CreateGetLockContentionCountDelegate();
+
+        public static ThreadingStats Empty => new ThreadingStats(0, 0, 0);
+
+        public long CompletedWorkItemCount { get; }
+        public long LockContentionCount { get; }
+        public long TotalOperations { get; }
+
+        public ThreadingStats(long completedWorkItemCount, long lockContentionCount, long totalOperations)
+        {
+            CompletedWorkItemCount = completedWorkItemCount;
+            LockContentionCount = lockContentionCount;
+            TotalOperations = totalOperations;
+        }
+
+        public static ThreadingStats Read()
+        {
+            long completedWorkItemCount = GetCompletedWorkItemCountDelegate != null ? GetCompletedWorkItemCountDelegate() : default;
+            long lockContentionCount = GetLockContentionCountDelegate != null ? GetLockContentionCountDelegate() : default;
+
+            return new ThreadingStats(completedWorkItemCount, lockContentionCount, 0);
+        }
+
+        public string ToOutputLine() => $"{ResultsLinePrefix} {CompletedWorkItemCount} {LockContentionCount} {TotalOperations}";
+
+        public static ThreadingStats Parse(string line)
+        {
+            if (!line.StartsWith(ResultsLinePrefix))
+                throw new NotSupportedException($"Line must start with {ResultsLinePrefix}");
+
+            var measurementSplit = line.Remove(0, ResultsLinePrefix.Length).Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (!long.TryParse(measurementSplit[0], out long completedWorkItemCount)
+                || !long.TryParse(measurementSplit[1], out long lockContentionCount)
+                || !long.TryParse(measurementSplit[2], out long totalOperationsCount))
+            {
+                throw new NotSupportedException("Invalid string");
+            }
+
+            return new ThreadingStats(completedWorkItemCount, lockContentionCount, totalOperationsCount);
+        }
+
+        public static ThreadingStats operator +(ThreadingStats left, ThreadingStats right) 
+            => new ThreadingStats(
+                left.CompletedWorkItemCount + right.CompletedWorkItemCount,
+                left.LockContentionCount + right.LockContentionCount,
+                left.TotalOperations + right.TotalOperations);
+
+        public static ThreadingStats operator -(ThreadingStats left, ThreadingStats right)
+            => new ThreadingStats(
+                left.CompletedWorkItemCount - right.CompletedWorkItemCount,
+                left.LockContentionCount - right.LockContentionCount,
+                left.TotalOperations - right.TotalOperations);
+
+        public ThreadingStats WithTotalOperations(long totalOperationsCount) => this + new ThreadingStats(0, 0, totalOperationsCount);
+
+        public override string ToString() => ToOutputLine();
+
+        // BDN targets .NET Standard 2.0, these methods are not part of it
+        private static Func<long> CreateGetCompletedWorkItemCountDelegate() => CreateGetterDelegate(typeof(ThreadPool), "CompletedWorkItemCount");
+
+        private static Func<long> CreateGetLockContentionCountDelegate() => CreateGetterDelegate(typeof(Monitor), "LockContentionCount");
+
+        private static Func<long> CreateGetterDelegate(Type type, string propertyName)
+        {
+            var property = type.GetProperty(propertyName);
+
+            // we create delegate to avoid boxing, IMPORTANT!
+            return property != null ? (Func<long>)property.GetGetMethod().CreateDelegate(typeof(Func<long>)) : null;
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Reports/BenchmarkReport.cs
+++ b/src/BenchmarkDotNet/Reports/BenchmarkReport.cs
@@ -15,7 +15,6 @@ namespace BenchmarkDotNet.Reports
         public BenchmarkCase BenchmarkCase { get; }
         public IReadOnlyList<Measurement> AllMeasurements { get; }
         public GcStats GcStats { get; }
-        public ThreadingStats ThreadingStats { get; }
         [PublicAPI] public bool Success { get; }
         [PublicAPI] public GenerateResult GenerateResult { get; }
         [PublicAPI] public BuildResult BuildResult { get; }

--- a/src/BenchmarkDotNet/Reports/BenchmarkReport.cs
+++ b/src/BenchmarkDotNet/Reports/BenchmarkReport.cs
@@ -15,6 +15,7 @@ namespace BenchmarkDotNet.Reports
         public BenchmarkCase BenchmarkCase { get; }
         public IReadOnlyList<Measurement> AllMeasurements { get; }
         public GcStats GcStats { get; }
+        public ThreadingStats ThreadingStats { get; }
         [PublicAPI] public bool Success { get; }
         [PublicAPI] public GenerateResult GenerateResult { get; }
         [PublicAPI] public BuildResult BuildResult { get; }

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -330,6 +330,7 @@ namespace BenchmarkDotNet.Running
             var success = true;
             var executeResults = new List<ExecuteResult>();
             var gcStats = default(GcStats);
+            var threadingStats = default(ThreadingStats);
             var metrics = new List<Metric>();
 
             logger.WriteLineInfo("// *** Execute ***");
@@ -401,10 +402,13 @@ namespace BenchmarkDotNet.Running
                 {
                     if (benchmarkCase.Config.HasMemoryDiagnoser())
                         gcStats = GcStats.Parse(executeResult.Data.Last(line => !string.IsNullOrEmpty(line) && line.StartsWith(GcStats.ResultsLinePrefix)));
-                    
+
+                    if (benchmarkCase.Config.HasThreadingDiagnoser())
+                        threadingStats = ThreadingStats.Parse(executeResult.Data.Last(line => !string.IsNullOrEmpty(line) && line.StartsWith(ThreadingStats.ResultsLinePrefix)));
+
                     metrics.AddRange(
                         noOverheadCompositeDiagnoser.ProcessResults(
-                            new DiagnoserResults(benchmarkCase, measurements.Where(measurement => measurement.IsWorkload()).Sum(m => m.Operations), gcStats)));
+                            new DiagnoserResults(benchmarkCase, measurements.Where(measurement => measurement.IsWorkload()).Sum(m => m.Operations), gcStats, threadingStats)));
                 }
 
                 if (autoLaunchCount && launchIndex == 2 && analyzeRunToRunVariance)
@@ -443,7 +447,7 @@ namespace BenchmarkDotNet.Running
 
                 metrics.AddRange(
                     extraRunCompositeDiagnoser.ProcessResults(
-                        new DiagnoserResults(benchmarkCase, allRuns.Where(measurement => measurement.IsWorkload()).Sum(m => m.Operations), gcStats)));
+                        new DiagnoserResults(benchmarkCase, allRuns.Where(measurement => measurement.IsWorkload()).Sum(m => m.Operations), gcStats, threadingStats)));
 
                 logger.WriteLine();
             }

--- a/src/BenchmarkDotNet/Templates/BenchmarkType.txt
+++ b/src/BenchmarkDotNet/Templates/BenchmarkType.txt
@@ -37,7 +37,7 @@
                 IterationCleanupAction = instance.iterationCleanupAction,
                 TargetJob = job,
                 OperationsPerInvoke = $OperationsPerInvoke$,
-                MeasureGcStats = $MeasureGcStats$,
+                MeasureExtraStats = $MeasureExtraStats$,
                 Encoding = $Encoding$,
                 BenchmarkName = benchmarkName
             };

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
@@ -191,6 +191,12 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
         <Assembly Name=""System.Runtime"">
             <Type Name=""System.GC"" Dynamic=""Required All"" />
         </Assembly>
+        <Assembly Name=""System.Threading.ThreadPool"">
+            <Type Name=""System.Threading.ThreadPool"" Dynamic=""Required All"" />
+        </Assembly>
+        <Assembly Name=""System.Threading"">
+            <Type Name=""System.Threading.Monitor"" Dynamic=""Required All"" />
+        </Assembly>
     </Application>
 </Directives>
 ";

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
@@ -86,6 +86,9 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
         public bool Is(TargetFrameworkMoniker targetFrameworkMoniker) => targetFrameworkMoniker.ToMsBuildName() == TargetFrameworkMoniker;
 
+        public bool IsOlderThan(TargetFrameworkMoniker targetFrameworkMoniker) 
+            => TargetFrameworkMoniker.CompareTo(targetFrameworkMoniker.ToMsBuildName()) < 0;
+
         public NetCoreAppSettings WithCustomDotNetCliPath(string customDotNetCliPath, string displayName = null)
             => new NetCoreAppSettings(TargetFrameworkMoniker, RuntimeFrameworkVersion, displayName ?? Name, customDotNetCliPath, PackagesPath, Timeout);
         

--- a/src/BenchmarkDotNet/Toolchains/InProcess.Emit.Implementation/Runnable/RunnableReuse.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.Emit.Implementation/Runnable/RunnableReuse.cs
@@ -101,7 +101,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation
                 IterationCleanupAction = CallbackFromField(instance, IterationSetupActionFieldName),
                 TargetJob = benchmarkCase.Job,
                 OperationsPerInvoke = benchmarkCase.Descriptor.OperationsPerInvoke,
-                MeasureGcStats = benchmarkCase.Config.HasMemoryDiagnoser(),
+                MeasureExtraStats = benchmarkCase.Config.HasExtraStatsDiagnoser(),
                 Encoding = benchmarkCase.Config.Encoding,
                 BenchmarkName = FullNameProvider.GetBenchmarkName(benchmarkCase)
             };

--- a/src/BenchmarkDotNet/Toolchains/InProcess.Emit/InProcessEmitExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.Emit/InProcessEmitExecutor.cs
@@ -138,6 +138,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess.Emit
 
             var lines = runResults.GetMeasurements().Select(measurement => measurement.ToOutputLine()).ToList();
             lines.Add(runResults.GCStats.ToOutputLine());
+            lines.Add(runResults.ThreadingStats.ToOutputLine());
 
             return new ExecuteResult(true, 0, default, lines.ToArray(), Array.Empty<string>());
         }

--- a/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitExecutor.cs
@@ -128,6 +128,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
 
             var lines = runResults.GetMeasurements().Select(measurement => measurement.ToOutputLine()).ToList();
             lines.Add(runResults.GCStats.ToOutputLine());
+            lines.Add(runResults.GCStats.ToOutputLine());
 
             return new ExecuteResult(true, 0, default, lines.ToArray(), Array.Empty<string>());
         }

--- a/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitRunner.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitRunner.cs
@@ -151,7 +151,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
                     IterationCleanupAction = iterationCleanupAction.InvokeSingle,
                     TargetJob = job,
                     OperationsPerInvoke = target.OperationsPerInvoke,
-                    MeasureExtraStats = benchmarkCase.Config.HasThreadingDiagnoser(),
+                    MeasureExtraStats = benchmarkCase.Config.HasExtraStatsDiagnoser(),
                     Encoding = benchmarkCase.Config.Encoding,
                     BenchmarkName = FullNameProvider.GetBenchmarkName(benchmarkCase)
                 };

--- a/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitRunner.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitRunner.cs
@@ -151,7 +151,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
                     IterationCleanupAction = iterationCleanupAction.InvokeSingle,
                     TargetJob = job,
                     OperationsPerInvoke = target.OperationsPerInvoke,
-                    MeasureGcStats = benchmarkCase.Config.HasMemoryDiagnoser(),
+                    MeasureExtraStats = benchmarkCase.Config.HasThreadingDiagnoser(),
                     Encoding = benchmarkCase.Config.Encoding,
                     BenchmarkName = FullNameProvider.GetBenchmarkName(benchmarkCase)
                 };

--- a/src/BenchmarkDotNet/Toolchains/InProcess/InProcessExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/InProcessExecutor.cs
@@ -132,6 +132,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess
 
             var lines = runResults.GetMeasurements().Select(measurement => measurement.ToOutputLine()).ToList();
             lines.Add(runResults.GCStats.ToOutputLine());
+            lines.Add(runResults.ThreadingStats.ToOutputLine());
 
             return new ExecuteResult(true, 0, default, lines.ToArray(), Array.Empty<string>());
         }

--- a/src/BenchmarkDotNet/Toolchains/InProcess/InProcessRunner.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/InProcessRunner.cs
@@ -149,7 +149,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess
                     IterationCleanupAction = iterationCleanupAction.InvokeSingle,
                     TargetJob = job,
                     OperationsPerInvoke = target.OperationsPerInvoke,
-                    MeasureExtraStats = benchmarkCase.Config.HasThreadingDiagnoser(),
+                    MeasureExtraStats = benchmarkCase.Config.HasExtraStatsDiagnoser(),
                     BenchmarkName = FullNameProvider.GetBenchmarkName(benchmarkCase)
                 };
 

--- a/src/BenchmarkDotNet/Toolchains/InProcess/InProcessRunner.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/InProcessRunner.cs
@@ -149,7 +149,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess
                     IterationCleanupAction = iterationCleanupAction.InvokeSingle,
                     TargetJob = job,
                     OperationsPerInvoke = target.OperationsPerInvoke,
-                    MeasureGcStats = benchmarkCase.Config.HasMemoryDiagnoser(),
+                    MeasureExtraStats = benchmarkCase.Config.HasThreadingDiagnoser(),
                     BenchmarkName = FullNameProvider.GetBenchmarkName(benchmarkCase)
                 };
 

--- a/tests/BenchmarkDotNet.IntegrationTests/CustomEngineTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/CustomEngineTests.cs
@@ -80,6 +80,7 @@ namespace BenchmarkDotNet.IntegrationTests
                     new List<Measurement> { new Measurement(1, IterationMode.Workload, IterationStage.Actual, 1, 1, 1) },
                     OutlierMode.DontRemove,
                     default,
+                    default,
                     default);
             }
 

--- a/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
@@ -1,0 +1,153 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Portability;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Tests.Loggers;
+using BenchmarkDotNet.Toolchains;
+using BenchmarkDotNet.Toolchains.DotNetCli;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class ThreadingDiagnoserTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public ThreadingDiagnoserTests(ITestOutputHelper outputHelper) => output = outputHelper;
+
+        public static IEnumerable<object[]> GetToolchains()
+            => !RuntimeInformation.IsNetCore || !NetCoreAppSettings.GetCurrentVersion().Is(TargetFrameworkMoniker.NetCoreApp30) // APIs added in .NET Core 3.0 https://github.com/dotnet/corefx/issues/35500
+                ? Array.Empty<object[]>()
+                : new[]
+                {
+                    new object[] { Job.Default.GetToolchain() },
+                    new object[] { InProcessEmitToolchain.Instance },
+                };
+
+        [Theory, MemberData(nameof(GetToolchains))]
+        public void CompletedWorkItemCounIsAccurate(IToolchain toolchain)
+        {
+            var config = CreateConfig(toolchain);
+
+            var summary = BenchmarkRunner.Run<CompletedWorkItemCount>(config);
+
+            AssertStats(summary, new Dictionary<string, Action<ThreadingStats>>
+            {
+                { nameof(CompletedWorkItemCount.DoNothing), stats => Assert.Equal(0, stats.CompletedWorkItemCount) },
+                { nameof(CompletedWorkItemCount.CompleteOneWorkItem), stats => Assert.Equal(1, stats.CompletedWorkItemCount) }
+            });
+        }
+
+        public class CompletedWorkItemCount
+        {
+            [Benchmark]
+            public void CompleteOneWorkItem()
+            {
+                ManualResetEvent done = new ManualResetEvent(false);
+                ThreadPool.QueueUserWorkItem(m => (m as ManualResetEvent).Set(), done);
+                done.WaitOne();
+            }
+
+            [Benchmark]
+            public void DoNothing() { }
+        }
+
+        [Theory, MemberData(nameof(GetToolchains))]
+        public void LockContentionCountIsAccurate(IToolchain toolchain)
+        {
+            var config = CreateConfig(toolchain);
+
+            var summary = BenchmarkRunner.Run<LockContentionCount>(config);
+
+            AssertStats(summary, new Dictionary<string, Action<ThreadingStats>>
+            {
+                { nameof(LockContentionCount.DoNothing), stats => Assert.Equal(0, stats.LockContentionCount) },
+                { nameof(LockContentionCount.RunIntoLockContention), stats => Assert.Equal(1, stats.LockContentionCount) }
+            });
+        }
+
+        public class LockContentionCount
+        {
+            private readonly object guard = new object();
+
+            private ManualResetEvent lockTaken;
+            private ManualResetEvent failedToAcquire;
+
+            [Benchmark]
+            public void DoNothing() { }
+
+            [Benchmark]
+            public void RunIntoLockContention()
+            {
+                lockTaken = new ManualResetEvent(false);
+                failedToAcquire = new ManualResetEvent(false);
+
+                Thread first = new Thread(FirstThread);
+                Thread second = new Thread(SecondThread);
+
+                first.Start();
+                second.Start();
+
+                second.Join();
+                first.Join();
+            }
+
+            void FirstThread()
+            {
+                Monitor.Enter(guard);
+                lockTaken.Set();
+
+                failedToAcquire.WaitOne();
+                Monitor.Exit(guard);
+            }
+
+            void SecondThread()
+            {
+                lockTaken.WaitOne();
+
+                bool taken = Monitor.TryEnter(guard, TimeSpan.FromMilliseconds(10));
+
+                if (taken)
+                {
+                    throw new InvalidOperationException("Impossible!");
+                }
+
+                failedToAcquire.Set();
+            }
+        }
+
+        private IConfig CreateConfig(IToolchain toolchain)
+            => ManualConfig.CreateEmpty()
+                .With(Job.ShortRun
+                    .WithEvaluateOverhead(false) // no need to run idle for this test
+                    .WithWarmupCount(0) // don't run warmup to save some time for our CI runs
+                    .WithIterationCount(1) // single iteration is enough for us
+                    .WithGcForce(false)
+                    .With(toolchain))
+                .With(DefaultColumnProviders.Instance)
+                .With(ThreadingDiagnoser.Default)
+                .With(toolchain.IsInProcess ? ConsoleLogger.Default : new OutputLogger(output)); // we can't use OutputLogger for the InProcess toolchains because it allocates memory on the same thread
+
+        private void AssertStats(Summary summary, Dictionary<string, Action<ThreadingStats>> assertions)
+        {
+            foreach (var assertion in assertions)
+            {
+                var selectedReport = summary.Reports.Single(report => report.BenchmarkCase.DisplayInfo.Contains(assertion.Key));
+
+                assertion.Value(selectedReport.ThreadingStats);
+            }
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
@@ -1,4 +1,5 @@
-﻿using BenchmarkDotNet.Attributes;
+#if NETCOREAPP3_0
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
@@ -27,15 +28,12 @@ namespace BenchmarkDotNet.IntegrationTests
 
         public ThreadingDiagnoserTests(ITestOutputHelper outputHelper) => output = outputHelper;
 
-        public static IEnumerable<object[]> GetToolchains()
-            => !RuntimeInformation.IsNetCore || !NetCoreAppSettings.GetCurrentVersion().Is(TargetFrameworkMoniker.NetCoreApp30) // APIs added in .NET Core 3.0 https://github.com/dotnet/corefx/issues/35500
-                ? Array.Empty<object[]>()
-                : new[]
-                {
-                    new object[] { Job.Default.GetToolchain() },
-                    new object[] { CoreRtToolchain.LatestBuild },
-                    new object[] { InProcessEmitToolchain.Instance },
-                };
+        public static IEnumerable<object[]> GetToolchains() => new[]
+        {
+            new object[] { Job.Default.GetToolchain() },
+            new object[] { CoreRtToolchain.LatestBuild },
+            new object[] { InProcessEmitToolchain.Instance },
+        };
 
         [Theory, MemberData(nameof(GetToolchains))]
         public void CompletedWorkItemCounIsAccurate(IToolchain toolchain)
@@ -155,3 +153,4 @@ namespace BenchmarkDotNet.IntegrationTests
         }
     }
 }
+#endif

--- a/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
@@ -147,7 +147,8 @@ namespace BenchmarkDotNet.IntegrationTests
 
                 var metric = selectedReport.Metrics.Single(m => m.Key == assertion.Value.metricName);
 
-                Assert.Equal(assertion.Value.expectedValue, metric.Value.Value);
+                // precision is set to 3 because CoreCLR might schedule some work item on it's own and hence affect the results..
+                Assert.Equal(assertion.Value.expectedValue, metric.Value.Value, precision: 3);
             }
         }
     }

--- a/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
@@ -9,6 +9,7 @@ using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Tests.Loggers;
 using BenchmarkDotNet.Toolchains;
+using BenchmarkDotNet.Toolchains.CoreRt;
 using BenchmarkDotNet.Toolchains.DotNetCli;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using System;
@@ -32,6 +33,7 @@ namespace BenchmarkDotNet.IntegrationTests
                 : new[]
                 {
                     new object[] { Job.Default.GetToolchain() },
+                    new object[] { CoreRtToolchain.LatestBuild },
                     new object[] { InProcessEmitToolchain.Instance },
                 };
 

--- a/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
@@ -16,7 +16,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
         public class ValuesReturnedByBenchmark
         {
-#if !CORE
+#if !NETCOREAPP
             [Benchmark]
             public System.Windows.Point? TypeFromCustomFrameworkAssembly() => new System.Windows.Point();
 

--- a/tests/BenchmarkDotNet.Tests/Engine/EngineResultStageTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Engine/EngineResultStageTests.cs
@@ -31,7 +31,7 @@ namespace BenchmarkDotNet.Tests.Engine
         [AssertionMethod]
         private static void CheckResults(int expectedResultCount, List<Measurement> measurements, OutlierMode outlierMode)
         {
-            Assert.Equal(expectedResultCount, new RunResults(null, measurements, outlierMode, default, default).GetMeasurements().Count());
+            Assert.Equal(expectedResultCount, new RunResults(null, measurements, outlierMode, default, default, default).GetMeasurements().Count());
         }
 
         private static void Add(List<Measurement> measurements, int time)

--- a/tests/BenchmarkDotNet.Tests/NetCoreAppSettingsTests.cs
+++ b/tests/BenchmarkDotNet.Tests/NetCoreAppSettingsTests.cs
@@ -1,0 +1,21 @@
+﻿using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.DotNetCli;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests
+{
+    public class NetCoreAppSettingsTests
+    {
+        [Fact]
+        public void IsOlderThanWorksAsExpected()
+        {
+            Assert.True(NetCoreAppSettings.NetCoreApp20.IsOlderThan(TargetFrameworkMoniker.NetCoreApp30));
+            Assert.True(NetCoreAppSettings.NetCoreApp21.IsOlderThan(TargetFrameworkMoniker.NetCoreApp30));
+            Assert.True(NetCoreAppSettings.NetCoreApp22.IsOlderThan(TargetFrameworkMoniker.NetCoreApp30));
+
+            Assert.False(NetCoreAppSettings.NetCoreApp30.IsOlderThan(TargetFrameworkMoniker.NetCoreApp30));
+            Assert.True(NetCoreAppSettings.NetCoreApp30.IsOlderThan(TargetFrameworkMoniker.NetCoreApp31));
+            Assert.True(NetCoreAppSettings.NetCoreApp30.IsOlderThan(TargetFrameworkMoniker.NetCoreApp50));
+        }
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/dotnet/BenchmarkDotNet/issues/1154

The `ThreadingDiagnoser` uses new APIs [exposed](https://github.com/dotnet/corefx/issues/35500) in .NET Core 3.0 to report:

* Completed Work Items: The number of work items that have been processed in ThreadPool (per single operation)
* Lock Contentions: The number of times there **was contention** upon trying to take a Monitor's lock (per single operation)

Sample:

```cs
[ThreadingDiagnoser] // ENABLE the diagnoser
public class IntroThreadingDiagnoser
{
    [Benchmark]
    public void CompleteOneWorkItem()
    {
        ManualResetEvent done = new ManualResetEvent(initialState: false);

        ThreadPool.QueueUserWorkItem(m => (m as ManualResetEvent).Set(), done);

        done.WaitOne();
    }

   [Benchmark]
    public void DoNothing() { }
}
```

|              Method |        Median | Completed Work Items | Lock Contentions |
|-------------------- |--------------:|---------------------:|-----------------:|
| CompleteOneWorkItem | 8,111.6074 ns |               1.0000 |                - |
|           DoNothing |     0.0000 ns |               0.0000 |                - |

I've implemented integration tests to make sure it works as expected for .NET Core 3.0, CoreRT and the `InProcessEmitToolchain`.

/cc @stephentoub
