### PR TITLE
Allow users to hide Gen X columns

### DIFF
--- a/src/BenchmarkDotNet/Attributes/MemoryDiagnoserAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/MemoryDiagnoserAttribute.cs
@@ -9,9 +9,10 @@ namespace BenchmarkDotNet.Attributes
     {
         public IConfig Config { get; }
 
-        public MemoryDiagnoserAttribute()
+        /// <param name="displayGenColumns">Display Garbage Collections per Generation columns (Gen 0, Gen 1, Gen 2). True by default.</param>
+        public MemoryDiagnoserAttribute(bool displayGenColumns = true)
         {
-            Config = ManualConfig.CreateEmpty().AddDiagnoser(MemoryDiagnoser.Default);
+            Config = ManualConfig.CreateEmpty().AddDiagnoser(new MemoryDiagnoser(new MemoryDiagnoserConfig(displayGenColumns)));
         }
     }
 }

--- a/src/BenchmarkDotNet/Columns/MetricColumn.cs
+++ b/src/BenchmarkDotNet/Columns/MetricColumn.cs
@@ -16,7 +16,7 @@ namespace BenchmarkDotNet.Columns
         public string Legend => descriptor.Legend;
         public bool AlwaysShow => true;
         public ColumnCategory Category => ColumnCategory.Metric;
-        public int PriorityInCategory => 0;
+        public int PriorityInCategory => descriptor.PriorityInCategory;
         public bool IsNumeric => true;
         public UnitType UnitType => descriptor.UnitType;
 

--- a/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
@@ -92,7 +92,7 @@ namespace BenchmarkDotNet.Configs
         public IAnalyser GetCompositeAnalyser() => new CompositeAnalyser(analysers);
         public IDiagnoser GetCompositeDiagnoser() => new CompositeDiagnoser(diagnosers);
 
-        public bool HasMemoryDiagnoser() => diagnosers.Contains(MemoryDiagnoser.Default);
+        public bool HasMemoryDiagnoser() => diagnosers.OfType<MemoryDiagnoser>().Any();
 
         public bool HasThreadingDiagnoser() => diagnosers.Contains(ThreadingDiagnoser.Default);
 

--- a/src/BenchmarkDotNet/Diagnosers/AllocatedNativeMemoryDescriptor.cs
+++ b/src/BenchmarkDotNet/Diagnosers/AllocatedNativeMemoryDescriptor.cs
@@ -12,6 +12,7 @@ namespace BenchmarkDotNet.Diagnosers
         public UnitType UnitType => UnitType.Size;
         public string Unit => SizeUnit.B.Name;
         public bool TheGreaterTheBetter => false;
+        public int PriorityInCategory => 0;
     }
 
     internal class NativeMemoryLeakDescriptor : IMetricDescriptor
@@ -23,5 +24,6 @@ namespace BenchmarkDotNet.Diagnosers
         public UnitType UnitType => UnitType.Size;
         public string Unit => SizeUnit.B.Name;
         public bool TheGreaterTheBetter => false;
+        public int PriorityInCategory => 0;
     }
 }

--- a/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
@@ -56,6 +56,7 @@ namespace BenchmarkDotNet.Diagnosers
             public UnitType UnitType => UnitType.Size;
             public string Unit => SizeUnit.B.Name;
             public bool TheGreaterTheBetter => false;
+            public int PriorityInCategory => GC.MaxGeneration + 1;
         }
 
         private class GarbageCollectionsMetricDescriptor : IMetricDescriptor
@@ -69,6 +70,7 @@ namespace BenchmarkDotNet.Diagnosers
                 Id = $"Gen{generationId}Collects";
                 DisplayName = $"Gen {generationId}";
                 Legend = $"GC Generation {generationId} collects per 1000 operations";
+                PriorityInCategory = generationId;
             }
 
             public string Id { get; }
@@ -78,6 +80,7 @@ namespace BenchmarkDotNet.Diagnosers
             public UnitType UnitType => UnitType.Dimensionless;
             public string Unit => "Count";
             public bool TheGreaterTheBetter => false;
+            public int PriorityInCategory { get; }
         }
     }
 }

--- a/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
@@ -33,9 +33,13 @@ namespace BenchmarkDotNet.Diagnosers
 
         public IEnumerable<Metric> ProcessResults(DiagnoserResults diagnoserResults)
         {
-            yield return new Metric(GarbageCollectionsMetricDescriptor.Gen0, diagnoserResults.GcStats.Gen0Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
-            yield return new Metric(GarbageCollectionsMetricDescriptor.Gen1, diagnoserResults.GcStats.Gen1Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
-            yield return new Metric(GarbageCollectionsMetricDescriptor.Gen2, diagnoserResults.GcStats.Gen2Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
+            if (diagnoserResults.GcStats.Gen0Collections > 0)
+                yield return new Metric(GarbageCollectionsMetricDescriptor.Gen0, diagnoserResults.GcStats.Gen0Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
+            if (diagnoserResults.GcStats.Gen1Collections > 0)
+                yield return new Metric(GarbageCollectionsMetricDescriptor.Gen1, diagnoserResults.GcStats.Gen1Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
+            if (diagnoserResults.GcStats.Gen2Collections > 0)
+                yield return new Metric(GarbageCollectionsMetricDescriptor.Gen2, diagnoserResults.GcStats.Gen2Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
+
             yield return new Metric(AllocatedMemoryMetricDescriptor.Instance, diagnoserResults.GcStats.BytesAllocatedPerOperation);
         }
 

--- a/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
@@ -15,9 +15,11 @@ namespace BenchmarkDotNet.Diagnosers
     {
         private const string DiagnoserId = nameof(MemoryDiagnoser);
 
-        public static readonly MemoryDiagnoser Default = new MemoryDiagnoser();
+        public static readonly MemoryDiagnoser Default = new MemoryDiagnoser(new MemoryDiagnoserConfig(displayGenColumns: true));
 
-        private MemoryDiagnoser() { } // we want to have only a single instance of MemoryDiagnoser
+        public MemoryDiagnoser(MemoryDiagnoserConfig config) => Config = config;
+
+        public MemoryDiagnoserConfig Config { get; }
 
         public RunMode GetRunMode(BenchmarkCase benchmarkCase) => RunMode.NoOverhead;
 
@@ -33,11 +35,11 @@ namespace BenchmarkDotNet.Diagnosers
 
         public IEnumerable<Metric> ProcessResults(DiagnoserResults diagnoserResults)
         {
-            if (diagnoserResults.GcStats.Gen0Collections > 0)
+            if (diagnoserResults.GcStats.Gen0Collections > 0 && Config.DisplayGenColumns)
                 yield return new Metric(GarbageCollectionsMetricDescriptor.Gen0, diagnoserResults.GcStats.Gen0Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
-            if (diagnoserResults.GcStats.Gen1Collections > 0)
+            if (diagnoserResults.GcStats.Gen1Collections > 0 && Config.DisplayGenColumns)
                 yield return new Metric(GarbageCollectionsMetricDescriptor.Gen1, diagnoserResults.GcStats.Gen1Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
-            if (diagnoserResults.GcStats.Gen2Collections > 0)
+            if (diagnoserResults.GcStats.Gen2Collections > 0 && Config.DisplayGenColumns)
                 yield return new Metric(GarbageCollectionsMetricDescriptor.Gen2, diagnoserResults.GcStats.Gen2Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
 
             yield return new Metric(AllocatedMemoryMetricDescriptor.Instance, diagnoserResults.GcStats.BytesAllocatedPerOperation);

--- a/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoserConfig.cs
+++ b/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoserConfig.cs
@@ -1,0 +1,16 @@
+﻿using JetBrains.Annotations;
+
+namespace BenchmarkDotNet.Diagnosers
+{
+    public class MemoryDiagnoserConfig
+    {
+        /// <param name="displayGenColumns">Display Garbage Collections per Generation columns (Gen 0, Gen 1, Gen 2). True by default.</param>
+        [PublicAPI]
+        public MemoryDiagnoserConfig(bool displayGenColumns = true)
+        {
+            DisplayGenColumns = displayGenColumns;
+        }
+
+        public bool DisplayGenColumns { get; }
+    }
+}

--- a/src/BenchmarkDotNet/Diagnosers/PmcMetricDescriptor.cs
+++ b/src/BenchmarkDotNet/Diagnosers/PmcMetricDescriptor.cs
@@ -20,5 +20,6 @@ namespace BenchmarkDotNet.Diagnosers
         public string NumberFormat => "N0";
         public UnitType UnitType => UnitType.Dimensionless;
         public string Unit => "Count";
+        public int PriorityInCategory => 0;
     }
 }

--- a/src/BenchmarkDotNet/Diagnosers/ThreadingDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/ThreadingDiagnoser.cs
@@ -61,6 +61,7 @@ namespace BenchmarkDotNet.Diagnosers
             public UnitType UnitType => UnitType.Dimensionless;
             public string Unit => "Count";
             public bool TheGreaterTheBetter => false;
+            public int PriorityInCategory => 0;
         }
 
         private class LockContentionCountMetricDescriptor : IMetricDescriptor
@@ -74,6 +75,7 @@ namespace BenchmarkDotNet.Diagnosers
             public UnitType UnitType => UnitType.Dimensionless;
             public string Unit => "Count";
             public bool TheGreaterTheBetter => false;
+            public int PriorityInCategory => 0;
         }
     }
 }

--- a/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
+++ b/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
@@ -169,6 +169,7 @@ namespace BenchmarkDotNet.Diagnosers
             public UnitType UnitType => UnitType.Size;
             public string Unit => SizeUnit.B.Name;
             public bool TheGreaterTheBetter => false;
+            public int PriorityInCategory => 0;
         }
     }
 }

--- a/src/BenchmarkDotNet/Reports/Metric.cs
+++ b/src/BenchmarkDotNet/Reports/Metric.cs
@@ -32,6 +32,8 @@ namespace BenchmarkDotNet.Reports
         [PublicAPI] string Unit { get; }
 
         [PublicAPI] bool TheGreaterTheBetter { get; }
+
+        [PublicAPI] int PriorityInCategory { get; }
     }
 
     public class MetricDescriptorEqualityComparer : EqualityComparer<IMetricDescriptor>

--- a/tests/BenchmarkDotNet.Tests/Reports/FakeMetricDescriptor.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/FakeMetricDescriptor.cs
@@ -19,5 +19,6 @@ namespace BenchmarkDotNet.Tests.Reports
         public UnitType UnitType { get; }
         public string Unit { get; }
         public bool TheGreaterTheBetter { get; }
+        public int PriorityInCategory => 0;
     }
 }

--- a/tests/BenchmarkDotNet.Tests/Reports/SummaryTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/SummaryTests.cs
@@ -92,6 +92,7 @@ namespace BenchmarkDotNet.Tests.Reports
             public UnitType UnitType { get; }
             public string Unit { get; } = nameof(Unit);
             public bool TheGreaterTheBetter { get; }
+            public int PriorityInCategory => 0;
         }
     }
 }


### PR DESCRIPTION
Some of our users, are not interested in the `Gen 0/1/2` columns, all they want to see is the `Allocated` column.

Example:

```cs
public class AccurateAllocations
{
    [Benchmark] public byte[] EightBytesArray() => new byte[8];
    [Benchmark] public byte[] SixtyFourBytesArray() => new byte[64];
    [Benchmark] public Task<int> AllocateTask() => Task.FromResult(default(int));
}
```

Before:

|              Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|     EightBytesArray | 4.245 ns | 0.0804 ns | 0.0671 ns | 0.0041 |     - |     - |      32 B |
| SixtyFourBytesArray | 8.160 ns | 0.1413 ns | 0.1180 ns | 0.0112 |     - |     - |      88 B |
|        AllocateTask | 7.561 ns | 0.1613 ns | 0.1430 ns | 0.0092 |     - |     - |      72 B |


First commit (don't display Gen X collumn if there was no collections in Gen X):

|              Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
|-------------------- |---------:|----------:|----------:|-------:|----------:|
|     EightBytesArray | 4.184 ns | 0.0623 ns | 0.0552 ns | 0.0041 |      32 B |
| SixtyFourBytesArray | 8.255 ns | 0.2031 ns | 0.1801 ns | 0.0112 |      88 B |
|        AllocateTask | 7.996 ns | 0.1210 ns | 0.1073 ns | 0.0092 |      72 B |


```cs
[MemoryDiagnoser(displayGenColumns: false)]
```

|              Method |     Mean |     Error |    StdDev | Allocated |
|-------------------- |---------:|----------:|----------:|----------:|
|     EightBytesArray | 4.546 ns | 0.1317 ns | 0.1232 ns |      32 B |
| SixtyFourBytesArray | 8.713 ns | 0.2251 ns | 0.1995 ns |      88 B |
|        AllocateTask | 8.324 ns | 0.1991 ns | 0.2213 ns |      72 B |

cc @stephentoub