### PR TITLE
Add possibility to disable the log file

### DIFF
--- a/docs/articles/configs/configoptions.md
+++ b/docs/articles/configs/configoptions.md
@@ -1,0 +1,58 @@
+---
+uid: docs.configoptions
+name: Configoptions
+---
+
+# Config Options
+
+The config options let you customize some behavior of BenchmarkDotNet - mainly regarding the output.
+Available config options are:
+
+* `ConfigOptions.Default` - No configuration option is set - this is the default.
+* `ConfigOptions.KeepBenchmarkFiles` - All auto-generated files should be kept after running the benchmarks (be default they are removed).
+* `ConfigOptions.JoinSummary` - All benchmarks results should be joined into a single summary (by default we have a summary per type).
+* `ConfigOptions.StopOnFirstError` - Benchmarking should be stopped after the first error (by default it's not).
+* `ConfigOptions.DisableOptimizationsValidator` - Mandatory optimizations validator should be entirely turned off.
+* `ConfigOptions.DontOverwriteResults` - The exported result files should not be overwritten (be default they are overwritten).
+* `ConfigOptions.DisableLogFile` - Disables the log file written on disk.
+
+All of these options could be combined and are available as CLI (Comand Line Interface) option (except `DisableOptimizationsValidator`), see [Console Arguments](xref:docs.console-args) for further information how to use the CLI.
+
+Any of these options could be used either in `object style config` or `fluent style config`:
+
+### Object style config
+
+```cs
+public class Config : ManualConfig
+{
+    public Config()
+    {
+        Options.Set(true, ConfigOptions.JoinSummary);
+        Options.Set(true, ConfigOptions.DisableLogFile);
+
+        // or
+        Options.Set(true, ConfigOptions.JoinSummary | ConfigOptions.DisableLogFile);
+
+        // or using the With() factory method:
+        this.With(ConfigOptions.JoinSummary)
+            .With(ConfigOptions.DisableLogFile);
+
+    }
+}
+```
+
+### Fluent style config
+
+```cs
+    public static void Run()
+    {
+        BenchmarkRunner
+            .Run<Benchmarks>(
+                ManualConfig
+                    .Create(DefaultConfig.Instance)
+                    .With(ConfigOptions.JoinSummary)
+                    .With(ConfigOptions.DisableLogFile)
+                    // or
+                    .With(ConfigOptions.JoinSummary | ConfigOptions.DisableLogFile));
+    }
+```

--- a/docs/articles/configs/toc.yml
+++ b/docs/articles/configs/toc.yml
@@ -22,3 +22,5 @@
   href: orderers.md
 - name: Encoding
   href: encoding.md
+- name: ConfigOptions
+  href: configoptions.md

--- a/docs/articles/guides/console-args.md
+++ b/docs/articles/guides/console-args.md
@@ -210,3 +210,4 @@ dotnet run -c Release -- --filter * --runtimes netcoreapp2.0 netcoreapp2.1 --sta
 * `--version` Display version information.
 * `--keepFiles` Determines if all auto-generated files should be kept or removed after running the benchmarks.
 * `--noOverwrite` Determines if the exported result files should not be overwritten.
+* `--disableLogFile` Disables the logfile.

--- a/src/BenchmarkDotNet/Configs/ConfigOptions.cs
+++ b/src/BenchmarkDotNet/Configs/ConfigOptions.cs
@@ -28,7 +28,11 @@ namespace BenchmarkDotNet.Configs
         /// <summary>
         /// determines if the exported result files should not be overwritten (be default they are overwritten)
         /// </summary>
-        DontOverwriteResults = 1 << 4
+        DontOverwriteResults = 1 << 4,
+        /// <summary>
+        /// Determines if the log file should be disabled. 
+        /// </summary>
+        DisableLogFile = 1 << 5
     }
 
     internal static class ConfigOptionsExtensions

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -154,7 +154,10 @@ namespace BenchmarkDotNet.ConsoleArguments
         
         [Option("statisticalTest", Required = false, HelpText = "Threshold for Mann–Whitney U Test. Examples: 5%, 10ms, 100ns, 1s")]
         public string StatisticalTestThreshold { get; set; }
-        
+
+        [Option("disableLogFile", Required = false, HelpText = "Disables the logfile.")]
+        public bool DisableLogFile { get; set; }
+
         internal bool UserProvidedFilters => Filters.Any() || AttributeNames.Any() || AllCategories.Any() || AnyCategories.Any();
 
         [Usage(ApplicationAlias = "")]

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -212,6 +212,7 @@ namespace BenchmarkDotNet.ConsoleArguments
             config.Options = config.Options.Set(options.KeepBenchmarkFiles, ConfigOptions.KeepBenchmarkFiles);
             config.Options = config.Options.Set(options.DontOverwriteResults, ConfigOptions.DontOverwriteResults);
             config.Options = config.Options.Set(options.StopOnFirstError, ConfigOptions.StopOnFirstError);
+            config.Options = config.Options.Set(options.DisableLogFile, ConfigOptions.DisableLogFile);
 
             return config;
         }

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -41,7 +41,7 @@ namespace BenchmarkDotNet.Running
             var resultsFolderPath = GetResultsFolderPath(rootArtifactsFolderPath, benchmarkRunInfos);
             var logFilePath = Path.Combine(rootArtifactsFolderPath, title + ".log");
 
-            using (var streamLogger = new StreamLogger(new StreamWriter(logFilePath, append: false)))
+            using (var streamLogger = new StreamLogger(GetLogFileStreamWriter(benchmarkRunInfos, logFilePath)))
             {
                 var compositeLogger = CreateCompositeLogger(benchmarkRunInfos, streamLogger);
                 
@@ -533,6 +533,14 @@ namespace BenchmarkDotNet.Running
                 return Path.Combine(rootArtifactsFolderPath, DateTime.Now.ToString(DateTimeFormat)).CreateIfNotExists();
 
             return Path.Combine(rootArtifactsFolderPath, "results").CreateIfNotExists();
+        }
+
+        private static StreamWriter GetLogFileStreamWriter(BenchmarkRunInfo[] benchmarkRunInfos, string logFilePath)
+        {
+            if (benchmarkRunInfos.Any(info => info.Config.Options.IsSet(ConfigOptions.DisableLogFile)))
+                return StreamWriter.Null;
+
+            return new StreamWriter(logFilePath, append: false);
         }
 
         private static ILogger CreateCompositeLogger(BenchmarkRunInfo[] benchmarkRunInfos, StreamLogger streamLogger)

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkSwitcherTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkSwitcherTest.cs
@@ -13,6 +13,7 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Tests.Loggers;
 using BenchmarkDotNet.Tests.XUnit;
 using Xunit.Abstractions;
+using System.IO;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
@@ -124,7 +125,59 @@ namespace BenchmarkDotNet.IntegrationTests
             Assert.Contains("BenchmarkDotNet.IntegrationTests.ClassA.Method1", logger.GetLog());
             Assert.DoesNotContain("BenchmarkDotNet.IntegrationTests.ClassA.Method2", logger.GetLog());
         }
-        
+
+
+        [Fact]
+        public void WhenDisableLogFileWeDontWriteToFile()
+        {
+            var logger = new OutputLogger(Output);
+            var config = ManualConfig.CreateEmpty().With(logger).With(ConfigOptions.DisableLogFile);
+            string logFilePath = null;
+            try
+            {
+                var summaries = BenchmarkSwitcher
+                    .FromTypes(new[] { typeof(ClassA) })
+                    .RunAll(config);
+
+                var summary = summaries.Single();
+                logFilePath = summary.LogFilePath;
+                Assert.False(File.Exists(logFilePath), $"Logfile '{logFilePath}' should not exist, but it does.");
+            }
+            finally
+            {
+                if (!string.IsNullOrWhiteSpace(logFilePath))
+                {
+                    File.Delete(logFilePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void EnsureLogFileIsWritten()
+        {
+            var logger = new OutputLogger(Output);
+            var config = ManualConfig.CreateEmpty().With(logger);
+            string logFilePath = null;
+            try
+            {
+                var summaries = BenchmarkSwitcher
+                    .FromTypes(new[] { typeof(ClassA) })
+                    .RunAll(config);
+
+                var summary = summaries.Single();
+                logFilePath = summary.LogFilePath;
+                Assert.True(File.Exists(logFilePath), $"Logfile '{logFilePath}' should exist, but it does not.");
+            }
+            finally
+            {
+                if (!string.IsNullOrWhiteSpace(logFilePath))
+                {
+                    File.Delete(logFilePath);
+                }
+            }
+        }
+
+
         [Fact]
         public void WhenUserDoesNotProvideFilterOrCategoriesViaCommandLineWeAskToChooseBenchmark()
         {

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkSwitcherTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkSwitcherTest.cs
@@ -177,7 +177,6 @@ namespace BenchmarkDotNet.IntegrationTests
             }
         }
 
-
         [Fact]
         public void WhenUserDoesNotProvideFilterOrCategoriesViaCommandLineWeAskToChooseBenchmark()
         {

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -231,7 +231,30 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(tfm, ((DotNetCliGenerator)toolchain.Generator).TargetFrameworkMoniker);
             Assert.Equal(fakeDotnetCliPath, toolchain.CustomDotNetCliPath);
         }
-        
+
+        [Theory]
+        [InlineData(ConfigOptions.JoinSummary, "--join")]
+        [InlineData(ConfigOptions.KeepBenchmarkFiles, "--keepFiles")]
+        [InlineData(ConfigOptions.DontOverwriteResults, "--noOverwrite")]
+        [InlineData(ConfigOptions.StopOnFirstError, "--stopOnFirstError")]
+        [InlineData(ConfigOptions.DisableLogFile, "--disableLogFile" )]
+        [InlineData(
+            ConfigOptions.JoinSummary | 
+            ConfigOptions.KeepBenchmarkFiles | 
+            ConfigOptions.DontOverwriteResults | 
+            ConfigOptions.StopOnFirstError | 
+            ConfigOptions.DisableLogFile, "--join", "--keepFiles", "--noOverwrite", "--stopOnFirstError", "--disableLogFile")]
+        [InlineData(
+            ConfigOptions.JoinSummary |
+            ConfigOptions.KeepBenchmarkFiles |
+            ConfigOptions.StopOnFirstError, "--join", "--keepFiles", "--stopOnFirstError")]
+        public void ConfigOptionsParsedCorrectly(ConfigOptions expectedConfigOption, params string[] configOptionArgs)
+        {
+            var config = ConfigParser.Parse(configOptionArgs, new OutputLogger(Output)).config;
+            Assert.Equal(expectedConfigOption, config.Options);
+            Assert.NotEqual(ConfigOptions.Default, config.Options);
+        }
+
         [Fact]
         public void PackagesPathParsedCorrectly()
         {

--- a/tests/BenchmarkDotNet.Tests/Configs/ConfigOptionsTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/ConfigOptionsTests.cs
@@ -18,6 +18,9 @@ namespace BenchmarkDotNet.Tests.Configs
         public void DefaultConfigDoesNotStopOnFirstError() => Assert.False(DefaultConfig.Instance.Options.HasFlag(ConfigOptions.StopOnFirstError));
 
         [Fact]
+        public void DefaultConfigDoesNotDisableLogFile() => Assert.False(DefaultConfig.Instance.Options.HasFlag(ConfigOptions.DisableLogFile));
+        
+        [Fact]
         public void DefaultConfigDoesDisableOptimizationsValidator() => Assert.False(DefaultConfig.Instance.Options.HasFlag(ConfigOptions.DisableOptimizationsValidator));
 
         [Fact]


### PR DESCRIPTION
The proposed solution emphasizes:

* Minimal change
* Keeping the current behavior
* No IO when the log file is disabled (perf+)
* Simple to use for the users (relies on well-known API, `IConfig.With(ConfigOptions.DisableLogFile);`)

- [x] Unit Tests
- [x] Xml Doc (Intelisense)
- [x] Documentation (docs)

Documentation will be done, as soon the proposed solution is accepted and final.

Closes #198 