### PR TITLE
Bugfix in ImmutableConfigBuilder. Fixes #1789

### DIFF
--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -129,7 +129,7 @@ namespace BenchmarkDotNet.Configs
 
             foreach (var diagnoser in uniqueDiagnosers)
             foreach (var analyser in diagnoser.Analysers)
-                if (builder.Contains(analyser))
+                if (!builder.Contains(analyser))
                     builder.Add(analyser);
 
             return builder.ToImmutable();


### PR DESCRIPTION
Diagnoser-provided Analysers weren't automatically added to config before this fix.