### PR TITLE
Add wasmnet50 wasmnet60 monikers

### DIFF
--- a/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
+++ b/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
@@ -126,8 +126,18 @@ namespace BenchmarkDotNet.Jobs
         CoreRt60,
 
         /// <summary>
-        /// WebAssembly
+        /// WebAssembly with default .Net version
         /// </summary>
-        Wasm
+        Wasm,
+
+        /// <summary>
+        /// WebAssembly with .net5.0
+        /// </summary>
+        WasmNet50,
+
+        /// <summary>
+        /// WebAssembly with .net6.0
+        /// </summary>
+        WasmNet60
     }
 }


### PR DESCRIPTION
Currently there is no way to specify whether to use net5.0 or net6.0 for wasm; this change introduces that ability. With out it there is no way to do wasm net6.0 runs.

This fixes: https://github.com/dotnet/BenchmarkDotNet/issues/1591