### PR TITLE
allow the users to specify Platform via console args

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using BenchmarkDotNet.ConsoleArguments.ListBenchmarks;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Helpers;
 using CommandLine;
 using CommandLine.Text;
@@ -130,6 +131,9 @@ namespace BenchmarkDotNet.ConsoleArguments
 
         [Option("strategy", Required = false, HelpText = "The RunStrategy that should be used. Throughput/ColdStart/Monitoring.")]
         public RunStrategy? RunStrategy { get; set; }
+
+        [Option("platform", Required = false, HelpText = "The Platform that should be used. If not specified, the host process platform is used (default). AnyCpu/X86/X64/Arm/Arm64.")]
+        public Platform? Platform { get; set; }
 
         [Option("runOncePerIteration", Required = false, Default = false, HelpText = "Run the benchmark exactly once per iteration.")]
         public bool RunOncePerIteration { get; set; }

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -262,6 +262,8 @@ namespace BenchmarkDotNet.ConsoleArguments
                 baseJob = baseJob.WithUnrollFactor(options.UnrollFactor.Value);
             if (options.RunStrategy.HasValue)
                 baseJob = baseJob.WithStrategy(options.RunStrategy.Value);
+            if (options.Platform.HasValue)
+                baseJob = baseJob.WithPlatform(options.Platform.Value);
             if (options.RunOncePerIteration)
                 baseJob = baseJob.RunOncePerIteration();
 

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -434,6 +434,22 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(value, envVar.Value);
         }
 
+        [Theory]
+        [InlineData(Platform.AnyCpu)]
+        [InlineData(Platform.X86)]
+        [InlineData(Platform.X64)]
+        [InlineData(Platform.Arm)]
+        [InlineData(Platform.Arm64)]
+        public void UserCanSpecifyProcessPlatform(Platform platform)
+        {
+            var parsedConfig = ConfigParser.Parse(new[] { "--platform", platform.ToString() }, new OutputLogger(Output)).config;
+
+            var job = parsedConfig.GetJobs().Single();
+            var parsed = job.Environment.Platform;
+
+            Assert.Equal(platform, parsed);
+        }
+
         [Fact]
         public void InvalidEnvVarAreRecognized()
         {


### PR DESCRIPTION
While reviewing [ClrMd benchmarks](https://github.com/microsoft/clrmd/tree/master/src/Benchmarks) I've realized that we don't support specyfing platform via console line args