### PR TITLE
[wasm] Set the $RUNTIMESRCDIR$ for interpreter

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -112,7 +112,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                     logger.WriteLineError($"The provided runtime \"{runtime}\" is invalid. Available options are: {string.Join(", ", Enum.GetNames(typeof(RuntimeMoniker)).Select(name => name.ToLower()))}.");
                     return false;
                 }
-                else if (runtimeMoniker == RuntimeMoniker.Wasm && !(options.AOTCompilerMode == MonoAotCompilerMode.wasm) && (options.WasmMainJs == null || options.WasmMainJs.IsNotNullButDoesNotExist()))
+                else if (runtimeMoniker == RuntimeMoniker.Wasm && (options.WasmMainJs == null || options.WasmMainJs.IsNotNullButDoesNotExist()))
                 {
                     logger.WriteLineError($"The provided {nameof(options.WasmMainJs)} \"{options.WasmMainJs}\" does NOT exist. It MUST be provided.");
                     return false;

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -66,6 +66,9 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
         {
             BenchmarkCase benchmark = buildPartition.RepresentativeBenchmarkCase;
             var projectFile = GetProjectFilePath(benchmark.Descriptor.Type, logger);
+
+            WasmRuntime runtime = (WasmRuntime)buildPartition.Runtime;
+
             using (var file = new StreamReader(File.OpenRead(projectFile.FullName)))
             {
                 var (customProperties, sdkName) = GetSettingsThatNeedsToBeCopied(file, projectFile);

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -76,6 +76,7 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
                     .Replace("$CSPROJPATH$", projectFile.FullName)
                     .Replace("$TFM$", TargetFrameworkMoniker)
                     .Replace("$PROGRAMNAME$", artifactsPaths.ProgramName)
+                    .Replace("$RUNTIMESRCDIR$", runtime.RuntimeSrcDir.ToString())
                     .Replace("$COPIEDSETTINGS$", customProperties)
                     .Replace("$CONFIGURATIONNAME$", buildPartition.BuildConfiguration)
                     .Replace("$SDKNAME$", sdkName)


### PR DESCRIPTION
Fixes:

    The "WasmAppBuilder" task failed unexpectedly.
    System.ArgumentException: File MainJS='$RUNTIMESRCDIR$\src\mono\wasm\runtime-test.js' doesn't exist.
       at WasmAppBuilder.Execute() in WasmAppBuilder.dll:token 0x6000042+0x27
       at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() in Microsoft.Build.dll:token 0x6001602+0x3e
       at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) in Microsoft.Build.dll:token 0x6001481+0x2b5