### PR TITLE
Fix wrongly reported os brand string for Windows 10 1909

### DIFF
--- a/src/BenchmarkDotNet/Environments/OsBrandStringHelper.cs
+++ b/src/BenchmarkDotNet/Environments/OsBrandStringHelper.cs
@@ -136,7 +136,7 @@ namespace BenchmarkDotNet.Environments
                 new Windows10Version(1803, "Redstone 4", "April 2018 Update", 17134),
                 new Windows10Version(1809, "Redstone 5", "October 2018 Update", 17763),
                 new Windows10Version(1903, "19H1", "May 2019 Update", 18362),
-                new Windows10Version(1909, "19H2", "November 2018 Update", 18363),
+                new Windows10Version(1909, "19H2", "November 2019 Update", 18363),
                 new Windows10Version(2004, "20H1", "?", 19041)
             };
 

--- a/tests/BenchmarkDotNet.Tests/Environments/OsBrandStringTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Environments/OsBrandStringTests.cs
@@ -40,7 +40,7 @@ namespace BenchmarkDotNet.Tests.Environments
         [InlineData("10.0.17134", 48, "Windows 10.0.17134.48 (1803/April2018Update/Redstone4)")]
         [InlineData("10.0.17763", 1, "Windows 10.0.17763.1 (1809/October2018Update/Redstone5)")]
         [InlineData("10.0.18362", 693, "Windows 10.0.18362.693 (1903/May2019Update/19H1)")]
-        [InlineData("10.0.18363", 657, "Windows 10.0.18363.657 (1909/November2018Update/19H2)")]
+        [InlineData("10.0.18363", 657, "Windows 10.0.18363.657 (1909/November2019Update/19H2)")]
         [InlineData("10.0.19041", 1, "Windows 10.0.19041.1 (2004/?/20H1)")]
         public void WindowsWithUbrIsPrettified(string originalVersion, int ubr, string prettifiedName)
             => Check(OsBrandStringHelper.Prettify("Windows", originalVersion, ubr), prettifiedName);


### PR DESCRIPTION
Fixes #1436