### PR TITLE
Added <WasmNativeWorkload>false</WasmNativeWorkload> to Wasm cs proj

### DIFF
--- a/src/BenchmarkDotNet/Templates/WasmAotCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmAotCsProj.txt
@@ -14,6 +14,7 @@
     <WasmMainJSPath>$(RuntimeSrcDir)\src\mono\wasm\runtime-test.js</WasmMainJSPath>
     <WasmGenerateRunV8Script>true</WasmGenerateRunV8Script>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
+    <WasmNativeWorkload>false</WasmNativeWorkload>
     $COPIEDSETTINGS$
   </PropertyGroup>
 

--- a/src/BenchmarkDotNet/Templates/WasmCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmCsProj.txt
@@ -10,6 +10,7 @@
     <MicrosoftNetCoreAppRuntimePackDir>$RUNTIMEPACK$</MicrosoftNetCoreAppRuntimePackDir>
     <UsingBrowserRuntimeWorkload>false</UsingBrowserRuntimeWorkload>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
+    <WasmNativeWorkload>false</WasmNativeWorkload>
     $COPIEDSETTINGS$
   </PropertyGroup>
 


### PR DESCRIPTION
This is needed to prevent another check in the SDK that is not needed for BDN, and unblock an issue we are seeing in wasm-aot.