### PR TITLE
Fixed display text for array parameters and arguments

### DIFF
--- a/src/BenchmarkDotNet/Code/ArrayParam.cs
+++ b/src/BenchmarkDotNet/Code/ArrayParam.cs
@@ -7,6 +7,12 @@ using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Code
 {
+    internal static class ArrayParam
+    {
+        public static string GetDisplayString(Array array)
+            => $"{array.GetType().GetElementType().Name}[{array.Length}]";
+    }
+
     public class ArrayParam<T> : IParam
     {
         private readonly T[] array;
@@ -20,7 +26,7 @@ namespace BenchmarkDotNet.Code
 
         public object Value => array;
 
-        public string DisplayText => $"Array[{array.Length}]";
+        public string DisplayText => ArrayParam.GetDisplayString(array);
 
         public string ToSourceCode()
             => $"new {typeof(T).GetCorrectCSharpTypeName()}[] {{ {string.Join(", ", array.Select(item => toSourceCode?.Invoke(item) ?? SourceCodeHelper.ToSourceCode(item)))} }}";

--- a/src/BenchmarkDotNet/Code/ArrayParam.cs
+++ b/src/BenchmarkDotNet/Code/ArrayParam.cs
@@ -10,7 +10,7 @@ namespace BenchmarkDotNet.Code
     internal static class ArrayParam
     {
         public static string GetDisplayString(Array array)
-            => $"{array.GetType().GetElementType().Name}[{array.Length}]";
+            => $"{array.GetType().GetElementType().GetDisplayName()}[{array.Length}]";
     }
 
     public class ArrayParam<T> : IParam

--- a/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
+++ b/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
@@ -81,7 +81,7 @@ namespace BenchmarkDotNet.Parameters
 
         public object Value { get; }
 
-        public string DisplayText => Value.ToString();
+        public string DisplayText => Value is Array array ? $"Array[{array.Length}]" : Value.ToString();
 
         public string ToSourceCode()
         {
@@ -115,7 +115,7 @@ namespace BenchmarkDotNet.Parameters
 
         public object Value { get; }
 
-        public string DisplayText => Value.ToString();
+        public string DisplayText => Value is Array array ? $"Array[{array.Length}]" : Value.ToString();
 
         public string ToSourceCode()
         {

--- a/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
+++ b/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
@@ -81,7 +81,7 @@ namespace BenchmarkDotNet.Parameters
 
         public object Value { get; }
 
-        public string DisplayText => Value is Array array ? $"Array[{array.Length}]" : Value.ToString();
+        public string DisplayText => Value is Array array ? ArrayParam.GetDisplayString(array) : Value.ToString();
 
         public string ToSourceCode()
         {
@@ -115,7 +115,7 @@ namespace BenchmarkDotNet.Parameters
 
         public object Value { get; }
 
-        public string DisplayText => Value is Array array ? $"Array[{array.Length}]" : Value.ToString();
+        public string DisplayText => Value is Array array ? ArrayParam.GetDisplayString(array) : Value.ToString();
 
         public string ToSourceCode()
         {


### PR DESCRIPTION
Fixes #1348.

It would be better to unify display text generation across all parameters, but cannot find a good place for a common method. Maybe a base class?