### PR TITLE
Ensure proper SummaryStyle handling

### DIFF
--- a/azure-pipelines.Ubuntu.yml
+++ b/azure-pipelines.Ubuntu.yml
@@ -11,12 +11,12 @@ jobs:
 - template: build/azure-pipelines.job.template.yml
   parameters:
     name: Ubuntu
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
     scriptFileName: ./build.sh
     initialization:
       - bash: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main"
+          sudo apt-add-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal-9 main"
           sudo apt-get update
       - bash: |
-          sudo apt-get install cmake clang-3.9 libicu55 uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev
+          sudo apt-get install cmake clang-9 libicu66 uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev

--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -6,6 +6,7 @@ using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Order;
+using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Validators;
 
 namespace BenchmarkDotNet.Configs
@@ -63,7 +64,7 @@ namespace BenchmarkDotNet.Configs
                 source.ArtifactsPath ?? DefaultConfig.Instance.ArtifactsPath,
                 source.CultureInfo,
                 source.Orderer ?? DefaultOrderer.Instance,
-                source.SummaryStyle,
+                source.SummaryStyle ?? SummaryStyle.Default,
                 source.Options
             );
         }

--- a/src/BenchmarkDotNet/Validators/ConfigCompatibilityValidator.cs
+++ b/src/BenchmarkDotNet/Validators/ConfigCompatibilityValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Collections.Generic;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Reports;
 
 namespace BenchmarkDotNet.Validators
 {
@@ -21,6 +22,17 @@ namespace BenchmarkDotNet.Validators
 
             if (orderers.Count() > 1)
                 yield return new ValidationError(true, "You use JoinSummary options, but provided configurations cannot be joined. Only one Orderer per benchmark cases is allowed.");
+
+            var styles =
+                validationParameters
+                    .Benchmarks
+                    .Where(benchmark => benchmark.Config.SummaryStyle != SummaryStyle.Default
+                           && benchmark.Config.SummaryStyle != null) // Paranoid
+                    .Select(benchmark => benchmark.Config.SummaryStyle)
+                    .Distinct();
+
+            if (styles.Count() > 1)
+                yield return new ValidationError(true, "You use JoinSummary options, but provided configurations cannot be joined. Only one SummaryStyle per benchmark cases is allowed.");
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
@@ -287,6 +287,14 @@ namespace BenchmarkDotNet.Tests.Configs
             Assert.Equal(final.Orderer, DefaultOrderer.Instance);
         }
 
+        [Fact]
+        public void WhenSummaryStyleIsNullDefaultValueShouldBeUsed()
+        {
+            var mutable = ManualConfig.CreateEmpty();
+            var final = ImmutableConfigBuilder.Create(mutable);
+            Assert.Equal(final.SummaryStyle, SummaryStyle.Default);
+        }
+
         private static ManualConfig CreateConfigFromJobs(params Job[] jobs)
         {
             var config = ManualConfig.CreateEmpty();


### PR DESCRIPTION
ImmutableConfigBuilder.cs
- Force default for SummaryStyle if null (like it's already done for Orderer etc).
- Test added to ImmutableConfigTests.cs

Summary.cs
- Same behavior for getting SummaryStyle as for Orderer. Style property can no longer be null.

ConfigCompatibilityValidator.cs
- Add check against multiple, non-equal SummaryStyles.
- Test added to ConfigCompatibilityValidatorTests

Repro for previous behavior:
```cs
using System;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Columns;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Reports;
using BenchmarkDotNet.Running;

namespace BDNSummaryStyle
{
    [DryJob]
    public class Benchmarks1
    {
        [Benchmark] public void Method1() { }
    }

    [DryJob]
    public class Benchmarks2
    {
        [Benchmark] public void Method2() { }
    }

    internal class Program
    {
        internal static void Main()
        {
            try
            {
                Console.WriteLine("____________ Example 1 _____________");
                Summary[] summaries = BenchmarkRunner.Run(new[]
                    {
                        BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks1),
                            ManualConfig.CreateMinimumViable()), // SummaryStyle is null
                        BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks2),
                            DefaultConfig.Instance               // SummaryStyle is SummaryStyle.Default
                                .WithOption(ConfigOptions.JoinSummary, true)),
                    });
            }
            catch (Exception ex)
            {
                // Throws:
                // System.InvalidOperationException: Sequence contains more than one element
                //   @ BenchmarkDotNet.Reports.Summary.GetConfiguredSummaryStyleOrNull(ImmutableArray`1 benchmarkCases)
                // but shouldn't throw at all because SummaryStyle == null means the same as SummaryStyle.Default.
                Console.WriteLine(ex);
            }

            try
            {
                Console.WriteLine("____________ Example 2 _____________");
                Summary[] summaries = BenchmarkRunner.Run(new[]
                    {
                        BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks1),
                            DefaultConfig.Instance
                                .WithSummaryStyle(SummaryStyle.Default.WithRatioStyle(RatioStyle.Percentage))),
                        BenchmarkConverter.TypeToBenchmarks(typeof(Benchmarks2),
                            DefaultConfig.Instance
                                .WithSummaryStyle(SummaryStyle.Default.WithRatioStyle(RatioStyle.Trend))
                                .WithOption(ConfigOptions.JoinSummary, true)),
                    });
            }
            catch (Exception ex)
            {
                // Throws the same as above. This time, there are really multiple SummaryStyles.
                // In any case, neither should throw, conflicts should be detected in ConfigCompatibilityValidator.
                Console.WriteLine(ex);
            }
            Console.WriteLine("____________ Finished _____________");
        }
    }
}
```