### PR TITLE
LINQPad 6 support using InProcessEmitToolchain

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.Windows/Sessions.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/Sessions.cs
@@ -138,7 +138,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
 
             // if we run for more than one toolchain, the output file name should contain the name too so we can differ net461 vs netcoreapp2.1 etc
             if (details.Config.GetJobs().Select(job => job.GetToolchain()).Distinct().Count() > 1)
-                fileName += $"-{details.BenchmarkCase.Job.Environment.Runtime?.Name ?? details.BenchmarkCase.Job.GetToolchain()?.Name ?? details.BenchmarkCase.Job.Id}";
+                fileName += $"-{details.BenchmarkCase.Job.Environment.Runtime?.Name ?? details.BenchmarkCase.GetToolchain()?.Name ?? details.BenchmarkCase.Job.Id}";
 
             fileName += $"-{creationTime.ToString(BenchmarkRunnerClean.DateTimeFormat)}";
 

--- a/src/BenchmarkDotNet/Code/CodeGenerator.cs
+++ b/src/BenchmarkDotNet/Code/CodeGenerator.cs
@@ -98,7 +98,7 @@ namespace BenchmarkDotNet.Code
         {
             string benchmarkDotNetLocation = Path.GetDirectoryName(typeof(CodeGenerator).GetTypeInfo().Assembly.Location);
 
-            if (benchmarkDotNetLocation != null && benchmarkDotNetLocation.ToUpper().Contains("LINQPAD"))
+            if (benchmarkDotNetLocation != null && benchmarkDotNetLocation.IndexOf("LINQPAD", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 /* "LINQPad normally puts the compiled query into a different folder than the referenced assemblies 
                  * - this allows for optimizations to reduce file I/O, which is important in the scratchpad scenario"

--- a/src/BenchmarkDotNet/Extensions/ReflectionExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ReflectionExtensions.cs
@@ -210,6 +210,6 @@ namespace BenchmarkDotNet.Extensions
                 (!typeInfo.IsGenericTypeDefinition || typeInfo.GenericTypeArguments.Any() || typeInfo.GetCustomAttributes(true).OfType<GenericTypeArgumentsAttribute>().Any())
                     && typeInfo.DeclaredConstructors.Any(ctor => ctor.IsPublic && ctor.GetParameters().Length == 0); // we need public parameterless ctor to create it       
 
-        internal static bool IsLinqPad(this Assembly assembly) => assembly.FullName.ToUpper().Contains("LINQPAD");
+        internal static bool IsLinqPad(this Assembly assembly) => assembly.FullName.IndexOf("LINQPAD", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 }

--- a/src/BenchmarkDotNet/Loggers/LinqPadLogger.cs
+++ b/src/BenchmarkDotNet/Loggers/LinqPadLogger.cs
@@ -17,13 +17,15 @@ namespace BenchmarkDotNet.Loggers
         {
             // Detect if being run from LINQPad; see https://github.com/dotnet/BenchmarkDotNet/issues/445#issuecomment-300723741
             MethodInfo withStyle = null;
-            if (AppDomain.CurrentDomain.FriendlyName.StartsWith("LINQPad Query Server", StringComparison.OrdinalIgnoreCase))
+            if (AppDomain.CurrentDomain.FriendlyName.StartsWith("LINQPad", StringComparison.OrdinalIgnoreCase))
             {
                 try
                 {
                     // Use reflection to avoid taking a dependency on the LINQPad assembly
-                    var util = Type.GetType("LINQPad.Util, LINQPad, Version=1.0.0.0, Culture=neutral, PublicKeyToken=21353812cd2a2db5", throwOnError: true);
-                    withStyle = util.GetMethod("WithStyle", BindingFlags.Static | BindingFlags.Public);
+                    var util = Type.GetType("LINQPad.Util, LINQPad, Version=1.0.0.0, Culture=neutral, PublicKeyToken=21353812cd2a2db5", throwOnError: false) ??
+                               Type.GetType("LINQPad.Util, LINQPad.Runtime, Version=1.0.0.0, Culture=neutral, PublicKeyToken=21353812cd2a2db5", throwOnError: false);
+
+                    withStyle = util?.GetMethod("WithStyle", BindingFlags.Static | BindingFlags.Public);
                 }
                 catch (Exception)
                 {

--- a/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
@@ -35,7 +35,7 @@ namespace BenchmarkDotNet.Running
 
                 if (AreDifferent(GetRuntime(jobX), GetRuntime(jobY))) // Mono vs .NET vs Core
                     return false;
-                if (AreDifferent(jobX.GetToolchain(), jobY.GetToolchain())) // Mono vs .NET vs Core vs InProcess
+                if (AreDifferent(x.GetToolchain(), y.GetToolchain())) // Mono vs .NET vs Core vs InProcess
                     return false;
                 if (jobX.Environment.Jit != jobY.Environment.Jit) // Jit is set per exe in .config file
                     return false;
@@ -67,7 +67,7 @@ namespace BenchmarkDotNet.Running
             {
                 var job = obj.Job;
 
-                int hashCode = job.GetToolchain().GetHashCode();
+                int hashCode = obj.GetToolchain().GetHashCode();
 
                 hashCode ^=  GetRuntime(job).GetType().MetadataToken;
 

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -286,7 +286,7 @@ namespace BenchmarkDotNet.Running
 
         private static BuildResult Build(BuildPartition buildPartition, string rootArtifactsFolderPath, ILogger buildLogger)
         {
-            var toolchain = buildPartition.RepresentativeBenchmarkCase.Job.GetToolchain(); // it's guaranteed that all the benchmarks in single partition have same toolchain
+            var toolchain = buildPartition.RepresentativeBenchmarkCase.GetToolchain(); // it's guaranteed that all the benchmarks in single partition have same toolchain
 
             var generateResult = toolchain.Generator.GenerateProject(buildPartition, buildLogger, rootArtifactsFolderPath);
 
@@ -305,7 +305,7 @@ namespace BenchmarkDotNet.Running
 
         private static BenchmarkReport RunCore(BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, ILogger logger, IResolver resolver, BuildResult buildResult)
         {
-            var toolchain = benchmarkCase.Job.GetToolchain();
+            var toolchain = benchmarkCase.GetToolchain();
 
             logger.WriteLineHeader("// **************************");
             logger.WriteLineHeader("// Benchmark: " + benchmarkCase.DisplayInfo);
@@ -495,7 +495,7 @@ namespace BenchmarkDotNet.Running
 
         private static BenchmarkRunInfo[] GetSupportedBenchmarks(BenchmarkRunInfo[] benchmarkRunInfos, ILogger logger, IResolver resolver)
             => benchmarkRunInfos.Select(info => new BenchmarkRunInfo(
-                    info.BenchmarksCases.Where(benchmark => benchmark.Job.GetToolchain().IsSupported(benchmark, logger, resolver)).ToArray(),
+                    info.BenchmarksCases.Where(benchmark => benchmark.GetToolchain().IsSupported(benchmark, logger, resolver)).ToArray(),
                     info.Type,
                     info.Config))
                 .Where(infos => infos.BenchmarksCases.Any())

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
@@ -1,11 +1,11 @@
-﻿using System.Reflection;
-using BenchmarkDotNet.Characteristics;
+﻿using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.DotNetCli;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Toolchains.CsProj
@@ -63,7 +63,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
             var benchmarkAssembly = benchmarkCase.Descriptor.Type.Assembly;
             if (benchmarkAssembly.IsLinqPad())
             {
-                logger.WriteLineError($"Currently LINQPad does not support .NET Core benchmarks (see dotnet/BenchmarkDotNet#975), benchmark '{benchmarkCase.DisplayInfo}' will not be executed");
+                logger.WriteLineError($"Currently CsProjCoreToolchain does not support LINQPad 6+. Please use {nameof(InProcessEmitToolchain)} instead. Benchmark '{benchmarkCase.DisplayInfo}' will not be executed");
                 return false;
             }
 

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
@@ -60,7 +60,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
                 return false;
             }
 
-            var benchmarkAssembly = benchmarkCase.Descriptor.Type.GetTypeInfo().Assembly;
+            var benchmarkAssembly = benchmarkCase.Descriptor.Type.Assembly;
             if (benchmarkAssembly.IsLinqPad())
             {
                 logger.WriteLineError($"Currently LINQPad does not support .NET Core benchmarks (see dotnet/BenchmarkDotNet#975), benchmark '{benchmarkCase.DisplayInfo}' will not be executed");

--- a/src/BenchmarkDotNet/Validators/CompilationValidator.cs
+++ b/src/BenchmarkDotNet/Validators/CompilationValidator.cs
@@ -55,7 +55,7 @@ namespace BenchmarkDotNet.Validators
                          .Select(benchmark => new ValidationError(true, $"Generic class {benchmark.Descriptor.Type.GetDisplayName()} has non public generic argument(s)"));
 
         private static IEnumerable<ValidationError> ValidateBindingModifiers(IEnumerable<BenchmarkCase> benchmarks)
-            => benchmarks.Where(x => x.Descriptor.WorkloadMethod.IsStatic && !x.Job.GetToolchain().IsInProcess)
+            => benchmarks.Where(x => x.Descriptor.WorkloadMethod.IsStatic && !x.GetToolchain().IsInProcess)
                           .Distinct(BenchmarkMethodEqualityComparer.Instance)
                           .Select(benchmark
                               => new ValidationError(


### PR DESCRIPTION
@AndreyAkinshin @albahari I don't have LINQPad 6 license so I was unable to test it properly.

Can any of you test BenchmarkDotNet version `0.11.5.1170` from our CI feed when [this](https://ci.appveyor.com/project/dotnetfoundation/benchmarkdotnet/builds/27384769) build finishes? (should be in half an hour from now)

```xml
<packageSources>
  <add key="bdn-ci" value="https://ci.appveyor.com/nuget/benchmarkdotnet" />
</packageSources
```

fixes #1241