### PR TITLE
Changed default debug type to pdbonly

### DIFF
--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/_BenchmarkProjectName_.csproj
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/_BenchmarkProjectName_.csproj
@@ -8,7 +8,7 @@
  </PropertyGroup>
   <PropertyGroup>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>portable</DebugType>
+    <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/_BenchmarkProjectName_.fsproj
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/_BenchmarkProjectName_.fsproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>portable</DebugType>
+    <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/_BenchmarkProjectName_.vbproj
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/_BenchmarkProjectName_.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>portable</DebugType>
+    <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>


### PR DESCRIPTION
Since `DisassemblyDiagnoser` requires `pdbonly` it makes sense to use it by default.