### PR TITLE
Set allow unsafe blocks to true in MonoAOTLLVM runtime

### DIFF
--- a/src/BenchmarkDotNet/Templates/MonoAOTLLVMCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/MonoAOTLLVMCsProj.txt
@@ -9,6 +9,7 @@
     <PublishTrimmed>false</PublishTrimmed>
     <AssemblyName>$PROGRAMNAME$</AssemblyName>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/performance/issues/1927