### PR TITLE
Upgrades ClrMD to a version that will not crash on Linux :(

### DIFF
--- a/src/BenchmarkDotNet.Disassembler.x64/BenchmarkDotNet.Disassembler.x64.csproj
+++ b/src/BenchmarkDotNet.Disassembler.x64/BenchmarkDotNet.Disassembler.x64.csproj
@@ -15,6 +15,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.57604" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.126102" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarkDotNet.Disassembler.x86/BenchmarkDotNet.Disassembler.x86.csproj
+++ b/src/BenchmarkDotNet.Disassembler.x86/BenchmarkDotNet.Disassembler.x86.csproj
@@ -21,6 +21,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.57604" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.126102" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.4.3" />
     <PackageReference Include="Iced" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.57604" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.126102" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
     <PackageReference Include="Perfolizer" Version="0.2.1" />


### PR DESCRIPTION
An unfortunate turn of events led me to a place where I need to perform this sort of upgrade to avoid crashing on Linux with a disassembler.

As far as I could tell, the windows version is completely unaffected / not crashing with the previous version.