### PR TITLE
[xamarin] fix for DebugConfig and read-only file system

### DIFF
--- a/samples/BenchmarkDotNet.Samples.Forms/MainPage.xaml.cs
+++ b/samples/BenchmarkDotNet.Samples.Forms/MainPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
@@ -24,7 +25,11 @@ namespace BenchmarkDotNet.Samples.Forms
                 var logger = new AccumulationLogger();
                 await Task.Run(() =>
                 {
-                    var summary = BenchmarkRunner.Run<IntroBasic>();
+                    var config = default(IConfig);
+#if DEBUG
+                    config = new DebugInProcessConfig();
+#endif
+                    var summary = BenchmarkRunner.Run<IntroBasic>(config);
                     MarkdownExporter.Console.ExportToLog(summary, logger);
                     ConclusionHelper.Print(logger,
                             summary.BenchmarksCases

--- a/src/BenchmarkDotNet/Configs/DebugConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DebugConfig.cs
@@ -10,6 +10,7 @@ using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Order;
+using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using BenchmarkDotNet.Validators;
@@ -65,7 +66,18 @@ namespace BenchmarkDotNet.Configs
         public IOrderer Orderer => DefaultOrderer.Instance;
         public SummaryStyle SummaryStyle => SummaryStyle.Default;
         public ConfigUnionRule UnionRule => ConfigUnionRule.Union;
-        public string ArtifactsPath => Path.Combine(Directory.GetCurrentDirectory(), "BenchmarkDotNet.Artifacts");
+
+        public string ArtifactsPath
+        {
+            get
+            {
+                var root = RuntimeInformation.IsAndroid () ?
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) :
+                    Directory.GetCurrentDirectory();
+                return Path.Combine(root, "BenchmarkDotNet.Artifacts");
+            }
+        }
+
         public CultureInfo CultureInfo => null;
         public IEnumerable<BenchmarkLogicalGroupRule> GetLogicalGroupRules() => Array.Empty<BenchmarkLogicalGroupRule>();
 

--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -11,6 +11,7 @@ using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Order;
+using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Validators;
 
@@ -81,11 +82,9 @@ namespace BenchmarkDotNet.Configs
         {
             get
             {
-                var root = Directory.GetCurrentDirectory();
-                if (root == "/")
-                {
-                    root = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-                }
+                var root = RuntimeInformation.IsAndroid() ?
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) :
+                    Directory.GetCurrentDirectory();
                 return Path.Combine(root, "BenchmarkDotNet.Artifacts");
             }
         }

--- a/src/BenchmarkDotNet/Environments/Runtimes/MonoRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/MonoRuntime.cs
@@ -13,15 +13,7 @@ namespace BenchmarkDotNet.Environments
 
         public string MonoBclPath { get; }
 
-        public bool IsXamarinAndroid { get; }
-
-        public bool IsXamariniOS { get; }
-
-        private MonoRuntime(string name) : base(RuntimeMoniker.Mono, "mono", name)
-        {
-            IsXamarinAndroid = Type.GetType("Java.Lang.Object, Mono.Android") != null;
-            IsXamariniOS = !IsXamarinAndroid && Type.GetType("Foundation.NSObject, Xamarin.iOS") != null;
-        }
+        private MonoRuntime(string name) : base(RuntimeMoniker.Mono, "mono", name) { }
 
         public MonoRuntime(string name, string customPath) : this(name) => CustomPath = customPath;
 

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -58,6 +58,10 @@ namespace BenchmarkDotNet.Portability
 
         internal static bool IsMacOSX() => IsOSPlatform(OSPlatform.OSX);
 
+        internal static bool IsAndroid() => Type.GetType("Java.Lang.Object, Mono.Android") != null;
+
+        internal static bool IsiOS() => Type.GetType("Foundation.NSObject, Xamarin.iOS") != null;
+
         public static string GetOsVersion()
         {
             if (IsMacOSX())

--- a/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
@@ -43,9 +43,9 @@ namespace BenchmarkDotNet.Toolchains
                     return RoslynToolchain.Instance;
 
                 case MonoRuntime mono:
-                    if (mono.IsXamarinAndroid)
+                    if (RuntimeInformation.IsAndroid())
                         return InProcessEmitToolchain.Instance;
-                    if (mono.IsXamariniOS)
+                    if (RuntimeInformation.IsiOS())
                         return InProcessNoEmitToolchain.Instance;
                     if (!string.IsNullOrEmpty(mono.AotArgs))
                         return MonoAotToolchain.Instance;


### PR DESCRIPTION
Using `DebugInProcessConfig` results in an error on Android:

    System.IO.IOException: Read-only file system
        at System.IO.FileSystem.CreateDirectory (System.String fullPath) [0x00187] in /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/corefx/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs:317
        at System.IO.Directory.CreateDirectory (System.String path) [0x0002c] in /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/corefx/src/System.IO.FileSystem/src/System/IO/Directory.cs:40
        at BenchmarkDotNet.Extensions.CommonExtensions.CreateIfNotExists (System.String directoryPath) [0x0000e] in C:\src\BenchmarkDotNet\src\BenchmarkDotNet\Extensions\CommonExtensions.cs:71
        at BenchmarkDotNet.Running.BenchmarkRunnerClean.GetRootArtifactsFolderPath (BenchmarkDotNet.Running.BenchmarkRunInfo[] benchmarkRunInfos) [0x00058] in C:\src\BenchmarkDotNet\src\BenchmarkDotNet\Running\BenchmarkRunnerClean.cs:534
        at BenchmarkDotNet.Running.BenchmarkRunnerClean.Run (BenchmarkDotNet.Running.BenchmarkRunInfo[] benchmarkRunInfos) [0x00014] in C:\src\BenchmarkDotNet\src\BenchmarkDotNet\Running\BenchmarkRunnerClean.cs:40
        at BenchmarkDotNet.Running.BenchmarkRunner.RunWithDirtyAssemblyResolveHelper (System.Type type, BenchmarkDotNet.Configs.IConfig config) [0x00000] in C:\src\BenchmarkDotNet\src\BenchmarkDotNet\Running\BenchmarkRunnerDirty.cs:77
        at BenchmarkDotNet.Running.BenchmarkRunner+<>c__DisplayClass0_0`1[T].<Run>b__0 () [0x00000] in C:\src\BenchmarkDotNet\src\BenchmarkDotNet\Running\BenchmarkRunnerDirty.cs:23
        at BenchmarkDotNet.Running.BenchmarkRunner.RunWithExceptionHandling (System.Func`1[TResult] run) [0x00002] in C:\src\BenchmarkDotNet\src\BenchmarkDotNet\Running\BenchmarkRunnerDirty.cs:107
        at BenchmarkDotNet.Running.BenchmarkRunner.Run[T] (BenchmarkDotNet.Configs.IConfig config) [0x00014] in C:\src\BenchmarkDotNet\src\BenchmarkDotNet\Running\BenchmarkRunnerDirty.cs:23
        at BenchmarkDotNet.Samples.Forms.MainPage+<>c__DisplayClass1_0.<Button_Clicked>b__0 () [0x0000f] in C:\src\BenchmarkDotNet\samples\BenchmarkDotNet.Samples.Forms\MainPage.xaml.cs:32
        at System.Threading.Tasks.Task.InnerInvoke () [0x0000f] in /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:2476
        at System.Threading.Tasks.Task.Execute () [0x00000] in /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:2319
        --- End of stack trace from previous location where exception was thrown ---
        at BenchmarkDotNet.Samples.Forms.MainPage.Button_Clicked (System.Object sender, System.EventArgs e) [0x00077] in C:\src\BenchmarkDotNet\samples\BenchmarkDotNet.Samples.Forms\MainPage.xaml.cs:26

In 9c0f5239, I fixed `DefaultConfig.ArtifactPath`'s usage of
`Directory.GetCurrentDirectory()` so that `ArtifactPath` defaults to a
writeable directory on Android.

We need the same fix in `DebugConfig.ArtifactPath`, but I also added
`RuntimeInformation.IsAndroid()` and `RuntimeInformation.IsiOS()` to
make things a bit better.

I updated the Xamarin sample to use a `DebugInProcessConfig` for
`Debug` configurations.