### PR TITLE
FactorialWithTailing - incorrect implementation

### DIFF
--- a/samples/BenchmarkDotNet.Samples/IntroTailcall.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroTailcall.cs
@@ -17,6 +17,6 @@ namespace BenchmarkDotNet.Samples
             => pos == 0 ? depth : FactorialWithTailing(pos - 1, depth * pos);
 
         private static long FactorialWithTailing(int depth)
-            => FactorialWithTailing(1, depth);
+            => FactorialWithTailing(depth - 1, depth);
     }
 }


### PR DESCRIPTION
There's a tiny error in the following code
private static long FactorialWithTailing(int depth)
            => FactorialWithTailing(1, depth); // The first parameter value must be 'depth - 1' instead of just '1'