### PR TITLE
Remove unneeded files after etw profiler

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.Windows/Tracing/TraceLogParser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/Tracing/TraceLogParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Reports;
 using Microsoft.Diagnostics.Tracing.Etlx;
 using Microsoft.Diagnostics.Tracing.Parsers;
@@ -17,11 +18,20 @@ namespace BenchmarkDotNet.Diagnostics.Windows.Tracing
 
         public static IEnumerable<Metric> Parse(string etlFilePath, PreciseMachineCounter[] counters)
         {
-            using (var traceLog = new TraceLog(TraceLog.CreateFromEventTraceLogFile(etlFilePath)))
-            {
-                var traceLogEventSource = traceLog.Events.GetSource();
+            var etlxFilePath = TraceLog.CreateFromEventTraceLogFile(etlFilePath);
 
-                return new TraceLogParser().Parse(traceLogEventSource, counters);
+            try
+            {
+                using (var traceLog = new TraceLog(etlxFilePath))
+                {
+                    var traceLogEventSource = traceLog.Events.GetSource();
+
+                    return new TraceLogParser().Parse(traceLogEventSource, counters);
+                }
+            }
+            finally
+            {
+                etlxFilePath.DeleteFileIfExists();
             }
         }
 

--- a/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
@@ -73,6 +73,14 @@ namespace BenchmarkDotNet.Extensions
             return directoryPath;
         }
 
+        internal static string DeleteFileIfExists(this string filePath)
+        {
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+
+            return filePath;
+        }
+
         internal static string EnsureFolderExists(this string filePath)
         {
             string directoryPath = Path.GetDirectoryName(filePath);

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -175,7 +175,7 @@ namespace BenchmarkDotNet.Portability
                 if (CoreRuntime.TryGetVersion(out var version) && version >= new Version(5, 0))
                 {
                     // after the merge of dotnet/corefx and dotnet/coreclr into dotnet/runtime the version should always be the same
-                    Debug.Assert(coreclrAssemblyInfo.FileVersion == corefxAssemblyInfo.FileVersion); 
+                    Debug.Assert(coreclrAssemblyInfo.FileVersion == corefxAssemblyInfo.FileVersion);
 
                     return $".NET {version} ({coreclrAssemblyInfo.FileVersion})";
                 }


### PR DESCRIPTION
This PR is NOT a solution for https://twitter.com/lukaszpyrzyk/status/1295003260990959621, it's just a small improvement.
It just removes etlx files after run ETW Profiler and NativeMemoryProfiler.  

![image](https://user-images.githubusercontent.com/17333903/94349382-30b6e200-0044-11eb-899e-192863b756e6.png)
