### PR TITLE
Fix argument escaping

### DIFF
--- a/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace BenchmarkDotNet.Extensions
 {
@@ -14,7 +15,17 @@ namespace BenchmarkDotNet.Extensions
 
         internal static string ToLowerCase(this bool value) => value ? "true" : "false"; // to avoid .ToString().ToLower() allocation
 
-        internal static string Escape(this string path) => "\"" + path + "\"";
+        // source: https://stackoverflow.com/a/12364234/5852046
+        internal static string Escape(this string cliArg)
+        {
+            if (string.IsNullOrEmpty(cliArg))
+                return cliArg;
+
+            string value = Regex.Replace(cliArg, @"(\\*)" + "\"", @"$1\$0");
+            value = Regex.Replace(value, @"^(.*\s.*?)(\\*)$", "\"$1$2$2\"", RegexOptions.Singleline);
+
+            return value;
+        }
 
         /// <summary>
         /// replaces all invalid file name chars with their number representation

--- a/tests/BenchmarkDotNet.IntegrationTests/ArgumentsTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ArgumentsTests.cs
@@ -770,6 +770,18 @@ namespace BenchmarkDotNet.IntegrationTests
             }
         }
 
+        [Theory, MemberData(nameof(GetToolchains))]
+        public void ComplexStringPattersAreSupported(IToolchain toolchain) => CanExecute<Perf_Regex_Industry_RustLang_Sherlock>(toolchain);
+
+        public class Perf_Regex_Industry_RustLang_Sherlock
+        {
+            [Params(@"[""'][^""']{0,30}[?!.][""']")]
+            public string Pattern { get; set; }
+
+            [Benchmark]
+            public int Consume() => Pattern.Length;
+        }
+
         [Fact]
         public void UnusedDisposableParamsAreDisposed() => CanExecute<WithDisposableArguments>(Job.Default.GetToolchain());
 


### PR DESCRIPTION
Fixes a bug reported by @stephentoub in https://github.com/dotnet/performance/pull/2125/files/52b20996fa82093a0daed0cecedec39017c11abb#r750329575

Ideally I would just use [ProcessStartInfo.ArgumentList](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.argumentlist?view=net-5.0) and let it take care of all the args escaping, but BDN targets .NET Standard 2.0 and I can't do that.