### PR TITLE
don't require the JitDiagnosers (TailCall & Inlining) to run benchmarks once again just to gather JIT info, the overhead is very small

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.Windows/JitDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/JitDiagnoser.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
-using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Validators;
 using Microsoft.Diagnostics.Tracing.Parsers;
 
@@ -15,6 +15,8 @@ namespace BenchmarkDotNet.Diagnostics.Windows
         protected override ulong EventType => (ulong)ClrTraceEventParser.Keywords.JitTracing;
 
         protected override string SessionNamePrefix => "JitTracing";
+
+        public override RunMode GetRunMode(BenchmarkCase benchmarkCase) => RunMode.NoOverhead;
 
         public abstract IEnumerable<string> Ids { get; }
 


### PR DESCRIPTION
While working on https://github.com/dotnet/runtime/issues/2191 I got surprised by how long it takes to get the benchmark results.

It turned out that so far we were always running the benchmarks one more time if `Inlining` or `TailCall` diagnosers were enabled. We simply don't need to do that, the overhead of these two diagnosers is very, very small (we just sign up for 3 events).

```cmd
git clone https://github.com/dotnet/BenchmarkDotNet/
cd BenchmarkDotNet
cd samples
cd BenchmarkDotNet.Samples.FSharp
dotnet run -c Release -f net461 --filter TailCallDetector
```

Before:

| Method | facRank |      Mean |     Error |    StdDev |
|------- |-------- |----------:|----------:|----------:|
|   test |       7 |  9.460 ns | 0.2158 ns | 0.2310 ns |
|  test1 |       7 |  4.758 ns | 0.0824 ns | 0.0731 ns |
|  test2 |       7 | 51.820 ns | 0.9814 ns | 0.9180 ns |

```log
Run time: 00:02:29 (149.11 sec), executed benchmarks: 3

Global total time: 00:02:31 (151.73 sec), executed benchmarks: 3
```

After:

| Method | facRank |      Mean |     Error |    StdDev |
|------- |-------- |----------:|----------:|----------:|
|   test |       7 |  9.383 ns | 0.0837 ns | 0.0783 ns |
|  test1 |       7 |  4.688 ns | 0.0655 ns | 0.0613 ns |
|  test2 |       7 | 49.748 ns | 0.2633 ns | 0.2199 ns |

```log
Run time: 00:01:23 (83.31 sec), executed benchmarks: 3

Global total time: 00:01:26 (86.03 sec), executed benchmarks: 3
```

