### PR TITLE
MemoryDiagnoser fix

### DIFF
--- a/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
@@ -36,7 +36,7 @@ namespace BenchmarkDotNet.Diagnosers
             yield return new Metric(GarbageCollectionsMetricDescriptor.Gen0, diagnoserResults.GcStats.Gen0Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
             yield return new Metric(GarbageCollectionsMetricDescriptor.Gen1, diagnoserResults.GcStats.Gen1Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
             yield return new Metric(GarbageCollectionsMetricDescriptor.Gen2, diagnoserResults.GcStats.Gen2Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
-            yield return new Metric(AllocatedMemoryMetricDescriptor.Instance, diagnoserResults.GcStats.BytesAllocatedPerOperation);
+            yield return new Metric(AllocatedMemoryMetricDescriptor.Instance, diagnoserResults.GcStats.GetBytesAllocatedPerOperation(diagnoserResults.BenchmarkCase));
         }
 
         private class AllocatedMemoryMetricDescriptor : IMetricDescriptor

--- a/src/BenchmarkDotNet/Exporters/Csv/CsvMeasurementsExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/Csv/CsvMeasurementsExporter.cs
@@ -69,7 +69,7 @@ namespace BenchmarkDotNet.Exporters.Csv
                 new MeasurementColumn("Gen_0", (_, report, __) => report.GcStats.Gen0Collections.ToString(summary.GetCultureInfo())),
                 new MeasurementColumn("Gen_1", (_, report, __) => report.GcStats.Gen1Collections.ToString(summary.GetCultureInfo())),
                 new MeasurementColumn("Gen_2", (_, report, __) => report.GcStats.Gen2Collections.ToString(summary.GetCultureInfo())),
-                new MeasurementColumn("Allocated_Bytes", (_, report, __) => report.GcStats.BytesAllocatedPerOperation.ToString(summary.GetCultureInfo()))
+                new MeasurementColumn("Allocated_Bytes", (_, report, __) => report.GcStats.GetBytesAllocatedPerOperation(report.BenchmarkCase).ToString(summary.GetCultureInfo()))
             };
 
             return columns.ToArray();

--- a/src/BenchmarkDotNet/Reports/SummaryTable.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTable.cs
@@ -50,7 +50,7 @@ namespace BenchmarkDotNet.Reports
 
             if (style.SizeUnit == null)
             {
-                style = style.WithSizeUnit(SizeUnit.GetBestSizeUnit(summary.Reports.Select(r => r.GcStats.BytesAllocatedPerOperation).ToArray()));
+                style = style.WithSizeUnit(SizeUnit.GetBestSizeUnit(summary.Reports.Select(r => r.GcStats.GetBytesAllocatedPerOperation(r.BenchmarkCase)).ToArray()));
             }
 
             var columns = summary.GetColumns();

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -276,7 +276,7 @@ namespace BenchmarkDotNet.IntegrationTests
                 {
                     var benchmarkReport = summary.Reports.Single(report => report.BenchmarkCase == benchmark);
 
-                    Assert.Equal(benchmarkAllocationsValidator.Value, benchmarkReport.GcStats.BytesAllocatedPerOperation);
+                    Assert.Equal(benchmarkAllocationsValidator.Value, benchmarkReport.GcStats.GetBytesAllocatedPerOperation(benchmark));
 
                     if (benchmarkAllocationsValidator.Value == 0)
                     {


### PR DESCRIPTION
use benchmark process runtime (not host process runtime) when deciding whether allocation quantum side effects should be excluded

Repro reported offline by @stephentoub

```cs
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Buffers;
using System.Linq;
using System.IO;
using System.Threading.Tasks;
using System.Security.Cryptography;
[MemoryDiagnoser]
public class Program
{
    public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
    private byte[] _data = Enumerable.Range(0, 10_000_000).Select(i => (byte)i).ToArray();
    private MemoryStream _destination = new MemoryStream();
    [Benchmark]
    public async Task Encode()
    {
        _destination.Position = 0;
        using (var toBase64 = new ToBase64Transform())
        using (var stream = new CryptoStream(_destination, toBase64, CryptoStreamMode.Write, leaveOpen: true))
        {
            await stream.WriteAsync(_data, 0, _data.Length);
        }
    }
}
```

```cmd
dotnet run -c Release -f net48 --filter * --runtimes net5.0 --memory
```

Before:

```ini
BenchmarkDotNet=v0.13.0.20210803-develop, OS=Windows 10.0.18363.1621 (1909/November2019Update/19H2)
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4300.0), X64 RyuJIT
  Job-YHYGQI : .NET 5.0.8 (5.0.821.31504), X64 RyuJIT

Runtime=.NET 5.0  Toolchain=net5.0
```

| Method |     Mean |   Error |  StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|--------:|--------:|------:|------:|------:|----------:|
| Encode | 172.6 ms | 2.29 ms | 2.03 ms |     - |     - |     - |         - |

After:

```ini
BenchmarkDotNet=v0.13.0.20210803-develop, OS=Windows 10.0.18363.1621 (1909/November2019Update/19H2)
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4300.0), X64 RyuJIT
  Job-YHYGQI : .NET 5.0.8 (5.0.821.31504), X64 RyuJIT

Runtime=.NET 5.0  Toolchain=net5.0
```

| Method |     Mean |   Error |  StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|--------:|--------:|------:|------:|------:|----------:|
| Encode | 177.1 ms | 2.17 ms | 2.03 ms |     - |     - |     - |     768 B |
