### PR TITLE
Fix add missing culuture info to ToString in RatioStyle

### DIFF
--- a/src/BenchmarkDotNet/Columns/BaselineRatioColumn.cs
+++ b/src/BenchmarkDotNet/Columns/BaselineRatioColumn.cs
@@ -68,16 +68,16 @@ namespace BenchmarkDotNet.Columns
                             return isBaseline
                                 ? "baseline"
                                 : ratio.Mean >= 1.0
-                                    ? "+" + ((ratio.Mean - 1.0) * 100).ToString(advancedPrecision ? "N1" : "N0") + "%"
-                                    : "-" + ((1.0 - ratio.Mean) * 100).ToString(advancedPrecision ? "N1" : "N0") + "%";
+                                    ? "+" + ((ratio.Mean - 1.0) * 100).ToString(advancedPrecision ? "N1" : "N0", cultureInfo) + "%"
+                                    : "-" + ((1.0 - ratio.Mean) * 100).ToString(advancedPrecision ? "N1" : "N0", cultureInfo) + "%";
                         case RatioStyle.Trend:
                             return isBaseline
                                 ? "baseline"
                                 : ratio.Mean >= 1.0
-                                    ? ratio.Mean.ToString(advancedPrecision ? "N3" : "N2") + "x slower"
+                                    ? ratio.Mean.ToString(advancedPrecision ? "N3" : "N2", cultureInfo) + "x slower"
                                     : invertedRatio == null
                                         ? "NA"
-                                        : invertedRatio.Mean.ToString(advancedPrecision ? "N3" : "N2") + "x faster";
+                                        : invertedRatio.Mean.ToString(advancedPrecision ? "N3" : "N2", cultureInfo) + "x faster";
                         default:
                             throw new ArgumentOutOfRangeException(nameof(summary), ratioStyle, "RatioStyle is not supported");
                     }


### PR DESCRIPTION
Fixes the following test on machines with different culture info: RatioPrecisionTestWithBaseline(testDataKey: "Trend")