### PR TITLE
Filter hint improvements

### DIFF
--- a/src/BenchmarkDotNet/Filters/GlobFilter.cs
+++ b/src/BenchmarkDotNet/Filters/GlobFilter.cs
@@ -1,7 +1,5 @@
 using System.Linq;
 using System.Text.RegularExpressions;
-using BenchmarkDotNet.Extensions;
-using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Running;
 
 namespace BenchmarkDotNet.Filters
@@ -20,9 +18,8 @@ namespace BenchmarkDotNet.Filters
         {
             var benchmark = benchmarkCase.Descriptor.WorkloadMethod;
             string fullBenchmarkName = benchmarkCase.Descriptor.GetFilterName();
-            string typeName = benchmark.DeclaringType.GetDisplayName();
 
-            return patterns.Any(pattern => typeName.EqualsWithIgnoreCase(pattern.userValue) || pattern.regex.IsMatch(fullBenchmarkName));
+            return patterns.Any(pattern => pattern.regex.IsMatch(fullBenchmarkName));
         }
 
         // https://stackoverflow.com/a/6907849/5852046 not perfect but should work for all we need

--- a/tests/BenchmarkDotNet.Tests/CorrectionsSuggesterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/CorrectionsSuggesterTests.cs
@@ -61,7 +61,7 @@ namespace BenchmarkDotNet.Tests
                 typeof(NamespaceB.NamespaceC.MyClassC),
                 typeof(AnotherNamespace.InnerNamespaceA.MyClassA)
             }).SuggestFor("NmespaceB.NamespaceC");
-            Assert.Equal(new[] { "NamespaceB.NamespaceC", "NamespaceA.NamespaceC" }, suggestedNames);
+            Assert.Equal(new[] { "NamespaceB.NamespaceC*", "NamespaceA.NamespaceC*" }, suggestedNames);
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace BenchmarkDotNet.Tests
                 typeof(AnotherNamespace.MyClassZ),
                 typeof(NamespaceB.NamespaceC.MyClassC)
             }).SuggestFor("Nmespace");
-            Assert.Equal(new[] { "NamespaceA", "NamespaceB", "NamespaceC" }, suggestedNames);
+            Assert.Equal(new[] { "NamespaceA*", "NamespaceB*" }, suggestedNames);
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace BenchmarkDotNet.Tests
                 typeof(AnotherNamespace.InnerNamespaceB.MyClassA),
                 typeof(Lexicographical.MyClassLexicAACDE)
             }).SuggestFor("InerNamespaceB");
-            Assert.Equal(new[] { "InnerNamespaceB", "InnerNamespaceA" }, suggestedNames);
+            Assert.Equal(new[] { "*InnerNamespaceB*" }, suggestedNames);
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace BenchmarkDotNet.Tests
         {
             var suggestedNames = new CorrectionsSuggester(new[] { typeof(MyClassA), typeof(NamespaceA.MyClassA) })
                 .SuggestFor("MyClasA");
-            Assert.Equal(new[] { "MyClassA" }, suggestedNames);
+            Assert.Equal(new[] { "*MyClassA*" }, suggestedNames);
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace BenchmarkDotNet.Tests
                 typeof(MyClassA), typeof(MyClassB), typeof(MyClassC), typeof(MyClassZ), typeof(NamespaceB.NamespaceC.MyClassA),
                 typeof(MyClassZ.MyClassY)
             }).SuggestFor("MyClasZ");
-            Assert.Equal(new[] { "MyClassZ", "MyClassA", "MyClassB", "MyClassC", "MyClassY" }, suggestedNames);
+            Assert.Equal(new[] { "*MyClassZ*" }, suggestedNames);
         }
 
         [Fact]
@@ -113,7 +113,7 @@ namespace BenchmarkDotNet.Tests
         {
             var suggestedNames = new CorrectionsSuggester(new[]
             {
-                typeof(MyClassA),
+                typeof(NamespaceB.MyClassA),
                 typeof(NamespaceA.MyClassA),
                 typeof(NamespaceB.NamespaceC.MyClassA)
             }).SuggestFor("NamespaceA.MyClasA.MethodA");
@@ -122,8 +122,6 @@ namespace BenchmarkDotNet.Tests
                 "NamespaceA.MyClassA.MethodA",
                 "NamespaceA.MyClassA.MethodB",
                 "NamespaceB.MyClassA.MethodA",
-                "NamespaceC.MyClassA.MethodA",
-                "NamespaceC.MyClassA.MethodB"
             }, suggestedNames);
         }
 
@@ -135,7 +133,7 @@ namespace BenchmarkDotNet.Tests
                 typeof(Generics.GenericA<int>),
                 typeof(Generics.GenericB<int>)
             }).SuggestFor("GeneriA<Int32>");
-            Assert.Equal(new[] { "GenericA<Int32>", "GenericB<Int32>" }, suggestedNames);
+            Assert.Equal(new[] { "*GenericA<Int32>*" }, suggestedNames);
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/GlobFilterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/GlobFilterTests.cs
@@ -9,9 +9,9 @@ namespace BenchmarkDotNet.Tests
     public class GlobFilterTests
     {
         [Theory]
-        [InlineData(nameof(TypeWithBenchmarks), true)] // type name
-        [InlineData("typewithbenchmarks", true)] // type name lowercase
-        [InlineData("TYPEWITHBENCHMARKS", true)] // type name uppercase
+        [InlineData(nameof(TypeWithBenchmarks), false)] // type name
+        [InlineData("typewithbenchmarks", false)] // type name lowercase
+        [InlineData("TYPEWITHBENCHMARKS", false)] // type name uppercase
         [InlineData("*TypeWithBenchmarks*", true)] // regular expression
         [InlineData("*typewithbenchmarks*", true)] // regular expression lowercase
         [InlineData("*TYPEWITHBENCHMARKS*", true)] // regular expression uppercase

--- a/tests/BenchmarkDotNet.Tests/TypeFilterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/TypeFilterTests.cs
@@ -103,16 +103,13 @@ namespace BenchmarkDotNet.Tests
         }
 
         [Fact]
-        public void CanSelectClassesUsingTypeNames()
+        public void CanNotSelectClassesUsingTypeNames()
         {
             var benchmarks = Filter(
                 new[] { typeof(ClassA), typeof(ClassB) },
                 new[] { "--filter", "ClassC", "ClassA" });
 
-            // ClassC not matched as it has NO methods with the [Benchmark] attribute
-            Assert.Equal(2, benchmarks.Count);
-            Assert.Contains("ClassA.Method1", benchmarks);
-            Assert.Contains("ClassA.Method2", benchmarks);
+            Assert.Empty(benchmarks); // it's not supported anymore
         }
 
         [Fact]


### PR DESCRIPTION
fixes #1539

1. don't allow for `--filter typeName` anymore, always use globs. doc does not need to be updated as it was not recommended and not mentioned anywhere that it was possible. This was causing confusion as it was an exception from using globs with `*`
2. change the filter suggestions to use full names and globs only

