### PR TITLE
don't redirect Standard Error, as we don't read it and writing to it by benchmark can cause deadlocks

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
@@ -98,7 +98,6 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                 startInfo.StandardErrorEncoding = Encoding.UTF8;
             }
 
-
             if (environmentVariables != null)
                 foreach (var environmentVariable in environmentVariables)
                     startInfo.EnvironmentVariables[environmentVariable.Key] = environmentVariable.Value;

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
@@ -76,7 +76,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         }
 
         internal static ProcessStartInfo BuildStartInfo(string customDotNetCliPath, string workingDirectory, string arguments,
-            IReadOnlyList<EnvironmentVariable> environmentVariables = null, bool redirectStandardInput = false)
+            IReadOnlyList<EnvironmentVariable> environmentVariables = null, bool redirectStandardInput = false, bool redirectStandardError = true)
         {
             const string dotnetMultiLevelLookupEnvVarName = "DOTNET_MULTILEVEL_LOOKUP";
 
@@ -88,11 +88,16 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
+                RedirectStandardError = redirectStandardError,
                 RedirectStandardInput = redirectStandardInput,
-                StandardErrorEncoding = Encoding.UTF8,
                 StandardOutputEncoding = Encoding.UTF8,
             };
+
+            if (redirectStandardError) // StandardErrorEncoding is only supported when standard error is redirected
+            {
+                startInfo.StandardErrorEncoding = Encoding.UTF8;
+            }
+
 
             if (environmentVariables != null)
                 foreach (var environmentVariable in environmentVariables)

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
@@ -64,7 +64,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                 CustomDotNetCliPath,
                 artifactsPaths.BinariesDirectoryPath,
                 $"{executableName.Escape()} {benchmarkId.ToArguments()}",
-                redirectStandardInput: true);
+                redirectStandardInput: true,
+                redirectStandardError: false); // #1629
 
             startInfo.SetEnvironmentVariables(benchmarkCase, resolver);
 

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -89,7 +89,7 @@ namespace BenchmarkDotNet.Toolchains
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardInput = true,
-                RedirectStandardError = true,
+                RedirectStandardError = false, // #1629
                 CreateNoWindow = true,
                 WorkingDirectory = null // by default it's null
             };

--- a/tests/BenchmarkDotNet.IntegrationTests/StandardErrorTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/StandardErrorTests.cs
@@ -1,0 +1,43 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Tests.Loggers;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class StandardErrorTests : BenchmarkTestExecutor
+    {
+        private const string ErrorMessage = "ErrorMessage";
+
+        public StandardErrorTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void BenchmarkCanWriteToStandardError() => CanExecute<WritingToStandardError>();
+
+        public class WritingToStandardError
+        {
+            [Benchmark]
+            public void Write() => Console.Error.Write(new string('a', 10_000)); // the text needs to be big enough to hit the deadlock
+        }
+
+        [Fact]
+        public void ExceptionMessageIsNotLost()
+        {
+            var logger = new OutputLogger(Output);
+            var config = CreateSimpleConfig(logger);
+
+            CanExecute<ThrowingException>(config, fullValidation: false);
+
+            Assert.Contains(ErrorMessage, logger.GetLog());
+        }
+
+        public class ThrowingException
+        {
+            [Benchmark]
+            public void Write() => throw new Exception(ErrorMessage);
+        }
+    }
+}


### PR DESCRIPTION
fixes #1629

@AndreyAkinshin PTAL

cc @jonsequitur 