### PR TITLE
Unhelpful rounding in MemoryDiagnoser #1727

### DIFF
--- a/src/BenchmarkDotNet/Columns/SizeUnit.cs
+++ b/src/BenchmarkDotNet/Columns/SizeUnit.cs
@@ -36,6 +36,14 @@ namespace BenchmarkDotNet.Columns
                 return B;
             // Use the largest unit to display the smallest recorded measurement without loss of precision.
             long minValue = values.Min();
+            long maxValue = values.Max();
+
+            const long maxSmallBytes = 9 * 1024;
+
+            if (minValue <= maxSmallBytes && maxValue <= maxSmallBytes) {
+              return B; // its useful to show small amount of bytes like bytes and not rounded to kilobytes if all bytes are small
+            }
+
             foreach (var sizeUnit in All)
             {
                 if (minValue < sizeUnit.ByteAmount * BytesInKiloByte)

--- a/src/BenchmarkDotNet/Columns/SizeUnit.cs
+++ b/src/BenchmarkDotNet/Columns/SizeUnit.cs
@@ -40,8 +40,9 @@ namespace BenchmarkDotNet.Columns
 
             const long maxSmallBytes = 9 * 1024;
 
-            if (minValue <= maxSmallBytes && maxValue <= maxSmallBytes) {
-              return B; // its useful to show small amount of bytes like bytes and not rounded to kilobytes if all bytes are small
+            if (minValue <= maxSmallBytes && maxValue <= maxSmallBytes)
+            {
+              return B; // its useful to show small amount of bytes as bytes and not rounded to kilobytes if all bytes are small
             }
 
             foreach (var sizeUnit in All)

--- a/tests/BenchmarkDotNet.Tests/SizeUnitTests.cs
+++ b/tests/BenchmarkDotNet.Tests/SizeUnitTests.cs
@@ -13,7 +13,6 @@ namespace BenchmarkDotNet.Tests
             this.output = output;
         }
 
-
         [Fact]
         public void ConvertTest()
         {
@@ -31,10 +30,13 @@ namespace BenchmarkDotNet.Tests
         [InlineData("100 B", 100)]
         [InlineData("1000 B", 1000)]
         [InlineData("1023 B", 1023)]
-        [InlineData("1 KB", 1024)]
-        [InlineData("1 KB", 1025)]
-        [InlineData("1.07 KB", 1100)]
-        [InlineData("1.5 KB", 1024 + 512)]
+        [InlineData("1024 B", 1024)]
+        [InlineData("1025 B", 1025)]
+        [InlineData("1100 B", 1100)]
+        [InlineData("1536 B", 1024 + 512)]
+        [InlineData("9216 B", 9 * 1024)]
+        [InlineData("9 KB", 9 * 1024 + 1)]
+        [InlineData("9.5 KB", 9 * 1024 + 512)]
         [InlineData("10 KB", 10 * 1024)]
         [InlineData("1023 KB", 1023 * 1024)]
         [InlineData("1 MB", 1024 * 1024)]


### PR DESCRIPTION
Pull request for [Unhelpful rounding in MemoryDiagnoser](https://github.com/dotnet/BenchmarkDotNet/issues/1727).

There is arbitrary value 9KB which is "small enough" for printing bytes instead of kilobytes.
Maybe it is too much. I have no strong opinion about that.