### PR TITLE
Pr wasm set runtimesrcdir for interpreter

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -425,7 +425,7 @@ namespace BenchmarkDotNet.ConsoleArguments
             bool wasmAot = options.AOTCompilerMode == MonoAotCompilerMode.wasm;
 
             var wasmRuntime = new WasmRuntime(
-                mainJs: options.WasmMainJs ?? new FileInfo(options.RuntimeSrcDir.ToString() + @"\src\mono\wasm\runtime-test.js"),
+                mainJs: options.WasmMainJs ?? new FileInfo(Path.Combine(options.RuntimeSrcDir.FullName, "src", "mono", "wasm", "runtime-test.js")),
                 msBuildMoniker: msBuildMoniker,
                 javaScriptEngine: options.WasmJavascriptEngine?.FullName ?? "v8",
                 javaScriptEngineArguments: options.WasmJavaScriptEngineArguments,

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -112,9 +112,12 @@ namespace BenchmarkDotNet.ConsoleArguments
                     logger.WriteLineError($"The provided runtime \"{runtime}\" is invalid. Available options are: {string.Join(", ", Enum.GetNames(typeof(RuntimeMoniker)).Select(name => name.ToLower()))}.");
                     return false;
                 }
-                else if (runtimeMoniker == RuntimeMoniker.Wasm && !(options.AOTCompilerMode == MonoAotCompilerMode.wasm) && (options.WasmMainJs == null || options.WasmMainJs.IsNotNullButDoesNotExist()))
+                else if (runtimeMoniker == RuntimeMoniker.Wasm && options.WasmMainJs == null && options.RuntimeSrcDir == null) {
+                    logger.WriteLine("Either runtimeSrcDir or WasmMainJS must be specified.");
+                }
+                else if (runtimeMoniker == RuntimeMoniker.Wasm && options.WasmMainJs.IsNotNullButDoesNotExist())
                 {
-                    logger.WriteLineError($"The provided {nameof(options.WasmMainJs)} \"{options.WasmMainJs}\" does NOT exist. It MUST be provided.");
+                    logger.WriteLineError($"The provided {nameof(options.WasmMainJs)} \"{options.WasmMainJs}\" does NOT exist.");
                     return false;
                 }
                 else if (runtimeMoniker == RuntimeMoniker.MonoAOTLLVM && (options.AOTCompilerPath == null || options.AOTCompilerPath.IsNotNullButDoesNotExist()))
@@ -123,7 +126,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 }
                 else if (runtimeMoniker == RuntimeMoniker.Wasm && options.AOTCompilerMode == MonoAotCompilerMode.wasm && (options.RuntimeSrcDir == null || options.RuntimeSrcDir.IsNotNullButDoesNotExist()))
                 {
-                    logger.WriteLineError($"The provided {nameof(options.RuntimeSrcDir)} \"{options.RuntimeSrcDir}\" does NOT exist. It MUST be provided.");
+                    logger.WriteLineError($"The provided {nameof(options.RuntimeSrcDir)} \"{options.RuntimeSrcDir}\" does NOT exist. It MUST be provided for wasm-aot.");
                     return false;
                 }
             }
@@ -422,7 +425,7 @@ namespace BenchmarkDotNet.ConsoleArguments
             bool wasmAot = options.AOTCompilerMode == MonoAotCompilerMode.wasm;
 
             var wasmRuntime = new WasmRuntime(
-                mainJs: options.WasmMainJs,
+                mainJs: options.WasmMainJs ?? new FileInfo(options.RuntimeSrcDir.ToString() + @"\src\mono\wasm\runtime-test.js"),
                 msBuildMoniker: msBuildMoniker,
                 javaScriptEngine: options.WasmJavascriptEngine?.FullName ?? "v8",
                 javaScriptEngineArguments: options.WasmJavaScriptEngineArguments,

--- a/src/BenchmarkDotNet/Templates/WasmCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmCsProj.txt
@@ -9,7 +9,7 @@
     <AppDir>$(MSBuildThisFileDirectory)\bin\$TFM$\browser-wasm\publish</AppDir>
     <AssemblyName>$PROGRAMNAME$</AssemblyName>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
-    <WasmMainJSPath>$(RuntimeSrcDir)\src\mono\wasm\runtime-test.js</WasmMainJSPath>
+    <WasmMainJSPath>$MAINJS$</WasmMainJSPath>
     <MicrosoftNetCoreAppRuntimePackDir>$RUNTIMEPACK$</MicrosoftNetCoreAppRuntimePackDir>
     <UsingBrowserRuntimeWorkload>false</UsingBrowserRuntimeWorkload>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -66,6 +66,9 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
         {
             BenchmarkCase benchmark = buildPartition.RepresentativeBenchmarkCase;
             var projectFile = GetProjectFilePath(benchmark.Descriptor.Type, logger);
+
+            WasmRuntime runtime = (WasmRuntime)buildPartition.Runtime;
+
             using (var file = new StreamReader(File.OpenRead(projectFile.FullName)))
             {
                 var (customProperties, sdkName) = GetSettingsThatNeedsToBeCopied(file, projectFile);

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -76,6 +76,7 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
                     .Replace("$CSPROJPATH$", projectFile.FullName)
                     .Replace("$TFM$", TargetFrameworkMoniker)
                     .Replace("$PROGRAMNAME$", artifactsPaths.ProgramName)
+                    .Replace("$RUNTIMESRCDIR$", runtime.RuntimeSrcDir.ToString())
                     .Replace("$COPIEDSETTINGS$", customProperties)
                     .Replace("$CONFIGURATIONNAME$", buildPartition.BuildConfiguration)
                     .Replace("$SDKNAME$", sdkName)

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -85,7 +85,8 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
                     .Replace("$SDKNAME$", sdkName)
                     .Replace("$RUNTIMEPACK$", CustomRuntimePack ?? "")
                     .Replace("$TARGET$", CustomRuntimePack != null ? "PublishWithCustomRuntimePack" : "Publish")
-                    .ToString();
+                    .Replace("$MAINJS$", runtime.MainJs.ToString())
+                .ToString();
 
                 File.WriteAllText(artifactsPaths.ProjectFilePath, content);
             }


### PR DESCRIPTION
I couldn't push to the branch for this PR: https://github.com/dotnet/BenchmarkDotNet/pull/1759 so I created this one to keep working on it.

Fixes:


```
The "WasmAppBuilder" task failed unexpectedly.
System.ArgumentException: File MainJS='$RUNTIMESRCDIR$\src\mono\wasm\runtime-test.js' doesn't exist.
   at WasmAppBuilder.Execute() in WasmAppBuilder.dll:token 0x6000042+0x27
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() in Microsoft.Build.dll:token 0x6001602+0x3e
   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) in Microsoft.Build.dll:token 0x6001481+0x2b5
```