### PR TITLE
Enable mono llvmaot tool chain to work with net7

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -13,5 +13,6 @@
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <!-- reuquired to run Mono AOT benchmarks -->
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
+++ b/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
@@ -166,7 +166,7 @@ namespace BenchmarkDotNet.Jobs
         MonoAOTLLVMNet60,
 
         /// <summary>
-        /// Mono with the Ahead of Time LLVM Compiler backend and .net70
+        /// Mono with the Ahead of Time LLVM Compiler backend and .net7.0
         /// </summary>
         MonoAOTLLVMNet70
 

--- a/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
+++ b/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
@@ -158,6 +158,17 @@ namespace BenchmarkDotNet.Jobs
         /// <summary>
         /// Mono with the Ahead of Time LLVM Compiler backend
         /// </summary>
-        MonoAOTLLVM
+        MonoAOTLLVM,
+
+        /// <summary>
+        /// Mono with the Ahead of Time LLVM Compiler backend and .net6.0
+        /// </summary>
+        MonoAOTLLVMNet60,
+
+        /// <summary>
+        /// Mono with the Ahead of Time LLVM Compiler backend and .net70
+        /// </summary>
+        MonoAOTLLVMNet70
+
     }
 }

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -396,24 +396,33 @@ namespace BenchmarkDotNet.ConsoleArguments
                 case RuntimeMoniker.WasmNet70:
                     return MakeWasmJob(baseJob, options, timeOut, "net7.0");
                 case RuntimeMoniker.MonoAOTLLVM:
-                    var monoAotLLVMRuntime = new MonoAotLLVMRuntime(aotCompilerPath: options.AOTCompilerPath);
-
-                    var toolChain = MonoAotLLVMToolChain.From(
-                    new NetCoreAppSettings(
-                        targetFrameworkMoniker: monoAotLLVMRuntime.MsBuildMoniker,
-                        runtimeFrameworkVersion: null,
-                        name: monoAotLLVMRuntime.Name,
-                        customDotNetCliPath: options.CliPath?.FullName,
-                        packagesPath: options.RestorePath?.FullName,
-                        timeout: timeOut ?? NetCoreAppSettings.DefaultBuildTimeout,
-                        customRuntimePack: options.CustomRuntimePack,
-                        aotCompilerPath: options.AOTCompilerPath.ToString(),
-                        aotCompilerMode: options.AOTCompilerMode));
-
-                    return baseJob.WithRuntime(monoAotLLVMRuntime).WithToolchain(toolChain);
+                    return MakeMonoAOTLLVMJob(baseJob, options, timeOut, RuntimeInformation.IsNetCore ? CoreRuntime.GetCurrentVersion().MsBuildMoniker : "net6.0");
+                case RuntimeMoniker.MonoAOTLLVMNet60:
+                    return MakeMonoAOTLLVMJob(baseJob, options, timeOut, "net6.0");
+                case RuntimeMoniker.MonoAOTLLVMNet70:
+                    return MakeMonoAOTLLVMJob(baseJob, options, timeOut, "net7.0");
                 default:
                     throw new NotSupportedException($"Runtime {runtimeId} is not supported");
             }
+        }
+
+        private static Job MakeMonoAOTLLVMJob(Job baseJob, CommandLineOptions options, TimeSpan? timeOut, string msBuildMoniker)
+        {
+            var monoAotLLVMRuntime = new MonoAotLLVMRuntime(aotCompilerPath: options.AOTCompilerPath, msBuildMoniker: msBuildMoniker);
+
+            var toolChain = MonoAotLLVMToolChain.From(
+            new NetCoreAppSettings(
+                targetFrameworkMoniker: monoAotLLVMRuntime.MsBuildMoniker,
+                runtimeFrameworkVersion: null,
+                name: monoAotLLVMRuntime.Name,
+                customDotNetCliPath: options.CliPath?.FullName,
+                packagesPath: options.RestorePath?.FullName,
+                timeout: timeOut ?? NetCoreAppSettings.DefaultBuildTimeout,
+                customRuntimePack: options.CustomRuntimePack,
+                aotCompilerPath: options.AOTCompilerPath.ToString(),
+                aotCompilerMode: options.AOTCompilerMode));
+
+            return baseJob.WithRuntime(monoAotLLVMRuntime).WithToolchain(toolChain);
         }
 
         private static Job MakeWasmJob(Job baseJob, CommandLineOptions options, TimeSpan? timeOut, string msBuildMoniker)


### PR DESCRIPTION
This change lets the llvmaot tool chain work with net7 (and, in principle, netX for any X), and also allows selecting net6. 

Also add a .net7 nuget feed.

Fixes: https://github.com/dotnet/performance/issues/2100