### PR TITLE
use Environment.Version to determine .NET 5+ versions

### DIFF
--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
@@ -76,6 +76,13 @@ namespace BenchmarkDotNet.Environments
             // we can't just use System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription
             // because it can be null and it reports versions like 4.6.* for .NET Core 2.*
 
+            // for .NET 5+ we can use Environment.Version
+            if (Environment.Version.Major >= 5)
+            {
+                version = Environment.Version;
+                return true;
+            }
+
             string runtimeDirectory = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
             if (TryGetVersionFromRuntimeDirectory(runtimeDirectory, out version))
             {
@@ -89,6 +96,9 @@ namespace BenchmarkDotNet.Environments
                 return true;
             }
 
+            // it's OK to use this method only after checking the previous ones
+            // because we might have a benchmark app build for .NET Core X but executed using CoreRun Y
+            // example: -f netcoreapp3.1 --corerun $omittedForBrevity\Microsoft.NETCore.App\6.0.0\CoreRun.exe - built as 3.1, run as 6.0 (#1576)
             string frameworkName = Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
             if (TryGetVersionFromFrameworkName(frameworkName, out version))
             {


### PR DESCRIPTION
Fixes #1576

I've tested it both with CoreRun from 3.1 dotnet/corefx and 6.0 dotnet/runtime and it works properly now:

```cmd
dotnet run -c Release -f netcoreapp2.1 --filter IntroArguments --job dry --corerun 
C:\Projects\forks\corefx\artifacts\bin\testhost\netcoreapp-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\3.1.9\CoreRun.exe 
C:\Projects\forks\corefx\artifacts\bin\testhost\netcoreapp-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\copy\CoreRun.exe
```

![obraz](https://user-images.githubusercontent.com/6011991/97709600-e4374a00-1aba-11eb-9a0a-f04593e1b43f.png)


```cmd
dotnet run -c Release -f netcoreapp2.1 --filter IntroArguments --job dry --corerun
C:\Projects\forks\corefx\artifacts\bin\testhost\netcoreapp-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\3.1.9\CoreRun.exe
C:\Projects\runtime\artifacts\bin\testhost\net5.0-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\6.0.0\CoreRun.exe
```

![obraz](https://user-images.githubusercontent.com/6011991/97709565-d8e41e80-1aba-11eb-9704-4346411a2045.png)

cc @stephentoub