### PR TITLE
Update PackageReference for System.Management to latest (5.0.0).

### DIFF
--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -18,9 +18,9 @@
     <PackageReference Include="Iced" Version="1.8.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.126102" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Perfolizer" Version="0.2.1" />
-    <PackageReference Include="System.Management" Version="4.5.0" />
+    <PackageReference Include="System.Management" Version="5.0.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
- Also updated Microsoft.Win32.Registry to latest (5.0.0) since it is a direct dependency of the former.
- Fixes bugs in .Net Core >=3.1 builds in RuntimeInformation.GetAntivirusProducts() and GetVirtualMachineHypervisor() where the use of ManagementObjectSearcher throws a silently eaten exception.

Theoretically, this would also have affected MosCpuInfoProvider.MosCpuInfo, but its use is limited to .Net Framework by the caller.

You can easily see this in previous CI logs where the net461 build shows VM=Hyper-V in the system info while the net5.0 build doesn't.
