### PR TITLE
update TraceEvent to 2.0.49 to get TailCalls working again

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.Windows/BenchmarkDotNet.Diagnostics.Windows.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/BenchmarkDotNet.Diagnostics.Windows.csproj
@@ -12,6 +12,6 @@
     <ProjectReference Include="..\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.44" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.49" PrivateAssets="contentfiles;analyzers" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Due to some strange bug in old version of `TraceEvent` library, the `TailCall` diagnoser reports... inlining events for .NET Core 2.2+ (2.1 works fine). Not tail call events. 

For details you can go to: https://github.com/dotnet/runtime/issues/2191

