### PR TITLE
Set ValidateExecutableReferencesMatchSelfContained to false in aotllvm template

### DIFF
--- a/src/BenchmarkDotNet/Templates/MonoAOTLLVMCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/MonoAOTLLVMCsProj.txt
@@ -8,6 +8,7 @@
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
     <PublishTrimmed>false</PublishTrimmed>
     <AssemblyName>$PROGRAMNAME$</AssemblyName>
+    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Set ValidateExecutableReferencesMatchSelfContained to false in aotllvm template. 

Fixes: https://github.com/dotnet/performance/issues/1804