### PR TITLE
[samples] UI tweaks to Xamarin samples

### DIFF
--- a/samples/BenchmarkDotNet.Samples.Forms/MainPage.xaml
+++ b/samples/BenchmarkDotNet.Samples.Forms/MainPage.xaml
@@ -5,6 +5,13 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              x:Class="BenchmarkDotNet.Samples.Forms.MainPage">
+    <ContentPage.Padding>
+        <OnPlatform x:TypeArguments="Thickness">
+            <OnPlatform.Platforms>
+                <On Platform="iOS" Value="0,44,0,0" />
+            </OnPlatform.Platforms>
+        </OnPlatform>
+    </ContentPage.Padding>
     <Grid RowSpacing="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -13,14 +20,22 @@
         <Button
             x:Name="Run"
             Text="Run"
-            Padding="10,10,10,0"
+            Margin="10,10,10,0"
             Clicked="Button_Clicked" />
         <ScrollView Orientation="Both" Grid.Row="1">
             <Label
                 x:Name="Summary"
                 Grid.Row="1"
-                Padding="10"
-                FontFamily="monospace" />
+                Padding="10">
+                <Label.FontFamily>
+                    <OnPlatform x:TypeArguments="x:String">
+                        <OnPlatform.Platforms>
+                            <On Platform="Android" Value="monospace" />
+                            <On Platform="iOS" Value="Courier" />
+                        </OnPlatform.Platforms>
+                    </OnPlatform>
+                </Label.FontFamily>
+            </Label>
         </ScrollView>
         <ActivityIndicator
             x:Name="Indicator"


### PR DESCRIPTION
These are just general UI improvements to the sample. Which is still admittedly, a bit ugly.

* Use a `Padding` for the entire page on iOS, to accomodate an iOS device/simulator with the "notch".
* Use a valid mono-spaced font on iOS: `Courier`
* Use `Margin` instead of `Padding` on the "Run" button. The wrong property was used before.