### PR TITLE
Escape the build arguments containing backslash

### DIFF
--- a/src/BenchmarkDotNet/Jobs/Argument.cs
+++ b/src/BenchmarkDotNet/Jobs/Argument.cs
@@ -33,6 +33,20 @@ namespace BenchmarkDotNet.Jobs
     [PublicAPI]
     public class MsBuildArgument : Argument
     {
-        public MsBuildArgument(string value) => TextRepresentation = value;
+
+        public MsBuildArgument(string value) => TextRepresentation = EscapeBuildArguments(value);
+
+        /// <summary>
+        /// Escapes the \ with \\ when \ is part of the build argument.
+        /// <see href="https://github.com/dotnet/BenchmarkDotNet/issues/1536">Fixes issue 1536</see>
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public string EscapeBuildArguments(string args)
+        {
+            if (args.Contains("\\"))
+                args = args.Replace("\\", "\\\\");
+            return args;
+        }
     }
 }

--- a/src/BenchmarkDotNet/Jobs/Argument.cs
+++ b/src/BenchmarkDotNet/Jobs/Argument.cs
@@ -40,9 +40,7 @@ namespace BenchmarkDotNet.Jobs
         /// Escapes the \ with \\ when \ is part of the build argument.
         /// <see href="https://github.com/dotnet/BenchmarkDotNet/issues/1536">Fixes issue 1536</see>
         /// </summary>
-        /// <param name="args"></param>
-        /// <returns></returns>
-        public string EscapeBuildArguments(string args)
+        internal string EscapeBuildArguments(string args)
         {
             if (args.Contains("\\"))
                 args = args.Replace("\\", "\\\\");

--- a/tests/BenchmarkDotNet.Tests/Configs/EnvironmentVariableTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/EnvironmentVariableTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Extensions;
 using Xunit;
 
 namespace BenchmarkDotNet.Tests.Configs
@@ -66,6 +67,19 @@ namespace BenchmarkDotNet.Tests.Configs
                 .WithEnvironmentVariable("a", "b")
                 .WithoutEnvironmentVariables();
             Assert.Empty(job.Environment.EnvironmentVariables);
+        }
+
+        [Fact]
+        public void TestShouldEscapeMSBuildArguments()
+        {
+            string escapedString = new MsBuildArgument(@"/p:a=b\\").TextRepresentation.Escape();
+            Assert.Equal("\"/p:a=b\\\\\\\\\"", escapedString);
+
+            escapedString = new MsBuildArgument(@"/p:\a=b\").TextRepresentation.Escape();
+            Assert.Equal("\"/p:\\\\a=b\\\\\"", escapedString);
+
+            escapedString = new MsBuildArgument(@"/p:\a=\nb\").TextRepresentation.Escape();
+            Assert.Equal("\"/p:\\\\a=\\\\nb\\\\\"", escapedString);
         }
     }
 }


### PR DESCRIPTION
Fixes the following issue with passing build arguments 
[System.FormatException in AfterAssemblyLoadingAttached](https://github.com/dotnet/BenchmarkDotNet/issues/1536)