### PR TITLE
Bugfix for merged PR #1855

### DIFF
--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -72,7 +72,7 @@ namespace BenchmarkDotNet.Reports
                    && PrintUnitsInContent == other.PrintUnitsInContent
                    && PrintZeroValuesInContent == other.PrintZeroValuesInContent
                    && Equals(SizeUnit, other.SizeUnit)
-                   && Equals(SizeUnit, other.CodeSizeUnit)
+                   && Equals(CodeSizeUnit, other.CodeSizeUnit)
                    && Equals(TimeUnit, other.TimeUnit)
                    && MaxParameterColumnWidth == other.MaxParameterColumnWidth
                    && RatioStyle == other.RatioStyle;


### PR DESCRIPTION
Bugfix for a likely typo in merged PR #1855: Equals(SizeUnit, other.CodeSizeUnit)` -> Equals(**Code**SizeUnit, other.CodeSizeUnit)