### PR TITLE
Prevent dotnet pack from packaging benchmark projects

### DIFF
--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/_BenchmarkProjectName_.csproj
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/_BenchmarkProjectName_.csproj
@@ -13,6 +13,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <Configuration>Release</Configuration>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/_BenchmarkProjectName_.fsproj
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/_BenchmarkProjectName_.fsproj
@@ -13,6 +13,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <Configuration>Release</Configuration>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <Tailcalls>true</Tailcalls>

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/_BenchmarkProjectName_.vbproj
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/_BenchmarkProjectName_.vbproj
@@ -13,6 +13,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <Configuration>Release</Configuration>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />


### PR DESCRIPTION
Prevent the dotnet pack command from unexpectedly packaging benchmarking projects built via the dotnet new templates.