### PR TITLE
1655 doc with options obsolete usage of with

### DIFF
--- a/docs/articles/configs/configoptions.md
+++ b/docs/articles/configs/configoptions.md
@@ -27,9 +27,12 @@ public class Config : ManualConfig
 {
     public Config()
     {
-        // or using the With() factory method:
-        this.With(ConfigOptions.JoinSummary)
-            .With(ConfigOptions.DisableLogFile);
+        // Using the WithOptions() factory method:
+        this.WithOptions(ConfigOptions.JoinSummary)
+            .WithOptions(ConfigOptions.DisableLogFile);
+        
+        // Or (The ConfigOptions Enum is defined as a BitField)
+        this.WithOptions(ConfigOptions.JoinSummary | ConfigOptions.DisableLogFile);
 
     }
 }
@@ -44,9 +47,9 @@ public class Config : ManualConfig
             .Run<Benchmarks>(
                 ManualConfig
                     .Create(DefaultConfig.Instance)
-                    .With(ConfigOptions.JoinSummary)
-                    .With(ConfigOptions.DisableLogFile)
+                    .WithOptions(ConfigOptions.JoinSummary)
+                    .WithOptions(ConfigOptions.DisableLogFile)
                     // or
-                    .With(ConfigOptions.JoinSummary | ConfigOptions.DisableLogFile));
+                    .WithOptions(ConfigOptions.JoinSummary | ConfigOptions.DisableLogFile));
     }
 ```

--- a/docs/articles/configs/configoptions.md
+++ b/docs/articles/configs/configoptions.md
@@ -27,12 +27,6 @@ public class Config : ManualConfig
 {
     public Config()
     {
-        Options.Set(true, ConfigOptions.JoinSummary);
-        Options.Set(true, ConfigOptions.DisableLogFile);
-
-        // or
-        Options.Set(true, ConfigOptions.JoinSummary | ConfigOptions.DisableLogFile);
-
         // or using the With() factory method:
         this.With(ConfigOptions.JoinSummary)
             .With(ConfigOptions.DisableLogFile);


### PR DESCRIPTION
Fix #1655 

Update the documentation [https://github.com/dotnet/BenchmarkDotNet/blob/master/docs/articles/configs/configoptions.md/#L1](https://github.com/dotnet/BenchmarkDotNet/blob/master/docs/articles/configs/configoptions.md/#L1)

- Replace the method `With` by `WithOptions`
- Remove the section about the use of `Options.Set(<boolean>, <ConfigOptions>)`, because `ConfigOptionsExtensions` is `internal`.