### PR TITLE
Simplify code: remove sort before adding to HashSet

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/CorrectionsSuggester.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CorrectionsSuggester.cs
@@ -31,7 +31,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 possibleBenchmarkNames.AddRange(names);
             }
 
-            allBenchmarkNames.AddRange(benchmarkNames.OrderBy(name => name));
+            allBenchmarkNames.AddRange(benchmarkNames);
         }
 
         public string[] SuggestFor([NotNull] string userInput)


### PR DESCRIPTION
`allBenchmarkNames` is a `HashSet` so the order of the added elements should not matter.