### PR TITLE
Added UsingBrowserRuntimeWorkload false

### DIFF
--- a/src/BenchmarkDotNet/Templates/WasmAotCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmAotCsProj.txt
@@ -15,6 +15,7 @@
     <WasmGenerateRunV8Script>true</WasmGenerateRunV8Script>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     <WasmNativeWorkload>false</WasmNativeWorkload>
+    <UsingBrowserRuntimeWorkload>false</UsingBrowserRuntimeWorkload>
     $COPIEDSETTINGS$
   </PropertyGroup>
 


### PR DESCRIPTION
This disables another check in the SDK that we don't actually need for wasm.