### PR TITLE
Fix #1604 - pass SummaryStyle to ParameterInstance.ToDisplayText()

### DIFF
--- a/src/BenchmarkDotNet/Columns/ParamColumn.cs
+++ b/src/BenchmarkDotNet/Columns/ParamColumn.cs
@@ -17,7 +17,7 @@ namespace BenchmarkDotNet.Columns
 
         public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
         public string GetValue(Summary summary, BenchmarkCase benchmarkCase) =>
-            benchmarkCase.Parameters.Items.FirstOrDefault(item => item.Name == ColumnName)?.ToDisplayText(summary.GetCultureInfo()) ??
+            benchmarkCase.Parameters.Items.FirstOrDefault(item => item.Name == ColumnName)?.ToDisplayText(summary.Style) ??
             ParameterInstance.NullParameterTextRepresentation;
 
         public bool IsAvailable(Summary summary) => true;

--- a/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
@@ -60,10 +60,7 @@ namespace BenchmarkDotNet.Parameters
             return summary != null ? ToDisplayText(summary.CultureInfo, summary.MaxParameterColumnWidth) : ToDisplayText();
         }
 
-        public string ToDisplayText() => ToDisplayText(CultureInfo.CurrentCulture);
-
-        private string ToDisplayText(CultureInfo cultureInfo) => ToDisplayText(cultureInfo, maxParameterColumnWidthFromConfig);
-
+        public string ToDisplayText() => ToDisplayText(cultureInfo, maxParameterColumnWidthFromConfig);
         public override string ToString() => ToDisplayText();
 
         private static string Trim(string value, int maxDisplayTextInnerLength)

--- a/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
@@ -60,7 +60,8 @@ namespace BenchmarkDotNet.Parameters
             return summary != null ? ToDisplayText(summary.CultureInfo, summary.MaxParameterColumnWidth) : ToDisplayText();
         }
 
-        public string ToDisplayText() => ToDisplayText(cultureInfo, maxParameterColumnWidthFromConfig);
+        public string ToDisplayText() => ToDisplayText(CultureInfo.CurrentCulture, maxParameterColumnWidthFromConfig);
+
         public override string ToString() => ToDisplayText();
 
         private static string Trim(string value, int maxDisplayTextInnerLength)

--- a/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
@@ -15,13 +15,13 @@ namespace BenchmarkDotNet.Parameters
         [PublicAPI] public ParameterDefinition Definition { get; }
 
         private readonly object value;
-        private readonly int defaultMaxParameterColumnWidth;
+        private readonly int maxParameterColumnWidthFromConfig;
 
         public ParameterInstance(ParameterDefinition definition, object value, SummaryStyle summaryStyle)
         {
             Definition = definition;
             this.value = value;
-            defaultMaxParameterColumnWidth = summaryStyle?.MaxParameterColumnWidth ?? SummaryStyle.DefaultMaxParameterColumnWidth;
+            maxParameterColumnWidthFromConfig = summaryStyle?.MaxParameterColumnWidth ?? SummaryStyle.DefaultMaxParameterColumnWidth;
         }
 
         public void Dispose() => (Value as IDisposable)?.Dispose();

--- a/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
@@ -57,7 +57,7 @@ namespace BenchmarkDotNet.Parameters
 
         public string ToDisplayText(SummaryStyle summary) => ToDisplayText(summary.CultureInfo, summary.MaxParameterColumnWidth);
 
-        public string ToDisplayText(CultureInfo cultureInfo) => ToDisplayText(cultureInfo, defaultMaxParameterColumnWidth);
+        private string ToDisplayText(CultureInfo cultureInfo) => ToDisplayText(cultureInfo, maxParameterColumnWidthFromConfig);
 
         public string ToDisplayText() => ToDisplayText(CultureInfo.CurrentCulture);
 

--- a/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
@@ -15,13 +15,13 @@ namespace BenchmarkDotNet.Parameters
         [PublicAPI] public ParameterDefinition Definition { get; }
 
         private readonly object value;
-        private readonly int maxParameterColumnWidth;
+        private readonly int defaultMaxParameterColumnWidth;
 
         public ParameterInstance(ParameterDefinition definition, object value, SummaryStyle summaryStyle)
         {
             Definition = definition;
             this.value = value;
-            maxParameterColumnWidth = summaryStyle?.MaxParameterColumnWidth ?? SummaryStyle.DefaultMaxParameterColumnWidth;
+            defaultMaxParameterColumnWidth = summaryStyle?.MaxParameterColumnWidth ?? SummaryStyle.DefaultMaxParameterColumnWidth;
         }
 
         public void Dispose() => (Value as IDisposable)?.Dispose();
@@ -37,7 +37,7 @@ namespace BenchmarkDotNet.Parameters
                 ? parameter.ToSourceCode()
                 : SourceCodeHelper.ToSourceCode(value);
 
-        public string ToDisplayText(CultureInfo cultureInfo)
+        public string ToDisplayText(CultureInfo cultureInfo, int maxParameterColumnWidth)
         {
             switch (value)
             {
@@ -54,6 +54,10 @@ namespace BenchmarkDotNet.Parameters
                     return Trim(value.ToString(), maxParameterColumnWidth);
             }
         }
+
+        public string ToDisplayText(SummaryStyle summary) => ToDisplayText(summary.CultureInfo, summary.MaxParameterColumnWidth);
+
+        public string ToDisplayText(CultureInfo cultureInfo) => ToDisplayText(cultureInfo, defaultMaxParameterColumnWidth);
 
         public string ToDisplayText() => ToDisplayText(CultureInfo.CurrentCulture);
 

--- a/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
@@ -37,7 +37,7 @@ namespace BenchmarkDotNet.Parameters
                 ? parameter.ToSourceCode()
                 : SourceCodeHelper.ToSourceCode(value);
 
-        public string ToDisplayText(CultureInfo cultureInfo, int maxParameterColumnWidth)
+        private string ToDisplayText(CultureInfo cultureInfo, int maxParameterColumnWidth)
         {
             switch (value)
             {

--- a/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
@@ -55,11 +55,14 @@ namespace BenchmarkDotNet.Parameters
             }
         }
 
-        public string ToDisplayText(SummaryStyle summary) => ToDisplayText(summary.CultureInfo, summary.MaxParameterColumnWidth);
-
-        private string ToDisplayText(CultureInfo cultureInfo) => ToDisplayText(cultureInfo, maxParameterColumnWidthFromConfig);
+        public string ToDisplayText(SummaryStyle summary)
+        {
+            return summary != null ? ToDisplayText(summary.CultureInfo, summary.MaxParameterColumnWidth) : ToDisplayText();
+        }
 
         public string ToDisplayText() => ToDisplayText(CultureInfo.CurrentCulture);
+
+        private string ToDisplayText(CultureInfo cultureInfo) => ToDisplayText(cultureInfo, maxParameterColumnWidthFromConfig);
 
         public override string ToString() => ToDisplayText();
 


### PR DESCRIPTION
Fix proposal for #1604 

By enabling to pass the summary style to ParameterInstances, it is possible to have different max column widths for different exporters. It also fixes the problem when not parsing the config through the run method (at which point the constructor for ParameterInstance is called).