### PR TITLE
Fix change runtime target to Core50

### DIFF
--- a/samples/BenchmarkDotNet.Samples/IntroEventPipeProfilerAdvanced.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroEventPipeProfilerAdvanced.cs
@@ -17,7 +17,7 @@ namespace BenchmarkDotNet.Samples
         {
             public CustomConfig()
             {
-                AddJob(Job.ShortRun.WithRuntime(CoreRuntime.Core30));
+                AddJob(Job.ShortRun.WithRuntime(CoreRuntime.Core50));
 
                 var providers = new[]
                 {


### PR DESCRIPTION
Necessary, since Core30 is not a build target for samples anymore.

Error message when running `#25`

```
// Build Error: The project which defines benchmarks does not target 'netcoreapp3.0'.
You need to add 'netcoreapp3.0' to <TargetFrameworks> in your project file ('C:\Data\Documents\CSharp\Knowledge\BenchmarkDotNet\samples\BenchmarkDotNet.Samples\BenchmarkDotNet.Samples.csproj').
Example: <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
```

This is the last occurance of Core30 in the samples.