### PR TITLE
make it possible to configure MaxParamterColumnWidth

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -159,7 +159,7 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option("disableLogFile", Required = false, HelpText = "Disables the logfile.")]
         public bool DisableLogFile { get; set; }
 
-        [Option("maxWidth", Required = false, HelpText = "Max Paramter Column Width, the default is 20.")]
+        [Option("maxWidth", Required = false, HelpText = "Max paramter column width, the default is 20.")]
         public int? MaxParamterColumnWidth { get; set; }
 
         internal bool UserProvidedFilters => Filters.Any() || AttributeNames.Any() || AllCategories.Any() || AnyCategories.Any();

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -7,6 +7,7 @@ using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Helpers;
 using BenchmarkDotNet.Mathematics;
+using BenchmarkDotNet.Parameters;
 using CommandLine;
 using CommandLine.Text;
 using JetBrains.Annotations;
@@ -157,6 +158,9 @@ namespace BenchmarkDotNet.ConsoleArguments
 
         [Option("disableLogFile", Required = false, HelpText = "Disables the logfile.")]
         public bool DisableLogFile { get; set; }
+
+        [Option("maxWidth", Required = false, HelpText = "Max Paramter Column Width, the default is 20.")]
+        public int? MaxParamterColumnWidth { get; set; }
 
         internal bool UserProvidedFilters => Filters.Any() || AttributeNames.Any() || AllCategories.Any() || AnyCategories.Any();
 

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -20,6 +20,7 @@ using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Mathematics;
 using BenchmarkDotNet.Mathematics.StatisticalTesting;
 using BenchmarkDotNet.Portability;
+using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Toolchains.CoreRt;
 using BenchmarkDotNet.Toolchains.CoreRun;
 using BenchmarkDotNet.Toolchains.CsProj;
@@ -213,6 +214,9 @@ namespace BenchmarkDotNet.ConsoleArguments
             config.Options = config.Options.Set(options.DontOverwriteResults, ConfigOptions.DontOverwriteResults);
             config.Options = config.Options.Set(options.StopOnFirstError, ConfigOptions.StopOnFirstError);
             config.Options = config.Options.Set(options.DisableLogFile, ConfigOptions.DisableLogFile);
+
+            if (options.MaxParamterColumnWidth.HasValue)
+                config.SummaryStyle = SummaryStyle.Default.WithMaxParameterColumnWidth(options.MaxParamterColumnWidth.Value);
 
             return config;
         }

--- a/src/BenchmarkDotNet/Parameters/ParameterDefinitions.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterDefinitions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Extensions;
 using JetBrains.Annotations;
 
@@ -9,14 +10,11 @@ namespace BenchmarkDotNet.Parameters
     {
         [PublicAPI] public IReadOnlyList<ParameterDefinition> Items { get; }
 
-        public ParameterDefinitions(IReadOnlyList<ParameterDefinition> items)
-        {
-            Items = items;
-        }
+        public ParameterDefinitions(IReadOnlyList<ParameterDefinition> items) => Items = items;
 
-        public IReadOnlyList<ParameterInstances> Expand() => Expand(new[] { new ParameterInstances(new List<ParameterInstance>()) }, Items);
+        public IReadOnlyList<ParameterInstances> Expand(ImmutableConfig config) => Expand(new[] { new ParameterInstances(new List<ParameterInstance>()) }, Items, config);
 
-        private static IReadOnlyList<ParameterInstances> Expand(IReadOnlyList<ParameterInstances> instancesList, IReadOnlyList<ParameterDefinition> definitions)
+        private static IReadOnlyList<ParameterInstances> Expand(IReadOnlyList<ParameterInstances> instancesList, IReadOnlyList<ParameterDefinition> definitions, ImmutableConfig config)
         {
             if (definitions.IsNullOrEmpty())
                 return instancesList;
@@ -28,11 +26,11 @@ namespace BenchmarkDotNet.Parameters
                 {
                     var items = new List<ParameterInstance>();
                     items.AddRange(instances.Items);
-                    items.Add(new ParameterInstance(nextDefinition, value));
+                    items.Add(new ParameterInstance(nextDefinition, value, config));
                     newInstancesList.Add(new ParameterInstances(items));
                 }
             }
-            return Expand(newInstancesList, definitions.Skip(1).ToArray());
+            return Expand(newInstancesList, definitions.Skip(1).ToArray(), config);
         }
 
         public override string ToString() => Items.Any() ? string.Join(",", Items.Select(item => item.Name)) : "<empty>";

--- a/src/BenchmarkDotNet/Parameters/ParameterDefinitions.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterDefinitions.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Reports;
 using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Parameters
@@ -12,9 +12,9 @@ namespace BenchmarkDotNet.Parameters
 
         public ParameterDefinitions(IReadOnlyList<ParameterDefinition> items) => Items = items;
 
-        public IReadOnlyList<ParameterInstances> Expand(ImmutableConfig config) => Expand(new[] { new ParameterInstances(new List<ParameterInstance>()) }, Items, config);
+        public IReadOnlyList<ParameterInstances> Expand(SummaryStyle summaryStyle) => Expand(new[] { new ParameterInstances(new List<ParameterInstance>()) }, Items, summaryStyle);
 
-        private static IReadOnlyList<ParameterInstances> Expand(IReadOnlyList<ParameterInstances> instancesList, IReadOnlyList<ParameterDefinition> definitions, ImmutableConfig config)
+        private static IReadOnlyList<ParameterInstances> Expand(IReadOnlyList<ParameterInstances> instancesList, IReadOnlyList<ParameterDefinition> definitions, SummaryStyle summaryStyle)
         {
             if (definitions.IsNullOrEmpty())
                 return instancesList;
@@ -26,11 +26,11 @@ namespace BenchmarkDotNet.Parameters
                 {
                     var items = new List<ParameterInstance>();
                     items.AddRange(instances.Items);
-                    items.Add(new ParameterInstance(nextDefinition, value, config));
+                    items.Add(new ParameterInstance(nextDefinition, value, summaryStyle));
                     newInstancesList.Add(new ParameterInstances(items));
                 }
             }
-            return Expand(newInstancesList, definitions.Skip(1).ToArray(), config);
+            return Expand(newInstancesList, definitions.Skip(1).ToArray(), summaryStyle);
         }
 
         public override string ToString() => Items.Any() ? string.Join(",", Items.Select(item => item.Name)) : "<empty>";

--- a/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using BenchmarkDotNet.Code;
-using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Helpers;
+using BenchmarkDotNet.Reports;
 using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Parameters
@@ -10,18 +10,17 @@ namespace BenchmarkDotNet.Parameters
     public class ParameterInstance
     {
         public const string NullParameterTextRepresentation = "?";
-        internal const int DefaultMaxDisplayTextInnerLength = 15 + 5; // 5 is for postfix " [15]"
 
         [PublicAPI] public ParameterDefinition Definition { get; }
 
         private readonly object value;
-        private readonly ImmutableConfig config;
+        private readonly int maxParamterColumnWidth;
 
-        public ParameterInstance(ParameterDefinition definition, object value, ImmutableConfig config)
+        public ParameterInstance(ParameterDefinition definition, object value, SummaryStyle summaryStyle)
         {
             Definition = definition;
             this.value = value;
-            this.config = config;
+            maxParamterColumnWidth = summaryStyle?.MaxParamterColumnWidth ?? SummaryStyle.DefaultMaxParameterColumnWidth;
         }
 
         public string Name => Definition.Name;
@@ -41,13 +40,13 @@ namespace BenchmarkDotNet.Parameters
                 case null:
                     return NullParameterTextRepresentation;
                 case IParam parameter:
-                    return Trim(parameter.DisplayText, config.SummaryStyle?.MaxParamterColumnWidth ?? DefaultMaxDisplayTextInnerLength);
+                    return Trim(parameter.DisplayText, maxParamterColumnWidth);
                 // no trimming for types!
                 case Type type:
                     return type.IsNullable() ? $"{Nullable.GetUnderlyingType(type).GetDisplayName()}?" : type.GetDisplayName();
             }
 
-            return Trim(value.ToString(), config.SummaryStyle?.MaxParamterColumnWidth ?? DefaultMaxDisplayTextInnerLength);
+            return Trim(value.ToString(), maxParamterColumnWidth);
         }
 
         public override string ToString() => ToDisplayText();

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Horology;
-using BenchmarkDotNet.Parameters;
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace BenchmarkDotNet.Reports
@@ -9,6 +8,7 @@ namespace BenchmarkDotNet.Reports
     public class SummaryStyle : IEquatable<SummaryStyle>
     {
         public static readonly SummaryStyle Default = new SummaryStyle(printUnitsInHeader: false, printUnitsInContent: true, printZeroValuesInContent: false, sizeUnit: null, timeUnit: null);
+        internal const int DefaultMaxParameterColumnWidth = 15 + 5; // 5 is for postfix " [15]"
 
         public bool PrintUnitsInHeader { get; }
         public bool PrintUnitsInContent { get; }
@@ -17,10 +17,10 @@ namespace BenchmarkDotNet.Reports
         public SizeUnit SizeUnit { get; }
         public TimeUnit TimeUnit { get; }
 
-        public SummaryStyle(bool printUnitsInHeader, SizeUnit sizeUnit, TimeUnit timeUnit, bool printUnitsInContent = true, bool printZeroValuesInContent = false, int maxParameterColumnWidth = ParameterInstance.DefaultMaxDisplayTextInnerLength)
+        public SummaryStyle(bool printUnitsInHeader, SizeUnit sizeUnit, TimeUnit timeUnit, bool printUnitsInContent = true, bool printZeroValuesInContent = false, int maxParameterColumnWidth = DefaultMaxParameterColumnWidth)
         {
-            if (maxParameterColumnWidth < ParameterInstance.DefaultMaxDisplayTextInnerLength)
-                throw new ArgumentOutOfRangeException(nameof(maxParameterColumnWidth), $"{ParameterInstance.DefaultMaxDisplayTextInnerLength} is the minimum.");
+            if (maxParameterColumnWidth < DefaultMaxParameterColumnWidth)
+                throw new ArgumentOutOfRangeException(nameof(maxParameterColumnWidth), $"{DefaultMaxParameterColumnWidth} is the minimum.");
 
             PrintUnitsInHeader = printUnitsInHeader;
             PrintUnitsInContent = printUnitsInContent;

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Horology;
+using BenchmarkDotNet.Parameters;
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace BenchmarkDotNet.Reports
@@ -12,16 +13,21 @@ namespace BenchmarkDotNet.Reports
         public bool PrintUnitsInHeader { get; }
         public bool PrintUnitsInContent { get; }
         public bool PrintZeroValuesInContent { get; }
+        public int MaxParamterColumnWidth { get; }
         public SizeUnit SizeUnit { get; }
         public TimeUnit TimeUnit { get; }
 
-        public SummaryStyle(bool printUnitsInHeader, SizeUnit sizeUnit, TimeUnit timeUnit, bool printUnitsInContent = true, bool printZeroValuesInContent = false)
+        public SummaryStyle(bool printUnitsInHeader, SizeUnit sizeUnit, TimeUnit timeUnit, bool printUnitsInContent = true, bool printZeroValuesInContent = false, int maxParameterColumnWidth = ParameterInstance.DefaultMaxDisplayTextInnerLength)
         {
+            if (maxParameterColumnWidth < ParameterInstance.DefaultMaxDisplayTextInnerLength)
+                throw new ArgumentOutOfRangeException(nameof(maxParameterColumnWidth), $"{ParameterInstance.DefaultMaxDisplayTextInnerLength} is the minimum.");
+
             PrintUnitsInHeader = printUnitsInHeader;
             PrintUnitsInContent = printUnitsInContent;
             SizeUnit = sizeUnit;
             TimeUnit = timeUnit;
             PrintZeroValuesInContent = printZeroValuesInContent;
+            MaxParamterColumnWidth = maxParameterColumnWidth;
         }
 
         public SummaryStyle WithTimeUnit(TimeUnit timeUnit)
@@ -33,6 +39,9 @@ namespace BenchmarkDotNet.Reports
         public SummaryStyle WithZeroMetricValuesInContent()
             => new SummaryStyle(PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, printZeroValuesInContent: true);
 
+        public SummaryStyle WithMaxParameterColumnWidth(int maxParamterColumnWidth)
+            => new SummaryStyle(PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, maxParamterColumnWidth);
+
         public bool Equals(SummaryStyle other)
         {
             if (ReferenceEquals(null, other))
@@ -43,19 +52,11 @@ namespace BenchmarkDotNet.Reports
                 && PrintUnitsInContent == other.PrintUnitsInContent
                 && PrintZeroValuesInContent == other.PrintZeroValuesInContent
                 && Equals(SizeUnit, other.SizeUnit)
-                && Equals(TimeUnit, other.TimeUnit);
+                && Equals(TimeUnit, other.TimeUnit)
+                && MaxParamterColumnWidth == other.MaxParamterColumnWidth;
         }
 
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != this.GetType())
-                return false;
-            return Equals((SummaryStyle) obj);
-        }
+        public override bool Equals(object obj) => obj is SummaryStyle summary && Equals(summary);
 
         public override int GetHashCode()
         {
@@ -66,6 +67,7 @@ namespace BenchmarkDotNet.Reports
                 hashCode = (hashCode * 397) ^ PrintZeroValuesInContent.GetHashCode();
                 hashCode = (hashCode * 397) ^ (SizeUnit != null ? SizeUnit.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (TimeUnit != null ? TimeUnit.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ MaxParamterColumnWidth;
                 return hashCode;
             }
         }

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -10,6 +10,7 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Parameters;
+using BenchmarkDotNet.Reports;
 
 namespace BenchmarkDotNet.Running
 {
@@ -50,7 +51,7 @@ namespace BenchmarkDotNet.Running
             var targetMethods = benchmarkMethods.Where(method => method.HasAttribute<BenchmarkAttribute>()).ToArray();
 
             var parameterDefinitions = GetParameterDefinitions(containingType);
-            var parameterInstancesList = parameterDefinitions.Expand(immutableConfig);
+            var parameterInstancesList = parameterDefinitions.Expand(immutableConfig.SummaryStyle);
 
             var jobs = immutableConfig.GetJobs();
 
@@ -59,7 +60,7 @@ namespace BenchmarkDotNet.Running
             var benchmarks = new List<BenchmarkCase>();
             foreach (var target in targets)
             {
-                var argumentsDefinitions = GetArgumentsDefinitions(target.WorkloadMethod, target.Type, immutableConfig).ToArray();
+                var argumentsDefinitions = GetArgumentsDefinitions(target.WorkloadMethod, target.Type, immutableConfig.SummaryStyle).ToArray();
 
                 var parameterInstances =
                     (from parameterInstance in parameterInstancesList
@@ -193,7 +194,7 @@ namespace BenchmarkDotNet.Running
             return new ParameterDefinitions(definitions);
         }
 
-        private static IEnumerable<ParameterInstances> GetArgumentsDefinitions(MethodInfo benchmark, Type target, ImmutableConfig config)
+        private static IEnumerable<ParameterInstances> GetArgumentsDefinitions(MethodInfo benchmark, Type target, SummaryStyle summaryStyle)
         {
             var parameterDefinitions = benchmark.GetParameters()
                 .Select(parameter => new ParameterDefinition(parameter.Name, false, Array.Empty<object>(), true, parameter.ParameterType))
@@ -211,7 +212,7 @@ namespace BenchmarkDotNet.Running
                     throw new InvalidOperationException($"Benchmark {benchmark.Name} has invalid number of defined arguments provided with [Arguments]! {argumentsAttribute.Values.Length} instead of {parameterDefinitions.Length}.");
 
                 yield return new ParameterInstances(
-                    argumentsAttribute.Values.Select((value, index) => new ParameterInstance(parameterDefinitions[index], Map(value), config)).ToArray());
+                    argumentsAttribute.Values.Select((value, index) => new ParameterInstance(parameterDefinitions[index], Map(value), summaryStyle)).ToArray());
             }
 
             if (!benchmark.HasAttribute<ArgumentsSourceAttribute>())
@@ -221,7 +222,7 @@ namespace BenchmarkDotNet.Running
 
             var valuesInfo = GetValidValuesForParamsSource(target, argumentsSourceAttribute.Name);
             for (int sourceIndex = 0; sourceIndex < valuesInfo.values.Length; sourceIndex++)
-                yield return SmartParamBuilder.CreateForArguments(benchmark, parameterDefinitions, valuesInfo, sourceIndex, config);
+                yield return SmartParamBuilder.CreateForArguments(benchmark, parameterDefinitions, valuesInfo, sourceIndex, summaryStyle);
         }
 
         private static string[] GetCategories(MethodInfo method)

--- a/tests/BenchmarkDotNet.Tests/CharacteristicPresenterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/CharacteristicPresenterTests.cs
@@ -1,13 +1,5 @@
 ﻿using System;
-using System.Linq;
-using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Characteristics;
-using BenchmarkDotNet.Columns;
-using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Extensions;
-using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Portability;
-using BenchmarkDotNet.Running;
 using Xunit;
 
 namespace BenchmarkDotNet.Tests

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -400,10 +400,24 @@ namespace BenchmarkDotNet.Tests
                     .WithWarmupCount(1)
                     .AsDefault());
 
-            var parserdConfig = ConfigParser.Parse(new[] { "--warmupCount", "2"}, new OutputLogger(Output), globalConfig).config;
+            var parsedConfig = ConfigParser.Parse(new[] { "--warmupCount", "2"}, new OutputLogger(Output), globalConfig).config;
 
-            Assert.Equal(2, parserdConfig.GetJobs().Single().Run.WarmupCount);
-            Assert.False(parserdConfig.GetJobs().Single().Meta.IsDefault); // after the merge the job is not "default" anymore
+            Assert.Equal(2, parsedConfig.GetJobs().Single().Run.WarmupCount);
+            Assert.False(parsedConfig.GetJobs().Single().Meta.IsDefault); // after the merge the job is not "default" anymore
+        }
+
+        [Fact]
+        public void UserCanSpecifyCustomMaxParamterColumnWidth()
+        {
+            const int customValue = 1234;
+
+            var globalConfig = DefaultConfig.Instance;
+
+            Assert.NotEqual(customValue, globalConfig.SummaryStyle.MaxParamterColumnWidth);
+
+            var parsedConfig = ConfigParser.Parse(new[] { "--maxWidth", customValue.ToString() }, new OutputLogger(Output), globalConfig).config;
+
+            Assert.Equal(customValue, parsedConfig.SummaryStyle.MaxParamterColumnWidth);
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/ParameterComparerTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ParameterComparerTests.cs
@@ -2,6 +2,7 @@
 using BenchmarkDotNet.Parameters;
 using System.Linq;
 using Xunit;
+using BenchmarkDotNet.Configs;
 
 namespace BenchmarkDotNet.Tests
 {
@@ -11,21 +12,22 @@ namespace BenchmarkDotNet.Tests
         public void BasicComparisionTest()
         {
             var comparer = ParameterComparer.Instance;
+            var config = DefaultConfig.Instance.CreateImmutableConfig();
 
             var sharedDefinition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false, parameterType: null);
             var originalData = new[]
             {
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 5)
+                    new ParameterInstance(sharedDefinition, 5, config)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 1)
+                    new ParameterInstance(sharedDefinition, 1, config)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 3)
+                    new ParameterInstance(sharedDefinition, 3, config)
                 })
             };
             var sortedData = originalData.OrderBy(d => d, comparer).ToArray();
@@ -39,33 +41,34 @@ namespace BenchmarkDotNet.Tests
         public void MultiParameterComparisionTest()
         {
             var comparer = ParameterComparer.Instance;
+            var config = DefaultConfig.Instance.CreateImmutableConfig();
 
             var sharedDefinition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false, parameterType: null);
             var originalData = new[]
             {
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 5),
-                    new ParameterInstance(sharedDefinition, "z"),
-                    new ParameterInstance(sharedDefinition, 1.0)
+                    new ParameterInstance(sharedDefinition, 5, config),
+                    new ParameterInstance(sharedDefinition, "z", config),
+                    new ParameterInstance(sharedDefinition, 1.0, config)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 5),
-                    new ParameterInstance(sharedDefinition, "a"),
-                    new ParameterInstance(sharedDefinition, 0.0)
+                    new ParameterInstance(sharedDefinition, 5, config),
+                    new ParameterInstance(sharedDefinition, "a", config),
+                    new ParameterInstance(sharedDefinition, 0.0, config)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 5),
-                    new ParameterInstance(sharedDefinition, "a"),
-                    new ParameterInstance(sharedDefinition, 1.0)
+                    new ParameterInstance(sharedDefinition, 5, config),
+                    new ParameterInstance(sharedDefinition, "a", config),
+                    new ParameterInstance(sharedDefinition, 1.0, config)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 3),
-                    new ParameterInstance(sharedDefinition, "a"),
-                    new ParameterInstance(sharedDefinition, 97.5)
+                    new ParameterInstance(sharedDefinition, 3, config),
+                    new ParameterInstance(sharedDefinition, "a", config),
+                    new ParameterInstance(sharedDefinition, 97.5, config)
                 })
             };
 
@@ -93,25 +96,26 @@ namespace BenchmarkDotNet.Tests
         public void AlphaNumericComparisionTest()
         {
             var comparer = ParameterComparer.Instance;
+            var config = DefaultConfig.Instance.CreateImmutableConfig();
 
             var sharedDefinition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false, parameterType: null);
             var originalData = new[]
             {
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 100)
+                    new ParameterInstance(sharedDefinition, 100, config)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 1000)
+                    new ParameterInstance(sharedDefinition, 1000, config)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 2000)
+                    new ParameterInstance(sharedDefinition, 2000, config)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 500)
+                    new ParameterInstance(sharedDefinition, 500, config)
                 })
             };
 

--- a/tests/BenchmarkDotNet.Tests/ParameterComparerTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ParameterComparerTests.cs
@@ -2,7 +2,6 @@
 using BenchmarkDotNet.Parameters;
 using System.Linq;
 using Xunit;
-using BenchmarkDotNet.Configs;
 
 namespace BenchmarkDotNet.Tests
 {
@@ -12,22 +11,21 @@ namespace BenchmarkDotNet.Tests
         public void BasicComparisionTest()
         {
             var comparer = ParameterComparer.Instance;
-            var config = DefaultConfig.Instance.CreateImmutableConfig();
 
             var sharedDefinition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false, parameterType: null);
             var originalData = new[]
             {
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 5, config)
+                    new ParameterInstance(sharedDefinition, 5, null)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 1, config)
+                    new ParameterInstance(sharedDefinition, 1, null)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 3, config)
+                    new ParameterInstance(sharedDefinition, 3, null)
                 })
             };
             var sortedData = originalData.OrderBy(d => d, comparer).ToArray();
@@ -41,34 +39,33 @@ namespace BenchmarkDotNet.Tests
         public void MultiParameterComparisionTest()
         {
             var comparer = ParameterComparer.Instance;
-            var config = DefaultConfig.Instance.CreateImmutableConfig();
 
             var sharedDefinition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false, parameterType: null);
             var originalData = new[]
             {
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 5, config),
-                    new ParameterInstance(sharedDefinition, "z", config),
-                    new ParameterInstance(sharedDefinition, 1.0, config)
+                    new ParameterInstance(sharedDefinition, 5, null),
+                    new ParameterInstance(sharedDefinition, "z", null),
+                    new ParameterInstance(sharedDefinition, 1.0, null)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 5, config),
-                    new ParameterInstance(sharedDefinition, "a", config),
-                    new ParameterInstance(sharedDefinition, 0.0, config)
+                    new ParameterInstance(sharedDefinition, 5, null),
+                    new ParameterInstance(sharedDefinition, "a", null),
+                    new ParameterInstance(sharedDefinition, 0.0, null)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 5, config),
-                    new ParameterInstance(sharedDefinition, "a", config),
-                    new ParameterInstance(sharedDefinition, 1.0, config)
+                    new ParameterInstance(sharedDefinition, 5, null),
+                    new ParameterInstance(sharedDefinition, "a", null),
+                    new ParameterInstance(sharedDefinition, 1.0, null)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 3, config),
-                    new ParameterInstance(sharedDefinition, "a", config),
-                    new ParameterInstance(sharedDefinition, 97.5, config)
+                    new ParameterInstance(sharedDefinition, 3, null),
+                    new ParameterInstance(sharedDefinition, "a", null),
+                    new ParameterInstance(sharedDefinition, 97.5, null)
                 })
             };
 
@@ -96,26 +93,25 @@ namespace BenchmarkDotNet.Tests
         public void AlphaNumericComparisionTest()
         {
             var comparer = ParameterComparer.Instance;
-            var config = DefaultConfig.Instance.CreateImmutableConfig();
 
             var sharedDefinition = new ParameterDefinition("Testing", isStatic: false, values: Array.Empty<object>(), isArgument: false, parameterType: null);
             var originalData = new[]
             {
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 100, config)
+                    new ParameterInstance(sharedDefinition, 100, null)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 1000, config)
+                    new ParameterInstance(sharedDefinition, 1000, null)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 2000, config)
+                    new ParameterInstance(sharedDefinition, 2000, null)
                 }),
                 new ParameterInstances(new[]
                 {
-                    new ParameterInstance(sharedDefinition, 500, config)
+                    new ParameterInstance(sharedDefinition, 500, null)
                 })
             };
 

--- a/tests/BenchmarkDotNet.Tests/ParameterInstanceTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ParameterInstanceTests.cs
@@ -1,4 +1,6 @@
-﻿using BenchmarkDotNet.Parameters;
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Parameters;
+using BenchmarkDotNet.Reports;
 using System;
 using System.Collections.Generic;
 using Xunit;
@@ -15,18 +17,20 @@ namespace BenchmarkDotNet.Tests
         [InlineData("short")]
         public void ShortParameterValuesDisplayOriginalValue(object value)
         {
-            var parameter = new ParameterInstance(definition, value);
+            var config = DefaultConfig.Instance.CreateImmutableConfig();
+            var parameter = new ParameterInstance(definition, value, config);
 
             Assert.Equal(value.ToString(), parameter.ToDisplayText());
         }
 
         [Theory]
         [InlineData("text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7", "text/(...)q=0.7 [86]")]
-        [InlineData("All the world's a stage, and all the men and women merely players: they have their exits and their entrances; and one man in his time plays many parts, his acts being seven ages.", "All t(...)ages. [178]")]
+        [InlineData("All the world's a stage, and all the men and women merely players: they have their exits and their entrances; and one man in his time plays many parts, his acts being seven ages.", "All (...)ges. [178]")]
         [InlineData("this is a test to see what happens when we call tolower.", "this (...)ower. [56]")]
         public void VeryLongParameterValuesAreTrimmed(string initialLongText, string expectedDisplayText)
         {
-            var parameter = new ParameterInstance(definition, initialLongText);
+            var config = DefaultConfig.Instance.CreateImmutableConfig();
+            var parameter = new ParameterInstance(definition, initialLongText, config);
 
             Assert.NotEqual(initialLongText, parameter.ToDisplayText());
 
@@ -42,7 +46,8 @@ namespace BenchmarkDotNet.Tests
         [InlineData("012345678901234567890", "01234(...)67890 [21]")]
         public void TrimmingTheValuesMakesThemActuallyShorter(string initialLongText, string expectedDisplayText)
         {
-            var parameter = new ParameterInstance(definition, initialLongText);
+            var config = DefaultConfig.Instance.CreateImmutableConfig();
+            var parameter = new ParameterInstance(definition, initialLongText, config);
 
             Assert.Equal(expectedDisplayText, parameter.ToDisplayText());
         }
@@ -54,10 +59,29 @@ namespace BenchmarkDotNet.Tests
         [InlineData(typeof(List<int>), "List<Int32>")]
         public void TypeParameterValuesDisplayNotTrimmedTypeNameWithoutNamespace(Type type, string expectedName)
         {
-            var parameter = new ParameterInstance(definition, type);
+            var config = DefaultConfig.Instance.CreateImmutableConfig();
+            var parameter = new ParameterInstance(definition, type, config);
 
             Assert.Equal(expectedName, parameter.ToDisplayText());
         }
+
+        [Theory]
+        [InlineData("012345678901234567890", 21, "012345678901234567890")] // the default is 20
+        [InlineData("0123456789012345678901234567890123456789", 30, "0123456789(...)0123456789 [40]")]
+        public void MaxParamterColumnWidthCanBeCustomized(string initialLongText, int maxParameterColumnWidth, string expectedDisplayText)
+        {
+            var config = DefaultConfig.Instance.With(SummaryStyle.Default.WithMaxParameterColumnWidth(maxParameterColumnWidth)).CreateImmutableConfig();
+            var parameter = new ParameterInstance(definition, initialLongText, config);
+
+            Assert.Equal(expectedDisplayText, parameter.ToDisplayText());
+        }
+
+        [Theory]
+        [InlineData(-100)]
+        [InlineData(0)]
+        [InlineData(10)]
+        public void MaxParamterColumnWidthCanNotBeSetToValueLessThanDefault(int newWidth)
+            => Assert.Throws<ArgumentOutOfRangeException>(() => SummaryStyle.Default.WithMaxParameterColumnWidth(newWidth));
     }
 
     public class ATypeWithAVeryVeryVeryVeryVeryVeryLongNameeeeeeeee { }

--- a/tests/BenchmarkDotNet.Tests/ParameterInstanceTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ParameterInstanceTests.cs
@@ -17,8 +17,7 @@ namespace BenchmarkDotNet.Tests
         [InlineData("short")]
         public void ShortParameterValuesDisplayOriginalValue(object value)
         {
-            var config = DefaultConfig.Instance.CreateImmutableConfig();
-            var parameter = new ParameterInstance(definition, value, config);
+            var parameter = new ParameterInstance(definition, value, null);
 
             Assert.Equal(value.ToString(), parameter.ToDisplayText());
         }
@@ -29,8 +28,7 @@ namespace BenchmarkDotNet.Tests
         [InlineData("this is a test to see what happens when we call tolower.", "this (...)ower. [56]")]
         public void VeryLongParameterValuesAreTrimmed(string initialLongText, string expectedDisplayText)
         {
-            var config = DefaultConfig.Instance.CreateImmutableConfig();
-            var parameter = new ParameterInstance(definition, initialLongText, config);
+            var parameter = new ParameterInstance(definition, initialLongText, null);
 
             Assert.NotEqual(initialLongText, parameter.ToDisplayText());
 
@@ -46,8 +44,7 @@ namespace BenchmarkDotNet.Tests
         [InlineData("012345678901234567890", "01234(...)67890 [21]")]
         public void TrimmingTheValuesMakesThemActuallyShorter(string initialLongText, string expectedDisplayText)
         {
-            var config = DefaultConfig.Instance.CreateImmutableConfig();
-            var parameter = new ParameterInstance(definition, initialLongText, config);
+            var parameter = new ParameterInstance(definition, initialLongText, null);
 
             Assert.Equal(expectedDisplayText, parameter.ToDisplayText());
         }
@@ -59,8 +56,7 @@ namespace BenchmarkDotNet.Tests
         [InlineData(typeof(List<int>), "List<Int32>")]
         public void TypeParameterValuesDisplayNotTrimmedTypeNameWithoutNamespace(Type type, string expectedName)
         {
-            var config = DefaultConfig.Instance.CreateImmutableConfig();
-            var parameter = new ParameterInstance(definition, type, config);
+            var parameter = new ParameterInstance(definition, type, null);
 
             Assert.Equal(expectedName, parameter.ToDisplayText());
         }
@@ -70,8 +66,8 @@ namespace BenchmarkDotNet.Tests
         [InlineData("0123456789012345678901234567890123456789", 30, "0123456789(...)0123456789 [40]")]
         public void MaxParamterColumnWidthCanBeCustomized(string initialLongText, int maxParameterColumnWidth, string expectedDisplayText)
         {
-            var config = DefaultConfig.Instance.With(SummaryStyle.Default.WithMaxParameterColumnWidth(maxParameterColumnWidth)).CreateImmutableConfig();
-            var parameter = new ParameterInstance(definition, initialLongText, config);
+            var summaryStyle = SummaryStyle.Default.WithMaxParameterColumnWidth(maxParameterColumnWidth);
+            var parameter = new ParameterInstance(definition, initialLongText, summaryStyle);
 
             Assert.Equal(expectedDisplayText, parameter.ToDisplayText());
         }


### PR DESCRIPTION
Recently I've been working on improving the performance of `StartsWith` and `EndsWith` on Linux. I am interested in some test cases, not all possible permutations so I am using a `[ParamsSource]` combined with `ValueTuple`.

Example:

```cs
public static IEnumerable<(CultureInfo CultureInfo, CompareOptions CompareOptions, bool highChars)> GetOptions()
{
    // Ordinal and OrdinalIgnoreCase use single execution path for all cultures, so we test it only for "en-US"
    // without enforcing highChars - the execution path would be the same
    yield return (new CultureInfo("en-US"), CompareOptions.Ordinal, false);
    yield return (new CultureInfo("en-US"), CompareOptions.OrdinalIgnoreCase, false);

    yield return (new CultureInfo("en-US"), CompareOptions.None, false); // no high chars = fast path (managed code on Unix)
    yield return (new CultureInfo("en-US"), CompareOptions.None, true); // high chars = slow path (call to ICU on Unix)
    yield return (new CultureInfo("en-US"), CompareOptions.IgnoreCase, false);
    yield return (new CultureInfo("en-US"), CompareOptions.IgnoreCase, true);

    // IgnoreSymbols always uses the slow path
    // https://github.com/dotnet/coreclr/blob/cd6bc26bdc4ac06fe2165b283eaf9fb5ff5293f4/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs#L911-L912
    yield return (new CultureInfo("en-US"), CompareOptions.IgnoreSymbols, false);

    // too rarely used to test both slow and fast path
    yield return (new CultureInfo("en-US"), CompareOptions.IgnoreNonSpace, false);

    yield return (CultureInfo.InvariantCulture, CompareOptions.None, false);
    yield return (CultureInfo.InvariantCulture, CompareOptions.None, true);
    yield return (CultureInfo.InvariantCulture, CompareOptions.IgnoreCase, false);
    yield return (CultureInfo.InvariantCulture, CompareOptions.IgnoreCase, true);

    // both en-US and Invariant cultures have an optimized execution path on Unix systems:
    // https://github.com/dotnet/coreclr/blob/cd6bc26bdc4ac06fe2165b283eaf9fb5ff5293f4/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs#L35
    // so we need one more culture to test the "slow path"
    // Polish language has a lot of special characters, for example 'ch', 'rz', 'sz', 'cz' use two chars to express one ;)
    // it also has a lot of characters with accent so we use it as an example of "complex" language
    yield return (new CultureInfo("pl-PL"), CompareOptions.None, false);
}

[ParamsSource(nameof(GetOptions))]
public (CultureInfo CultureInfo, CompareOptions CompareOptions, bool highChars) Options;
```

The problem is that some important information (`CompareOptions` value in this case) gets trimmed in the summary table:

|              Options |
|--------------------- |
| (, Ig(...)alse) [21] |
| (, IgnoreCase, True) |
|      (, None, False) |
|       (, None, True) |
| (en-U(...)alse) [26] |
| (en-U(...)True) [25] |
| (en-U(...)alse) [30] |
| (en-U(...)alse) [29] |
| (en-US, None, False) |
|  (en-US, None, True) |
| (en-U(...)alse) [23] |
| (en-U(...)alse) [33] |
| (pl-PL, None, False) |

This PR makes it possible to customize the max width.

Example:

|                           Options |
|---------------------------------- |
|             (, IgnoreCase, False) |
|              (, IgnoreCase, True) |
|                   (, None, False) |
|                    (, None, True) |
|        (en-US, IgnoreCase, False) |
|         (en-US, IgnoreCase, True) |
|    (en-US, IgnoreNonSpace, False) |
|     (en-US, IgnoreSymbols, False) |
|              (en-US, None, False) |
|               (en-US, None, True) |
|           (en-US, Ordinal, False) |
| (en-US, OrdinalIgnoreCase, False) |
|              (pl-PL, None, False) |

