### PR TITLE
Update Build Tools to use .NET Core SDK to 3.0.100

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,7 @@ Param(
 )
 
 $CakeVersion = "0.30.0"
-$DotNetVersion = "2.1.503";
+$DotNetVersion = "3.0.100";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,7 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://dot.net/v1/dotnet-install.sh
 sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 3.0.100 --install-dir .dotnet --no-path
+sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 2.1.802 --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
   mkdir "$SCRIPT_DIR/.dotnet"
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://dot.net/v1/dotnet-install.sh
-sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 2.1.503 --install-dir .dotnet --no-path
+sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 3.0.100 --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1


### PR DESCRIPTION
 

closes #1254 
required for #1253