### PR TITLE
set process output encoding to utf8 so BenchmarkRunnerDotNet works in self hosted VSTS agent.

### DIFF
--- a/src/BenchmarkDotNet/Reports/Measurement.cs
+++ b/src/BenchmarkDotNet/Reports/Measurement.cs
@@ -118,7 +118,7 @@ namespace BenchmarkDotNet.Reports
         // ReSharper disable once UnusedParameter.Global
         public static Measurement Parse(ILogger logger, string line, int processIndex)
         {
-            if (line == null || line.StartsWith(GcStats.ResultsLinePrefix))
+            if (string.IsNullOrWhiteSpace(line) || line.StartsWith(GcStats.ResultsLinePrefix))
                 return Error();
 
             try

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Helpers;
@@ -31,7 +32,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
                 if (!process.WaitForExit((int)parameters.Timeout.TotalMilliseconds))
                 {
-                    parameters.Logger.WriteLineError($"// command took more than the timeout: {parameters.Timeout.TotalSeconds:0.##}s. Killing the process tree!");
+                    parameters.Logger.WriteLineError($"// command took more that the timeout: {parameters.Timeout.TotalSeconds:0.##}s. Killing the process tree!");
 
                     outputReader.CancelRead();
                     process.KillTree();
@@ -88,7 +89,9 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
-                RedirectStandardInput = redirectStandardInput
+                RedirectStandardInput = redirectStandardInput,
+                StandardErrorEncoding = Encoding.UTF8,
+                StandardOutputEncoding = Encoding.UTF8,
             };
 
             if (environmentVariables != null)


### PR DESCRIPTION
This seems to fix issue: https://github.com/dotnet/BenchmarkDotNet/issues/1480

![image](https://user-images.githubusercontent.com/18707114/86036140-47707d00-b9f2-11ea-907a-4e534775eed3.png)
