### PR TITLE
ParamsSource returning IEnumerable<object[]> fixes

### DIFF
--- a/src/BenchmarkDotNet/Exporters/FullNameProvider.cs
+++ b/src/BenchmarkDotNet/Exporters/FullNameProvider.cs
@@ -125,7 +125,7 @@ namespace BenchmarkDotNet.Exporters
                     parametersBuilder.Append(", ");
 
                 parametersBuilder.Append(parameter.Name).Append(':').Append(' ');
-                parametersBuilder.Append(GetArgument(parameter.Value, parameter.Value?.GetType()));
+                parametersBuilder.Append(GetArgument(parameter.Value, parameter.Definition.ParameterType));
             }
 
             return parametersBuilder.Append(')').ToString();

--- a/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
+++ b/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
@@ -14,8 +14,13 @@ namespace BenchmarkDotNet.Parameters
         [SuppressMessage("ReSharper", "CoVariantArrayConversion")]
         internal static object[] CreateForParams(MemberInfo source, object[] values)
         {
+            // IEnumerable<object>
             if (values.IsEmpty() || values.All(SourceCodeHelper.IsCompilationTimeConstant))
                 return values;
+
+            // IEnumerable<object[]>
+            if (values.All(value => value is object[] array && array.Length == 1 && SourceCodeHelper.IsCompilationTimeConstant(array[0])))
+                return values.Select(x => ((object[])x)[0]).ToArray();
 
             return values.Select((value, index) => new SmartParameter(source, value, index)).ToArray();
         }

--- a/tests/BenchmarkDotNet.IntegrationTests/ArgumentsTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ArgumentsTests.cs
@@ -651,6 +651,101 @@ namespace BenchmarkDotNet.IntegrationTests
             }
         }
 
+        [Theory, MemberData(nameof(GetToolchains))]
+        public void StaticMethodsAndPropertiesCanBeUsedAsSources_EnumerableOfObjects(IToolchain toolchain)
+            => CanExecute<WithStaticSources_EnumerableOfObjects>(toolchain);
+
+        public class WithStaticSources_EnumerableOfObjects
+        {
+            public static IEnumerable<object> StaticMethod() { yield return 1; }
+
+            public static IEnumerable<object> StaticProperty
+            {
+                get
+                {
+                    yield return 2;
+                    yield return 3;
+                }
+            }
+
+            [ParamsSource(nameof(StaticMethod))]
+            public int ParamOne { get; set; }
+
+            [ParamsSource(nameof(StaticProperty))]
+            public int ParamTwo { get; set; }
+
+            [Benchmark]
+            [ArgumentsSource(nameof(StaticMethod))]
+            public void TestMethod(int argument)
+            {
+                if (argument != 1)
+                    throw new ArgumentException("The argument value is incorrect!");
+                if (ParamOne != 1)
+                    throw new ArgumentException("The ParamOne value is incorrect!");
+                if (ParamTwo != 2 && ParamTwo != 3)
+                    throw new ArgumentException("The ParamTwo value is incorrect!");
+            }
+
+            [Benchmark]
+            [ArgumentsSource(nameof(StaticProperty))]
+            public void TestProperty(int argument)
+            {
+                if (argument != 2 && argument != 3)
+                    throw new ArgumentException("The argument value is incorrect!");
+                if (ParamOne != 1)
+                    throw new ArgumentException("The ParamOne value is incorrect!");
+                if (ParamTwo != 2 && ParamTwo != 3)
+                    throw new ArgumentException("The ParamTwo value is incorrect!");
+            }
+        }
+
+        [Theory, MemberData(nameof(GetToolchains))]
+        public void StaticMethodsAndPropertiesCanBeUsedAsSources_EnumerableOfArrayOfObjects(IToolchain toolchain)
+            => CanExecute<WithStaticSources_EnumerableOfArrayOfObjects>(toolchain);
+
+        public class WithStaticSources_EnumerableOfArrayOfObjects
+        {
+            public static IEnumerable<object[]> StaticMethod() { yield return new object[] { 1 }; }
+            public static IEnumerable<object[]> StaticProperty
+            {
+                get
+                {
+                    yield return new object[] { 2 };
+                    yield return new object[] { 3 };
+                }
+            }
+
+            [ParamsSource(nameof(StaticMethod))]
+            public int ParamOne { get; set; }
+
+            [ParamsSource(nameof(StaticProperty))]
+            public int ParamTwo { get; set; }
+
+            [Benchmark]
+            [ArgumentsSource(nameof(StaticMethod))]
+            public void TestMethod(int argument)
+            {
+                if (argument != 1)
+                    throw new ArgumentException("The argument value is incorrect!");
+                if (ParamOne != 1)
+                    throw new ArgumentException("The ParamOne value is incorrect!");
+                if (ParamTwo != 2 && ParamTwo != 3)
+                    throw new ArgumentException("The ParamTwo value is incorrect!");
+            }
+
+            [Benchmark]
+            [ArgumentsSource(nameof(StaticProperty))]
+            public void TestProperty(int argument)
+            {
+                if (argument != 2 && argument != 3)
+                    throw new ArgumentException("The argument value is incorrect!");
+                if (ParamOne != 1)
+                    throw new ArgumentException("The ParamOne value is incorrect!");
+                if (ParamTwo != 2)
+                    throw new ArgumentException("The ParamTwo value is incorrect!");
+            }
+        }
+
         private void CanExecute<T>(IToolchain toolchain)
         {
             var config = CreateSimpleConfig(job: Job.Dry.WithToolchain(toolchain));

--- a/tests/BenchmarkDotNet.IntegrationTests/ArgumentsTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ArgumentsTests.cs
@@ -741,7 +741,7 @@ namespace BenchmarkDotNet.IntegrationTests
                     throw new ArgumentException("The argument value is incorrect!");
                 if (ParamOne != 1)
                     throw new ArgumentException("The ParamOne value is incorrect!");
-                if (ParamTwo != 2)
+                if (ParamTwo != 2 && ParamTwo != 3)
                     throw new ArgumentException("The ParamTwo value is incorrect!");
             }
         }


### PR DESCRIPTION
I wanted to reproduce https://github.com/dotnet/BenchmarkDotNet/issues/1476 but I've failed.

Instead, I've found few cases where a combination of params and args did not work well with params source that was returning `IEnumerable<object[]>` so I've fixed that