### PR TITLE
Fix MSB4086 if LangVersion is a keyword

### DIFF
--- a/src/BenchmarkDotNet/Templates/CsProj.txt
+++ b/src/BenchmarkDotNet/Templates/CsProj.txt
@@ -17,7 +17,7 @@
     <CodeAnalysisRuleSet></CodeAnalysisRuleSet>
     $COPIEDSETTINGS$
     <!-- we set LangVersion after $COPIEDSETTINGS$ which might contain LangVersion copied from the benchmarks project -->
-    <LangVersion Condition="'$(LangVersion)' == '' Or '$(LangVersion)' &lt; '7.3'">latest</LangVersion>
+    <LangVersion Condition="'$(LangVersion)' == '' Or ($([System.Char]::IsDigit('$(LangVersion)', 0)) And '$(LangVersion)' &lt; '7.3')">latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix compilation error MSB4086 with version 0.12.1 if the `LangVersion` MSBuild property is already set to one of the keywords such as `preview`, `latest` and `latestMajor` ([docs](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/langversion-compiler-option)).

Otherwise MSBuild complains that it cannot perform a numeric comparison and compilation fails.

Example compilation error from a project with `<LangVersion>latest</LangVersion>` specified in a `Directory.Build.props` file in the repository root:

```
\BenchmarkDotNet.Autogenerated.csproj(20,18): error MSB4086: A numeric comparison was attempted on "$(LangVersion)" that evaluates to "latest" instead of a number, in condition "'$(LangVersion)' == '' Or '$(LangVersion)' < '7.3'".
```

Open to alternative suggestions for the fix, but I've gone with just checking whether the first character of the existing value is a digit (implying it's a version number) before performing the comparison. Otherwise it assumes that the keyword resolves to a version greater than 7.3.

I'm also not sure on what the best way to add a regression test for this, again open to suggestions.

Issue appears to have been introduced by #1389 (d02c8c36bd3b5b8604fc2bce37bb865f98a4c186).
