### PR TITLE
Make PrepareForWasmBuild work with wasm workload

### DIFF
--- a/src/BenchmarkDotNet/Templates/WasmAotCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmAotCsProj.txt
@@ -33,9 +33,9 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <WasmBuildAppDependsOn>PrepareForWasmBuild;$(WasmBuildAppDependsOn)</WasmBuildAppDependsOn>
+    <WasmBuildAppAfterThisTarget>PrepareForWasmBuild</WasmBuildAppAfterThisTarget>
   </PropertyGroup>
-  <Target Name="PrepareForWasmBuild">
+  <Target Name="PrepareForWasmBuild" AfterTargets="Publish">
     <ItemGroup>
       <WasmAssembliesToBundle Include="$(TargetDir)publish\*.dll" />
     </ItemGroup>

--- a/src/BenchmarkDotNet/Templates/WasmCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmCsProj.txt
@@ -34,9 +34,9 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <WasmBuildAppDependsOn>PrepareForWasmBuild;$(WasmBuildAppDependsOn)</WasmBuildAppDependsOn>
+    <WasmBuildAppAfterThisTarget>PrepareForWasmBuild</WasmBuildAppAfterThisTarget>
   </PropertyGroup>
-  <Target Name="PrepareForWasmBuild">
+  <Target Name="PrepareForWasmBuild" AfterTargets="Publish">
     <ItemGroup>
       <WasmAssembliesToBundle Include="$(TargetDir)publish\*.dll" />
     </ItemGroup>


### PR DESCRIPTION
The `WasmBuildAppDependsOn` property gets overwritten by the wasm-tools
workload's https://github.com/dotnet/runtime/blob/main/src/mono/wasm/build/WasmApp.props#L9-L18

So instead, set the `WasmBuildAppAfterThisTarget` property to our
`PrepareForWasmBuild` target and make it run after `Publish` target.

The workload's `WasmApp` has condition on `WasmBuildAppAfterThisTarget`
and should not overwrite it.