### PR TITLE
Fix Merge operation failed for EtwProfiler

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.Windows/BenchmarkDotNet.Diagnostics.Windows.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/BenchmarkDotNet.Diagnostics.Windows.csproj
@@ -12,6 +12,6 @@
     <ProjectReference Include="..\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.57" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.61" PrivateAssets="contentfiles;analyzers" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.57" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.61" PrivateAssets="contentfiles;analyzers" />
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <ProjectReference Include="..\BenchmarkDotNet.Disassembler.x64\BenchmarkDotNet.Disassembler.x64.csproj">

--- a/src/BenchmarkDotNet/Helpers/ArtifactFileNameHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/ArtifactFileNameHelper.cs
@@ -20,6 +20,8 @@ namespace BenchmarkDotNet.Helpers
 
             int limit = PathFeatures.AreAllLongPathsAvailable() ? CommonSenseLimit : WindowsOldPathLimit;
 
+            limit -= "userheap.etl".Length; // we should consider trace file extension as part of the name
+
             if (nameNoLimit.Length <= limit)
             {
                 return nameNoLimit;
@@ -40,7 +42,7 @@ namespace BenchmarkDotNet.Helpers
             string shortTypeName = FolderNameHelper.ToFolderName(details.BenchmarkCase.Descriptor.Type, includeNamespace: false);
             string methodName = details.BenchmarkCase.Descriptor.WorkloadMethod.Name;
             string parameters = details.BenchmarkCase.HasParameters
-                ? $"-hash{Hashing.HashString(FullNameProvider.GetMethodName(details.BenchmarkCase)).ToString()}"
+                ? $"-hash{Hashing.HashString(FullNameProvider.GetMethodName(details.BenchmarkCase))}"
                 : string.Empty;
 
             string fileName = $@"{shortTypeName}.{methodName}{parameters}";

--- a/src/BenchmarkDotNet/Helpers/ArtifactFileNameHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/ArtifactFileNameHelper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains;
 
@@ -18,9 +19,9 @@ namespace BenchmarkDotNet.Helpers
         {
             string nameNoLimit = GetFilePathNoLimits(details, creationTime, fileExtension);
 
-            int limit = PathFeatures.AreAllLongPathsAvailable() ? CommonSenseLimit : WindowsOldPathLimit;
-
-            limit -= "userheap.etl".Length; // we should consider trace file extension as part of the name
+            // long paths can be enabled on Windows but it does not mean that ETW is going to work fine..
+            // so we always use 260 as limit on Windows
+            int limit =  RuntimeInformation.IsWindows() ? WindowsOldPathLimit : CommonSenseLimit;
 
             if (nameNoLimit.Length <= limit)
             {

--- a/src/BenchmarkDotNet/Helpers/ArtifactFileNameHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/ArtifactFileNameHelper.cs
@@ -21,7 +21,9 @@ namespace BenchmarkDotNet.Helpers
 
             // long paths can be enabled on Windows but it does not mean that ETW is going to work fine..
             // so we always use 260 as limit on Windows
-            int limit =  RuntimeInformation.IsWindows() ? WindowsOldPathLimit : CommonSenseLimit;
+            int limit =  RuntimeInformation.IsWindows()
+                ? WindowsOldPathLimit - "userheap.etl".Length // the session files get merged, they need to have same name (without extension)
+                : CommonSenseLimit;
 
             if (nameNoLimit.Length <= limit)
             {

--- a/tests/BenchmarkDotNet.Tests/ArtifactFileNameHelperTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ArtifactFileNameHelperTests.cs
@@ -28,7 +28,7 @@ namespace BenchmarkDotNet.Tests
 
             var traceFilePath = ArtifactFileNameHelper.GetTraceFilePath(parameters, new System.DateTime(2020, 10, 1), "etl");
 
-            Assert.True(traceFilePath.Length < 260);
+            Assert.InRange(actual: traceFilePath.Length, low: 0, high: 260);
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/ArtifactFileNameHelperTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ArtifactFileNameHelperTests.cs
@@ -1,0 +1,84 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Helpers;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Tests.XUnit;
+using System.Buffers.Tests;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests
+{
+    public class ArtifactFileNameHelperTests
+    {
+        [FactWindowsOnly(nonWindowsSkipReason: "ETW Sessions can be created only on Windows")]
+        public void OnWindowsWeMustAlwaysUseOldLongPathsLimitForSessionFiles()
+        {
+            var config = DefaultConfig.Instance
+                .WithArtifactsPath(@"C:\Projects\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp5.0\BenchmarkDotNet.Artifacts");
+
+            var benchmarkCase = BenchmarkConverter.TypeToBenchmarks(typeof(RentReturnArrayPoolTests<byte>), config).BenchmarksCases.First();
+
+            var parameters = new DiagnoserActionParameters(
+                process: null,
+                benchmarkCase: benchmarkCase,
+                new BenchmarkId(0, benchmarkCase));
+
+            var traceFilePath = ArtifactFileNameHelper.GetTraceFilePath(parameters, new System.DateTime(2020, 10, 1), "etl");
+
+            Assert.True(traceFilePath.Length < 260);
+        }
+    }
+}
+
+namespace System.Buffers.Tests
+{
+    [GenericTypeArguments(typeof(byte))] // value type
+    [GenericTypeArguments(typeof(object))] // reference type
+    public class RentReturnArrayPoolTests<T>
+    {
+        private readonly ArrayPool<T> _createdPool = ArrayPool<T>.Create();
+        private const int Iterations = 100_000;
+        [Params(4096)]
+        public int RentalSize;
+
+        [Params(false, true)]
+        public bool ManipulateArray { get; set; }
+
+        [Params(false, true)]
+        public bool Async { get; set; }
+
+        [Params(false, true)]
+        public bool UseSharedPool { get; set; }
+
+        private ArrayPool<T> Pool => UseSharedPool ? ArrayPool<T>.Shared : _createdPool;
+
+        private static void Clear(T[] arr) => arr.AsSpan().Clear();
+
+        private static T IterateAll(T[] arr)
+        {
+            T ret = default;
+            foreach (T item in arr)
+            {
+                ret = item;
+            }
+            return ret;
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public async Task SingleSerial()
+        {
+            ArrayPool<T> pool = Pool;
+            for (int i = 0; i < Iterations; i++)
+            {
+                T[] arr = pool.Rent(RentalSize);
+                if (ManipulateArray) Clear(arr);
+                if (Async) await Task.Yield();
+                if (ManipulateArray) IterateAll(arr);
+                pool.Return(arr);
+            }
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.Tests/ArtifactFileNameHelperTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ArtifactFileNameHelperTests.cs
@@ -26,9 +26,12 @@ namespace BenchmarkDotNet.Tests
                 benchmarkCase: benchmarkCase,
                 new BenchmarkId(0, benchmarkCase));
 
-            var traceFilePath = ArtifactFileNameHelper.GetTraceFilePath(parameters, new System.DateTime(2020, 10, 1), "etl");
+            foreach (string fileExtension in new[] { "etl", "kernel.etl", "userheap.etl" })
+            {
+                var traceFilePath = ArtifactFileNameHelper.GetTraceFilePath(parameters, new System.DateTime(2020, 10, 1), fileExtension);
 
-            Assert.InRange(actual: traceFilePath.Length, low: 0, high: 260);
+                Assert.InRange(actual: traceFilePath.Length, low: 0, high: 260);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1544 

to tell the long story short, if Long Paths support is enabled on Windows, the ETW might still throw errors.

The fix is to always use 260 characters limit 