### PR TITLE
Fix project file order

### DIFF
--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/_BenchmarkProjectName_.fsproj
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/_BenchmarkProjectName_.fsproj
@@ -21,11 +21,11 @@
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="$(BenchmarkDotNetVersion)" Condition="'$(OS)' == 'Windows_NT'"/>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="$(BenchmarkName).fs" />
-  </ItemGroup>
   <ItemGroup Condition="'$(config)' == true">
     <Compile Include="BenchmarkConfig.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(BenchmarkName).fs" />
   </ItemGroup>
   <ItemGroup Condition="'$(consoleApp)' == true">
     <Compile Include="Program.fs" />


### PR DESCRIPTION
## Reproduce

```
mkdir benchmark
cd benchmark
dotnet new benchmark -lang f# -c true --console-app
dotnet run
```

>...\benchmark\Benchmarks.fs(7,28): error FS0039: The type 'BenchmarkConfig' is not defined in 'BenchmarkDotNet.Configs'. Maybe you want one of the following:↔   BenchmarkLogicalGroupRule [C:\git\local\benches\benches.fsproj]
>...benchmark\Benchmarks.fs(7,10): error FS0267: This is not a valid constant expression or custom attribute value [C:\git\local\benches\benches.fsproj]
>
>The build failed. Fix the build errors and run again.

## Solution

Since `BenckmarConfig` is used within `(BenchmarkName).fs` it should precede it