### PR TITLE
Update DotNetCliCommandExecutor.cs

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
@@ -35,7 +35,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
                 if (!process.WaitForExit((int)parameters.Timeout.TotalMilliseconds))
                 {
-                    parameters.Logger.WriteLineError($"// command took more that the timeout: {parameters.Timeout.TotalSeconds:0.##}s. Killing the process tree!");
+                    parameters.Logger.WriteLineError($"// command took longer than the timeout: {parameters.Timeout.TotalSeconds:0.##}s. Killing the process tree!");
 
                     outputReader.CancelRead();
                     process.KillTree();


### PR DESCRIPTION
#1794 [Fix:]
Fix a logger message typo in the DotNetCliCommandExecutor Execute method