### PR TITLE
Added UsingBrowserRuntimeWorkload

### DIFF
--- a/src/BenchmarkDotNet/Templates/WasmCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmCsProj.txt
@@ -8,6 +8,7 @@
     <AssemblyName>$PROGRAMNAME$</AssemblyName>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
     <MicrosoftNetCoreAppRuntimePackDir>$RUNTIMEPACK$</MicrosoftNetCoreAppRuntimePackDir>
+    <UsingBrowserRuntimeWorkload>false</UsingBrowserRuntimeWorkload>
     $COPIEDSETTINGS$
   </PropertyGroup>
 


### PR DESCRIPTION
A check was added to the SDK to check for the wasm "workloads" to be installed when building wasm apps, but BDN doesn't actually need this. So this PR adds a msbuild property to disable  the check.

Fixes: https://github.com/dotnet/performance/issues/1823