### PR TITLE
Amend SummaryStyle to support visualization of '0' in reports

### DIFF
--- a/src/BenchmarkDotNet/Columns/MetricColumn.cs
+++ b/src/BenchmarkDotNet/Columns/MetricColumn.cs
@@ -28,7 +28,7 @@ namespace BenchmarkDotNet.Columns
         
         public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style) 
         {
-            if (!summary.HasReport(benchmarkCase) || !summary[benchmarkCase].Metrics.TryGetValue(descriptor.Id, out Metric metric) || metric.Value == 0.0)
+            if (!summary.HasReport(benchmarkCase) || !summary[benchmarkCase].Metrics.TryGetValue(descriptor.Id, out Metric metric) || (metric.Value == 0.0 && !style.PrintZeroValuesInContent))
                 return "-";
 
             if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Size)

--- a/src/BenchmarkDotNet/Exporters/Csv/CsvExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/Csv/CsvExporter.cs
@@ -10,9 +10,9 @@ namespace BenchmarkDotNet.Exporters.Csv
         private readonly CsvSeparator separator;
         protected override string FileExtension => "csv";
 
-        public static readonly IExporter Default = new CsvExporter(CsvSeparator.CurrentCulture, SummaryStyle.Default);
+        public static readonly IExporter Default = new CsvExporter(CsvSeparator.CurrentCulture, SummaryStyle.Default.WithZeroMetricValuesInContent());
 
-        public CsvExporter(CsvSeparator separator) : this (separator, SummaryStyle.Default)
+        public CsvExporter(CsvSeparator separator) : this (separator, SummaryStyle.Default.WithZeroMetricValuesInContent())
         {
         }
 

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -7,26 +7,31 @@ namespace BenchmarkDotNet.Reports
 {
     public class SummaryStyle : IEquatable<SummaryStyle>
     {
-        public static readonly SummaryStyle Default = new SummaryStyle(printUnitsInHeader: false, printUnitsInContent: true, sizeUnit: null, timeUnit: null);
+        public static readonly SummaryStyle Default = new SummaryStyle(printUnitsInHeader: false, printUnitsInContent: true, printZeroValuesInContent: false, sizeUnit: null, timeUnit: null);
 
         public bool PrintUnitsInHeader { get; }
         public bool PrintUnitsInContent { get; }
+        public bool PrintZeroValuesInContent { get; }
         public SizeUnit SizeUnit { get; }
         public TimeUnit TimeUnit { get; }
 
-        public SummaryStyle(bool printUnitsInHeader, SizeUnit sizeUnit, TimeUnit timeUnit, bool printUnitsInContent = true)
+        public SummaryStyle(bool printUnitsInHeader, SizeUnit sizeUnit, TimeUnit timeUnit, bool printUnitsInContent = true, bool printZeroValuesInContent = false)
         {
             PrintUnitsInHeader = printUnitsInHeader;
             PrintUnitsInContent = printUnitsInContent;
             SizeUnit = sizeUnit;
             TimeUnit = timeUnit;
+            PrintZeroValuesInContent = printZeroValuesInContent;
         }
 
         public SummaryStyle WithTimeUnit(TimeUnit timeUnit)
-            => new SummaryStyle(PrintUnitsInHeader, SizeUnit, timeUnit, PrintUnitsInContent);
+            => new SummaryStyle(PrintUnitsInHeader, SizeUnit, timeUnit, PrintUnitsInContent, PrintZeroValuesInContent);
 
         public SummaryStyle WithSizeUnit(SizeUnit sizeUnit)
-            => new SummaryStyle(PrintUnitsInHeader, sizeUnit, TimeUnit, PrintUnitsInContent);
+            => new SummaryStyle(PrintUnitsInHeader, sizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent);
+
+        public SummaryStyle WithZeroMetricValuesInContent()
+            => new SummaryStyle(PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, printZeroValuesInContent: true);
 
         public bool Equals(SummaryStyle other)
         {
@@ -34,7 +39,11 @@ namespace BenchmarkDotNet.Reports
                 return false;
             if (ReferenceEquals(this, other))
                 return true;
-            return PrintUnitsInHeader == other.PrintUnitsInHeader && PrintUnitsInContent == other.PrintUnitsInContent && Equals(SizeUnit, other.SizeUnit) && Equals(TimeUnit, other.TimeUnit);
+            return PrintUnitsInHeader == other.PrintUnitsInHeader
+                && PrintUnitsInContent == other.PrintUnitsInContent
+                && PrintZeroValuesInContent == other.PrintZeroValuesInContent
+                && Equals(SizeUnit, other.SizeUnit)
+                && Equals(TimeUnit, other.TimeUnit);
         }
 
         public override bool Equals(object obj)
@@ -54,6 +63,7 @@ namespace BenchmarkDotNet.Reports
             {
                 int hashCode = PrintUnitsInHeader.GetHashCode();
                 hashCode = (hashCode * 397) ^ PrintUnitsInContent.GetHashCode();
+                hashCode = (hashCode * 397) ^ PrintZeroValuesInContent.GetHashCode();
                 hashCode = (hashCode * 397) ^ (SizeUnit != null ? SizeUnit.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (TimeUnit != null ? TimeUnit.GetHashCode() : 0);
                 return hashCode;

--- a/tests/BenchmarkDotNet.Tests/Reports/FakeMetricDescriptor.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/FakeMetricDescriptor.cs
@@ -1,0 +1,23 @@
+﻿using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Reports;
+
+namespace BenchmarkDotNet.Tests.Reports
+{
+    internal sealed class FakeMetricDescriptor : IMetricDescriptor
+    {
+        public FakeMetricDescriptor(string id, string legend, string numberFormat = null)
+        {
+            Id = id;
+            Legend = legend;
+            NumberFormat = numberFormat;
+        }
+
+        public string Id { get; }
+        public string DisplayName => Id;
+        public string Legend { get; }
+        public string NumberFormat { get; }
+        public UnitType UnitType { get; }
+        public string Unit { get; }
+        public bool TheGreaterTheBetter { get; }
+    }
+}

--- a/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
@@ -75,5 +75,38 @@ namespace BenchmarkDotNet.Tests.Reports
                         defaultOrderer.SummaryOrderPolicy == SummaryOrderPolicy.FastestToSlowest &&
                         defaultOrderer.MethodOrderPolicy == MethodOrderPolicy.Alphabetical);
         }
+
+        [Fact] // Issue #1168
+        public void ZeroValueInMetricColumnIsDashedByDefault()
+        {
+            // arrange
+            var config = ManualConfig.Create(DefaultConfig.Instance);
+            var metrics = new[] { new Metric(new FakeMetricDescriptor("metric1", "some legend", "0.0"), 0.0) };
+
+            // act
+            var summary = MockFactory.CreateSummary(config, hugeSd: false, metrics);
+            var table = new SummaryTable(summary);
+            var actual = table.Columns.First(c => c.Header == "metric1").Content;
+
+            // assert
+            Assert.True(actual.All(value => "-" == value));
+        }
+
+        [Fact] // Issue #1168
+        public void ZeroValueInMetricColumnIsNotDashedWithCustomStyle()
+        {
+            // arrange
+            var config = ManualConfig.Create(DefaultConfig.Instance);
+            var metrics = new[] { new Metric(new FakeMetricDescriptor("metric1", "some legend", "0.0"), 0.0) };
+            var style = config.SummaryStyle.WithZeroMetricValuesInContent();
+
+            // act
+            var summary = MockFactory.CreateSummary(config, hugeSd: false, metrics);
+            var table = new SummaryTable(summary, style);
+            var actual = table.Columns.First(c => c.Header == "metric1").Content;
+
+            // assert
+            Assert.True(actual.All(value => "0.0" == value));
+        }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/SummaryStyleTests.cs
+++ b/tests/BenchmarkDotNet.Tests/SummaryStyleTests.cs
@@ -15,6 +15,7 @@ namespace BenchmarkDotNet.Tests
             (
                 printUnitsInHeader: true,
                 printUnitsInContent: false,
+                printZeroValuesInContent: true,
                 sizeUnit: SizeUnit.B,
                 timeUnit: TimeUnit.Millisecond
             );
@@ -23,6 +24,7 @@ namespace BenchmarkDotNet.Tests
             
             Assert.True(config.SummaryStyle.PrintUnitsInHeader);
             Assert.False(config.SummaryStyle.PrintUnitsInContent);
+            Assert.True(config.SummaryStyle.PrintZeroValuesInContent);
             Assert.Equal(SizeUnit.B, config.SummaryStyle.SizeUnit);
             Assert.Equal(TimeUnit.Millisecond, config.SummaryStyle.TimeUnit);
         }


### PR DESCRIPTION
In order to use generated csv reports for publishing results to TSDB (e.g. Influx) we need to change the way '0' are visualized. By default they are dashed '-'. The goal of this PR is to change it for CsvExporter, but leave it as it is for the other exporters (console/GH/HTML).

Addresses #1168 