### PR TITLE
Documentation: add --maxWidth description

### DIFF
--- a/docs/articles/guides/console-args.md
+++ b/docs/articles/guides/console-args.md
@@ -211,3 +211,4 @@ dotnet run -c Release -- --filter * --runtimes netcoreapp2.0 netcoreapp2.1 --sta
 * `--keepFiles` Determines if all auto-generated files should be kept or removed after running the benchmarks.
 * `--noOverwrite` Determines if the exported result files should not be overwritten.
 * `--disableLogFile` Disables the logfile.
+* `--maxWidth` Max paramter column width, the default is 20.


### PR DESCRIPTION
`--maxWidth` console argument is described under [Command-line tool](https://benchmarkdotnet.org/articles/guides/tool.html) page, but is missing under page [How to use console arguments](https://benchmarkdotnet.org/articles/guides/console-args.html).