### PR TITLE
[wasm] Add WasmMainJSPath in interpreter projects

### DIFF
--- a/src/BenchmarkDotNet/Templates/WasmCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmCsProj.txt
@@ -2,12 +2,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <OutputPath>bin</OutputPath>
+    <RuntimeSrcDir>$RUNTIMESRCDIR$</RuntimeSrcDir>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFramework>$TFM$</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppDir>$(MSBuildThisFileDirectory)\bin\$TFM$\browser-wasm\publish</AppDir>
     <AssemblyName>$PROGRAMNAME$</AssemblyName>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
+    <WasmMainJSPath>$(RuntimeSrcDir)\src\mono\wasm\runtime-test.js</WasmMainJSPath>
     <MicrosoftNetCoreAppRuntimePackDir>$RUNTIMEPACK$</MicrosoftNetCoreAppRuntimePackDir>
     <UsingBrowserRuntimeWorkload>false</UsingBrowserRuntimeWorkload>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>


### PR DESCRIPTION
This should fix errors like:

    performance/tools/dotnet/x64/packs/Microsoft.NET.Runtime.WebAssembly.Sdk/6.0.0-rc.1.21378.3/Sdk/WasmApp.targets(139,5): error : $(WasmMainJSPath) property needs to be set