### PR TITLE
Fix typo in log message

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
@@ -31,7 +31,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
                 if (!process.WaitForExit((int)parameters.Timeout.TotalMilliseconds))
                 {
-                    parameters.Logger.WriteLineError($"// command took more that the timeout: {parameters.Timeout.TotalSeconds:0.##}s. Killing the process tree!");
+                    parameters.Logger.WriteLineError($"// command took more than the timeout: {parameters.Timeout.TotalSeconds:0.##}s. Killing the process tree!");
 
                     outputReader.CancelRead();
                     process.KillTree();


### PR DESCRIPTION
Fix typo in log message when command times out.
