### PR TITLE
Get rid of warning

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
@@ -156,7 +156,7 @@ namespace BenchmarkDotNet.IntegrationTests
                 var metric = selectedReport.Metrics.Single(m => m.Key == assertion.Value.metricName);
 
                 // precision is set to 2 because CoreCLR might schedule some work item on it's own and hence affect the results..
-                // precision = 3 is not enough (e.g., sometimes the actual value may be equal 1.0009765625 while the expected value is 1.0) 
+                // precision = 3 is not enough (e.g., sometimes the actual value may be equal 1.0009765625 while the expected value is 1.0)
                 Assert.Equal(assertion.Value.expectedValue, metric.Value.Value, precision: 2);
             }
         }


### PR DESCRIPTION
The trailing space was triggering

    tests\BenchmarkDotNet.IntegrationTests\ThreadingDiagnoserTests.cs(159,140): warning SA1028: Code should not contain trailing whitespace