### PR TITLE
Use 24-hour time in joined summary file name

### DIFF
--- a/src/BenchmarkDotNet/Reports/Summary.cs
+++ b/src/BenchmarkDotNet/Reports/Summary.cs
@@ -83,7 +83,7 @@ namespace BenchmarkDotNet.Reports
 
         internal static Summary Join(List<Summary> summaries, ClockSpan clockSpan)
             => new Summary(
-                $"BenchmarkRun-joined-{DateTime.Now:yyyy-MM-dd-hh-mm-ss}",
+                $"BenchmarkRun-joined-{DateTime.Now:yyyy-MM-dd-HH-mm-ss}",
                 summaries.SelectMany(summary => summary.Reports).ToImmutableArray(),
                 HostEnvironmentInfo.GetCurrent(),
                 summaries.First().ResultsDirectoryPath,


### PR DESCRIPTION
This prevents confusing ordering in the file system and should be more in line with the sane date format chosen for the file name as well.