### PR TITLE
[WIP] Add extra line after a code block in MarkdownExporter

### DIFF
--- a/src/BenchmarkDotNet/Exporters/MarkdownExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/MarkdownExporter.cs
@@ -144,7 +144,7 @@ namespace BenchmarkDotNet.Exporters
 
             if (UseCodeBlocks)
             {
-                logger.Write(CodeBlockEnd);
+                logger.WriteLine(CodeBlockEnd);
                 logger.WriteLine();
             }
 


### PR DESCRIPTION
This will fix violation MD031 in markdownlint.
Reference: https://github.com/DavidAnson/markdownlint/blob/v0.20.4/doc/Rules.md#md031