### PR TITLE
Fix size rounding

### DIFF
--- a/src/BenchmarkDotNet/Columns/MetricColumn.cs
+++ b/src/BenchmarkDotNet/Columns/MetricColumn.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using Perfolizer.Horology;
@@ -32,7 +33,7 @@ namespace BenchmarkDotNet.Columns
                 return "-";
 
             var cultureInfo = summary.GetCultureInfo();
-            if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.CodeSize)
+            if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Size && descriptor.Id == DisassemblyDiagnoser.DescriptorId)
                 return SizeValue.FromBytes((long)metric.Value).ToString(style.CodeSizeUnit, cultureInfo, descriptor.NumberFormat);
             if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Size)
                 return SizeValue.FromBytes((long)metric.Value).ToString(style.SizeUnit, cultureInfo, descriptor.NumberFormat);

--- a/src/BenchmarkDotNet/Columns/MetricColumn.cs
+++ b/src/BenchmarkDotNet/Columns/MetricColumn.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using Perfolizer.Horology;
@@ -33,8 +32,6 @@ namespace BenchmarkDotNet.Columns
                 return "-";
 
             var cultureInfo = summary.GetCultureInfo();
-            if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Size && descriptor.Id == DisassemblyDiagnoser.DescriptorId)
-                return SizeValue.FromBytes((long)metric.Value).ToString(style.CodeSizeUnit, cultureInfo, descriptor.NumberFormat);
             if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Size)
                 return SizeValue.FromBytes((long)metric.Value).ToString(style.SizeUnit, cultureInfo, descriptor.NumberFormat);
             if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Time)

--- a/src/BenchmarkDotNet/Columns/MetricColumn.cs
+++ b/src/BenchmarkDotNet/Columns/MetricColumn.cs
@@ -32,8 +32,10 @@ namespace BenchmarkDotNet.Columns
                 return "-";
 
             var cultureInfo = summary.GetCultureInfo();
-            if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Size)
-                return SizeValue.FromBytes((long)metric.Value).ToString(style.SizeUnit, cultureInfo, descriptor.NumberFormat);
+            if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Allocation)
+                return SizeValue.FromBytes((long)metric.Value).ToString(style.AllocationUnit, cultureInfo, descriptor.NumberFormat);
+            if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.CodeSize)
+                return SizeValue.FromBytes((long)metric.Value).ToString(style.CodeSizeUnit, cultureInfo, descriptor.NumberFormat);
             if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Time)
                 return TimeInterval.FromNanoseconds(metric.Value).ToString(style.TimeUnit, cultureInfo);
 

--- a/src/BenchmarkDotNet/Columns/MetricColumn.cs
+++ b/src/BenchmarkDotNet/Columns/MetricColumn.cs
@@ -32,6 +32,8 @@ namespace BenchmarkDotNet.Columns
                 return "-";
 
             var cultureInfo = summary.GetCultureInfo();
+            if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.CodeSize)
+                return SizeValue.FromBytes((long)metric.Value).ToString(style.CodeSizeUnit, cultureInfo, descriptor.NumberFormat);
             if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Size)
                 return SizeValue.FromBytes((long)metric.Value).ToString(style.SizeUnit, cultureInfo, descriptor.NumberFormat);
             if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Time)

--- a/src/BenchmarkDotNet/Columns/UnitType.cs
+++ b/src/BenchmarkDotNet/Columns/UnitType.cs
@@ -4,6 +4,7 @@
     {
         Dimensionless,
         Time,
-        Size
+        Size,
+        CodeSize
     }
 }

--- a/src/BenchmarkDotNet/Columns/UnitType.cs
+++ b/src/BenchmarkDotNet/Columns/UnitType.cs
@@ -1,9 +1,16 @@
-﻿namespace BenchmarkDotNet.Columns
+﻿using System;
+
+namespace BenchmarkDotNet.Columns
 {
     public enum UnitType
     {
         Dimensionless,
         Time,
-        Size
+        [Obsolete("Use " + nameof(Allocation))]
+        Size,
+#pragma warning disable CS0618
+        Allocation = Size,
+#pragma warning restore CS0618
+        CodeSize
     }
 }

--- a/src/BenchmarkDotNet/Columns/UnitType.cs
+++ b/src/BenchmarkDotNet/Columns/UnitType.cs
@@ -4,7 +4,6 @@
     {
         Dimensionless,
         Time,
-        Size,
-        CodeSize
+        Size
     }
 }

--- a/src/BenchmarkDotNet/Diagnosers/AllocatedNativeMemoryDescriptor.cs
+++ b/src/BenchmarkDotNet/Diagnosers/AllocatedNativeMemoryDescriptor.cs
@@ -9,7 +9,7 @@ namespace BenchmarkDotNet.Diagnosers
         public string DisplayName => $"Allocated native memory";
         public string Legend => $"Allocated native memory per single operation";
         public string NumberFormat => "N0";
-        public UnitType UnitType => UnitType.Size;
+        public UnitType UnitType => UnitType.Allocation;
         public string Unit => SizeUnit.B.Name;
         public bool TheGreaterTheBetter => false;
         public int PriorityInCategory => 0;
@@ -21,7 +21,7 @@ namespace BenchmarkDotNet.Diagnosers
         public string DisplayName => $"Native memory leak";
         public string Legend => $"Native memory leak size in byte.";
         public string NumberFormat => "N0";
-        public UnitType UnitType => UnitType.Size;
+        public UnitType UnitType => UnitType.Allocation;
         public string Unit => SizeUnit.B.Name;
         public bool TheGreaterTheBetter => false;
         public int PriorityInCategory => 0;

--- a/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
@@ -52,7 +52,7 @@ namespace BenchmarkDotNet.Diagnosers
             public string Id => "Allocated Memory";
             public string DisplayName => "Allocated";
             public string Legend => "Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)";
-            public string NumberFormat => "N0";
+            public string NumberFormat => "0.##";
             public UnitType UnitType => UnitType.Size;
             public string Unit => SizeUnit.B.Name;
             public bool TheGreaterTheBetter => false;

--- a/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
@@ -53,7 +53,7 @@ namespace BenchmarkDotNet.Diagnosers
             public string DisplayName => "Allocated";
             public string Legend => "Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)";
             public string NumberFormat => "0.##";
-            public UnitType UnitType => UnitType.Size;
+            public UnitType UnitType => UnitType.Allocation;
             public string Unit => SizeUnit.B.Name;
             public bool TheGreaterTheBetter => false;
             public int PriorityInCategory => GC.MaxGeneration + 1;

--- a/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
+++ b/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
@@ -165,7 +165,7 @@ namespace BenchmarkDotNet.Diagnosers
             public string Id => "Native Code Size";
             public string DisplayName => "Code Size";
             public string Legend => "Native code size of the disassembled method(s)";
-            public string NumberFormat => "N0";
+            public string NumberFormat => "0.##";
             public UnitType UnitType => UnitType.Size;
             public string Unit => SizeUnit.B.Name;
             public bool TheGreaterTheBetter => false;

--- a/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
+++ b/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
@@ -165,8 +165,8 @@ namespace BenchmarkDotNet.Diagnosers
             public string Id => "Native Code Size";
             public string DisplayName => "Code Size";
             public string Legend => "Native code size of the disassembled method(s)";
-            public string NumberFormat => "0.##";
-            public UnitType UnitType => UnitType.Size;
+            public string NumberFormat => "N0";
+            public UnitType UnitType => UnitType.CodeSize;
             public string Unit => SizeUnit.B.Name;
             public bool TheGreaterTheBetter => false;
             public int PriorityInCategory => 0;

--- a/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
+++ b/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
@@ -21,8 +21,6 @@ namespace BenchmarkDotNet.Diagnosers
 {
     public class DisassemblyDiagnoser : IDiagnoser
     {
-        internal static string DescriptorId { get; } = NativeCodeSizeMetricDescriptor.Instance.Id;
-        
         private static readonly Lazy<string> ptrace_scope = new Lazy<string>(() => ProcessHelper.RunAndReadOutput("cat", "/proc/sys/kernel/yama/ptrace_scope").Trim());
 
         private readonly WindowsDisassembler windowsDisassembler;

--- a/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
+++ b/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
@@ -21,6 +21,8 @@ namespace BenchmarkDotNet.Diagnosers
 {
     public class DisassemblyDiagnoser : IDiagnoser
     {
+        internal static string DescriptorId { get; } = NativeCodeSizeMetricDescriptor.Instance.Id;
+        
         private static readonly Lazy<string> ptrace_scope = new Lazy<string>(() => ProcessHelper.RunAndReadOutput("cat", "/proc/sys/kernel/yama/ptrace_scope").Trim());
 
         private readonly WindowsDisassembler windowsDisassembler;
@@ -165,8 +167,8 @@ namespace BenchmarkDotNet.Diagnosers
             public string Id => "Native Code Size";
             public string DisplayName => "Code Size";
             public string Legend => "Native code size of the disassembled method(s)";
-            public string NumberFormat => "N0";
-            public UnitType UnitType => UnitType.CodeSize;
+            public string NumberFormat => "0.##";
+            public UnitType UnitType => UnitType.Size;
             public string Unit => SizeUnit.B.Name;
             public bool TheGreaterTheBetter => false;
             public int PriorityInCategory => 0;

--- a/src/BenchmarkDotNet/Disassemblers/NativeCodeSizeMetricDescriptor.cs
+++ b/src/BenchmarkDotNet/Disassemblers/NativeCodeSizeMetricDescriptor.cs
@@ -1,0 +1,17 @@
+﻿using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Reports;
+
+namespace BenchmarkDotNet.Diagnosers
+{
+    internal class NativeCodeSizeMetricDescriptor : IMetricDescriptor
+    {
+        public string Id => "Native Code Size";
+        public string DisplayName => "Code Size";
+        public string Legend => "Native code size of the disassembled method(s)";
+        public string NumberFormat => "0.##";
+        public UnitType UnitType => UnitType.CodeSize;
+        public string Unit => SizeUnit.B.Name;
+        public bool TheGreaterTheBetter => false;
+        public int PriorityInCategory => 0;
+    }
+}

--- a/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
@@ -20,7 +20,7 @@ namespace BenchmarkDotNet.Extensions
             switch (column.UnitType)
             {
                 case UnitType.CodeSize:
-                    return $"{column.ColumnName} [{style.SizeUnit.Name}]";
+                    return $"{column.ColumnName} [{style.CodeSizeUnit.Name}]";
                 case UnitType.Size:
                     return $"{column.ColumnName} [{style.SizeUnit.Name}]";
                 case UnitType.Time:

--- a/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
@@ -19,6 +19,8 @@ namespace BenchmarkDotNet.Extensions
 
             switch (column.UnitType)
             {
+                case UnitType.CodeSize:
+                    return $"{column.ColumnName} [{style.SizeUnit.Name}]";
                 case UnitType.Size:
                     return $"{column.ColumnName} [{style.SizeUnit.Name}]";
                 case UnitType.Time:

--- a/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
@@ -19,8 +19,10 @@ namespace BenchmarkDotNet.Extensions
 
             switch (column.UnitType)
             {
-                case UnitType.Size:
-                    return $"{column.ColumnName} [{style.SizeUnit.Name}]";
+                case UnitType.Allocation:
+                    return $"{column.ColumnName} [{style.AllocationUnit.Name}]";
+                case UnitType.CodeSize:
+                    return $"{column.ColumnName} [{style.CodeSizeUnit.Name}]";
                 case UnitType.Time:
                     return $"{column.ColumnName} [{style.TimeUnit.Name}]";
                 case UnitType.Dimensionless:

--- a/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using BenchmarkDotNet.Columns;
-using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Reports;
 
 namespace BenchmarkDotNet.Extensions
@@ -20,8 +19,6 @@ namespace BenchmarkDotNet.Extensions
 
             switch (column.UnitType)
             {
-                case UnitType.Size when column.Id == DisassemblyDiagnoser.DescriptorId:
-                    return $"{column.ColumnName} [{style.CodeSizeUnit.Name}]";
                 case UnitType.Size:
                     return $"{column.ColumnName} [{style.SizeUnit.Name}]";
                 case UnitType.Time:

--- a/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Reports;
 
 namespace BenchmarkDotNet.Extensions
@@ -19,7 +20,7 @@ namespace BenchmarkDotNet.Extensions
 
             switch (column.UnitType)
             {
-                case UnitType.CodeSize:
+                case UnitType.Size when column.Id == DisassemblyDiagnoser.DescriptorId:
                     return $"{column.ColumnName} [{style.CodeSizeUnit.Name}]";
                 case UnitType.Size:
                     return $"{column.ColumnName} [{style.SizeUnit.Name}]";

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -19,6 +19,7 @@ namespace BenchmarkDotNet.Reports
         public bool PrintZeroValuesInContent { get; }
         public int MaxParameterColumnWidth { get; }
         public SizeUnit SizeUnit { get; }
+        internal SizeUnit CodeSizeUnit { get; }
         public TimeUnit TimeUnit { get; }
         [NotNull]
         public CultureInfo CultureInfo { get; }
@@ -39,6 +40,7 @@ namespace BenchmarkDotNet.Reports
             PrintZeroValuesInContent = printZeroValuesInContent;
             MaxParameterColumnWidth = maxParameterColumnWidth;
             RatioStyle = ratioStyle;
+            CodeSizeUnit = SizeUnit.B;
         }
 
         public SummaryStyle WithTimeUnit(TimeUnit timeUnit)
@@ -85,6 +87,7 @@ namespace BenchmarkDotNet.Reports
                 hashCode = (hashCode * 397) ^ PrintUnitsInContent.GetHashCode();
                 hashCode = (hashCode * 397) ^ PrintZeroValuesInContent.GetHashCode();
                 hashCode = (hashCode * 397) ^ (SizeUnit != null ? SizeUnit.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (CodeSizeUnit != null ? CodeSizeUnit.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (TimeUnit != null ? TimeUnit.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ MaxParameterColumnWidth;
                 hashCode = (hashCode * 397) ^ RatioStyle.GetHashCode();

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -19,7 +19,6 @@ namespace BenchmarkDotNet.Reports
         public bool PrintZeroValuesInContent { get; }
         public int MaxParameterColumnWidth { get; }
         public SizeUnit SizeUnit { get; }
-        public SizeUnit CodeSizeUnit { get; }
         public TimeUnit TimeUnit { get; }
         [NotNull]
         public CultureInfo CultureInfo { get; }
@@ -27,7 +26,7 @@ namespace BenchmarkDotNet.Reports
         public RatioStyle RatioStyle { get; }
 
         public SummaryStyle([CanBeNull] CultureInfo cultureInfo, bool printUnitsInHeader, SizeUnit sizeUnit, TimeUnit timeUnit, bool printUnitsInContent = true,
-            bool printZeroValuesInContent = false, int maxParameterColumnWidth = DefaultMaxParameterColumnWidth, RatioStyle ratioStyle = RatioStyle.Value, SizeUnit codeSizeUnit = null)
+            bool printZeroValuesInContent = false, int maxParameterColumnWidth = DefaultMaxParameterColumnWidth, RatioStyle ratioStyle = RatioStyle.Value)
         {
             if (maxParameterColumnWidth < DefaultMaxParameterColumnWidth)
                 throw new ArgumentOutOfRangeException(nameof(maxParameterColumnWidth), $"{DefaultMaxParameterColumnWidth} is the minimum.");
@@ -40,29 +39,25 @@ namespace BenchmarkDotNet.Reports
             PrintZeroValuesInContent = printZeroValuesInContent;
             MaxParameterColumnWidth = maxParameterColumnWidth;
             RatioStyle = ratioStyle;
-            CodeSizeUnit = codeSizeUnit;
         }
 
         public SummaryStyle WithTimeUnit(TimeUnit timeUnit)
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, timeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle, CodeSizeUnit);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, timeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle);
 
         public SummaryStyle WithSizeUnit(SizeUnit sizeUnit)
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, sizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle, CodeSizeUnit);
-
-        public SummaryStyle WithCodeSizeUnit(SizeUnit codeSizeUnit)
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle, codeSizeUnit);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, sizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle);
 
         public SummaryStyle WithZeroMetricValuesInContent()
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, printZeroValuesInContent: true, MaxParameterColumnWidth, RatioStyle, CodeSizeUnit);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, printZeroValuesInContent: true, MaxParameterColumnWidth, RatioStyle);
 
         public SummaryStyle WithMaxParameterColumnWidth(int maxParameterColumnWidth)
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, maxParameterColumnWidth, RatioStyle, CodeSizeUnit);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, maxParameterColumnWidth, RatioStyle);
 
         public SummaryStyle WithCultureInfo(CultureInfo cultureInfo)
-            => new SummaryStyle(cultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle, CodeSizeUnit);
+            => new SummaryStyle(cultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle);
 
         public SummaryStyle WithRatioStyle(RatioStyle ratioStyle)
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, ratioStyle, CodeSizeUnit);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, ratioStyle);
 
         public bool Equals(SummaryStyle other)
         {
@@ -75,7 +70,6 @@ namespace BenchmarkDotNet.Reports
                    && PrintUnitsInContent == other.PrintUnitsInContent
                    && PrintZeroValuesInContent == other.PrintZeroValuesInContent
                    && Equals(SizeUnit, other.SizeUnit)
-                   && Equals(CodeSizeUnit, other.CodeSizeUnit)
                    && Equals(TimeUnit, other.TimeUnit)
                    && MaxParameterColumnWidth == other.MaxParameterColumnWidth
                    && RatioStyle == other.RatioStyle;
@@ -91,7 +85,6 @@ namespace BenchmarkDotNet.Reports
                 hashCode = (hashCode * 397) ^ PrintUnitsInContent.GetHashCode();
                 hashCode = (hashCode * 397) ^ PrintZeroValuesInContent.GetHashCode();
                 hashCode = (hashCode * 397) ^ (SizeUnit != null ? SizeUnit.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (CodeSizeUnit != null ? CodeSizeUnit.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (TimeUnit != null ? TimeUnit.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ MaxParameterColumnWidth;
                 hashCode = (hashCode * 397) ^ RatioStyle.GetHashCode();

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -19,7 +19,7 @@ namespace BenchmarkDotNet.Reports
         public bool PrintZeroValuesInContent { get; }
         public int MaxParameterColumnWidth { get; }
         public SizeUnit SizeUnit { get; }
-        internal SizeUnit CodeSizeUnit { get; }
+        public SizeUnit CodeSizeUnit { get; }
         public TimeUnit TimeUnit { get; }
         [NotNull]
         public CultureInfo CultureInfo { get; }
@@ -27,7 +27,7 @@ namespace BenchmarkDotNet.Reports
         public RatioStyle RatioStyle { get; }
 
         public SummaryStyle([CanBeNull] CultureInfo cultureInfo, bool printUnitsInHeader, SizeUnit sizeUnit, TimeUnit timeUnit, bool printUnitsInContent = true,
-            bool printZeroValuesInContent = false, int maxParameterColumnWidth = DefaultMaxParameterColumnWidth, RatioStyle ratioStyle = RatioStyle.Value)
+            bool printZeroValuesInContent = false, int maxParameterColumnWidth = DefaultMaxParameterColumnWidth, RatioStyle ratioStyle = RatioStyle.Value, SizeUnit codeSizeUnit = null)
         {
             if (maxParameterColumnWidth < DefaultMaxParameterColumnWidth)
                 throw new ArgumentOutOfRangeException(nameof(maxParameterColumnWidth), $"{DefaultMaxParameterColumnWidth} is the minimum.");
@@ -40,26 +40,29 @@ namespace BenchmarkDotNet.Reports
             PrintZeroValuesInContent = printZeroValuesInContent;
             MaxParameterColumnWidth = maxParameterColumnWidth;
             RatioStyle = ratioStyle;
-            CodeSizeUnit = SizeUnit.B;
+            CodeSizeUnit = codeSizeUnit;
         }
 
         public SummaryStyle WithTimeUnit(TimeUnit timeUnit)
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, timeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, timeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle, CodeSizeUnit);
 
         public SummaryStyle WithSizeUnit(SizeUnit sizeUnit)
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, sizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, sizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle, CodeSizeUnit);
+
+        public SummaryStyle WithCodeSizeUnit(SizeUnit codeSizeUnit)
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle, codeSizeUnit);
 
         public SummaryStyle WithZeroMetricValuesInContent()
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, printZeroValuesInContent: true, MaxParameterColumnWidth, RatioStyle);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, printZeroValuesInContent: true, MaxParameterColumnWidth, RatioStyle, CodeSizeUnit);
 
         public SummaryStyle WithMaxParameterColumnWidth(int maxParameterColumnWidth)
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, maxParameterColumnWidth, RatioStyle);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, maxParameterColumnWidth, RatioStyle, CodeSizeUnit);
 
         public SummaryStyle WithCultureInfo(CultureInfo cultureInfo)
-            => new SummaryStyle(cultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle);
+            => new SummaryStyle(cultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle, CodeSizeUnit);
 
         public SummaryStyle WithRatioStyle(RatioStyle ratioStyle)
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, ratioStyle);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, ratioStyle, CodeSizeUnit);
 
         public bool Equals(SummaryStyle other)
         {
@@ -72,6 +75,7 @@ namespace BenchmarkDotNet.Reports
                    && PrintUnitsInContent == other.PrintUnitsInContent
                    && PrintZeroValuesInContent == other.PrintZeroValuesInContent
                    && Equals(SizeUnit, other.SizeUnit)
+                   && Equals(CodeSizeUnit, other.CodeSizeUnit)
                    && Equals(TimeUnit, other.TimeUnit)
                    && MaxParameterColumnWidth == other.MaxParameterColumnWidth
                    && RatioStyle == other.RatioStyle;

--- a/src/BenchmarkDotNet/Reports/SummaryTable.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTable.cs
@@ -50,7 +50,7 @@ namespace BenchmarkDotNet.Reports
 
             if (style.SizeUnit == null)
             {
-                style = style.WithSizeUnit(SizeUnit.GetBestSizeUnit(summary.Reports.Select(r => r.GcStats.GetBytesAllocatedPerOperation(r.BenchmarkCase)).ToArray()));
+                style = style.WithSizeUnit(SizeUnit.B);
             }
 
             var columns = summary.GetColumns();

--- a/src/BenchmarkDotNet/Reports/SummaryTable.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTable.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Extensions;
 using JetBrains.Annotations;
 using Perfolizer.Horology;
@@ -48,9 +49,14 @@ namespace BenchmarkDotNet.Reports
                     .ToArray()));
             }
 
-            if (style.SizeUnit == null)
+            if (style.AllocationUnit == null)
             {
-                style = style.WithSizeUnit(SizeUnit.GetBestSizeUnit(summary.Reports.Select(r => r.GcStats.GetBytesAllocatedPerOperation(r.BenchmarkCase)).ToArray()));
+                style = style.WithAllocationUnit(SizeUnit.GetBestSizeUnit(summary.Reports.Select(r => r.GcStats.GetBytesAllocatedPerOperation(r.BenchmarkCase)).ToArray()));
+            }
+
+            if (style.CodeSizeUnit == null)
+            {
+                style = style.WithCodeSizeUnit(SizeUnit.GetBestSizeUnit(summary.Reports.SelectMany(r => r.Metrics.Values).Where(m => m.Descriptor is NativeCodeSizeMetricDescriptor).Select(m => (long)m.Value).ToArray()));
             }
 
             var columns = summary.GetColumns();

--- a/src/BenchmarkDotNet/Reports/SummaryTable.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTable.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Columns;
-using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Extensions;
 using JetBrains.Annotations;
 using Perfolizer.Horology;
@@ -52,12 +51,6 @@ namespace BenchmarkDotNet.Reports
             if (style.SizeUnit == null)
             {
                 style = style.WithSizeUnit(SizeUnit.GetBestSizeUnit(summary.Reports.Select(r => r.GcStats.GetBytesAllocatedPerOperation(r.BenchmarkCase)).ToArray()));
-            }
-
-            if (style.CodeSizeUnit == null)
-            {
-                var methodsSizes = summary.Reports.SelectMany(r => r.Metrics).Where(m => m.Key == DisassemblyDiagnoser.DescriptorId).Select(x => (long)x.Value.Value).ToArray();
-                style = style.WithCodeSizeUnit(SizeUnit.GetBestSizeUnit(methodsSizes));
             }
 
             var columns = summary.GetColumns();

--- a/src/BenchmarkDotNet/Reports/SummaryTable.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTable.cs
@@ -50,7 +50,7 @@ namespace BenchmarkDotNet.Reports
 
             if (style.SizeUnit == null)
             {
-                style = style.WithSizeUnit(SizeUnit.B);
+                style = style.WithSizeUnit(SizeUnit.GetBestSizeUnit(summary.Reports.Select(r => r.GcStats.GetBytesAllocatedPerOperation(r.BenchmarkCase)).ToArray()));
             }
 
             var columns = summary.GetColumns();

--- a/src/BenchmarkDotNet/Reports/SummaryTable.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTable.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Extensions;
 using JetBrains.Annotations;
 using Perfolizer.Horology;
@@ -51,6 +52,12 @@ namespace BenchmarkDotNet.Reports
             if (style.SizeUnit == null)
             {
                 style = style.WithSizeUnit(SizeUnit.GetBestSizeUnit(summary.Reports.Select(r => r.GcStats.GetBytesAllocatedPerOperation(r.BenchmarkCase)).ToArray()));
+            }
+
+            if (style.CodeSizeUnit == null)
+            {
+                var methodsSizes = summary.Reports.SelectMany(r => r.Metrics).Where(m => m.Key == DisassemblyDiagnoser.DescriptorId).Select(x => (long)x.Value.Value).ToArray();
+                style = style.WithCodeSizeUnit(SizeUnit.GetBestSizeUnit(methodsSizes));
             }
 
             var columns = summary.GetColumns();

--- a/tests/BenchmarkDotNet.Tests/SummaryStyleTests.cs
+++ b/tests/BenchmarkDotNet.Tests/SummaryStyleTests.cs
@@ -18,7 +18,8 @@ namespace BenchmarkDotNet.Tests
                 printUnitsInHeader: true,
                 printUnitsInContent: false,
                 printZeroValuesInContent: true,
-                sizeUnit: SizeUnit.B,
+                allocationUnit: SizeUnit.B,
+                codeSizeUnit: SizeUnit.B,
                 timeUnit: TimeUnit.Millisecond
             );
 
@@ -28,7 +29,8 @@ namespace BenchmarkDotNet.Tests
             Assert.True(config.SummaryStyle.PrintUnitsInHeader);
             Assert.False(config.SummaryStyle.PrintUnitsInContent);
             Assert.True(config.SummaryStyle.PrintZeroValuesInContent);
-            Assert.Equal(SizeUnit.B, config.SummaryStyle.SizeUnit);
+            Assert.Equal(SizeUnit.B, config.SummaryStyle.AllocationUnit);
+            Assert.Equal(SizeUnit.B, config.SummaryStyle.CodeSizeUnit);
             Assert.Equal(TimeUnit.Millisecond, config.SummaryStyle.TimeUnit);
         }
     }


### PR DESCRIPTION
Fixes #1727.

For the benchmark:
```C#
[MemoryDiagnoser, DisassemblyDiagnoser]
public class Benchmarks
{
    [Benchmark] public int[] B1() => Enumerable.Range(0, 400).Where(i => i % 2 == 0).Select(i => i).ToArray();
    [Benchmark] public byte[] B2() => new byte[1024 * (1024 + 512)]; // 1.5 MB + 24b overhead
}
``` 
The current export result is:
| Method | Code Size | Allocated |
|--------- |------------:|-----------:|
|         B1 |          2 KB |         2 KB |
|         B2 |          0 KB |  1,536 **KB** |

The new result is:
| Method | Code Size |    Allocated |
|--------- |------------:|-------------:|
|         B1 |      1,772 B |       2,376 B |
|         B2 |          41 B | 1,572,888 B |

The rounding to specific `SizeUnit` can be returned by:
```C#
BenchmarkRunner.Run<Benchmarks>(
    ManualConfig.CreateMinimumViable().WithSummaryStyle(
            SummaryStyle.Default.WithSizeUnit(BenchmarkDotNet.Columns.SizeUnit.KB)));
```

If the rounding is pointless, should be opened another PR for removing/deprecated public `SummaryStyle.WithSizeUnit()` and public `SizeUnit`, `SizeValue` classes that are responsible for converting bytes?

https://github.com/dotnet/BenchmarkDotNet/blob/63e28c100a42a6492d09a0b93a8a4c141061bb0d/src/BenchmarkDotNet/Columns/SizeUnit.cs#L9
https://github.com/dotnet/BenchmarkDotNet/blob/63e28c100a42a6492d09a0b93a8a4c141061bb0d/src/BenchmarkDotNet/Columns/SizeValue.cs#L8