### PR TITLE
Memory diagnoser fix for Tiered Compilation

### DIFF
--- a/src/BenchmarkDotNet/Engines/Engine.cs
+++ b/src/BenchmarkDotNet/Engines/Engine.cs
@@ -183,6 +183,13 @@ namespace BenchmarkDotNet.Engines
             // it does not matter, because we have already obtained the results!
             EnableMonitoring();
 
+            if (RuntimeInformation.IsNetCore)
+            {
+                // we put the current thread to sleep so Tiered Compiler can kick in, compile it's stuff
+                // and NOT allocate anything on the background thread when we are measuring allocations
+                System.Threading.Thread.Sleep(TimeSpan.FromMilliseconds(250));
+            }
+
             IterationSetupAction(); // we run iteration setup first, so even if it allocates, it is not included in the results
 
             var initialThreadingStats = ThreadingStats.ReadInitial(); // this method might allocate

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -26,13 +26,13 @@ namespace BenchmarkDotNet.Portability
 
         public static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null; // it allocates a lot of memory, we need to check it once in order to keep Engine non-allocating!
 
-        public static bool IsFullFramework => FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+        public static bool IsFullFramework { get; } = FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 
         [PublicAPI]
         public static bool IsNetNative => FrameworkDescription.StartsWith(".NET Native", StringComparison.OrdinalIgnoreCase);
 
-        public static bool IsNetCore
-            => ((Environment.Version.Major >= 5) || FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase))
+        public static bool IsNetCore { get; }
+            = ((Environment.Version.Major >= 5) || FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase))
                 && !string.IsNullOrEmpty(typeof(object).Assembly.Location);
 
         /// <summary>


### PR DESCRIPTION
In #1542 @ronbrogan has reported a very unusual bug - a code that was CPU bound and not allocating at all was reporting allocations for .NET Core 3.1 (it works fine for 2.1 as there we use `GC.GetAllocatedBytesForCurrentThread` instead `GC.GetTotalAllocatedBytes`):

```cs
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Runtime.CompilerServices;

namespace BenchmarkAllocationDebug
{
    class Program
    {
        static void Main() => BenchmarkRunner.Run<Bench>();
    }

    [KeepBenchmarkFiles]
    public class Bench
    {
        [Benchmark] public ulong Benchmark1() => TestMethod();
        [Benchmark] public ulong Benchmark2() => TestMethod();
        [Benchmark] public ulong Benchmark3() => TestMethod();
        [Benchmark] public ulong Benchmark4() => TestMethod();
        [Benchmark] public ulong Benchmark5() => TestMethod();

        [MethodImpl(MethodImplOptions.NoInlining)]
        public static ulong TestMethod()
        {
            var r = 1ul;
            for (var i = 0; i < 50_000_000; i++)
            {
                r /= 1;
            }
            return r;
        }
    }
}
```

After some investigation, I've narrowed down the problem to Tiered JIT thread that from time to time would be promoting methods from Tier 0 to Tier 1 and allocating memory during the iteration where we call `GC.GetTotalAllocatedBytes`.

![obraz](https://user-images.githubusercontent.com/6011991/94825321-4fcbc000-0406-11eb-8c6e-45be1783a723.png)

I had few ideas, but the only one worked was putting the thread to sleep for 250ms before we call `GC.GetTotalAllocatedBytes`. In this time TC thread kicks-in and promotes the methods. It's of course far from perfect as TC might not finish the promotion before we make the first call to `GC.GetTotalAllocatedBytes`.  I don't want to prolong the sleeping period because it would increase the time we need to run the benchmarks.

@kouvel do you have a better idea of how we could prevent TC from working at a given point of time? 

I've confirmed that it works as expected by modifying the `GetExtraStats` method to emit some extra events and filtering the TC events in PerfView to this particular period of time:

<details>

```cs
private (GcStats, ThreadingStats) GetExtraStats(IterationData data)
{
    if (EngineEventSource.Log.IsEnabled())
        EngineEventSource.Log.IterationStart(data.IterationMode, data.IterationStage, -2);

    if (RuntimeInformation.IsNetCore)
    {
        // we put the current thread to sleep so Tiered Compiler can kick in, compile it's stuff
        // and NOT allocate anything on the background thread when we are measuring allocations
        System.Threading.Thread.Sleep(TimeSpan.FromMilliseconds(250));
    }

    if (EngineEventSource.Log.IsEnabled())
        EngineEventSource.Log.IterationStop(data.IterationMode, data.IterationStage, -2);

    if (EngineEventSource.Log.IsEnabled())
        EngineEventSource.Log.IterationStart(data.IterationMode, data.IterationStage, -1);

    // we enable monitoring after main target run, for this single iteration which is executed at the end
    // so even if we enable AppDomain monitoring in separate process
    // it does not matter, because we have already obtained the results!
    EnableMonitoring();

    IterationSetupAction(); // we run iteration setup first, so even if it allocates, it is not included in the results

    var initialThreadingStats = ThreadingStats.ReadInitial(); // this method might allocate
    var initialGcStats = GcStats.ReadInitial();

    WorkloadAction(data.InvokeCount / data.UnrollFactor);

    var finalGcStats = GcStats.ReadFinal();
    var finalThreadingStats = ThreadingStats.ReadFinal();

    IterationCleanupAction(); // we run iteration cleanup after collecting GC stats

    GcStats gcStats = (finalGcStats - initialGcStats).WithTotalOperations(data.InvokeCount * OperationsPerInvoke);
    ThreadingStats threadingStats = (finalThreadingStats - initialThreadingStats).WithTotalOperations(data.InvokeCount * OperationsPerInvoke);

    if (EngineEventSource.Log.IsEnabled())
        EngineEventSource.Log.IterationStop(data.IterationMode, data.IterationStage, -1);

    return (gcStats, threadingStats);
}
```

</details>

![obraz](https://user-images.githubusercontent.com/6011991/94826045-324b2600-0407-11eb-94d4-7044c34c552f.png)

![obraz](https://user-images.githubusercontent.com/6011991/94825889-f9ab4c80-0406-11eb-9626-db6017ecc4e5.png)









 