### PR TITLE
Export HTML by default for DisassemblyDiagnoser

### DIFF
--- a/src/BenchmarkDotNet/Attributes/DisassemblyDiagnoserAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/DisassemblyDiagnoserAttribute.cs
@@ -19,7 +19,7 @@ namespace BenchmarkDotNet.Attributes
             bool printSource = false,
             bool printInstructionAddresses = false,
             bool exportGithubMarkdown = true,
-            bool exportHtml = false,
+            bool exportHtml = true,
             bool exportCombinedDisassemblyReport = false,
             bool exportDiff = false)
         {


### PR DESCRIPTION
It's a tiny thing, and while I don't know about the whole TA of BDN, but in my opinion, when benching locally it's more convenient to open html than markdown (it's very straight and doesn't require a software being opened for markdown).

So I suggest to export the asm report as html by default :) .