### PR TITLE
Use CultureInfo when formatting parameter values

### DIFF
--- a/src/BenchmarkDotNet/Columns/ParamColumn.cs
+++ b/src/BenchmarkDotNet/Columns/ParamColumn.cs
@@ -17,7 +17,8 @@ namespace BenchmarkDotNet.Columns
 
         public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
         public string GetValue(Summary summary, BenchmarkCase benchmarkCase) =>
-            benchmarkCase.Parameters.Items.FirstOrDefault(item => item.Name == ColumnName)?.ToDisplayText() ?? ParameterInstance.NullParameterTextRepresentation;
+            benchmarkCase.Parameters.Items.FirstOrDefault(item => item.Name == ColumnName)?.ToDisplayText(summary.GetCultureInfo()) ??
+            ParameterInstance.NullParameterTextRepresentation;
 
         public bool IsAvailable(Summary summary) => true;
         public bool AlwaysShow => true;

--- a/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using BenchmarkDotNet.Code;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Helpers;
@@ -34,20 +35,25 @@ namespace BenchmarkDotNet.Parameters
                 ? parameter.ToSourceCode()
                 : SourceCodeHelper.ToSourceCode(value);
 
-        public string ToDisplayText()
+        public string ToDisplayText(CultureInfo cultureInfo)
         {
-            switch (value) {
+            switch (value)
+            {
                 case null:
                     return NullParameterTextRepresentation;
                 case IParam parameter:
                     return Trim(parameter.DisplayText, maxParameterColumnWidth);
+                case IFormattable formattable:
+                    return Trim(formattable.ToString(null, cultureInfo), maxParameterColumnWidth);
                 // no trimming for types!
                 case Type type:
                     return type.IsNullable() ? $"{Nullable.GetUnderlyingType(type).GetDisplayName()}?" : type.GetDisplayName();
+                default:
+                    return Trim(value.ToString(), maxParameterColumnWidth);
             }
-
-            return Trim(value.ToString(), maxParameterColumnWidth);
         }
+
+        public string ToDisplayText() => ToDisplayText(CultureInfo.CurrentCulture);
 
         public override string ToString() => ToDisplayText();
 


### PR DESCRIPTION
Closes #1369

I added `ParameterInstance.ToDisplayText(CultureInfo cultureInfo)` that handles `IFormattable` values. To preserve backwards-compatibility I also added a parameter-less overload that uses current culture, which is how it works right now.

Before the change (notice the commas instead of periods for values of parameter `B`):
![2020-02-12 23_18_06-BenchmarkDotNet  F__Projects_Softdev_!Open Source_BenchmarkDotNet  -  _src_Ben](https://user-images.githubusercontent.com/1935960/74378282-59a8a080-4dee-11ea-9215-0701e7612a15.png)

After the change (notice there are no commas):
![2020-02-12 23_15_53-BenchmarkDotNet  F__Projects_Softdev_!Open Source_BenchmarkDotNet  - ParameterIn](https://user-images.githubusercontent.com/1935960/74378298-61684500-4dee-11ea-8890-9892850965b9.png)
