### PR TITLE
fix issue #1561

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.Windows/Tracing/NativeMemoryLogParser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/Tracing/NativeMemoryLogParser.cs
@@ -29,7 +29,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows.Tracing
 
         private readonly string moduleName;
 
-        private readonly string functionName;
+        private readonly string[] functionNames;
 
         public NativeMemoryLogParser(string etlFilePath, BenchmarkCase benchmarkCase, ILogger logger,
             string programName)
@@ -39,7 +39,11 @@ namespace BenchmarkDotNet.Diagnostics.Windows.Tracing
             this.logger = logger;
 
             moduleName = programName;
-            functionName = nameof(EngineParameters.WorkloadActionUnroll);
+            functionNames = new[]
+            {
+                nameof(EngineParameters.WorkloadActionUnroll),
+                nameof(EngineParameters.WorkloadActionNoUnroll)
+            };
         }
 
         public IEnumerable<Metric> Parse()
@@ -136,7 +140,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows.Tracing
                         var name = stackSource.GetFrameName(frame, false);
 
                         if (name.StartsWith(moduleName, StringComparison.Ordinal) &&
-                            name.IndexOf(functionName, StringComparison.Ordinal) > 0)
+                            functionNames.Any(functionName => name.IndexOf(functionName, StringComparison.Ordinal) > 0))
                         {
                             return true;
                         }


### PR DESCRIPTION
This PR fixes issue #1561. I've improved NativeMemoryProfiler and it always should show results, but I found a few cases that I need to check deeply. 

I've run benchmarks twice with :

```c#
                .WithWarmupCount(1)
                .WithLaunchCount(1)
                .WithIterationCount(1)
                .WithInvocationCount(1)
                .WithUnrollFactor(1)
```

And for some benchmarks I got different results for `Allocated native memory` `Native memory leaks` for each run (number 1 on the following picture)
![image](https://user-images.githubusercontent.com/17333903/99667196-5375dd80-2a6c-11eb-8025-df9d7e17db61.png)

I will check it, but it requires more time, so I think we should merge this fix now.

@adamsitnik On the picture above you can see that the `Allocated` column is different for each run. Did you know about it?


