### PR TITLE
Add linker description for wasm AOT

### DIFF
--- a/src/BenchmarkDotNet/Templates/WasmAotCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmAotCsProj.txt
@@ -10,6 +10,7 @@
     <AssemblyName>$PROGRAMNAME$</AssemblyName>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
     <PublishTrimmed>true</PublishTrimmed>
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
     <RunAOTCompilation>true</RunAOTCompilation>
     <WasmMainJSPath>$(RuntimeSrcDir)\src\mono\wasm\runtime-test.js</WasmMainJSPath>
     <WasmGenerateRunV8Script>true</WasmGenerateRunV8Script>
@@ -24,6 +25,7 @@
 
   <ItemGroup>
     <Compile Include="$CODEFILENAME$" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
+    <TrimmerRootDescriptor Include="WasmLinkerDescription.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BenchmarkDotNet/Templates/WasmLinkerDescription.xml
+++ b/src/BenchmarkDotNet/Templates/WasmLinkerDescription.xml
@@ -1,0 +1,5 @@
+<linker>
+  <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.IntPtr" />
+  </assembly>
+</linker>

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -26,8 +26,10 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
             if (((WasmRuntime)buildPartition.Runtime).Aot)
             {
                 GenerateProjectAot(buildPartition, artifactsPaths, logger);
-            }
-            else
+
+                var linkDescriptionFileName = "WasmLinkerDescription.xml";
+                File.WriteAllText (Path.Combine (Path.GetDirectoryName (artifactsPaths.ProjectFilePath), linkDescriptionFileName), ResourceHelper.LoadTemplate (linkDescriptionFileName));
+            } else
             {
                 GenerateProjectInterpreter(buildPartition, artifactsPaths, logger);
             }

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -28,7 +28,7 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
                 GenerateProjectAot(buildPartition, artifactsPaths, logger);
 
                 var linkDescriptionFileName = "WasmLinkerDescription.xml";
-                File.WriteAllText (Path.Combine (Path.GetDirectoryName (artifactsPaths.ProjectFilePath), linkDescriptionFileName), ResourceHelper.LoadTemplate (linkDescriptionFileName));
+                File.WriteAllText(Path.Combine(Path.GetDirectoryName(artifactsPaths.ProjectFilePath), linkDescriptionFileName), ResourceHelper.LoadTemplate(linkDescriptionFileName));
             } else
             {
                 GenerateProjectInterpreter(buildPartition, artifactsPaths, logger);


### PR DESCRIPTION
This fixes build errors, where `System.IntPtr` wasn't fully preserved.

Example error:

    runtime/src/mono/wasm/build/WasmApp.Native.targets(425,5): error : Precompiling failed for .../performance/artifacts/bin/MicroBenchmarks/Release/net6.0/Job-DGQDZJ/bin/net6.0/browser-wasm/publish/System.Private.CoreLib.dll: Unable to compile method 'object System.Enum:GetValue ()' due to: 'VTable setup of type System.IntPtr failed assembly:.../performance/artifacts/bin/MicroBenchmarks/Release/net6.0/Job-DGQDZJ/bin/net6.0/browser-wasm/publish/System.Private.CoreLib.dll type:IntPtr member:(null)'.

Also suppress linker warnings. There are too many of them (around 414)
and we cannot fix them currently as most of them comes
from the referenced assemblies.