### PR TITLE
Add EnumParam preserving type information

### DIFF
--- a/src/BenchmarkDotNet/Code/EnumParam.cs
+++ b/src/BenchmarkDotNet/Code/EnumParam.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Globalization;
+using BenchmarkDotNet.Extensions;
+
+namespace BenchmarkDotNet.Code
+{
+    public class EnumParam : IParam
+    {
+        // Preserves type information for enum values from F# code
+        // See also:
+        // https://github.com/dotnet/fsharp/issues/995
+        private readonly Type type;
+
+        private EnumParam(object value, Type type)
+        {
+            this.Value = value;
+            this.type = type;
+        }
+
+        public object Value { get; }
+
+        public string DisplayText => $"{Enum.ToObject(type, Value)}";
+
+        public string ToSourceCode() =>
+            $"({type.GetCorrectCSharpTypeName()})({ToInvariantCultureString()})";
+
+        internal static IParam FromObject(object value, Type type = null)
+        {
+            type = type ?? value.GetType();
+            if (!type.IsEnum)
+                throw new ArgumentOutOfRangeException(nameof(type));
+
+            return new EnumParam(value, type);
+        }
+
+        private string ToInvariantCultureString()
+        {
+            switch (Type.GetTypeCode(Enum.GetUnderlyingType(type)))
+            {
+                case TypeCode.Byte:
+                    return ((byte)Value).ToString(CultureInfo.InvariantCulture);
+                case TypeCode.Int16:
+                    return ((short)Value).ToString(CultureInfo.InvariantCulture);
+                case TypeCode.Int32:
+                    return ((int)Value).ToString(CultureInfo.InvariantCulture);
+                case TypeCode.Int64:
+                    return ((long)Value).ToString(CultureInfo.InvariantCulture);
+                case TypeCode.SByte:
+                    return ((sbyte)Value).ToString(CultureInfo.InvariantCulture);
+                case TypeCode.UInt16:
+                    return ((ushort)Value).ToString(CultureInfo.InvariantCulture);
+                case TypeCode.UInt32:
+                    return ((uint)Value).ToString(CultureInfo.InvariantCulture);
+                case TypeCode.UInt64:
+                    return ((ulong)Value).ToString(CultureInfo.InvariantCulture);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(Value));
+            }
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -212,7 +212,15 @@ namespace BenchmarkDotNet.Running
                     throw new InvalidOperationException($"Benchmark {benchmark.Name} has invalid number of defined arguments provided with [Arguments]! {argumentsAttribute.Values.Length} instead of {parameterDefinitions.Length}.");
 
                 yield return new ParameterInstances(
-                    argumentsAttribute.Values.Select((value, index) => new ParameterInstance(parameterDefinitions[index], Map(value), summaryStyle)).ToArray());
+                    argumentsAttribute
+                        .Values
+                        .Select((value, index) =>
+                            { 
+                                var definition = parameterDefinitions[index];
+                                var type = definition.ParameterType;
+                                return new ParameterInstance(parameterDefinitions[index], Map(value, type), summaryStyle);
+                            })
+                        .ToArray());
             }
 
             if (!benchmark.HasAttribute<ArgumentsSourceAttribute>())
@@ -278,15 +286,24 @@ namespace BenchmarkDotNet.Running
                 return new object[] { null };
             }
 
-            return values?.Select(Map).ToArray();
+            return values?.Select(value => Map(value, parameterType)).ToArray();
         }
 
-        private static object Map(object providedValue)
+        private static object Map(object providedValue, Type type)
         {
             if (providedValue == null)
                 return null;
 
-            return providedValue.GetType().IsArray ? ArrayParam<IParam>.FromObject(providedValue) : providedValue;
+            type = type ?? providedValue.GetType();
+            if (type.IsArray)
+            {
+                return ArrayParam<IParam>.FromObject(providedValue);
+            }
+            else if (type.IsEnum)
+            {
+                return EnumParam.FromObject(providedValue, type);
+            }            
+            return providedValue;
         }
 
         private static (MemberInfo source, object[] values) GetValidValuesForParamsSource(Type parentType, string sourceName)

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -218,7 +218,7 @@ namespace BenchmarkDotNet.Running
                             { 
                                 var definition = parameterDefinitions[index];
                                 var type = definition.ParameterType;
-                                return new ParameterInstance(parameterDefinitions[index], Map(value, type), summaryStyle);
+                                return new ParameterInstance(definition, Map(value, type), summaryStyle);
                             })
                         .ToArray());
             }
@@ -294,12 +294,16 @@ namespace BenchmarkDotNet.Running
             if (providedValue == null)
                 return null;
 
-            type = type ?? providedValue.GetType();
-            if (type.IsArray)
+            if (providedValue.GetType().IsArray)
             {
                 return ArrayParam<IParam>.FromObject(providedValue);
             }
-            else if (type.IsEnum)
+            // Usually providedValue contains all needed type information,
+            // but in case of F# enum types in attributes are erased.
+            // We can to restore them from types of arguments and fields.
+            // See also:
+            // https://github.com/dotnet/fsharp/issues/995
+            else if (providedValue.GetType().IsEnum || type.IsEnum)
             {
                 return EnumParam.FromObject(providedValue, type);
             }            

--- a/tests/BenchmarkDotNet.IntegrationTests.FSharp/Program.fs
+++ b/tests/BenchmarkDotNet.IntegrationTests.FSharp/Program.fs
@@ -1,8 +1,8 @@
-﻿module FSharpBenchmark
+﻿module FSharpBenchmarks
 
-open BenchmarkDotNet.Attributes
-open BenchmarkDotNet.Running
 open System.Threading
+open System.Collections.Generic
+open BenchmarkDotNet.Attributes
 
 type File = 
     { Name : string
@@ -24,3 +24,17 @@ type Db() =
         printfn "// ### F# Benchmark method called ###"
         Thread.Sleep(50)
         createDoc("Testing")
+
+type TestEnum = | A = 0 | B = 1 | C = 2
+
+type EnumParamsTest() =
+    let mutable collectedParams = HashSet<TestEnum>()
+
+    [<Params(TestEnum.A, TestEnum.B)>]
+    member val EnumParamValue = TestEnum.A with get, set
+
+    [<Benchmark>]
+    member this.Benchmark() =
+        if not <| collectedParams.Contains(this.EnumParamValue) then
+            printfn "// ### New Parameter %A ###" this.EnumParamValue
+            collectedParams.Add(this.EnumParamValue) |> ignore

--- a/tests/BenchmarkDotNet.IntegrationTests/FSharpTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/FSharpTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Xunit;
+using Xunit.Abstractions;
+
+using BenchmarkDotNet.Tests.Loggers;
+using static FSharpBenchmarks;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class FSharpTests : BenchmarkTestExecutor
+    {
+        public FSharpTests(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void ParamsSupportFSharpEnums()
+        {
+            var logger = new OutputLogger(Output);
+            var config = CreateSimpleConfig(logger);
+
+            CanExecute<EnumParamsTest>(config);
+            foreach (var param in new[] { TestEnum.A, TestEnum.B })
+                Assert.Contains($"// ### New Parameter {param} ###" + Environment.NewLine, logger.GetLog());
+            Assert.DoesNotContain($"// ### New Parameter {TestEnum.C} ###" + Environment.NewLine, logger.GetLog());
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.IntegrationTests/ReferencesTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ReferencesTests.cs
@@ -17,7 +17,7 @@ namespace BenchmarkDotNet.IntegrationTests
             => CanExecute<BenchmarkDotNet.IntegrationTests.CustomPaths.BenchmarksThatReturnTypeFromCustomPathDll>();
 #endif
         [Fact]
-        public void FSharpIsSupported() => CanExecute<FSharpBenchmark.Db>();
+        public void FSharpIsSupported() => CanExecute<FSharpBenchmarks.Db>();
 
         [Fact]
         public void VisualBasicIsSupported() => CanExecute<VisualBasic.Sample>();


### PR DESCRIPTION
Closes #1262 

I've added new type for enum params, that preserves type information for erasured F# enums in attributes. There is obvious code duplication, but that's for reason to keep code changes small and local. We can remove it after F# compiler is fixed. ;)

- [x] Fix F# benchmarks compilation with enum params
- [x] Fix enum values names in Summary
- [x] Write tests for this case

See also:
https://github.com/dotnet/fsharp/issues/995

Happy #hacktoberfest!