### PR TITLE
add .NET 6.0 support, rename .NET Core 5.0 to .NET 5.0

### DIFF
--- a/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
+++ b/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
@@ -86,6 +86,11 @@ namespace BenchmarkDotNet.Jobs
         Net50, // it's after NetCoreApp50 in the enum definition because the value of enumeration is used for framework version comparison using > < operators
 
         /// <summary>
+        /// .NET 6.0
+        /// </summary>
+        Net60, // it's after NetCoreApp50 and Net50 in the enum definition because the value of enumeration is used for framework version comparison using > < operators
+
+        /// <summary>
         /// CoreRT compiled as netcoreapp2.0
         /// </summary>
         CoreRt20,

--- a/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
+++ b/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
@@ -121,6 +121,11 @@ namespace BenchmarkDotNet.Jobs
         CoreRt50,
 
         /// <summary>
+        /// CoreRT compiled as net6.0
+        /// </summary>
+        CoreRt60,
+
+        /// <summary>
         /// WebAssembly
         /// </summary>
         Wasm

--- a/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
+++ b/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace BenchmarkDotNet.Jobs
 {
     public enum RuntimeMoniker
@@ -75,7 +77,13 @@ namespace BenchmarkDotNet.Jobs
         /// <summary>
         /// .NET Core 5.0 aka ".NET 5"
         /// </summary>
+        [Obsolete("Please switch to the 'RuntimeMoniker.Net50'")]
         NetCoreApp50,
+
+        /// <summary>
+        /// .NET 5.0
+        /// </summary>
+        Net50, // it's after NetCoreApp50 in the enum definition because the value of enumeration is used for framework version comparison using > < operators
 
         /// <summary>
         /// CoreRT compiled as netcoreapp2.0
@@ -103,7 +111,7 @@ namespace BenchmarkDotNet.Jobs
         CoreRt31,
 
         /// <summary>
-        /// CoreRT compiled as netcoreapp5.0
+        /// CoreRT compiled as net5.0
         /// </summary>
         CoreRt50,
 

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -344,6 +344,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 case RuntimeMoniker.NetCoreApp50:
 #pragma warning restore CS0618 // Type or member is obsolete
                 case RuntimeMoniker.Net50:
+                case RuntimeMoniker.Net60:
                     return baseJob
                         .WithRuntime(runtimeMoniker.GetRuntime())
                         .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings(runtimeId, null, runtimeId, options.CliPath?.FullName, options.RestorePath?.FullName, timeOut)));

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -356,6 +356,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 case RuntimeMoniker.CoreRt30:
                 case RuntimeMoniker.CoreRt31:
                 case RuntimeMoniker.CoreRt50:
+                case RuntimeMoniker.CoreRt60:
                     var builder = CoreRtToolchain.CreateBuilder();
 
                     if (options.CliPath != null)

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -340,7 +340,10 @@ namespace BenchmarkDotNet.ConsoleArguments
                 case RuntimeMoniker.NetCoreApp22:
                 case RuntimeMoniker.NetCoreApp30:
                 case RuntimeMoniker.NetCoreApp31:
+#pragma warning disable CS0618 // Type or member is obsolete
                 case RuntimeMoniker.NetCoreApp50:
+#pragma warning restore CS0618 // Type or member is obsolete
+                case RuntimeMoniker.Net50:
                     return baseJob
                         .WithRuntime(runtimeMoniker.GetRuntime())
                         .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings(runtimeId, null, runtimeId, options.CliPath?.FullName, options.RestorePath?.FullName, timeOut)));

--- a/src/BenchmarkDotNet/Environments/HostEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet/Environments/HostEnvironmentInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using BenchmarkDotNet.Helpers;
 using BenchmarkDotNet.Loggers;
@@ -98,7 +99,7 @@ namespace BenchmarkDotNet.Environments
             if (RuntimeInformation.IsNetCore && IsDotNetCliInstalled())
             {
                 // this wonderfull version number contains words like "preview" and ... 5 segments so it can not be parsed by Version.Parse. Example: "5.0.100-preview.8.20362.3"
-                if (DotNetSdkVersion.Value[0] >= '5')
+                if (int.TryParse(new string(DotNetSdkVersion.Value.TrimStart().TakeWhile(char.IsDigit).ToArray()), out int major) && major >= 5)
                     yield return $".NET SDK={DotNetSdkVersion.Value}";
                 else
                     yield return $".NET Core SDK={DotNetSdkVersion.Value}";

--- a/src/BenchmarkDotNet/Environments/HostEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet/Environments/HostEnvironmentInfo.cs
@@ -96,7 +96,13 @@ namespace BenchmarkDotNet.Environments
                 yield return $"Frequency={ChronometerFrequency}, Resolution={ChronometerResolution.ToString(cultureInfo)}, Timer={HardwareTimerKind.ToString().ToUpper()}";
 
             if (RuntimeInformation.IsNetCore && IsDotNetCliInstalled())
-                yield return $".NET SDK={DotNetSdkVersion.Value}";
+            {
+                // this wonderfull version number contains words like "preview" and ... 5 segments so it can not be parsed by Version.Parse. Example: "5.0.100-preview.8.20362.3"
+                if (DotNetSdkVersion.Value[0] >= '5')
+                    yield return $".NET SDK={DotNetSdkVersion.Value}";
+                else
+                    yield return $".NET Core SDK={DotNetSdkVersion.Value}";
+            }
         }
 
         [PublicAPI]

--- a/src/BenchmarkDotNet/Environments/HostEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet/Environments/HostEnvironmentInfo.cs
@@ -67,7 +67,7 @@ namespace BenchmarkDotNet.Environments
 
         protected HostEnvironmentInfo()
         {
-            BenchmarkDotNetVersion = GetBenchmarkDotNetVersion();
+            BenchmarkDotNetVersion = BenchmarkDotNetInfo.FullVersion;
             OsVersion = new Lazy<string>(RuntimeInformation.GetOsVersion);
             CpuInfo = new Lazy<CpuInfo>(RuntimeInformation.GetCpuInfo);
             ChronometerFrequency = Chronometer.Frequency;
@@ -108,8 +108,6 @@ namespace BenchmarkDotNet.Environments
 
         [PublicAPI]
         public bool IsDotNetCliInstalled() => !string.IsNullOrEmpty(DotNetSdkVersion.Value);
-
-        private static string GetBenchmarkDotNetVersion() => BenchmarkDotNetInfo.FullVersion;
 
         /// <summary>
         /// Return string representation of CPU and environment configuration including BenchmarkDotNet, OS and .NET version

--- a/src/BenchmarkDotNet/Environments/HostEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet/Environments/HostEnvironmentInfo.cs
@@ -96,7 +96,7 @@ namespace BenchmarkDotNet.Environments
                 yield return $"Frequency={ChronometerFrequency}, Resolution={ChronometerResolution.ToString(cultureInfo)}, Timer={HardwareTimerKind.ToString().ToUpper()}";
 
             if (RuntimeInformation.IsNetCore && IsDotNetCliInstalled())
-                yield return $".NET Core SDK={DotNetSdkVersion.Value}";
+                yield return $".NET SDK={DotNetSdkVersion.Value}";
         }
 
         [PublicAPI]

--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRtRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRtRuntime.cs
@@ -31,6 +31,10 @@ namespace BenchmarkDotNet.Environments
         /// CoreRT compiled as net5.0
         /// </summary>
         public static readonly CoreRtRuntime CoreRt50 = new CoreRtRuntime(RuntimeMoniker.CoreRt50, "net5.0", "CoreRt 5.0");
+        /// <summary>
+        /// CoreRT compiled as net6.0
+        /// </summary>
+        public static readonly CoreRtRuntime CoreRt60 = new CoreRtRuntime(RuntimeMoniker.CoreRt50, "net6.0", "CoreRt 6.0");
 
         private CoreRtRuntime(RuntimeMoniker runtimeMoniker, string msBuildMoniker, string displayName)
             : base(runtimeMoniker, msBuildMoniker, displayName)
@@ -47,7 +51,7 @@ namespace BenchmarkDotNet.Environments
             var frameworkDescription = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
             string netCoreAppVersion = new string(frameworkDescription.SkipWhile(c => !char.IsDigit(c)).ToArray());
             string[] versionNumbers = netCoreAppVersion.Split('.');
-            string msBuildMoniker = $"netcoreapp{versionNumbers[0]}.{versionNumbers[1]}";
+            string msBuildMoniker = int.Parse(versionNumbers[0]) >= 5 ? $"net{versionNumbers[0]}.{versionNumbers[1]}" : $"netcoreapp{versionNumbers[0]}.{versionNumbers[1]}";
             string displayName = $"CoreRT {versionNumbers[0]}.{versionNumbers[1]}";
 
             switch (msBuildMoniker)
@@ -57,8 +61,9 @@ namespace BenchmarkDotNet.Environments
                 case "netcoreapp2.2": return CoreRt22;
                 case "netcoreapp3.0": return CoreRt30;
                 case "netcoreapp3.1": return CoreRt31;
+                case "net5.0":
                 case "netcoreapp5.0": return CoreRt50;
-                case "net5.0": return CoreRt50;
+                case "net6.0": return CoreRt60;
                 default: // support future version of CoreRT
                     return new CoreRtRuntime(RuntimeMoniker.NotRecognized, msBuildMoniker, displayName);
             }

--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRtRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRtRuntime.cs
@@ -28,9 +28,9 @@ namespace BenchmarkDotNet.Environments
         /// </summary>
         public static readonly CoreRtRuntime CoreRt31 = new CoreRtRuntime(RuntimeMoniker.CoreRt31, "netcoreapp3.1", "CoreRt 3.1");
         /// <summary>
-        /// CoreRT compiled as netcoreapp5.0
+        /// CoreRT compiled as net5.0
         /// </summary>
-        public static readonly CoreRtRuntime CoreRt50 = new CoreRtRuntime(RuntimeMoniker.CoreRt50, "netcoreapp5.0", "CoreRt 5.0");
+        public static readonly CoreRtRuntime CoreRt50 = new CoreRtRuntime(RuntimeMoniker.CoreRt50, "net5.0", "CoreRt 5.0");
 
         private CoreRtRuntime(RuntimeMoniker runtimeMoniker, string msBuildMoniker, string displayName)
             : base(runtimeMoniker, msBuildMoniker, displayName)
@@ -58,6 +58,7 @@ namespace BenchmarkDotNet.Environments
                 case "netcoreapp3.0": return CoreRt30;
                 case "netcoreapp3.1": return CoreRt31;
                 case "netcoreapp5.0": return CoreRt50;
+                case "net5.0": return CoreRt50;
                 default: // support future version of CoreRT
                     return new CoreRtRuntime(RuntimeMoniker.NotRecognized, msBuildMoniker, displayName);
             }

--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
@@ -16,7 +16,7 @@ namespace BenchmarkDotNet.Environments
         public static readonly CoreRuntime Core22 = new CoreRuntime(RuntimeMoniker.NetCoreApp22, "netcoreapp2.2", ".NET Core 2.2");
         public static readonly CoreRuntime Core30 = new CoreRuntime(RuntimeMoniker.NetCoreApp30, "netcoreapp3.0", ".NET Core 3.0");
         public static readonly CoreRuntime Core31 = new CoreRuntime(RuntimeMoniker.NetCoreApp31, "netcoreapp3.1", ".NET Core 3.1");
-        public static readonly CoreRuntime Core50 = new CoreRuntime(RuntimeMoniker.NetCoreApp50, "netcoreapp5.0", ".NET Core 5.0");
+        public static readonly CoreRuntime Core50 = new CoreRuntime(RuntimeMoniker.Net50, "net5.0", ".NET 5.0");
 
         private CoreRuntime(RuntimeMoniker runtimeMoniker, string msBuildMoniker, string displayName)
             : base(runtimeMoniker, msBuildMoniker, displayName)

--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
@@ -17,6 +17,7 @@ namespace BenchmarkDotNet.Environments
         public static readonly CoreRuntime Core30 = new CoreRuntime(RuntimeMoniker.NetCoreApp30, "netcoreapp3.0", ".NET Core 3.0");
         public static readonly CoreRuntime Core31 = new CoreRuntime(RuntimeMoniker.NetCoreApp31, "netcoreapp3.1", ".NET Core 3.1");
         public static readonly CoreRuntime Core50 = new CoreRuntime(RuntimeMoniker.Net50, "net5.0", ".NET 5.0");
+        public static readonly CoreRuntime Core60 = new CoreRuntime(RuntimeMoniker.Net60, "net6.0", ".NET 6.0");
 
         private CoreRuntime(RuntimeMoniker runtimeMoniker, string msBuildMoniker, string displayName)
             : base(runtimeMoniker, msBuildMoniker, displayName)

--- a/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
@@ -32,7 +32,10 @@ namespace BenchmarkDotNet.Extensions
                     return CoreRuntime.Core30;
                 case RuntimeMoniker.NetCoreApp31:
                     return CoreRuntime.Core31;
+                case RuntimeMoniker.Net50:
+#pragma warning disable CS0618 // Type or member is obsolete
                 case RuntimeMoniker.NetCoreApp50:
+#pragma warning restore CS0618 // Type or member is obsolete
                     return CoreRuntime.Core50;
                 case RuntimeMoniker.Mono:
                     return MonoRuntime.Default;

--- a/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
@@ -53,6 +53,8 @@ namespace BenchmarkDotNet.Extensions
                     return CoreRtRuntime.CoreRt31;
                 case RuntimeMoniker.CoreRt50:
                     return CoreRtRuntime.CoreRt50;
+                case RuntimeMoniker.CoreRt60:
+                    return CoreRtRuntime.CoreRt60;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(runtimeMoniker), runtimeMoniker, "Runtime Moniker not supported");
             }

--- a/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
@@ -37,6 +37,8 @@ namespace BenchmarkDotNet.Extensions
                 case RuntimeMoniker.NetCoreApp50:
 #pragma warning restore CS0618 // Type or member is obsolete
                     return CoreRuntime.Core50;
+                case RuntimeMoniker.Net60:
+                    return CoreRuntime.Core60;
                 case RuntimeMoniker.Mono:
                     return MonoRuntime.Default;
                 case RuntimeMoniker.CoreRt20:

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -169,12 +169,22 @@ namespace BenchmarkDotNet.Portability
             }
             else if (IsNetCore)
             {
-                string runtimeVersion = CoreRuntime.TryGetVersion(out var version) ? version.ToString() : "?";
-
                 var coreclrAssemblyInfo = FileVersionInfo.GetVersionInfo(typeof(object).GetTypeInfo().Assembly.Location);
                 var corefxAssemblyInfo = FileVersionInfo.GetVersionInfo(typeof(Regex).GetTypeInfo().Assembly.Location);
 
-                return $".NET Core {runtimeVersion} (CoreCLR {coreclrAssemblyInfo.FileVersion}, CoreFX {corefxAssemblyInfo.FileVersion})";
+                if (CoreRuntime.TryGetVersion(out var version) && version >= new Version(5, 0))
+                {
+                    // after the merge of dotnet/corefx and dotnet/coreclr into dotnet/runtime the version should always be the same
+                    Debug.Assert(coreclrAssemblyInfo.FileVersion == corefxAssemblyInfo.FileVersion); 
+
+                    return $".NET {version} ({coreclrAssemblyInfo.FileVersion})";
+                }
+                else
+                {
+                    string runtimeVersion = version != default ? version.ToString() : "?";
+
+                    return $".NET Core {runtimeVersion} (CoreCLR {coreclrAssemblyInfo.FileVersion}, CoreFX {corefxAssemblyInfo.FileVersion})";
+                }
             }
             else if (IsCoreRT)
             {

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
@@ -28,9 +28,9 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
         /// </summary>
         public static readonly IToolchain Core31 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("netcoreapp3.1").ToToolchain();
         /// <summary>
-        /// compiled as netcoreapp5.0, targets latest (1.0.0-alpha-*) CoreRT build from https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+        /// compiled as net5.0, targets latest (1.0.0-alpha-*) CoreRT build from https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
         /// </summary>
-        public static readonly IToolchain Core50 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("netcoreapp5.0").ToToolchain();
+        public static readonly IToolchain Core50 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("net5.0").ToToolchain();
 
         internal CoreRtToolchain(string displayName,
             string coreRtVersion, string ilcPath, bool useCppCodeGenerator,

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
@@ -31,6 +31,10 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
         /// compiled as net5.0, targets latest (1.0.0-alpha-*) CoreRT build from https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
         /// </summary>
         public static readonly IToolchain Core50 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("net5.0").ToToolchain();
+        /// <summary>
+        /// compiled as net6.0, targets latest (1.0.0-alpha-*) CoreRT build from https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+        /// </summary>
+        public static readonly IToolchain Core60 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("net6.0").ToToolchain();
 
         internal CoreRtToolchain(string displayName,
             string coreRtVersion, string ilcPath, bool useCppCodeGenerator,

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
@@ -19,6 +19,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         [PublicAPI] public static readonly IToolchain NetCoreApp30 = From(NetCoreAppSettings.NetCoreApp30);
         [PublicAPI] public static readonly IToolchain NetCoreApp31 = From(NetCoreAppSettings.NetCoreApp31);
         [PublicAPI] public static readonly IToolchain NetCoreApp50 = From(NetCoreAppSettings.NetCoreApp50);
+        [PublicAPI] public static readonly IToolchain NetCoreApp60 = From(NetCoreAppSettings.NetCoreApp60);
 
         private CsProjCoreToolchain(string name, IGenerator generator, IBuilder builder, IExecutor executor, string customDotNetCliPath)
             : base(name, generator, builder, executor)

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/MsBuildErrorMapper.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/MsBuildErrorMapper.cs
@@ -81,6 +81,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                     return "netcoreapp3.1";
                 case ".NETCoreApp,Version=v5.0":
                     return "net5.0";
+                case ".NETCoreApp,Version=v6.0":
+                    return "net6.0";
                 default:
                     return capture.Value; // we don't want to throw for future versions of .NET
             }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/MsBuildErrorMapper.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/MsBuildErrorMapper.cs
@@ -80,7 +80,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                 case ".NETCoreApp,Version=v3.1":
                     return "netcoreapp3.1";
                 case ".NETCoreApp,Version=v5.0":
-                    return "netcoreapp5.0";
+                    return "net5.0";
                 default:
                     return capture.Value; // we don't want to throw for future versions of .NET
             }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
@@ -17,6 +17,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp30 = new NetCoreAppSettings("netcoreapp3.0", null, ".NET Core 3.0");
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp31 = new NetCoreAppSettings("netcoreapp3.1", null, ".NET Core 3.1");
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp50 = new NetCoreAppSettings("net5.0", null, ".NET 5.0");
+        [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp60 = new NetCoreAppSettings("net6.0", null, ".NET 6.0");
 
         /// <summary>
         /// <param name="targetFrameworkMoniker">

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
@@ -16,7 +16,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp22 = new NetCoreAppSettings("netcoreapp2.2", null, ".NET Core 2.2");
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp30 = new NetCoreAppSettings("netcoreapp3.0", null, ".NET Core 3.0");
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp31 = new NetCoreAppSettings("netcoreapp3.1", null, ".NET Core 3.1");
-        [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp50 = new NetCoreAppSettings("netcoreapp5.0", null, ".NET Core 5.0");
+        [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp50 = new NetCoreAppSettings("net5.0", null, ".NET 5.0");
 
         /// <summary>
         /// <param name="targetFrameworkMoniker">

--- a/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
@@ -118,6 +118,8 @@ namespace BenchmarkDotNet.Toolchains
                     return CoreRtToolchain.Core31;
                 case RuntimeMoniker.CoreRt50:
                     return CoreRtToolchain.Core50;
+                case RuntimeMoniker.CoreRt60:
+                    return CoreRtToolchain.Core60;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(runtimeMoniker), runtimeMoniker, "RuntimeMoniker not supported");
             }

--- a/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
@@ -58,7 +58,7 @@ namespace BenchmarkDotNet.Toolchains
                     if (coreRuntime.RuntimeMoniker != RuntimeMoniker.NotRecognized)
                         return GetToolchain(coreRuntime.RuntimeMoniker);
 
-                    return CsProjCoreToolchain.From(new DotNetCli.NetCoreAppSettings(coreRuntime.MsBuildMoniker, null, coreRuntime.Name));
+                    return CsProjCoreToolchain.From(new NetCoreAppSettings(coreRuntime.MsBuildMoniker, null, coreRuntime.Name));
 
                 case CoreRtRuntime coreRtRuntime:
                     return coreRtRuntime.RuntimeMoniker != RuntimeMoniker.NotRecognized
@@ -104,6 +104,8 @@ namespace BenchmarkDotNet.Toolchains
 #pragma warning restore CS0618 // Type or member is obsolete
                 case RuntimeMoniker.Net50:
                     return CsProjCoreToolchain.NetCoreApp50;
+                case RuntimeMoniker.Net60:
+                    return CsProjCoreToolchain.NetCoreApp60;
                 case RuntimeMoniker.CoreRt20:
                     return CoreRtToolchain.Core20;
                 case RuntimeMoniker.CoreRt21:

--- a/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
@@ -99,7 +99,10 @@ namespace BenchmarkDotNet.Toolchains
                     return CsProjCoreToolchain.NetCoreApp30;
                 case RuntimeMoniker.NetCoreApp31:
                     return CsProjCoreToolchain.NetCoreApp31;
+#pragma warning disable CS0618 // Type or member is obsolete
                 case RuntimeMoniker.NetCoreApp50:
+#pragma warning restore CS0618 // Type or member is obsolete
+                case RuntimeMoniker.Net50:
                     return CsProjCoreToolchain.NetCoreApp50;
                 case RuntimeMoniker.CoreRt20:
                     return CoreRtToolchain.Core20;

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -306,6 +306,19 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(tfm, ((DotNetCliGenerator)toolchain.Generator).TargetFrameworkMoniker);
         }
 
+        [Theory]
+        [InlineData("net50")]
+        [InlineData("net60")]
+        public void Net50AndNet60MonikersAreRecognizedAsNetCoreMonikers(string tfm)
+        {
+            var config = ConfigParser.Parse(new[] { "-r", tfm }, new OutputLogger(Output)).config;
+
+            Assert.Single(config.GetJobs());
+            CsProjCoreToolchain toolchain = config.GetJobs().Single().GetToolchain() as CsProjCoreToolchain;
+            Assert.NotNull(toolchain);
+            Assert.Equal(tfm, ((DotNetCliGenerator)toolchain.Generator).TargetFrameworkMoniker);
+        }
+
         [Fact]
         public void CanCompareFewDifferentRuntimes()
         {

--- a/tests/BenchmarkDotNet.Tests/RuntimeVersionDetectionTests.cs
+++ b/tests/BenchmarkDotNet.Tests/RuntimeVersionDetectionTests.cs
@@ -16,7 +16,7 @@ namespace BenchmarkDotNet.Tests
         [InlineData(".NETCoreApp,Version=v2.2", RuntimeMoniker.NetCoreApp22, "netcoreapp2.2")]
         [InlineData(".NETCoreApp,Version=v3.0", RuntimeMoniker.NetCoreApp30, "netcoreapp3.0")]
         [InlineData(".NETCoreApp,Version=v3.1", RuntimeMoniker.NetCoreApp31, "netcoreapp3.1")]
-        [InlineData(".NETCoreApp,Version=v5.0", RuntimeMoniker.NetCoreApp50, "netcoreapp5.0")]
+        [InlineData(".NETCoreApp,Version=v5.0", RuntimeMoniker.Net50, "net5.0")]
         [InlineData(".NETCoreApp,Version=v123.0", RuntimeMoniker.NotRecognized, "netcoreapp123.0")]
         public void TryGetVersionFromFrameworkNameHandlesValidInput(string frameworkName, RuntimeMoniker expectedTfm, string expectedMsBuildMoniker)
         {
@@ -43,7 +43,7 @@ namespace BenchmarkDotNet.Tests
         [InlineData(RuntimeMoniker.NetCoreApp22, "netcoreapp2.2", "Microsoft .NET Framework", "4.6.27817.03 @BuiltBy: dlab14-DDVSOWINAGE101 @Branch: release/2.2 @SrcCode: https://github.com/dotnet/coreclr/tree/ce1d090d33b400a25620c0145046471495067cc7")]
         [InlineData(RuntimeMoniker.NetCoreApp30, "netcoreapp3.0", "Microsoft .NET Core", "3.0.0-preview8-28379-12")]
         [InlineData(RuntimeMoniker.NetCoreApp31, "netcoreapp3.1", "Microsoft .NET Core", "3.1.0-something")]
-        [InlineData(RuntimeMoniker.NetCoreApp50, "netcoreapp5.0", "Microsoft .NET Core", "5.0.0-alpha1.19415.3")]
+        [InlineData(RuntimeMoniker.Net50, "net5.0", "Microsoft .NET Core", "5.0.0-alpha1.19415.3")]
         [InlineData(RuntimeMoniker.NotRecognized, "netcoreapp123.0", "Microsoft .NET Core", "123.0.0-future")]
         public void TryGetVersionFromProductInfoHandlesValidInput(RuntimeMoniker expectedTfm, string expectedMsBuildMoniker, string productName, string productVersion)
         {
@@ -73,7 +73,7 @@ namespace BenchmarkDotNet.Tests
             yield return new object[] { Path.Combine(directoryPrefix, "2.1.12") + Path.DirectorySeparatorChar, RuntimeMoniker.NetCoreApp21, "netcoreapp2.1" };
             yield return new object[] { Path.Combine(directoryPrefix, "2.2.6") + Path.DirectorySeparatorChar, RuntimeMoniker.NetCoreApp22, "netcoreapp2.2" };
             yield return new object[] { Path.Combine(directoryPrefix, "3.0.0-preview8-28379-12") + Path.DirectorySeparatorChar, RuntimeMoniker.NetCoreApp30, "netcoreapp3.0" };
-            yield return new object[] { Path.Combine(directoryPrefix, "5.0.0-alpha1.19422.13") + Path.DirectorySeparatorChar, RuntimeMoniker.NetCoreApp50, "netcoreapp5.0" };
+            yield return new object[] { Path.Combine(directoryPrefix, "5.0.0-alpha1.19422.13") + Path.DirectorySeparatorChar, RuntimeMoniker.Net50, "net5.0" };
             yield return new object[] { Path.Combine(directoryPrefix, "123.0.0") + Path.DirectorySeparatorChar, RuntimeMoniker.NotRecognized, "netcoreapp123.0" };
         }
 


### PR DESCRIPTION
This PR:

- adds `net6.0` support
- renames `netcoreapp5.0` to `net5.0` (I personally don't like it but well we have to live with that)
- simplifies displayed version numbers for .NET 5.0+

Before:

```ini
BenchmarkDotNet=v0.12.1.20200824-develop, OS=Windows 10.0.18363.959 (1909/November2019Update/19H2)
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.100-preview.8.20362.3
  [Host]     : .NET Core 2.1.21 (CoreCLR 4.6.29130.01, CoreFX 4.6.29130.02), X64 RyuJIT
  Job-ILZMMP : .NET Core 5.0.0 (CoreCLR 5.0.20.36102, CoreFX 5.0.20.36102), X64 RyuJIT
```

After:

```ini
BenchmarkDotNet=v0.12.1.20200824-develop, OS=Windows 10.0.18363.959 (1909/November2019Update/19H2)
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.100-preview.8.20362.3
  [Host]     : .NET Core 2.1.21 (CoreCLR 4.6.29130.01, CoreFX 4.6.29130.02), X64 RyuJIT
  Job-PBAJYZ : .NET 5.0.0 (5.0.20.36102), X64 RyuJIT
```

@AndreyAkinshin PTAL

cc @DrewScoggins @billwert @danmosemsft