### PR TITLE
Fix pointer-returning benchmarks support for InProcessToolchain

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -28,7 +28,7 @@
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(IsVisualBasic)' != 'true' AND '$(IsFsharp)' != 'true' ">
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>9.0</LangVersion>
     
     <Major>0</Major>
     <Minor>13</Minor>

--- a/src/BenchmarkDotNet/Engines/Consumer.cs
+++ b/src/BenchmarkDotNet/Engines/Consumer.cs
@@ -33,6 +33,7 @@ namespace BenchmarkDotNet.Engines
         private string stringHolder;
         private object objectHolder;
         private IntPtr ptrHolder;
+        private UIntPtr uptrHolder;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [PublicAPI]
@@ -80,6 +81,14 @@ namespace BenchmarkDotNet.Engines
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [PublicAPI]
         public void Consume(long longValue) => Volatile.Write(ref longHolder, longValue);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [PublicAPI]
+        public void Consume(IntPtr intPtrValue) => Volatile.Write(ref ptrHolder, intPtrValue);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [PublicAPI]
+        public void Consume(UIntPtr uintPtrValue) => Volatile.Write(ref uptrHolder, uintPtrValue);
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/BenchmarkDotNet/Toolchains/InProcess.Emit.Implementation/Emitters/ConsumableConsumeEmitter.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.Emit.Implementation/Emitters/ConsumableConsumeEmitter.cs
@@ -27,9 +27,12 @@ namespace BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation
                             // we are interested in "Consume<T>(T objectValue) where T : class"
                             return m.Name == nameof(Consumer.Consume) && m.IsGenericMethodDefinition
                                 && !firstParameterType.IsByRef // Consume<T>(in T value)
-                                && !firstParameterType.IsPointer; // Consume<T>(T* ptrValue) where T: unmanaged
+                                && firstParameterType.IsPointer == consumableType.IsPointer; // Consume<T>(T* ptrValue) where T: unmanaged
                         });
-                    consumeMethod = consumeMethod?.MakeGenericMethod(consumableType);
+
+                    consumeMethod = consumableType.IsPointer
+                        ? consumeMethod?.MakeGenericMethod(consumableType.GetElementType()) // consumableType is T*, we need T for Consume<T>(T* ptrValue)
+                        : consumeMethod?.MakeGenericMethod(consumableType);
                 }
                 else
                 {

--- a/src/BenchmarkDotNet/Toolchains/InProcess.Emit.Implementation/Emitters/ConsumableConsumeEmitter.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.Emit.Implementation/Emitters/ConsumableConsumeEmitter.cs
@@ -30,8 +30,8 @@ namespace BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation
                         });
 
                     consumeMethod = consumableType.IsPointer
-                        ? consumeMethod?.MakeGenericMethod(consumableType.GetElementType()) // consumableType is T*, we need T for Consume<T>(T* ptrValue)
-                        : consumeMethod?.MakeGenericMethod(consumableType);
+                        ? consumeMethod.MakeGenericMethod(consumableType.GetElementType()) // consumableType is T*, we need T for Consume<T>(T* ptrValue)
+                        : consumeMethod.MakeGenericMethod(consumableType);
                 }
                 else
                 {

--- a/src/BenchmarkDotNet/Toolchains/InProcess.Emit.Implementation/Emitters/ConsumableConsumeEmitter.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.Emit.Implementation/Emitters/ConsumableConsumeEmitter.cs
@@ -22,12 +22,11 @@ namespace BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation
                         .GetMethods()
                         .Single(m =>
                         {
-                            Type firstParameterType = m.GetParameterTypes().FirstOrDefault();
+                            Type argType = m.GetParameterTypes().FirstOrDefault();
 
-                            // we are interested in "Consume<T>(T objectValue) where T : class"
                             return m.Name == nameof(Consumer.Consume) && m.IsGenericMethodDefinition
-                                && !firstParameterType.IsByRef // Consume<T>(in T value)
-                                && firstParameterType.IsPointer == consumableType.IsPointer; // Consume<T>(T* ptrValue) where T: unmanaged
+                                && !argType.IsByRef // we are not interested in "Consume<T>(in T value)"
+                                && argType.IsPointer == consumableType.IsPointer; // use "Consume<T>(T objectValue) where T : class" or "Consume<T>(T* ptrValue) where T: unmanaged"
                         });
 
                     consumeMethod = consumableType.IsPointer

--- a/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
@@ -93,6 +93,9 @@ namespace BenchmarkDotNet.IntegrationTests
 
             [Benchmark]
             public NoNamespace TypeWithoutNamespace() => new NoNamespace();
+
+            [Benchmark]
+            public unsafe void* PointerToAnything() => IntPtr.Zero.ToPointer();
         }
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
@@ -116,6 +116,12 @@ namespace BenchmarkDotNet.IntegrationTests
 
             [Benchmark]
             public System.UIntPtr UIntPtr() => System.UIntPtr.Zero;
+
+            [Benchmark]
+            public nint NativeSizeInteger() => 0;
+
+            [Benchmark]
+            public uint UnsignedNativeSizeInteger() => 0;
         }
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
@@ -121,7 +121,7 @@ namespace BenchmarkDotNet.IntegrationTests
             public nint NativeSizeInteger() => 0;
 
             [Benchmark]
-            public uint UnsignedNativeSizeInteger() => 0;
+            public nuint UnsignedNativeSizeInteger() => 0;
         }
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
@@ -1,7 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -11,8 +16,14 @@ namespace BenchmarkDotNet.IntegrationTests
     {
         public ValuesReturnedByBenchmarkTest(ITestOutputHelper output) : base(output) { }
 
-        [Fact]
-        public void AnyValueCanBeReturned() => CanExecute<ValuesReturnedByBenchmark>();
+        public static IEnumerable<object[]> GetToolchains() => new[]
+        {
+            new object[] { Job.Default.GetToolchain() },
+            new object[] { InProcessEmitToolchain.Instance },
+        };
+
+        [Theory, MemberData(nameof(GetToolchains))]
+        public void AnyValueCanBeReturned(IToolchain toolchain) => CanExecute<ValuesReturnedByBenchmark>(ManualConfig.CreateEmpty().AddJob(Job.Dry.WithToolchain(toolchain)));
 
         public class ValuesReturnedByBenchmark
         {

--- a/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
@@ -96,6 +96,9 @@ namespace BenchmarkDotNet.IntegrationTests
 
             [Benchmark]
             public unsafe void* PointerToAnything() => IntPtr.Zero.ToPointer();
+
+            [Benchmark]
+            public unsafe int* PointerToUnmanagedType() => (int*)IntPtr.Zero.ToPointer();
         }
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
@@ -106,10 +106,16 @@ namespace BenchmarkDotNet.IntegrationTests
             public NoNamespace TypeWithoutNamespace() => new NoNamespace();
 
             [Benchmark]
-            public unsafe void* PointerToAnything() => IntPtr.Zero.ToPointer();
+            public unsafe void* PointerToAnything() => System.IntPtr.Zero.ToPointer();
 
             [Benchmark]
-            public unsafe int* PointerToUnmanagedType() => (int*)IntPtr.Zero.ToPointer();
+            public unsafe int* PointerToUnmanagedType() => (int*)System.IntPtr.Zero.ToPointer();
+
+            [Benchmark]
+            public System.IntPtr IntPtr() => System.IntPtr.Zero;
+
+            [Benchmark]
+            public System.UIntPtr UIntPtr() => System.UIntPtr.Zero;
         }
     }
 }


### PR DESCRIPTION
After I've merged #1739 one `MemoryDiagnoser` test started failing for `InProcessToolchain` I initially thought it's something related to `TieredJit` and ignored it (my bad).

It turned out that `InProcessToolchain` required a fix to make it work with #1739 

I've added tests for both `void*` and `T*` and ensured they now work for every toolchain (.NET, Core and InProcess).

This should make the CI green again cc @radekdoulik @kant2002