### PR TITLE
Enable supported GcMode characteristics with corerun

### DIFF
--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -9,6 +9,7 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.CoreRun;
 using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Extensions

--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -119,6 +119,9 @@ namespace BenchmarkDotNet.Extensions
             if (benchmarkCase.Job.Environment.Runtime is MonoRuntime monoRuntime && !string.IsNullOrEmpty(monoRuntime.MonoBclPath))
                 start.EnvironmentVariables["MONO_PATH"] = monoRuntime.MonoBclPath;
 
+            if (benchmarkCase.Job.Infrastructure.Toolchain is CoreRunToolchain _)
+                start.EnvironmentVariables["COMPlus_gcServer"] = benchmarkCase.Job.Environment.Gc.Server ? "1" : "0";
+
             if (!benchmarkCase.Job.HasValue(EnvironmentMode.EnvironmentVariablesCharacteristic))
                 return;
 

--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -247,6 +247,5 @@ namespace BenchmarkDotNet.Extensions
             if (gcMode.HasValue(GcMode.HeapCountCharacteristic))
                 start.EnvironmentVariables["COMPlus_GCHeapCount"] = gcMode.HeapCount.ToString("X");
         }
-        }
     }
 }

--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -120,7 +120,7 @@ namespace BenchmarkDotNet.Extensions
             if (benchmarkCase.Job.Environment.Runtime is MonoRuntime monoRuntime && !string.IsNullOrEmpty(monoRuntime.MonoBclPath))
                 start.EnvironmentVariables["MONO_PATH"] = monoRuntime.MonoBclPath;
 
-            if (benchmarkCase.Job.Infrastructure.Toolchain is CoreRunToolchain _)
+            if (benchmarkCase.Job.Infrastructure.Toolchain is CoreRunToolchain)
                 start.EnvironmentVariables["COMPlus_gcServer"] = benchmarkCase.Job.Environment.Gc.Server ? "1" : "0";
 
             if (!benchmarkCase.Job.HasValue(EnvironmentMode.EnvironmentVariablesCharacteristic))

--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -231,14 +231,24 @@ namespace BenchmarkDotNet.Extensions
 
         private static void SetCoreRunEnvironmentVariables(this ProcessStartInfo start, BenchmarkCase benchmarkCase)
         {
-            start.EnvironmentVariables["COMPlus_gcServer"] = benchmarkCase.Job.Environment.Gc.Server ? "1" : "0";
-            start.EnvironmentVariables["COMPlus_gcConcurrent"] = benchmarkCase.Job.Environment.Gc.Concurrent ? "1" : "0";
-            start.EnvironmentVariables["COMPlus_GCCpuGroup"] = benchmarkCase.Job.Environment.Gc.CpuGroups ? "1" : "0";
-            start.EnvironmentVariables["COMPlus_gcAllowVeryLargeObjects"] = benchmarkCase.Job.Environment.Gc.AllowVeryLargeObjects ? "1" : "0";
-            start.EnvironmentVariables["COMPlus_GCRetainVM"] = benchmarkCase.Job.Environment.Gc.RetainVm ? "1" : "0";
-            start.EnvironmentVariables["COMPlus_GCNoAffinitize"] = benchmarkCase.Job.Environment.Gc.NoAffinitize ? "1" : "0";
-            start.EnvironmentVariables["COMPlus_GCHeapAffinitizeMask"] = benchmarkCase.Job.Environment.Gc.HeapAffinitizeMask.ToString("X");
-            start.EnvironmentVariables["COMPlus_GCHeapCount"] = benchmarkCase.Job.Environment.Gc.HeapCount.ToString("X");
+        private static void SetCoreRunEnvironmentVariables(this ProcessStartInfo start, BenchmarkCase benchmarkCase)
+        {
+            var gcMode = benchmarkCase.Job.Environment.Gc;        
+            if (!gcMode.HasChanges)
+                return; // do nothing for the default settings
+            
+            start.EnvironmentVariables["COMPlus_gcServer"] = gcMode.Server ? "1" : "0";
+            start.EnvironmentVariables["COMPlus_gcConcurrent"] = gcMode.Concurrent ? "1" : "0";
+            start.EnvironmentVariables["COMPlus_GCCpuGroup"] = gcMode.CpuGroups ? "1" : "0";
+            start.EnvironmentVariables["COMPlus_gcAllowVeryLargeObjects"] = gcMode.AllowVeryLargeObjects ? "1" : "0";
+            start.EnvironmentVariables["COMPlus_GCRetainVM"] = gcMode.RetainVm ? "1" : "0";
+            start.EnvironmentVariables["COMPlus_GCNoAffinitize"] = gcMode.NoAffinitize ? "1" : "0";
+            
+            if (gcMode.HasValue(GcMode.HeapAffinitizeMaskCharacteristic))
+                start.EnvironmentVariables["COMPlus_GCHeapAffinitizeMask"] = gcMode.HeapAffinitizeMask.ToString("X");
+            if (gcMode.HasValue(GcMode.HeapCountCharacteristic))
+                start.EnvironmentVariables["COMPlus_GCHeapCount"] = gcMode.HeapCount.ToString("X");
+        }
         }
     }
 }

--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -231,8 +231,6 @@ namespace BenchmarkDotNet.Extensions
 
         private static void SetCoreRunEnvironmentVariables(this ProcessStartInfo start, BenchmarkCase benchmarkCase)
         {
-        private static void SetCoreRunEnvironmentVariables(this ProcessStartInfo start, BenchmarkCase benchmarkCase)
-        {
             var gcMode = benchmarkCase.Job.Environment.Gc;        
             if (!gcMode.HasChanges)
                 return; // do nothing for the default settings


### PR DESCRIPTION
`corerun` does not know how to load GC configuration from `runtimeconfig.json` files.
The only portable way is to set the `COMPlus_gcServer` environment variable when spawning the `corerun` child process.

Closes #1495