### PR TITLE
Fix location for NativeAOT publish files

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
@@ -62,7 +62,7 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
                 : base.GetBuildArtifactsDirectoryPath(buildPartition, programName);
 
         protected override string GetBinariesDirectoryPath(string buildArtifactsDirectoryPath, string configuration)
-            => Path.Combine(buildArtifactsDirectoryPath, "bin", configuration, TargetFrameworkMoniker, runtimeIdentifier, "native");
+            => Path.Combine(buildArtifactsDirectoryPath, "bin", configuration, TargetFrameworkMoniker, runtimeIdentifier, "publish");
 
         protected override void GenerateBuildScript(BuildPartition buildPartition, ArtifactsPaths artifactsPaths)
         {


### PR DESCRIPTION
Even if native folder contains generated output, that location contains only ompiled C# code, without additional native dependencies.
I project has Microsoft.Data.SqlClient dependency, then benchmark would not run, since it cannot find Microsoft.Data.SqlClient.SNI.dll
Proper location is to look for publish folder, where all nescessary files to run application copied.