### PR TITLE
Fix #1731.

### DIFF
--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -402,7 +402,14 @@ namespace BenchmarkDotNet.Running
 
                 if (executeResult.ProcessId.HasValue)
                 {
-                    logger.WriteLineInfo($"// Benchmark Process {executeResult.ProcessId} has exited with code {executeResult.ExitCode}");
+                    if (executeResult.ExitCode is int exitCode)
+                    {
+                        logger.WriteLineInfo($"// Benchmark Process {executeResult.ProcessId} has exited with code {exitCode}.");
+                    }
+                    else
+                    {
+                        logger.WriteLineInfo($"// Benchmark Process {executeResult.ProcessId} failed to exit.");
+                    }
                 }
 
                 executeResults.Add(executeResult);

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Engines;
@@ -21,6 +22,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         public DotNetCliExecutor(string customDotNetCliPath) => CustomDotNetCliPath = customDotNetCliPath;
 
         private string CustomDotNetCliPath { get; }
+        private readonly TimeSpan ProcessExitTimeout = TimeSpan.FromSeconds(2);
 
         public ExecuteResult Execute(ExecuteParameters executeParameters)
         {
@@ -88,14 +90,16 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
                 loggerWithDiagnoser.ProcessInput();
 
-                if (!process.WaitForExit(milliseconds: 250))
+                if (!process.WaitForExit(milliseconds: (int)ProcessExitTimeout.TotalMilliseconds))
                 {
-                    logger.WriteLineInfo("// The benchmarking process did not quit on time, it's going to get force killed now.");
+                    logger.WriteLineInfo($"// The benchmarking process did not quit within {ProcessExitTimeout.TotalSeconds} seconds, it's going to get force killed now.");
 
                     consoleExitHandler.KillProcessTree();
+                    // Give KillProcessTree a few moments to actually kill the benchmarking process.
+                    Thread.Sleep(millisecondsTimeout: 500);
                 }
 
-                return new ExecuteResult(true, process.ExitCode, process.Id, loggerWithDiagnoser.LinesWithResults, loggerWithDiagnoser.LinesWithExtraOutput);
+                return new ExecuteResult(true, process.HasExited ? (int?)process.ExitCode : null, process.Id, loggerWithDiagnoser.LinesWithResults, loggerWithDiagnoser.LinesWithExtraOutput);
             }
         }
     }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
@@ -22,7 +22,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         public DotNetCliExecutor(string customDotNetCliPath) => CustomDotNetCliPath = customDotNetCliPath;
 
         private string CustomDotNetCliPath { get; }
-        private readonly TimeSpan ProcessExitTimeout = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan ProcessExitTimeout = TimeSpan.FromSeconds(2);
 
         public ExecuteResult Execute(ExecuteParameters executeParameters)
         {

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
@@ -95,8 +95,6 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                     logger.WriteLineInfo($"// The benchmarking process did not quit within {ProcessExitTimeout.TotalSeconds} seconds, it's going to get force killed now.");
 
                     consoleExitHandler.KillProcessTree();
-                    // Give KillProcessTree a few moments to actually kill the benchmarking process.
-                    Thread.Sleep(millisecondsTimeout: 500);
                 }
 
                 return new ExecuteResult(true, process.HasExited ? (int?)process.ExitCode : null, process.Id, loggerWithDiagnoser.LinesWithResults, loggerWithDiagnoser.LinesWithExtraOutput);

--- a/src/BenchmarkDotNet/Toolchains/Results/ExecuteResult.cs
+++ b/src/BenchmarkDotNet/Toolchains/Results/ExecuteResult.cs
@@ -5,12 +5,12 @@ namespace BenchmarkDotNet.Toolchains.Results
     public class ExecuteResult
     {
         public bool FoundExecutable { get; }
-        public int ExitCode { get; }
+        public int? ExitCode { get; }
         public int? ProcessId { get; }
         public IReadOnlyList<string> Data { get; }
         public IReadOnlyList<string> ExtraOutput { get; }
 
-        public ExecuteResult(bool foundExecutable, int exitCode, int? processId, IReadOnlyList<string> data, IReadOnlyList<string> linesWithExtraOutput)
+        public ExecuteResult(bool foundExecutable, int? exitCode, int? processId, IReadOnlyList<string> data, IReadOnlyList<string> linesWithExtraOutput)
         {
             FoundExecutable = foundExecutable;
             Data = data;


### PR DESCRIPTION
This PR fixes #1731 by:

- Increasing process exit timeout from 250 to 2000 milliseconds.
- Waiting 500 milliseconds for `KillProcessTree()` to work.
- Guarding `process.ExitCode` on `process.HasExited` and giving more meaningful error messages for hung benchmarking processes.

Thank you!