### PR TITLE
Update framework symbol on dotnet new template #1512

### DIFF
--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json
@@ -32,8 +32,49 @@
     "frameworks": {
       "type": "parameter",
       "datatype": "string",
-      "description": "The target framework(s) for the project (e.g. netstandard2.0;net472). Default \"net5.0\"",
-      "defaultValue": "net5.0",
+      "description": "The target framework(s) for the project (e.g. netstandard2.0;net472). Default \"net5.0\" if \"--console-app\" is true, \"netstandard2.0\" if \"--console-app\" is true",
+      "defaultValue": ""
+    },
+    "frameworksDefaults": {
+      "type": "generated",
+      "generator": "switch",
+      "description": "generate a default framework value based on consoleApp",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "(frameworks == '' && consoleApp == true)",
+            "value": "net5.0"
+          },
+          {
+            "condition": "(frameworks == '' && consoleApp == false)",
+            "value": "netstandard2.0"
+          },
+          {
+            "condition": "(frameworks != '')",
+            "value": ""
+          }
+        ]
+      },
+      "replaces": "$(Frameworks)"
+    },
+    "frameworksValue": {
+      "type": "generated",
+      "generator": "join",
+      "description": "join frameworks and frameworksDefaults",
+      "parameters": {
+        "symbols": [
+          {
+            "type": "ref",
+            "value": "frameworks"
+          },
+          {
+            "type": "ref",
+            "value": "frameworksDefaults"
+          }
+        ]
+      },
       "replaces": "$(Frameworks)"
     },
     "config": {

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json
@@ -80,25 +80,25 @@
     "config": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "Adds a benchmark config class. Default \"false\"",
+      "description": "Adds a benchmark config class.",
       "defaultValue": "false"
     },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "If specified, skips the automatic restore of the project on create. Default \"false\"",
+      "description": "If specified, skips the automatic restore of the project on create.",
       "defaultValue": "false"
     },
     "consoleApp": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "If specified, the project is set up as console app. Default \"false\"",
+      "description": "If specified, the project is set up as console app.",
       "defaultValue": "false"
     },
     "version": {
       "type": "parameter",
       "datatype": "string",
-      "description": "Version of BenchmarkDotNet that will be referenced. Default \"0.12.0\"",
+      "description": "Version of BenchmarkDotNet that will be referenced.",
       "defaultValue": "0.12.0",
       "replaces": "$(BenchmarkDotNetVersion)"
     }

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json
@@ -32,32 +32,32 @@
     "frameworks": {
       "type": "parameter",
       "datatype": "string",
-      "description": "The target framework(s) for the project (e.g. netstandard2.0;net472).",
-      "defaultValue": "netstandard2.0",
+      "description": "The target framework(s) for the project (e.g. netstandard2.0;net472). Default \"net5.0\"",
+      "defaultValue": "net5.0",
       "replaces": "$(Frameworks)"
     },
     "config": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "Adds a benchmark config class.",
+      "description": "Adds a benchmark config class. Default \"false\"",
       "defaultValue": "false"
     },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "If specified, skips the automatic restore of the project on create.",
+      "description": "If specified, skips the automatic restore of the project on create. Default \"false\"",
       "defaultValue": "false"
     },
     "consoleApp": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "If specified, the project is set up as console app.",
+      "description": "If specified, the project is set up as console app. Default \"false\"",
       "defaultValue": "false"
     },
     "version": {
       "type": "parameter",
       "datatype": "string",
-      "description": "Version of BenchmarkDotNet that will be referenced.",
+      "description": "Version of BenchmarkDotNet that will be referenced. Default \"0.12.0\"",
       "defaultValue": "0.12.0",
       "replaces": "$(BenchmarkDotNetVersion)"
     }

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/_BenchmarkProjectName_.csproj
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/_BenchmarkProjectName_.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(consoleApp)' == 'true'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(consoleApp)' == 'false'">
+  <PropertyGroup>
     <TargetFrameworks>$(Frameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json
@@ -32,8 +32,49 @@
     "frameworks": {
       "type": "parameter",
       "datatype": "string",
-      "description": "The target framework(s) for the project (e.g. netstandard2.0;net472). Default \"net5.0\"",
-      "defaultValue": "net5.0",
+      "description": "The target framework(s) for the project (e.g. netstandard2.0;net472). Default \"net5.0\" if \"--console-app\" is true, \"netstandard2.0\" if \"--console-app\" is true",
+      "defaultValue": ""
+    },
+    "frameworksDefaults": {
+      "type": "generated",
+      "generator": "switch",
+      "description": "generate a default framework value based on consoleApp",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "(frameworks == '' && consoleApp == true)",
+            "value": "net5.0"
+          },
+          {
+            "condition": "(frameworks == '' && consoleApp == false)",
+            "value": "netstandard2.0"
+          },
+          {
+            "condition": "(frameworks != '')",
+            "value": ""
+          }
+        ]
+      },
+      "replaces": "$(Frameworks)"
+    },
+    "frameworksValue": {
+      "type": "generated",
+      "generator": "join",
+      "description": "join frameworks and frameworksDefaults",
+      "parameters": {
+        "symbols": [
+          {
+            "type": "ref",
+            "value": "frameworks"
+          },
+          {
+            "type": "ref",
+            "value": "frameworksDefaults"
+          }
+        ]
+      },
       "replaces": "$(Frameworks)"
     },
     "config": {

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json
@@ -80,25 +80,25 @@
     "config": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "Adds a benchmark config class. Default \"false\"",
+      "description": "Adds a benchmark config class.",
       "defaultValue": "false"
     },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "If specified, skips the automatic restore of the project on create. Default \"false\"",
+      "description": "If specified, skips the automatic restore of the project on create.",
       "defaultValue": "false"
     },
     "consoleApp": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "If specified, the project is set up as console app. Default \"false\"",
+      "description": "If specified, the project is set up as console app.",
       "defaultValue": "false"
     },
     "version": {
       "type": "parameter",
       "datatype": "string",
-      "description": "Version of BenchmarkDotNet that will be referenced. Default \"0.12.0\"",
+      "description": "Version of BenchmarkDotNet that will be referenced.",
       "defaultValue": "0.12.0",
       "replaces": "$(BenchmarkDotNetVersion)"
     }

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json
@@ -32,32 +32,32 @@
     "frameworks": {
       "type": "parameter",
       "datatype": "string",
-      "description": "The target framework(s) for the project (e.g. netstandard2.0;net472).",
-      "defaultValue": "netstandard2.0",
+      "description": "The target framework(s) for the project (e.g. netstandard2.0;net472). Default \"net5.0\"",
+      "defaultValue": "net5.0",
       "replaces": "$(Frameworks)"
     },
     "config": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "Adds a benchmark config class.",
+      "description": "Adds a benchmark config class. Default \"false\"",
       "defaultValue": "false"
     },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "If specified, skips the automatic restore of the project on create.",
+      "description": "If specified, skips the automatic restore of the project on create. Default \"false\"",
       "defaultValue": "false"
     },
     "consoleApp": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "If specified, the project is set up as console app.",
+      "description": "If specified, the project is set up as console app. Default \"false\"",
       "defaultValue": "false"
     },
     "version": {
       "type": "parameter",
       "datatype": "string",
-      "description": "Version of BenchmarkDotNet that will be referenced.",
+      "description": "Version of BenchmarkDotNet that will be referenced. Default \"0.12.0\"",
       "defaultValue": "0.12.0",
       "replaces": "$(BenchmarkDotNetVersion)"
     }

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/_BenchmarkProjectName_.fsproj
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/_BenchmarkProjectName_.fsproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(consoleApp)' == 'true'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(consoleApp)' == 'false'">
+  <PropertyGroup>
     <TargetFrameworks>$(Frameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json
@@ -32,32 +32,32 @@
     "frameworks": {
       "type": "parameter",
       "datatype": "string",
-      "description": "The target framework(s) for the project (e.g. netstandard2.0;net472).",
-      "defaultValue": "netstandard2.0",
+      "description": "The target framework(s) for the project (e.g. netstandard2.0;net472). Default \"net5.0\"",
+      "defaultValue": "net5.0",
       "replaces": "$(Frameworks)"
     },
     "config": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "Adds a benchmark config class.",
+      "description": "Adds a benchmark config class. Default \"false\"",
       "defaultValue": "false"
     },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "If specified, skips the automatic restore of the project on create.",
+      "description": "If specified, skips the automatic restore of the project on create. Default \"false\"",
       "defaultValue": "false"
     },
     "consoleApp": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "If specified, the project is set up as console app.",
+      "description": "If specified, the project is set up as console app. Default \"false\"",
       "defaultValue": "false"
     },
     "version": {
       "type": "parameter",
       "datatype": "string",
-      "description": "Version of BenchmarkDotNet that will be referenced.",
+      "description": "Version of BenchmarkDotNet that will be referenced.  Default \"0.12.0\"",
       "defaultValue": "0.12.0",
       "replaces": "$(BenchmarkDotNetVersion)"
     }

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json
@@ -32,8 +32,49 @@
     "frameworks": {
       "type": "parameter",
       "datatype": "string",
-      "description": "The target framework(s) for the project (e.g. netstandard2.0;net472). Default \"net5.0\"",
-      "defaultValue": "net5.0",
+      "description": "The target framework(s) for the project (e.g. netstandard2.0;net472). Default \"net5.0\" if \"--console-app\" is true, \"netstandard2.0\" if \"--console-app\" is true",
+      "defaultValue": ""
+    },
+    "frameworksDefaults": {
+      "type": "generated",
+      "generator": "switch",
+      "description": "generate a default framework value based on consoleApp",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "(frameworks == '' && consoleApp == true)",
+            "value": "net5.0"
+          },
+          {
+            "condition": "(frameworks == '' && consoleApp == false)",
+            "value": "netstandard2.0"
+          },
+          {
+            "condition": "(frameworks != '')",
+            "value": ""
+          }
+        ]
+      },
+      "replaces": "$(Frameworks)"
+    },
+    "frameworksValue": {
+      "type": "generated",
+      "generator": "join",
+      "description": "join frameworks and frameworksDefaults",
+      "parameters": {
+        "symbols": [
+          {
+            "type": "ref",
+            "value": "frameworks"
+          },
+          {
+            "type": "ref",
+            "value": "frameworksDefaults"
+          }
+        ]
+      },
       "replaces": "$(Frameworks)"
     },
     "config": {

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json
@@ -80,25 +80,25 @@
     "config": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "Adds a benchmark config class. Default \"false\"",
+      "description": "Adds a benchmark config class.",
       "defaultValue": "false"
     },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "If specified, skips the automatic restore of the project on create. Default \"false\"",
+      "description": "If specified, skips the automatic restore of the project on create.",
       "defaultValue": "false"
     },
     "consoleApp": {
       "type": "parameter",
       "datatype": "bool",
-      "description": "If specified, the project is set up as console app. Default \"false\"",
+      "description": "If specified, the project is set up as console app.",
       "defaultValue": "false"
     },
     "version": {
       "type": "parameter",
       "datatype": "string",
-      "description": "Version of BenchmarkDotNet that will be referenced.  Default \"0.12.0\"",
+      "description": "Version of BenchmarkDotNet that will be referenced.",
       "defaultValue": "0.12.0",
       "replaces": "$(BenchmarkDotNetVersion)"
     }

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/_BenchmarkProjectName_.vbproj
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/_BenchmarkProjectName_.vbproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(consoleApp)' == 'true'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(consoleApp)' == 'false'">
+  <PropertyGroup>
     <TargetFrameworks>$(Frameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
This is to address the issue #1512.
.template.json file as follow.
* Additional [generated switch](https://github.com/dotnet/templating/wiki/Available-Symbols-Generators#switch)  symbol `frameworksDefaults` to calculate the default values when `--console-app` is `true` or `false`
* [Generated join](https://github.com/dotnet/templating/wiki/Available-Symbols-Generators#join) with the original `frameworks` to take its value if its not empty.