### PR TITLE
fixes #641

### DIFF
--- a/src/BenchmarkDotNet/Exporters/RPlotExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/RPlotExporter.cs
@@ -69,7 +69,7 @@ namespace BenchmarkDotNet.Exporters
                         {
                             if (!string.IsNullOrWhiteSpace(args.Data))
                             {
-                                output.Append(args.Data);
+                                output.AppendLine(args.Data);
                             }
                         }
                     };
@@ -79,7 +79,7 @@ namespace BenchmarkDotNet.Exporters
                         {
                             if (!string.IsNullOrWhiteSpace(args.Data))
                             {
-                                output.Append(args.Data);
+                                output.AppendLine(args.Data);
                             }
                         }
                     };


### PR DESCRIPTION
Changed process stdout/stderr buffer to external buffer.

10x10 old code results artifact count: 504
10x10 old code run + Rscript runtime: Infinite (Cancelled after 9m6.493s)

10x10 new code results artifact count: 1,014
10x10 new code run + Rscript runtime: 6m47.011s

results artifact count = files in "netcoreapp2.2/BenchmarkDotNet.Artifacts/results/*"

```csharp
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Jobs;
using BenchmarkDotNet.Reports;
using BenchmarkDotNet.Running;
using System;

namespace BenchmarkDotNetTest
{
    class Program
    {
        static void Main(string[] args)
        {
            Console.WriteLine("Started");
            Summary summary = BenchmarkRunner.Run<Wide>();
            Console.WriteLine("Ended");
        }
    }

    [SimpleJob(RuntimeMoniker.NetCoreApp22, launchCount: 1, warmupCount: 0, targetCount: 1, invocationCount: 1)]
    [RPlotExporter]
    [BenchmarkDotNet.Attributes.DryJob]
    public class Wide
    {
        [Params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)]
        public int a;
        
        [Params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)]
        public int b;
    
        [Benchmark]
        public int Run()
        {
            return a * b;
        }
    }
}
```