### PR TITLE
Bump macOS Azure Pipeline vmImage to 10.14, fix #1396

### DIFF
--- a/azure-pipelines.macOS.yml
+++ b/azure-pipelines.macOS.yml
@@ -11,5 +11,5 @@ jobs:
 - template: build/azure-pipelines.job.template.yml
   parameters:
     name: macOS
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
     scriptFileName: ./build.sh


### PR DESCRIPTION
On March 23, 2020, vs2015-win2012r2, macOS-10.13, win1803 vmImages
will be removed. We should use macOS-10.14 to make our CI green again.
See https://aka.ms/blocked-hosted-agent for more information.