### PR TITLE
Copy UserSecrets from benchmark project

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -23,7 +23,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         private const string DefaultSdkName = "Microsoft.NET.Sdk";
 
         private static readonly ImmutableArray<string> SettingsWeWantToCopy =
-            new[] { "NetCoreAppImplicitPackageVersion", "RuntimeFrameworkVersion", "PackageTargetFallback", "LangVersion", "UseWpf", "UseWindowsForms", "CopyLocalLockFileAssemblies", "PreserveCompilationContext" }.ToImmutableArray();
+            new[] { "NetCoreAppImplicitPackageVersion", "RuntimeFrameworkVersion", "PackageTargetFallback", "LangVersion", "UseWpf", "UseWindowsForms", "CopyLocalLockFileAssemblies", "PreserveCompilationContext", "UserSecretsId" }.ToImmutableArray();
 
         public string RuntimeFrameworkVersion { get; }
 


### PR DESCRIPTION
This allow use UserSecrets which implicitly obtained from entry point assembly.
Just copy UserSecretsId from benchmark project if available

Closes #1305