### PR TITLE
Make mono/wasm run on Windows

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmToolChain.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmToolChain.cs
@@ -27,10 +27,8 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
                 return false;
 
             if (RuntimeInformation.IsWindows())
-            {
-                logger.WriteLineError($"{nameof(WasmToolChain)} is supported only on Unix, benchmark '{benchmarkCase.DisplayInfo}' will not be executed");
-                return false;
-            }
+                logger.WriteLineInfo($"{nameof(WasmToolChain)} is supported only on Unix, benchmark '{benchmarkCase.DisplayInfo}' might not work correctly");
+
             return true;
         }
 


### PR DESCRIPTION
Just log a warning about it. It eases development on Windows.

I tried to run a microbenchmark from the dotnet/performance repo and it
run the build phase just fine. I am not sure yet, whether it will run
fine, so I kept the log message there.