### PR TITLE
do not split surrogates in `ParameterInstance.ToDisplayText()`

### DIFF
--- a/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
@@ -71,9 +71,33 @@ namespace BenchmarkDotNet.Parameters
 
             var postfix = $" [{value.Length}]";
             const string dots = "(...)";
-            int take = (maxDisplayTextInnerLength - postfix.Length - dots.Length) / 2;
 
-            return value.Substring(0, take) + dots + value.Substring(value.Length - take, take) + postfix;
+            var takeFromStart = (maxDisplayTextInnerLength - postfix.Length - dots.Length) / 2;
+            var takeFromEnd = takeFromStart;
+
+            if (IsFirstCharInSurrogatePair(value[takeFromStart-1]))
+            {
+                takeFromStart = Math.Max(0, takeFromStart - 1);
+            }
+
+            if (IsSecondCharInSurrogatePair(value[value.Length - takeFromEnd]))
+            {
+                takeFromEnd = Math.Max(0, takeFromEnd - 1);
+            }
+
+            var result = value.Substring(0, takeFromStart) + dots + value.Substring(value.Length - takeFromEnd, takeFromEnd) + postfix;
+
+            return result;
+        }
+
+        private static bool IsFirstCharInSurrogatePair(char c)
+        {
+            return BitConverter.IsLittleEndian ? char.IsHighSurrogate(c) : char.IsLowSurrogate(c);
+        }
+
+        private static bool IsSecondCharInSurrogatePair(char c)
+        {
+            return BitConverter.IsLittleEndian ? char.IsLowSurrogate(c) : char.IsHighSurrogate(c);
         }
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/ParamSourceTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ParamSourceTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Xunit;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class ParamSourceTests: BenchmarkTestExecutor
+    {
+        [Fact]
+        public void ParamSourceCanHandleStringWithSurrogates()
+        {
+            CanExecute<ParamSourceIsStringWithSurrogates>(CreateSimpleConfig());
+        }
+
+        public class ParamSourceIsStringWithSurrogates
+        {
+            public IEnumerable<string> StringValues
+            {
+                get
+                {
+                    yield return "a" + string.Join("", Enumerable.Repeat("😀", 40)) + "a";
+                    yield return "a" + string.Join("", Enumerable.Repeat("😀", 40));
+                    yield return string.Join("", Enumerable.Repeat("😀", 40)) + "a";
+                    yield return string.Join("", Enumerable.Repeat("😀", 40));
+                }
+            }
+
+            [ParamsSource(nameof(StringValues))]
+            public string _ { get; set; }
+
+            [Benchmark]
+            public void Method() { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1703 

The original idea was to explicitly specify `UTF-8` as a `StreamWriter` encoding. It would cause `StreamWriter` to **not** throw an exception when only part of a surrogate pair left (it would be replaced with the replacement character).   

But actually updating `.ToDisplayText()` forbidding surrogate pairs splitting looks like a better fix.

Old `DisplayText`: `a😀☐(...)😀😀 [201]` (causes `StreamWriter` to throw the exception)
New `DisplayText`: `a😀(...)😀😀 [201]`

Logs:
```
// ***** BenchmarkRunner: Start   *****
// ***** Found 1 benchmark(s) in total *****
// ***** Building 1 exe(s) in Parallel: Start   *****
BuildScript: C:\Users\onovak\Documents\repos\BenchmarkDotNet\samples\BenchmarkDotNet.Samples\bin\Debug\net461\b681758f-a705-4498-bd08-6073e1006811.bat
// ***** Done, took 00:00:02 (2.91 sec)   *****
// Found 1 benchmarks:
//   PerfTests.OldBehavior: DefaultJob [_utf16String=a😀(...)😀a [202]]

// **************************
// Benchmark: PerfTests.OldBehavior: DefaultJob [_utf16String=a😀(...)😀a [202]]
// *** Execute ***
// Launch: 1 / 1
// Execute: C:\Users\onovak\Documents\repos\BenchmarkDotNet\samples\BenchmarkDotNet.Samples\bin\Debug\net461\b681758f-a705-4498-bd08-6073e1006811.exe --benchmarkName "BenchmarkDotNet.Samples.PerfTests.OldBehavior(_utf16String: "a😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀a")" --job "Default" --benchmarkId 0 in 
// BeforeAnythingElse

// Benchmark Process Environment Information:
// Runtime=.NET Framework 4.8 (4.8.4300.0), X64 RyuJIT
// GC=Concurrent Workstation
// Job: DefaultJob

OverheadJitting  1: 1 op, 245600.00 ns, 245.6000 us/op
WorkloadJitting  1: 1 op, 210000.00 ns, 210.0000 us/op
...
```