### PR TITLE
Support IEnumerable as benchmark argument

### DIFF
--- a/src/BenchmarkDotNet/Parameters/ParameterDefinition.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterDefinition.cs
@@ -1,4 +1,6 @@
-﻿namespace BenchmarkDotNet.Parameters
+﻿using System;
+
+namespace BenchmarkDotNet.Parameters
 {
     public class ParameterDefinition
     {
@@ -6,13 +8,15 @@
         public bool IsStatic { get; }
         public object[] Values { get; }
         public bool IsArgument { get; }
+        public Type ParameterType { get; }
 
-        public ParameterDefinition(string name, bool isStatic, object[] values, bool isArgument)
+        public ParameterDefinition(string name, bool isStatic, object[] values, bool isArgument, Type parameterType)
         {
             Name = name;
             IsStatic = isStatic;
             Values = values;
             IsArgument = isArgument;
+            ParameterType = parameterType;
         }
     }
 }

--- a/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
+++ b/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
@@ -83,7 +83,7 @@ namespace BenchmarkDotNet.Parameters
 
         public string ToSourceCode()
         {
-            string cast = $"({Value.GetType().GetCorrectCSharpTypeName()})"; // it's an object so we need to cast it to the right type
+            string cast = $"({parameterDefinitions[argumentIndex].ParameterType.GetCorrectCSharpTypeName()})"; // it's an object so we need to cast it to the right type
 
             string callPostfix = source is PropertyInfo ? string.Empty : "()";
 

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -174,7 +174,8 @@ namespace BenchmarkDotNet.Running
                         member.Name,
                         member.IsStatic,
                         getValidValues(member.Attribute, member.ParameterType),
-                        false));
+                        false,
+                        member.ParameterType));
             }
 
             var paramsDefinitions = GetDefinitions<ParamsAttribute>((attribute, parameterType) => GetValidValues(attribute.Values, parameterType));
@@ -195,7 +196,7 @@ namespace BenchmarkDotNet.Running
         private static IEnumerable<ParameterInstances> GetArgumentsDefinitions(MethodInfo benchmark, Type target)
         {
             var parameterDefinitions = benchmark.GetParameters()
-                .Select(parameter => new ParameterDefinition(parameter.Name, false, Array.Empty<object>(), true))
+                .Select(parameter => new ParameterDefinition(parameter.Name, false, Array.Empty<object>(), true, parameter.ParameterType))
                 .ToArray();
 
             if (parameterDefinitions.IsEmpty())

--- a/tests/BenchmarkDotNet.IntegrationTests/ArgumentsTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ArgumentsTests.cs
@@ -172,6 +172,31 @@ namespace BenchmarkDotNet.IntegrationTests
         }
 
         [Theory, MemberData(nameof(GetToolchains))]
+        public void IEnumerableCanBeUsedAsArgument(IToolchain toolchain) => CanExecute<WithIEnumerable>(toolchain);
+
+        public class WithIEnumerable
+        {
+            private static IEnumerable<int> Iterator() { yield return 1; }
+
+            public IEnumerable<object[]> Sources()
+            {
+                yield return new object[] { "Empty", Enumerable.Empty<int>() };
+                yield return new object[] { "Range", Enumerable.Range(0, 10) };
+                yield return new object[] { "List", new List<int>() { 1, 2, 3 } };
+                yield return new object[] { "int[]", new int[] { 1, 2, 3 } };
+                yield return new object[] { "int[].Select", new int[] { 1, 2, 3 }.Select(i => i) };
+                yield return new object[] { "int[].Select.Where", new int[] { 1, 2, 3 }.Select(i => i).Where(i => i % 2 == 0) };
+                yield return new object[] { "Iterator", Iterator() };
+                yield return new object[] { "Iterator.Select", Iterator().Select(i => i) };
+                yield return new object[] { "Iterator.Select.Where", Iterator().Select(i => i).Where(i => i % 2 == 0) };
+            }
+
+            [Benchmark]
+            [ArgumentsSource(nameof(Sources))]
+            public void Any(string name, IEnumerable<int> source) => source.Any();
+        }
+
+        [Theory, MemberData(nameof(GetToolchains))]
         public void JaggedArrayCanBeUsedAsArgument(IToolchain toolchain) => CanExecute<WithJaggedArray>(toolchain);
 
         public class WithJaggedArray

--- a/tests/BenchmarkDotNet.Tests/ParameterComparerTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ParameterComparerTests.cs
@@ -12,7 +12,7 @@ namespace BenchmarkDotNet.Tests
         {
             var comparer = ParameterComparer.Instance;
 
-            var sharedDefinition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false);
+            var sharedDefinition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false, parameterType: null);
             var originalData = new[]
             {
                 new ParameterInstances(new[]
@@ -40,7 +40,7 @@ namespace BenchmarkDotNet.Tests
         {
             var comparer = ParameterComparer.Instance;
 
-            var sharedDefinition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false);
+            var sharedDefinition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false, parameterType: null);
             var originalData = new[]
             {
                 new ParameterInstances(new[]
@@ -94,7 +94,7 @@ namespace BenchmarkDotNet.Tests
         {
             var comparer = ParameterComparer.Instance;
 
-            var sharedDefinition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false);
+            var sharedDefinition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false, parameterType: null);
             var originalData = new[]
             {
                 new ParameterInstances(new[]

--- a/tests/BenchmarkDotNet.Tests/ParameterInstanceTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ParameterInstanceTests.cs
@@ -7,7 +7,7 @@ namespace BenchmarkDotNet.Tests
 {
     public class ParameterInstanceTests
     {
-        private static readonly ParameterDefinition definition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false);
+        private static readonly ParameterDefinition definition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false, parameterType: null);
 
         [Theory]
         [InlineData(5)]


### PR DESCRIPTION
This is a fix for bug reported by @stephentoub in https://github.com/dotnet/corefx/pull/40377

