### PR TITLE
Add support for returning unmanaged types from benchmarks

### DIFF
--- a/src/BenchmarkDotNet/Engines/Consumer.cs
+++ b/src/BenchmarkDotNet/Engines/Consumer.cs
@@ -32,6 +32,7 @@ namespace BenchmarkDotNet.Engines
         private ulong ulongHolder;
         private string stringHolder;
         private object objectHolder;
+        private IntPtr ptrHolder;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [PublicAPI]
@@ -97,6 +98,12 @@ namespace BenchmarkDotNet.Engines
         [PublicAPI]
         public void Consume<T>(T objectValue) where T : class // class constraint prevents from boxing structs
             => Volatile.Write(ref objectHolder, objectValue);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe void Consume<T>(T* ptrValue) where T: unmanaged => Volatile.Write(ref ptrHolder, (IntPtr)ptrValue);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe void Consume(void* ptrValue) => Volatile.Write(ref ptrHolder, (IntPtr)ptrValue);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Consume<T>(in T value)

--- a/src/BenchmarkDotNet/Extensions/ReflectionExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ReflectionExtensions.cs
@@ -45,6 +45,8 @@ namespace BenchmarkDotNet.Extensions
 
             if (type == typeof(void))
                 return "void";
+            if (type == typeof(void*))
+                return "void*";
             string prefix = "";
             if (!string.IsNullOrEmpty(type.Namespace) && includeNamespace)
                 prefix += type.Namespace + ".";

--- a/src/BenchmarkDotNet/Templates/BenchmarkType.txt
+++ b/src/BenchmarkDotNet/Templates/BenchmarkType.txt
@@ -1,5 +1,5 @@
     // the type name must be in sync with WindowsDisassembler.BuildArguments
-    public class Runnable_$ID$ : global::$WorkloadTypeName$
+    public unsafe class Runnable_$ID$ : global::$WorkloadTypeName$
     {
         public static void Run(BenchmarkDotNet.Engines.IHost host, System.String benchmarkName)
         {

--- a/tests/BenchmarkDotNet.Tests/ReflectionTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ReflectionTests.cs
@@ -21,6 +21,7 @@ namespace BenchmarkDotNet.Tests
             CheckCorrectTypeName("System.Tuple<System.Int32, System.Int32>[]", typeof(Tuple<int, int>[]));
             CheckCorrectTypeName("System.ValueTuple<System.Int32, System.Int32>[]", typeof(ValueTuple<int, int>[]));
             CheckCorrectTypeName("void", typeof(void));
+            CheckCorrectTypeName("void*", typeof(void*));
             CheckCorrectTypeName("System.IEquatable<T>", typeof(IEquatable<>));
             CheckCorrectTypeName("BenchmarkDotNet.Tests.ReflectionTests.NestedNonGeneric1.NestedNonGeneric2", typeof(NestedNonGeneric1.NestedNonGeneric2));
             CheckCorrectTypeName("BenchmarkDotNet.Tests.ReflectionTests.NestedNonGeneric1.NestedGeneric2<System.Int16, System.Boolean, System.Decimal>",


### PR DESCRIPTION
- `System.Void*` is not supported as type in C#, so I map to `void*` in GetCorrectCSharpTypeName similarly to regular `void`
- `System.Void*` and other pointer types cannot be consumed, so I have to add two Consume functions. I do not mark them as `[PublicAPI]` since this is too would be much liberty from me.
- I mark whole autogenerated class as `unsafe` to not introduce special checks for unsafe types when generate code. Hopefully this is accepteable.

Closes #1720