### PR TITLE
Await non-generic ValueTask returning method

### DIFF
--- a/src/BenchmarkDotNet/Code/CodeGenerator.cs
+++ b/src/BenchmarkDotNet/Code/CodeGenerator.cs
@@ -149,7 +149,7 @@ namespace BenchmarkDotNet.Code
         {
             var method = descriptor.WorkloadMethod;
 
-            if (method.ReturnType == typeof(Task))
+            if (method.ReturnType == typeof(Task) || method.ReturnType == typeof(ValueTask))
             {
                 return new TaskDeclarationsProvider(descriptor);
             }

--- a/tests/BenchmarkDotNet.IntegrationTests/AsyncBenchmarksTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/AsyncBenchmarksTests.cs
@@ -35,13 +35,16 @@ namespace BenchmarkDotNet.IntegrationTests
             public Task ReturningTask() => Task.Delay(MillisecondsDelay);
 
             [Benchmark]
+            public ValueTask ReturningValueTask() => new ValueTask(Task.Delay(MillisecondsDelay));
+
+            [Benchmark]
             public async Task Awaiting() => await Task.Delay(MillisecondsDelay);
 
             [Benchmark]
             public Task<int> ReturningGenericTask() => ReturningTask().ContinueWith(_ => default(int));
 
             [Benchmark]
-            public ValueTask<int> ReturningValueTask() => new ValueTask<int>(ReturningGenericTask());
+            public ValueTask<int> ReturningGenericValueTask() => new ValueTask<int>(ReturningGenericTask());
         }
     }
 }


### PR DESCRIPTION
CodeGenerator does not correctly generate workload-code for non-generic `ValueTask` returning method. As a result, the runner does not await `ValueTask`, and the result is incorrect. This PR fixes it.

## Benchmark code
```csharp
[SimpleJob]
public class TestBenchmark
{
    [Benchmark]
    public async ValueTask ValueTask_NonGeneric()
    {
        await Task.Delay(100);
    }
    [Benchmark]
    public async Task Task_NonGeneric()
    {
        await Task.Delay(100);
    }
    [Benchmark]
    public async ValueTask<int> ValueTask_OfInt32()
    {
        await Task.Delay(100);
        return 0;
    }
    [Benchmark]
    public async Task<int> Task_OfInt32()
    {
        await Task.Delay(100);
        return 0;
    }
}
```

## v0.12.0: Benchmark result
```
BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.101
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT


|               Method |           Mean |       Error |      StdDev |
|--------------------- |---------------:|------------:|------------:|
| ValueTask_NonGeneric |       1.369 us |   0.0266 us |   0.0337 us |
|      Task_NonGeneric | 108,940.955 us | 502.6556 us | 470.1843 us |
|    ValueTask_OfInt32 | 108,966.428 us | 604.0630 us | 565.0409 us |
|         Task_OfInt32 | 108,848.281 us | 729.3760 us | 682.2587 us |
```

## v0.12.0: Generated code
```csharp
            workloadDelegate = ValueTask_NonGeneric;
...
            workloadDelegate = () => { Task_NonGeneric().GetAwaiter().GetResult(); };
...
            workloadDelegate = () => { return ValueTask_OfInt32().GetAwaiter().GetResult(); };
...
            workloadDelegate = () => { return Task_OfInt32().GetAwaiter().GetResult(); };
...
```

## Fixed: Benchmark result
```
BenchmarkDotNet=v0.12.0.20200202-develop, OS=Windows 10.0.18363
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.101
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT


|               Method |     Mean |   Error |  StdDev |
|--------------------- |---------:|--------:|--------:|
| ValueTask_NonGeneric | 108.8 ms | 0.78 ms | 0.73 ms |
|      Task_NonGeneric | 108.9 ms | 0.57 ms | 0.53 ms |
|    ValueTask_OfInt32 | 109.0 ms | 0.62 ms | 0.58 ms |
|         Task_OfInt32 | 108.9 ms | 0.68 ms | 0.64 ms |
```

## Fixed: Generated code
```csharp
...
            workloadDelegate = () => { ValueTask_NonGeneric().GetAwaiter().GetResult(); };
...
            workloadDelegate = () => { Task_NonGeneric().GetAwaiter().GetResult(); };
...
            workloadDelegate = () => { return ValueTask_OfInt32().GetAwaiter().GetResult(); };
...
            workloadDelegate = () => { return Task_OfInt32().GetAwaiter().GetResult(); };
...
```