### PR TITLE
Add support for netcoreapp2.2

### DIFF
--- a/src/BenchmarkDotNet.Tool/BenchmarkDotNet.Tool.csproj
+++ b/src/BenchmarkDotNet.Tool/BenchmarkDotNet.Tool.csproj
@@ -2,9 +2,10 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <ToolCommandName>dotnet-benchmark</ToolCommandName>
     <Description>A dotnet tool to execute BenchmarkDotNet benchmarks.</Description>
     <PackageTags>benchmark;benchmarking;performance;tool</PackageTags>


### PR DESCRIPTION
👉  Cannot be merge until the build .NET SDK is updated to 2.2 or 3.0.

closes #1249