### PR TITLE
Install local SDK without sudo on Unix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
   mkdir "$SCRIPT_DIR/.dotnet"
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://dot.net/v1/dotnet-install.sh
-sudo bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 2.1.503 --install-dir .dotnet --no-path
+bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version 2.1.503 --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1


### PR DESCRIPTION
When using `build.sh` on Unix, it prompts for user password upon installation of the .NET SDK. That even contradicts the .NET SDK installer instruction:

```sh
$ ./build.sh
Installing .NET CLI...
Password:
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
```
(line 2 and 4 indicate the said contradiction)

We don't need administrator's privilege to install the SDK in `{repo root direcotry}/.dotnet`.