### PR TITLE
Handle assemblies loaded via a stream

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -35,13 +35,12 @@ namespace BenchmarkDotNet.Toolchains.CsProj
 
         protected override string GetBuildArtifactsDirectoryPath(BuildPartition buildPartition, string programName)
         {
-            string directoryName = Path.GetDirectoryName(buildPartition.AssemblyLocation);
+            string assemblyLocation = buildPartition.AssemblyLocation;
 
             //Assembles loaded from a stream will have an empty location (https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location).
-            if (directoryName == null || directoryName.IsEmpty())
-            {
-                directoryName = Path.Combine(Directory.GetCurrentDirectory(), "BenchmarkDotNet.Bin");
-            }
+            string directoryName = assemblyLocation.IsEmpty() ?
+                Path.Combine(Directory.GetCurrentDirectory(), "BenchmarkDotNet.Bin") :
+                Path.GetDirectoryName(buildPartition.AssemblyLocation);
 
             return Path.Combine(directoryName, programName);
         }

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -35,8 +35,14 @@ namespace BenchmarkDotNet.Toolchains.CsProj
 
         protected override string GetBuildArtifactsDirectoryPath(BuildPartition buildPartition, string programName)
         {
-            string directoryName = Path.GetDirectoryName(buildPartition.AssemblyLocation)
-                ?? throw new DirectoryNotFoundException(buildPartition.AssemblyLocation);
+            string directoryName = Path.GetDirectoryName(buildPartition.AssemblyLocation);
+
+            //Assembles loaded from a stream will have an empty location (https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location).
+            if (directoryName == null || directoryName.IsEmpty())
+            {
+                directoryName = Path.Combine(Directory.GetCurrentDirectory(), "BenchmarkDotNet.Bin");
+            }
+
             return Path.Combine(directoryName, programName);
         }
 

--- a/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
@@ -1,13 +1,27 @@
 ﻿using System.IO;
+using System.Linq;
+using System.Reflection;
+using BenchmarkDotNet.Characteristics;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Tests.Mocks;
 using BenchmarkDotNet.Toolchains.CsProj;
 using JetBrains.Annotations;
 using Xunit;
+using BenchmarkDotNet.Extensions;
+using Xunit.Abstractions;
 
-namespace BenchmarkDotNet.Tests
+ namespace BenchmarkDotNet.Tests
 {
     public class CsProjGeneratorTests
     {
+        private readonly ITestOutputHelper testOutputHelper;
         private FileInfo TestAssemblyFileInfo = new FileInfo(typeof(CsProjGeneratorTests).Assembly.Location);
+        public CsProjGeneratorTests(ITestOutputHelper testOutputHelper)
+        {
+            this.testOutputHelper = testOutputHelper;
+        }
 
         [Theory]
         [InlineData("net471")]
@@ -139,6 +153,64 @@ namespace BenchmarkDotNet.Tests
             }
 
             File.Delete(propsFilePath);
+        }
+
+        [Fact]
+        public void TheDefaultFilePathShouldBeUsedWhenAnAssemblyLocationIsEmpty()
+        {
+            const string programName = "testProgram";
+            var config = ManualConfig.CreateEmpty().CreateImmutableConfig();
+            var asyncVoidMethod =
+                typeof(MockFactory.MockBenchmarkClass)
+                    .GetTypeInfo()
+                    .GetMethods()
+                    .Single(method => method.Name == nameof(MockFactory.MockBenchmarkClass.Foo));
+
+
+            //Simulate loading an assembly from a stream
+            var benchmarkDotNetAssembly = typeof(MockFactory.MockBenchmarkClass).GetTypeInfo().Assembly;
+            var streamLoadedAssembly = Assembly.Load(File.ReadAllBytes(benchmarkDotNetAssembly.Location));
+            var assemblyType = streamLoadedAssembly.GetRunnableBenchmarks().Select(type => type).FirstOrDefault();
+
+            var target = new Descriptor(assemblyType, asyncVoidMethod);
+            var benchmarkCase = BenchmarkCase.Create(target, Job.Default, null, config);
+
+            var benchmarks = new[] { new BenchmarkBuildInfo(benchmarkCase, config.CreateImmutableConfig(), 999) };
+            var projectGenerator = new SteamLoadedBuildPartition("netcoreapp3.0", null, null, null);
+            string binariesPath = projectGenerator.ResolvePathForBinaries(new BuildPartition(benchmarks, new Resolver()), programName);
+
+            string expectedPath = Path.Combine(Path.Combine(Directory.GetCurrentDirectory(), "BenchmarkDotNet.Bin"), programName);
+            Assert.Equal(expectedPath, binariesPath);
+        }
+
+        [Fact]
+        public void TestAssemblyFilePathIsUsedWhenTheAssemblyLocationIsNotEmpty()
+        {
+            const string programName = "testProgram";
+            var asyncVoidMethod =
+                typeof(MockFactory.MockBenchmarkClass)
+                    .GetTypeInfo()
+                    .GetMethods()
+                    .Single(method => method.Name == nameof(MockFactory.MockBenchmarkClass.Foo));
+            var target = new Descriptor(typeof(MockFactory.MockBenchmarkClass), asyncVoidMethod);
+            var benchmarkCase = BenchmarkCase.Create(target, Job.Default, null, ManualConfig.CreateEmpty().CreateImmutableConfig());
+            var benchmarks = new[] { new BenchmarkBuildInfo(benchmarkCase, ManualConfig.CreateEmpty().CreateImmutableConfig(), 0) };
+            var projectGenerator = new SteamLoadedBuildPartition("netcoreapp3.0", null, null, null);
+            var buildPartition = new BuildPartition(benchmarks, new Resolver());
+            string binariesPath = projectGenerator.ResolvePathForBinaries(buildPartition, programName);
+
+            string expectedPath = Path.Combine(Path.GetDirectoryName(buildPartition.AssemblyLocation), programName);
+            Assert.Equal(expectedPath, binariesPath);
+        }
+
+        private class SteamLoadedBuildPartition : CsProjGenerator
+        {
+            internal string ResolvePathForBinaries(BuildPartition buildPartition, string programName)
+            {
+                return base.GetBuildArtifactsDirectoryPath(buildPartition, programName);
+            }
+
+            public SteamLoadedBuildPartition(string targetFrameworkMoniker, string cliPath, string packagesPath, string runtimeFrameworkVersion) : base(targetFrameworkMoniker, cliPath, packagesPath, runtimeFrameworkVersion) { }
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
@@ -166,7 +166,7 @@ namespace BenchmarkDotNet.Tests
             var streamLoadedAssembly = Assembly.Load(File.ReadAllBytes(benchmarkDotNetAssembly.Location));
             var assemblyType = streamLoadedAssembly.GetRunnableBenchmarks().Select(type => type).FirstOrDefault();
 
-            var target = new Descriptor(assemblyType, asyncVoidMethod);
+            var target = new Descriptor(assemblyType, benchmarkMethod);
             var benchmarkCase = BenchmarkCase.Create(target, Job.Default, null, config);
 
             var benchmarks = new[] { new BenchmarkBuildInfo(benchmarkCase, config.CreateImmutableConfig(), 999) };
@@ -186,7 +186,7 @@ namespace BenchmarkDotNet.Tests
                     .GetTypeInfo()
                     .GetMethods()
                     .Single(method => method.Name == nameof(MockFactory.MockBenchmarkClass.Foo));
-            var target = new Descriptor(typeof(MockFactory.MockBenchmarkClass), asyncVoidMethod);
+            var target = new Descriptor(typeof(MockFactory.MockBenchmarkClass), benchmarkMethod);
             var benchmarkCase = BenchmarkCase.Create(target, Job.Default, null, ManualConfig.CreateEmpty().CreateImmutableConfig());
             var benchmarks = new[] { new BenchmarkBuildInfo(benchmarkCase, ManualConfig.CreateEmpty().CreateImmutableConfig(), 0) };
             var projectGenerator = new SteamLoadedBuildPartition("netcoreapp3.0", null, null, null);

--- a/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
@@ -10,18 +10,12 @@ using BenchmarkDotNet.Toolchains.CsProj;
 using JetBrains.Annotations;
 using Xunit;
 using BenchmarkDotNet.Extensions;
-using Xunit.Abstractions;
 
- namespace BenchmarkDotNet.Tests
+namespace BenchmarkDotNet.Tests
 {
     public class CsProjGeneratorTests
     {
-        private readonly ITestOutputHelper testOutputHelper;
         private FileInfo TestAssemblyFileInfo = new FileInfo(typeof(CsProjGeneratorTests).Assembly.Location);
-        public CsProjGeneratorTests(ITestOutputHelper testOutputHelper)
-        {
-            this.testOutputHelper = testOutputHelper;
-        }
 
         [Theory]
         [InlineData("net471")]

--- a/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
@@ -181,7 +181,7 @@ namespace BenchmarkDotNet.Tests
         public void TestAssemblyFilePathIsUsedWhenTheAssemblyLocationIsNotEmpty()
         {
             const string programName = "testProgram";
-            var asyncVoidMethod =
+            var benchmarkMethod =
                 typeof(MockFactory.MockBenchmarkClass)
                     .GetTypeInfo()
                     .GetMethods()

--- a/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
@@ -154,7 +154,7 @@ namespace BenchmarkDotNet.Tests
         {
             const string programName = "testProgram";
             var config = ManualConfig.CreateEmpty().CreateImmutableConfig();
-            var asyncVoidMethod =
+            var benchmarkMethod =
                 typeof(MockFactory.MockBenchmarkClass)
                     .GetTypeInfo()
                     .GetMethods()


### PR DESCRIPTION
Hello,

We are using a test framework called Gauge (https://gauge.org/) to do regression testing and wanted to roll performance tests in with those regression tests.  In our case we want to use Gauge steps to control and kick off different BenchmarkDotNet benchmarks (so we have a common top level framework for all of our regression tests).  

One issue we have run into is Gauge loads assemblies via streams, this causes the assembly location to be an empty string when running against net core/net standard.  More information about the assembly location being empty in this case can be found in Microsoft's documentation (https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location).

This PR provides a way to handle that scenario by providing a default location for the project build artifacts.  Other non-CsProjGenerators seem to do this by default so we have only updated this generator.

It's possible this could be handled a different way, but we've found this solution is working well for us.

Any feedback is welcomed.