### PR TITLE
Print GC and threading stats only if needed

### DIFF
--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -7,7 +7,7 @@ using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Engines
 {
-    public struct GcStats
+    public struct GcStats : IEquatable<GcStats>
     {
         internal const string ResultsLinePrefix = "GC: ";
 
@@ -221,6 +221,23 @@ namespace BenchmarkDotNet.Engines
             } while (result <= 0);
 
             return result;
+        }
+
+        public bool Equals(GcStats other) => Gen0Collections == other.Gen0Collections && Gen1Collections == other.Gen1Collections && Gen2Collections == other.Gen2Collections && AllocatedBytes == other.AllocatedBytes && TotalOperations == other.TotalOperations;
+
+        public override bool Equals(object obj) => obj is GcStats other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = Gen0Collections;
+                hashCode = (hashCode * 397) ^ Gen1Collections;
+                hashCode = (hashCode * 397) ^ Gen2Collections;
+                hashCode = (hashCode * 397) ^ AllocatedBytes.GetHashCode();
+                hashCode = (hashCode * 397) ^ TotalOperations.GetHashCode();
+                return hashCode;
+            }
         }
     }
 }

--- a/src/BenchmarkDotNet/Engines/RunResults.cs
+++ b/src/BenchmarkDotNet/Engines/RunResults.cs
@@ -68,8 +68,11 @@ namespace BenchmarkDotNet.Engines
             foreach (var measurement in GetMeasurements())
                 outWriter.WriteLine(measurement.ToOutputLine());
 
-            outWriter.WriteLine(GCStats.ToOutputLine());
-            outWriter.WriteLine(ThreadingStats.ToOutputLine());
+            if (!GCStats.Equals(GcStats.Empty))
+                outWriter.WriteLine(GCStats.ToOutputLine());
+            if (!ThreadingStats.Equals(ThreadingStats.Empty))
+                outWriter.WriteLine(ThreadingStats.ToOutputLine());
+
             outWriter.WriteLine();
         }
 

--- a/src/BenchmarkDotNet/Engines/ThreadingStats.cs
+++ b/src/BenchmarkDotNet/Engines/ThreadingStats.cs
@@ -3,7 +3,7 @@ using System.Threading;
 
 namespace BenchmarkDotNet.Engines
 {
-    public struct ThreadingStats
+    public struct ThreadingStats : IEquatable<ThreadingStats>
     {
         internal const string ResultsLinePrefix = "Threading: ";
 
@@ -80,6 +80,21 @@ namespace BenchmarkDotNet.Engines
 
             // we create delegate to avoid boxing, IMPORTANT!
             return property != null ? (Func<long>)property.GetGetMethod().CreateDelegate(typeof(Func<long>)) : () => 0;
+        }
+
+        public bool Equals(ThreadingStats other) => CompletedWorkItemCount == other.CompletedWorkItemCount && LockContentionCount == other.LockContentionCount && TotalOperations == other.TotalOperations;
+
+        public override bool Equals(object obj) => obj is ThreadingStats other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = CompletedWorkItemCount.GetHashCode();
+                hashCode = (hashCode * 397) ^ LockContentionCount.GetHashCode();
+                hashCode = (hashCode * 397) ^ TotalOperations.GetHashCode();
+                return hashCode;
+            }
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/InProcess.Emit/InProcessEmitExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.Emit/InProcessEmitExecutor.cs
@@ -137,8 +137,10 @@ namespace BenchmarkDotNet.Toolchains.InProcess.Emit
             }
 
             var lines = runResults.GetMeasurements().Select(measurement => measurement.ToOutputLine()).ToList();
-            lines.Add(runResults.GCStats.ToOutputLine());
-            lines.Add(runResults.ThreadingStats.ToOutputLine());
+            if (!runResults.GCStats.Equals(GcStats.Empty))
+                lines.Add(runResults.GCStats.ToOutputLine());
+            if (!runResults.ThreadingStats.Equals(ThreadingStats.Empty))
+                lines.Add(runResults.ThreadingStats.ToOutputLine());
 
             return new ExecuteResult(true, 0, default, lines.ToArray(), Array.Empty<string>());
         }

--- a/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitExecutor.cs
@@ -127,8 +127,10 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
             }
 
             var lines = runResults.GetMeasurements().Select(measurement => measurement.ToOutputLine()).ToList();
-            lines.Add(runResults.GCStats.ToOutputLine());
-            lines.Add(runResults.GCStats.ToOutputLine());
+            if (!runResults.GCStats.Equals(GcStats.Empty))
+                lines.Add(runResults.GCStats.ToOutputLine());
+            if (!runResults.ThreadingStats.Equals(ThreadingStats.Empty))
+                lines.Add(runResults.ThreadingStats.ToOutputLine());
 
             return new ExecuteResult(true, 0, default, lines.ToArray(), Array.Empty<string>());
         }

--- a/src/BenchmarkDotNet/Toolchains/InProcess/InProcessExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/InProcessExecutor.cs
@@ -131,8 +131,10 @@ namespace BenchmarkDotNet.Toolchains.InProcess
             }
 
             var lines = runResults.GetMeasurements().Select(measurement => measurement.ToOutputLine()).ToList();
-            lines.Add(runResults.GCStats.ToOutputLine());
-            lines.Add(runResults.ThreadingStats.ToOutputLine());
+            if (!runResults.GCStats.Equals(GcStats.Empty))
+                lines.Add(runResults.GCStats.ToOutputLine());
+            if (!runResults.ThreadingStats.Equals(ThreadingStats.Empty))
+                lines.Add(runResults.ThreadingStats.ToOutputLine());
 
             return new ExecuteResult(true, 0, default, lines.ToArray(), Array.Empty<string>());
         }


### PR DESCRIPTION
Fix for #1280 

Without stats:
```
cd samples\BenchmarkDotNet.Samples\bin\Release\net461
.\BenchmarkDotNet.Samples.exe --filter IntroBasic
```
![image](https://user-images.githubusercontent.com/17333903/66830980-ff3e2700-ef56-11e9-8aa9-08a77189765d.png)

With stats (with `-m` option):
```
cd samples\BenchmarkDotNet.Samples\bin\Release\net461
.\BenchmarkDotNet.Samples.exe --filter IntroBasic -m
```

![image](https://user-images.githubusercontent.com/17333903/66830941-e766a300-ef56-11e9-8c2d-78dd446b6fd0.png)
