### PR TITLE
Fix size specifier

### DIFF
--- a/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
@@ -52,7 +52,7 @@ namespace BenchmarkDotNet.Diagnosers
             public string Id => "Allocated Memory";
             public string DisplayName => "Allocated";
             public string Legend => "Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)";
-            public string NumberFormat => "N0";
+            public string NumberFormat => "0.##";
             public UnitType UnitType => UnitType.Size;
             public string Unit => SizeUnit.B.Name;
             public bool TheGreaterTheBetter => false;

--- a/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
+++ b/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
@@ -165,7 +165,7 @@ namespace BenchmarkDotNet.Diagnosers
             public string Id => "Native Code Size";
             public string DisplayName => "Code Size";
             public string Legend => "Native code size of the disassembled method(s)";
-            public string NumberFormat => "N0";
+            public string NumberFormat => "0.##";
             public UnitType UnitType => UnitType.Size;
             public string Unit => SizeUnit.B.Name;
             public bool TheGreaterTheBetter => false;


### PR DESCRIPTION
The split pull request of #1852. The Part 1.

master:
| Method | Code Size | Allocated |
|------- |----------:|----------:|
|      A |      0 KB |      1 KB |

| Method | Code Size | Allocated |
|------- |----------:|----------:|
|      C |   1,120 B |     432 B |

PR:
| Method | Code Size | Allocated |
|------- |----------:|----------:|
|      A |   0.04 KB |   1.49 KB |

| Method | Code Size | Allocated |
|------- |----------:|----------:|
|      C |    1120 B |     432 B |

Benchmarks:
```C#
    [MemoryDiagnoser, DisassemblyDiagnoser]
    public class Benchmark1
    {
        [Benchmark] public byte[] A() => new byte[1500];
    }

    [MemoryDiagnoser, DisassemblyDiagnoser]
    public class Benchmark2
    {
        [Benchmark] public byte[] C() => new byte[100].Select(x => x).Reverse().ToArray();
    }
```
