### PR TITLE
Update message to not suggest an obsolete API

### DIFF
--- a/src/BenchmarkDotNet/Validators/JitOptimizationsValidator.cs
+++ b/src/BenchmarkDotNet/Validators/JitOptimizationsValidator.cs
@@ -32,7 +32,7 @@ namespace BenchmarkDotNet.Validators
                             TreatsWarningsAsErrors,
                             $"Assembly {group.Key.GetName().Name} which defines benchmarks references non-optimized {referencedAssemblyName.Name}" +
                             $"{Environment.NewLine}\tIf you own this dependency, please, build it in RELEASE." +
-                            $"{Environment.NewLine}\tIf you don't, you can disable this policy by using 'config.With(ConfigOptions.DisableOptimizationsValidator)'.");
+                            $"{Environment.NewLine}\tIf you don't, you can disable this policy by using 'config.WithOptions(ConfigOptions.DisableOptimizationsValidator)'.");
                     }
                 }
 


### PR DESCRIPTION
Update the hint for non-optimised references to use the `WithOptions(ConfigOptions)` method, rather than the obsolete `With(ConfigOptions)` overload.
