### PR TITLE
Dont redirect standard input for WASM

### DIFF
--- a/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
+++ b/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Running;
+
 
 namespace BenchmarkDotNet.Loggers
 {
@@ -18,7 +20,7 @@ namespace BenchmarkDotNet.Loggers
         {
             if (!process.StartInfo.RedirectStandardOutput)
                 throw new NotSupportedException("set RedirectStandardOutput to true first");
-            if (!process.StartInfo.RedirectStandardInput)
+            if (!(process.StartInfo.RedirectStandardInput || benchmarkCase.GetRuntime() is WasmRuntime))
                 throw new NotSupportedException("set RedirectStandardInput to true first");
 
             this.logger = logger;
@@ -54,7 +56,11 @@ namespace BenchmarkDotNet.Loggers
                 else if (Engine.Signals.TryGetSignal(line, out var signal))
                 {
                     diagnoser?.Handle(signal, diagnoserActionParameters);
-                    process.StandardInput.WriteLine(Engine.Signals.Acknowledgment);
+
+                    if (process.StartInfo.RedirectStandardInput)
+                    {
+                        process.StandardInput.WriteLine(Engine.Signals.Acknowledgment);
+                    }
 
                     if (signal == HostSignal.AfterAll)
                     {

--- a/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
+++ b/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
@@ -6,7 +6,6 @@ using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Running;
 
-
 namespace BenchmarkDotNet.Loggers
 {
     internal class SynchronousProcessOutputLoggerWithDiagnoser

--- a/src/BenchmarkDotNet/Running/BenchmarkCase.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkCase.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Linq;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Parameters;
+using BenchmarkDotNet.Portability;
 
 namespace BenchmarkDotNet.Running
 {
@@ -24,6 +26,13 @@ namespace BenchmarkDotNet.Running
             Job = job;
             Parameters = parameters;
             Config = config;
+        }
+
+        public Runtime GetRuntime()
+        {
+            return Job.Environment.HasValue(EnvironmentMode.RuntimeCharacteristic)
+                              ? Job.Environment.Runtime
+                              : RuntimeInformation.GetCurrentRuntime();
         }
 
         public void Dispose() => Parameters.Dispose();

--- a/src/BenchmarkDotNet/Running/BenchmarkCase.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkCase.cs
@@ -28,12 +28,9 @@ namespace BenchmarkDotNet.Running
             Config = config;
         }
 
-        public Runtime GetRuntime()
-        {
-            return Job.Environment.HasValue(EnvironmentMode.RuntimeCharacteristic)
-                              ? Job.Environment.Runtime
-                              : RuntimeInformation.GetCurrentRuntime();
-        }
+        public Runtime GetRuntime() => Job.Environment.HasValue(EnvironmentMode.RuntimeCharacteristic)
+                ? Job.Environment.Runtime
+                : RuntimeInformation.GetCurrentRuntime();
 
         public void Dispose() => Parameters.Dispose();
 

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -98,9 +98,8 @@ namespace BenchmarkDotNet.Toolchains
 
             string exePath = artifactsPaths.ExecutablePath;
 
-            var runtime = benchmarkCase.Job.Environment.HasValue(EnvironmentMode.RuntimeCharacteristic)
-                ? benchmarkCase.Job.Environment.Runtime
-                : RuntimeInformation.GetCurrentRuntime();
+            var runtime = benchmarkCase.GetRuntime();
+
             // TODO: use resolver
 
             switch (runtime)
@@ -117,6 +116,7 @@ namespace BenchmarkDotNet.Toolchains
                     break;
                 case WasmRuntime wasm:
                     start.FileName = wasm.JavaScriptEngine;
+                    start.RedirectStandardInput = false;
                     start.Arguments = $"{wasm.JavaScriptEngineArguments} runtime.js -- --run {artifactsPaths.ProgramName}.dll {args} ";
                     start.WorkingDirectory = artifactsPaths.BinariesDirectoryPath;
                     break;

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -99,7 +99,6 @@ namespace BenchmarkDotNet.Toolchains
             string exePath = artifactsPaths.ExecutablePath;
 
             var runtime = benchmarkCase.GetRuntime();
-
             // TODO: use resolver
 
             switch (runtime)


### PR DESCRIPTION
This is needed to address this issue in dotnet/performance: https://github.com/dotnet/performance/issues/1720

To reiterate what is said there, since wasm processes cannot and is not reading from standard in, they do not wait for acknowledgements. This means the process can race ahead, and finish before the acknowledgement is even sent, at which point it will fail due to a closed pipe.

This change simply ignores the exception in that case, and prints an error.