### PR TITLE
Use non-deprecated macOS pool on Azure Pipelines

### DIFF
--- a/azure-pipelines.macOS.yml
+++ b/azure-pipelines.macOS.yml
@@ -11,5 +11,5 @@ jobs:
 - template: build/azure-pipelines.job.template.yml
   parameters:
     name: macOS
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
     scriptFileName: ./build.sh


### PR DESCRIPTION
Fixes the warning: "The macOS-10.14 environment is deprecated and will be removed on December 10, 2021. For more details see https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/"

/cc @AndreyAkinshin 