### PR TITLE
Clearly display names for .Net Framework

### DIFF
--- a/src/BenchmarkDotNet/Environments/Runtimes/ClrRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/ClrRuntime.cs
@@ -7,12 +7,12 @@ namespace BenchmarkDotNet.Environments
 {
     public class ClrRuntime : Runtime, IEquatable<ClrRuntime>
     {
-        public static readonly ClrRuntime Net461 = new ClrRuntime(RuntimeMoniker.Net461, "net461", ".NET 4.6.1");
-        public static readonly ClrRuntime Net462 = new ClrRuntime(RuntimeMoniker.Net462, "net462", ".NET 4.6.2");
-        public static readonly ClrRuntime Net47 = new ClrRuntime(RuntimeMoniker.Net47, "net47", ".NET 4.7");
-        public static readonly ClrRuntime Net471 = new ClrRuntime(RuntimeMoniker.Net471, "net471", ".NET 4.7.1");
-        public static readonly ClrRuntime Net472 = new ClrRuntime(RuntimeMoniker.Net472, "net472", ".NET 4.7.2");
-        public static readonly ClrRuntime Net48 = new ClrRuntime(RuntimeMoniker.Net48, "net48", ".NET 4.8");
+        public static readonly ClrRuntime Net461 = new ClrRuntime(RuntimeMoniker.Net461, "net461", ".NET Framework 4.6.1");
+        public static readonly ClrRuntime Net462 = new ClrRuntime(RuntimeMoniker.Net462, "net462", ".NET Framework 4.6.2");
+        public static readonly ClrRuntime Net47 = new ClrRuntime(RuntimeMoniker.Net47, "net47", ".NET Framework 4.7");
+        public static readonly ClrRuntime Net471 = new ClrRuntime(RuntimeMoniker.Net471, "net471", ".NET Framework 4.7.1");
+        public static readonly ClrRuntime Net472 = new ClrRuntime(RuntimeMoniker.Net472, "net472", ".NET Framework 4.7.2");
+        public static readonly ClrRuntime Net48 = new ClrRuntime(RuntimeMoniker.Net48, "net48", ".NET Framework 4.8");
 
         public string Version { get; }
 
@@ -45,7 +45,7 @@ namespace BenchmarkDotNet.Environments
         {
             if (!RuntimeInformation.IsWindows())
             {
-                throw new NotSupportedException("Full .NET Framework supports Windows OS only.");
+                throw new NotSupportedException(".NET Framework supports Windows OS only.");
             }
 
             // this logic is put to a separate method to avoid any assembly loading issues on non Windows systems
@@ -63,7 +63,7 @@ namespace BenchmarkDotNet.Environments
                 case "4.7.2": return Net472;
                 case "4.8":   return Net48;
                 default: // unlikely to happen but theoretically possible
-                    return new ClrRuntime(RuntimeMoniker.NotRecognized, $"net{version.Replace(".", null)}", $".NET {version}");
+                    return new ClrRuntime(RuntimeMoniker.NotRecognized, $"net{version.Replace(".", null)}", $".NET Framework {version}");
             }
         }
     }

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
@@ -15,15 +15,15 @@ namespace BenchmarkDotNet.Toolchains.CsProj
     [PublicAPI]
     public class CsProjClassicNetToolchain : Toolchain
     {
-        [PublicAPI] public static readonly IToolchain Net461 = new CsProjClassicNetToolchain("net461");
-        [PublicAPI] public static readonly IToolchain Net462 = new CsProjClassicNetToolchain("net462");
-        [PublicAPI] public static readonly IToolchain Net47 = new CsProjClassicNetToolchain("net47");
-        [PublicAPI] public static readonly IToolchain Net471 = new CsProjClassicNetToolchain("net471");
-        [PublicAPI] public static readonly IToolchain Net472 = new CsProjClassicNetToolchain("net472");
-        [PublicAPI] public static readonly IToolchain Net48 = new CsProjClassicNetToolchain("net48");
+        [PublicAPI] public static readonly IToolchain Net461 = new CsProjClassicNetToolchain("net461", ".NET Framework 4.6.1");
+        [PublicAPI] public static readonly IToolchain Net462 = new CsProjClassicNetToolchain("net462", ".NET Framework 4.6.2");
+        [PublicAPI] public static readonly IToolchain Net47 = new CsProjClassicNetToolchain("net47", ".NET Framework 4.7");
+        [PublicAPI] public static readonly IToolchain Net471 = new CsProjClassicNetToolchain("net471", ".NET Framework 4.7.1");
+        [PublicAPI] public static readonly IToolchain Net472 = new CsProjClassicNetToolchain("net472", ".NET Framework 4.7.2");
+        [PublicAPI] public static readonly IToolchain Net48 = new CsProjClassicNetToolchain("net48", ".NET Framework 4.8");
 
-        private CsProjClassicNetToolchain(string targetFrameworkMoniker, string packagesPath = null, TimeSpan? timeout = null)
-            : base(targetFrameworkMoniker,
+        private CsProjClassicNetToolchain(string targetFrameworkMoniker, string name, string packagesPath = null, TimeSpan? timeout = null)
+            : base(name,
                 new CsProjGenerator(targetFrameworkMoniker, cliPath: null, packagesPath: packagesPath, runtimeFrameworkVersion: null),
                 new DotNetCliBuilder(targetFrameworkMoniker, customDotNetCliPath: null, timeout: timeout),
                 new Executor())
@@ -31,7 +31,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         }
 
         public static IToolchain From(string targetFrameworkMoniker, string packagesPath = null, TimeSpan? timeout = null)
-            => new CsProjClassicNetToolchain(targetFrameworkMoniker, packagesPath, timeout);
+            => new CsProjClassicNetToolchain(targetFrameworkMoniker, targetFrameworkMoniker, packagesPath, timeout);
 
         public override bool IsSupported(BenchmarkCase benchmarkCase, ILogger logger, IResolver resolver)
         {


### PR DESCRIPTION
This changes the display for `CsProjClassicNetToolchain`, so that it properly shows the framework name, instead of just the TFM.

E.g. consider this benchmark:

```c#
[Config(typeof(Config))]
public unsafe class Toolchain
{
    private class Config : ManualConfig
    {
        public Config()
        {
            AddJob(Job.Default.WithToolchain(CsProjClassicNetToolchain.Net48));
            AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp31));
        }
    }

    [Benchmark]
    public void Sleep() => Thread.Sleep(1);
}
```

Before this change, its output is (notice the Toolchain column in the table):

```
// * Summary *

BenchmarkDotNet=v0.12.1.20200610-develop, OS=Windows 10.0.18362.836 (1903/May2019Update/19H1)
Intel Core i5-2300 CPU 2.80GHz (Sandy Bridge), 1 CPU, 4 logical and 4 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  Job-UPLABW : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  Job-JBFOWH : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT


| Method |        Job |     Toolchain |     Mean |     Error |    StdDev |
|------- |----------- |-------------- |---------:|----------:|----------:|
|  Sleep | Job-UPLABW | .NET Core 3.1 | 1.808 ms | 0.0332 ms | 0.0310 ms |
|  Sleep | Job-JBFOWH |         net48 | 1.783 ms | 0.0350 ms | 0.0612 ms |
```

After it, it's instead:

```
// * Summary *

BenchmarkDotNet=v0.12.1.20200610-develop, OS=Windows 10.0.18362.836 (1903/May2019Update/19H1)
Intel Core i5-2300 CPU 2.80GHz (Sandy Bridge), 1 CPU, 4 logical and 4 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  Job-UPLABW : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  Job-RMSQHR : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT


| Method |        Job |          Toolchain |     Mean |     Error |    StdDev |
|------- |----------- |------------------- |---------:|----------:|----------:|
|  Sleep | Job-UPLABW |      .NET Core 3.1 | 1.762 ms | 0.0351 ms | 0.0444 ms |
|  Sleep | Job-RMSQHR | .NET Framework 4.8 | 1.710 ms | 0.0226 ms | 0.0188 ms |
```

Also, it changes the name for `ClrRuntime`s from e.g. ".NET 4.8" to the more correct ".NET Framework 4.8". (Which is especially important to differentiate them from .Net 5.0.)