### PR TITLE
Dispose parameters, kill benchmarking process when it hangs after printing the results

### DIFF
--- a/src/BenchmarkDotNet/Helpers/ConsoleExitHandler.cs
+++ b/src/BenchmarkDotNet/Helpers/ConsoleExitHandler.cs
@@ -57,7 +57,7 @@ namespace BenchmarkDotNet.Helpers
         // the user has closed the console window so we kill the entire process tree
         private void ProcessExitEventHandlerHandlerCallback(object sender, EventArgs e) => KillProcessTree();
 
-        private void KillProcessTree()
+        internal void KillProcessTree()
         {
             try
             {

--- a/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
+++ b/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
@@ -55,6 +55,13 @@ namespace BenchmarkDotNet.Loggers
                 {
                     diagnoser?.Handle(signal, diagnoserActionParameters);
                     process.StandardInput.WriteLine(Engine.Signals.Acknowledgment);
+
+                    if (signal == HostSignal.AfterAll)
+                    {
+                        // we have received the last signal so we can stop reading the output
+                        // if the process won't exit after this, its hung and needs to be killed
+                        return;
+                    }
                 }
                 else if (!string.IsNullOrEmpty(line))
                 {

--- a/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
@@ -8,7 +8,7 @@ using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Parameters
 {
-    public class ParameterInstance
+    public class ParameterInstance : IDisposable
     {
         public const string NullParameterTextRepresentation = "?";
 
@@ -23,6 +23,8 @@ namespace BenchmarkDotNet.Parameters
             this.value = value;
             maxParameterColumnWidth = summaryStyle?.MaxParameterColumnWidth ?? SummaryStyle.DefaultMaxParameterColumnWidth;
         }
+
+        public void Dispose() => (Value as IDisposable)?.Dispose();
 
         public string Name => Definition.Name;
         public bool IsStatic => Definition.IsStatic;

--- a/src/BenchmarkDotNet/Parameters/ParameterInstances.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstances.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Extensions;
 
 namespace BenchmarkDotNet.Parameters
 {
-    public class ParameterInstances
+    public class ParameterInstances : IDisposable
     {
         public IReadOnlyList<ParameterInstance> Items { get; }
         public int Count => Items.Count;
@@ -16,6 +17,14 @@ namespace BenchmarkDotNet.Parameters
         public ParameterInstances(IReadOnlyList<ParameterInstance> items)
         {
             Items = items;
+        }
+
+        public void Dispose()
+        {
+            foreach (var parameterInstance in Items)
+            {
+                parameterInstance.Dispose();
+            }
         }
 
         public string FolderInfo => string.Join("_", Items.Select(p => $"{p.Name}-{p.ToDisplayText()}")).AsValidFileName();

--- a/src/BenchmarkDotNet/Running/BenchmarkCase.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkCase.cs
@@ -6,7 +6,7 @@ using BenchmarkDotNet.Parameters;
 
 namespace BenchmarkDotNet.Running
 {
-    public class BenchmarkCase : IComparable<BenchmarkCase>
+    public class BenchmarkCase : IComparable<BenchmarkCase>, IDisposable
     {
         public Descriptor Descriptor { get; }
         public Job Job { get; }
@@ -25,6 +25,8 @@ namespace BenchmarkDotNet.Running
             Parameters = parameters;
             Config = config;
         }
+
+        public void Dispose() => Parameters.Dispose();
 
         public int CompareTo(BenchmarkCase other) => string.Compare(FolderInfo, other.FolderInfo, StringComparison.Ordinal);
 

--- a/src/BenchmarkDotNet/Running/BenchmarkRunInfo.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunInfo.cs
@@ -3,13 +3,21 @@ using BenchmarkDotNet.Configs;
 
 namespace BenchmarkDotNet.Running
 {
-    public class BenchmarkRunInfo
+    public class BenchmarkRunInfo : IDisposable
     {
         public BenchmarkRunInfo(BenchmarkCase[] benchmarksCase, Type type, ImmutableConfig config)
         {
             BenchmarksCases = benchmarksCase;
             Type = type;
             Config = config;
+        }
+
+        public void Dispose()
+        {
+            foreach (var benchmarkCase in BenchmarksCases)
+            {
+                benchmarkCase.Dispose();
+            }
         }
 
         public BenchmarkCase[] BenchmarksCases { get; }

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -501,10 +501,12 @@ namespace BenchmarkDotNet.Running
                 logger.WriteLineError($"Executable {buildResult.ArtifactsPaths.ExecutablePath} not found");
             }
 
-            if (executeResult.ExitCode != 0)
+            // exit code can be different than 0 if the process has hanged at the end
+            // so we check if some results were reported, if not then it was a failure
+            if (executeResult.ExitCode != 0 && executeResult.Data.IsEmpty())
             {
                 success = false;
-                logger.WriteLineError("ExitCode != 0");
+                logger.WriteLineError("ExitCode != 0 and no results reported");
             }
 
             return executeResult;

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -107,6 +107,14 @@ namespace BenchmarkDotNet.Running
                 }
                 finally
                 {
+                    // some benchmarks might be using parameters that have locking finalizers
+                    // so we need to dispose them after we are done running the benchmarks
+                    // see https://github.com/dotnet/BenchmarkDotNet/issues/1383 and https://github.com/dotnet/runtime/issues/314 for more
+                    foreach (var benchmarkInfo in benchmarkRunInfos)
+                    {
+                        benchmarkInfo.Dispose();
+                    }
+
                     compositeLogger.WriteLineHeader("// * Artifacts cleanup *");
                     Cleanup(new HashSet<string>(artifactsToCleanup.Distinct()));
                     compositeLogger.Flush();

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
@@ -86,18 +86,12 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                 }
 
                 loggerWithDiagnoser.ProcessInput();
-                string standardError = process.StandardError.ReadToEnd();
 
                 process.WaitForExit(); // should we add timeout here?
 
                 if (process.ExitCode == 0)
                 {
                     return new ExecuteResult(true, process.ExitCode, process.Id, loggerWithDiagnoser.LinesWithResults, loggerWithDiagnoser.LinesWithExtraOutput);
-                }
-
-                if (!string.IsNullOrEmpty(standardError))
-                {
-                    logger.WriteError(standardError);
                 }
 
                 return new ExecuteResult(true, process.ExitCode, process.Id, Array.Empty<string>(), Array.Empty<string>());


### PR DESCRIPTION
#1383 contained a very unusual bug: benchmarks were executing fine, but hanging after printing "// AfterAll" to the console

I've dug into that and found out (https://github.com/dotnet/BenchmarkDotNet/issues/1383#issuecomment-714563319) that there is a locking finalizer which prevents the process from exiting which was a thing until it got fixed in .NET 5 (https://github.com/dotnet/runtime/issues/314)

The problem was that disposing the finalizable instance in the `[GlobalCleanup]` was not enough: https://github.com/JohnMasen/VirusSimulator/blob/432e185866b80aac69b95abbeb00d1bb2e3735c1/src/ComputeShaderTest/ComputeShaderPerformanceILGPU.cs#L63

For two reasons:
* when we are using `[ParamsSource]` or `[ArgumentsSource]` the boilerplate code was so far calling `.ToArray()[index]` on it, where `index` was the index of the test case. It meant that if the benchmark had 3 test cases, we were always creating 3 of them in the benchmarking process. The solution was to introduce a new method `ParameterExtractor.GetParameter` that enumerates over the arguments source and disposes unused arguments. It also does not create more than needed. So if we want just the first argument, it stops iterating after first occurrence and hence creates only one instance of the given type.
* `BenchmarkConverter` is also materializing all objects from `[ParamsSource]` or `[ArgumentsSource]` to be able to run the benchmarks. The solution was to add a `Dispose` after running the benchmarks. Thanks to that, the host process stopped hanging after printing `// * Artifacts cleanup *` at the end

Last but not least, the fix was specific to finalizable arguments. To make it more robust, I've extended the executors with the following logic:

* when the benchmark process sends the last signal (`AfterAll`) we stop processing the output stream of the benchmark process. we know it has finished, there is no need to try to read the stream (and hung while trying to do that). 

https://github.com/dotnet/BenchmarkDotNet/blob/09288954791df64a3da162df705b7701e1c7e8b9/src/BenchmarkDotNet/Templates/BenchmarkProgram.txt#L75

* provide a timeout when waiting for the benchmarking process to finish. If it does not quit within 250ms, we are force killing it.

I know that the changes are quite complex, but I have tested them very carefully and ensured that with this extra logic it will be now much harder to hang BenchmarkDotNet.

Fixes #1383
Fixes #828