### PR TITLE
Allow for enabling VeryLargeObjects setting

### DIFF
--- a/src/BenchmarkDotNet/Jobs/EnvironmentMode.cs
+++ b/src/BenchmarkDotNet/Jobs/EnvironmentMode.cs
@@ -38,7 +38,7 @@ namespace BenchmarkDotNet.Jobs
         public EnvironmentMode(string id) : base(id) => GcCharacteristic[this] = new GcMode();
 
         /// <summary>
-        /// Platform (x86 or x64)
+        /// Platform (x86, x64, ARM, ARM64, Wasm)
         /// </summary>
         public Platform Platform
         {

--- a/src/BenchmarkDotNet/Templates/CsProj.txt
+++ b/src/BenchmarkDotNet/Templates/CsProj.txt
@@ -27,6 +27,11 @@
     <Compile Include="$CODEFILENAME$" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <!-- don't generate App.config file for Full .NET Framework, BenchmarkDotNet does it on it's own -->
+    <None Include="App.config" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="$CSPROJPATH$" />
   </ItemGroup>

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
@@ -54,11 +54,6 @@ namespace BenchmarkDotNet.Toolchains.CsProj
                 logger.WriteLineError($"Currently project.json does not support CpuGroups (app.config does), benchmark '{benchmarkCase.DisplayInfo}' will not be executed");
                 return false;
             }
-            if (benchmarkCase.Job.ResolveValue(GcMode.AllowVeryLargeObjectsCharacteristic, resolver))
-            {
-                logger.WriteLineError($"Currently project.json does not support gcAllowVeryLargeObjects (app.config does), benchmark '{benchmarkCase.DisplayInfo}' will not be executed");
-                return false;
-            }
 
             var benchmarkAssembly = benchmarkCase.Descriptor.Type.Assembly;
             if (benchmarkAssembly.IsLinqPad())

--- a/tests/BenchmarkDotNet.IntegrationTests/GcModeTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/GcModeTests.cs
@@ -5,9 +5,7 @@ using Xunit.Abstractions;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
-#if CLASSIC
 using BenchmarkDotNet.Environments;
-#endif
 
 namespace BenchmarkDotNet.IntegrationTests
 {
@@ -59,7 +57,6 @@ namespace BenchmarkDotNet.IntegrationTests
             CanExecute<AvoidForcingGarbageCollection>(config);
         }
 
-#if CLASSIC // not supported by project.json so far
         [Fact]
         public void CanAllowToCreateVeryLargeObjectsFor64Bit()
         {
@@ -78,7 +75,6 @@ namespace BenchmarkDotNet.IntegrationTests
 
             CanExecute<CreateVeryLargeObjects>(config);
         }
-#endif
     }
 
     public class ServerModeEnabled


### PR DESCRIPTION
Fixes #1519

We were not supporting `VeryLargeObjects` because:

* it was not possible in .NET Core 1.0 when `project.json` was a thing. Now it's enabled by default and I have simply removed this artificial limitation
* in full .NET Framework project when using `CsProjClassicNetToolchain` because the `Generator` was generating the correct `.config` file but afterward when `Builder` was calling `dotnet build` and it was overwriting this file and removing the custom settings ;)