### PR TITLE
Improve documentation for version 0.12.0

### DIFF
--- a/docs/_changelog/header/v0.12.0.md
+++ b/docs/_changelog/header/v0.12.0.md
@@ -3,7 +3,7 @@ It's been few months since our last release, but we have been working hard and h
 ## Highlights
 
 * **Features**
-  * **NativeMemoryDiagnoser** - it uses `EtwProfiler` to profile the code using ETW and adds the extra columns `Allocated native memory` and `Native memory leak`.
+  * **NativeMemoryProfiler** - it uses `EtwProfiler` to profile the code using ETW and adds the extra columns `Allocated native memory` and `Native memory leak`.
     [#457](https://github.com/dotnet/BenchmarkDotNet/issues/457),
     [#1131](https://github.com/dotnet/BenchmarkDotNet/pull/1131),
     [#1208](https://github.com/dotnet/BenchmarkDotNet/pull/1208),
@@ -95,9 +95,9 @@ It's been few months since our last release, but we have been working hard and h
   * Make ids for tag columns unique - when using multiple `TagColumns` only one `TagColumn` was printed in the results.
     [#1146](https://github.com/dotnet/BenchmarkDotNet/issues/1146)
 
-## NativeMemoryDiagnoser
+## NativeMemoryProfiler
 
-The `NativeMemoryDiagnoser` diagnoser uses `EtwProfiler` to profile the code using ETW and adds the extra columns `Allocated native memory` and `Native memory leak` to the benchmark results table.
+The `NativeMemoryProfiler` diagnoser uses `EtwProfiler` to profile the code using ETW and adds the extra columns `Allocated native memory` and `Native memory leak` to the benchmark results table.
 
 ### Source code
 


### PR DESCRIPTION
In #1208 we renamed `NativeMemoryDiagnoser` to `NativeMemoryProfiler`.