### PR TITLE
introduce ManualConfig.CreateMinimumViable() method

### DIFF
--- a/docs/articles/configs/exporters.md
+++ b/docs/articles/configs/exporters.md
@@ -99,16 +99,17 @@ The CSV exporter and other compatible exporters may consume an instance of `ISum
 Example of CSV exporter configured to always use microseconds, kilobytes, and to render units only in column headers:
 
 ```cs
-var config = ManualConfig.Create(DefaultConfig.Instance);
-config.Add(new CsvExporter(
+var exporter = new CsvExporter(
     CsvSeparator.CurrentCulture,
-    new BenchmarkDotNet.Reports.SummaryStyle
-    {
-        PrintUnitsInHeader = true,
-        PrintUnitsInContent = false,
-        TimeUnit = BenchmarkDotNet.Horology.TimeUnit.Microsecond,
-        SizeUnit = BenchmarkDotNet.Columns.SizeUnit.KB
-    }));
+    new SummaryStyle(
+        cultureInfo: System.Globalization.CultureInfo.CurrentCulture,
+        printUnitsInHeader: true,
+        printUnitsInContent: false,
+        timeUnit: Perfolizer.Horology.TimeUnit.Microsecond,
+        sizeUnit: SizeUnit.KB
+    ));
+
+var config = ManualConfig.CreateMinimumViable().AddExporter(exporter);
 ```
 
 Excerpt from the resulting CSV file:

--- a/samples/BenchmarkDotNet.Samples/IntroCustomMono.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroCustomMono.cs
@@ -79,7 +79,7 @@ namespace BenchmarkDotNet.Samples
         public static void Run()
         {
             BenchmarkRunner.Run<IntroCustomMonoFluentConfig>(ManualConfig
-                .CreateEmpty()
+                .CreateMinimumViable()
                 .AddJob(Job.ShortRun.WithRuntime(new MonoRuntime(
                     "Mono x64", @"C:\Program Files\Mono\bin\mono.exe")))
                 .AddJob(Job.ShortRun.WithRuntime(new MonoRuntime(

--- a/src/BenchmarkDotNet/Configs/ManualConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ManualConfig.cs
@@ -215,7 +215,19 @@ namespace BenchmarkDotNet.Configs
             Options |= config.Options;
         }
 
+        /// <summary>
+        /// Creates a completely EMPTY config with no predefined settings.
+        /// </summary>
+        /// <remarks>You should most probably use the <see cref="CreateMinimumViable"></see> method instead.</remarks>
         public static ManualConfig CreateEmpty() => new ManualConfig();
+
+        /// <summary>
+        /// Creates a minimum viable config with predefined columns provider and console logger.
+        /// </summary>
+        public static ManualConfig CreateMinimumViable()
+            => CreateEmpty()
+                .AddColumnProvider(DefaultColumnProviders.Instance)
+                .AddLogger(ConsoleLogger.Default);
 
         public static ManualConfig Create(IConfig config)
         {

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -22,7 +22,7 @@ namespace BenchmarkDotNet.Reports
         public TimeUnit TimeUnit { get; }
         [NotNull]
         public CultureInfo CultureInfo { get; }
-        
+
         public RatioStyle RatioStyle { get; }
 
         public SummaryStyle([CanBeNull] CultureInfo cultureInfo, bool printUnitsInHeader, SizeUnit sizeUnit, TimeUnit timeUnit, bool printUnitsInContent = true,


### PR DESCRIPTION
when users use `ManualConfig.CreateEmpty` they often don't know that they should add column provider and logger.

Introducing this new method should make it easier for the users to define custom exporters etc by using `ManualConfig`

```cs
var config = ManualConfig.CreateEmpty()
    .AddColumnProvider(DefaultColumnProviders.Instance)
    .AddLogger(ConsoleLogger.Default);
```