### PR TITLE
Add Allocation Ratio column

### DIFF
--- a/src/BenchmarkDotNet/Columns/BaselineAllocationRatioColumn.cs
+++ b/src/BenchmarkDotNet/Columns/BaselineAllocationRatioColumn.cs
@@ -54,7 +54,7 @@ namespace BenchmarkDotNet.Columns
         {
             string logicalGroupKey = summary.GetLogicalGroupKey(benchmarkCase);
             var nonBaselines = summary.GetNonBaselines(logicalGroupKey);
-            return nonBaselines.Any(c => GetAllocationRatio(summary[c].Metrics, baselineMetric) < 0.01);
+            return nonBaselines.Any(c => GetAllocationRatio(summary[c].Metrics, baselineMetric) is > 0 and < 0.01);
         }
 
         private static double? GetAllocationRatio(

--- a/src/BenchmarkDotNet/Columns/BaselineAllocationRatioColumn.cs
+++ b/src/BenchmarkDotNet/Columns/BaselineAllocationRatioColumn.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Mathematics;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using JetBrains.Annotations;
+
+namespace BenchmarkDotNet.Columns
+{
+    public class BaselineAllocationRatioColumn : BaselineCustomColumn
+    {
+        public override string Id => nameof(BaselineAllocationRatioColumn);
+        public override string ColumnName => "Alloc Ratio";
+
+        public override string GetValue(Summary summary, BenchmarkCase benchmarkCase, Statistics baseline, IReadOnlyDictionary<string, Metric> baselineMetrics,
+            Statistics current, IReadOnlyDictionary<string, Metric> currentMetrics, bool isBaseline)
+        {
+            double? ratio = GetAllocationRatio(currentMetrics, baselineMetrics);
+            double? invertedRatio = GetAllocationRatio(baselineMetrics, currentMetrics);
+
+            if (ratio == null)
+                return "NA";
+
+            var cultureInfo = summary.GetCultureInfo();
+            var ratioStyle = summary?.Style?.RatioStyle ?? RatioStyle.Value;
+
+            bool advancedPrecision = IsNonBaselinesPrecise(summary, baselineMetrics, benchmarkCase);
+            switch (ratioStyle)
+            {
+                case RatioStyle.Value:
+                    return ratio.Value.ToString(advancedPrecision ? "N3" : "N2", cultureInfo);
+                case RatioStyle.Percentage:
+                    return isBaseline
+                        ? ""
+                        : ratio.Value >= 1.0
+                            ? "+" + ((ratio.Value - 1.0) * 100).ToString(advancedPrecision ? "N1" : "N0", cultureInfo) + "%"
+                            : "-" + ((1.0 - ratio.Value) * 100).ToString(advancedPrecision ? "N1" : "N0", cultureInfo) + "%";
+                case RatioStyle.Trend:
+                    return isBaseline
+                        ? ""
+                        : ratio.Value >= 1.0
+                            ? ratio.Value.ToString(advancedPrecision ? "N3" : "N2", cultureInfo) + "x more"
+                            : invertedRatio == null
+                                ? "NA"
+                                : invertedRatio.Value.ToString(advancedPrecision ? "N3" : "N2", cultureInfo) + "x less";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(summary), ratioStyle, "RatioStyle is not supported");
+            }
+        }
+
+        private static bool IsNonBaselinesPrecise(Summary summary, IReadOnlyDictionary<string, Metric> baselineMetric, BenchmarkCase benchmarkCase)
+        {
+            string logicalGroupKey = summary.GetLogicalGroupKey(benchmarkCase);
+            var nonBaselines = summary.GetNonBaselines(logicalGroupKey);
+            return nonBaselines.Any(c => GetAllocationRatio(summary[c].Metrics, baselineMetric) < 0.01);
+        }
+
+        private static double? GetAllocationRatio(
+            [CanBeNull] IReadOnlyDictionary<string, Metric> current,
+            [CanBeNull] IReadOnlyDictionary<string, Metric> baseline)
+        {
+            double? currentBytes = GetAllocatedBytes(current);
+            double? baselineBytes = GetAllocatedBytes(baseline);
+
+            if (currentBytes == null || baselineBytes == null)
+                return null;
+
+            if (baselineBytes == 0)
+                return null;
+
+            return currentBytes / baselineBytes;
+        }
+
+        private static double? GetAllocatedBytes([CanBeNull] IReadOnlyDictionary<string, Metric> metrics)
+        {
+            var metric = metrics?.Values.FirstOrDefault(m => m.Descriptor is AllocatedMemoryMetricDescriptor);
+            return metric?.Value;
+        }
+
+        public override ColumnCategory Category => ColumnCategory.Metric; //it should be displayed after Allocated column
+        public override int PriorityInCategory => GC.MaxGeneration + 2; //after AllocatedMemoryMetricDescriptor
+        public override bool IsNumeric => true;
+        public override UnitType UnitType => UnitType.Dimensionless;
+        public override string Legend => "Allocated memory ratio distribution ([Current]/[Baseline])";
+    }
+}

--- a/src/BenchmarkDotNet/Columns/BaselineAllocationRatioColumn.cs
+++ b/src/BenchmarkDotNet/Columns/BaselineAllocationRatioColumn.cs
@@ -80,7 +80,7 @@ namespace BenchmarkDotNet.Columns
         }
 
         public override ColumnCategory Category => ColumnCategory.Metric; //it should be displayed after Allocated column
-        public override int PriorityInCategory => AllocatedMemoryMetricDescriptor.Instance.PriorityInCategory + 1; //after AllocatedMemoryMetricDescriptor
+        public override int PriorityInCategory => AllocatedMemoryMetricDescriptor.Instance.PriorityInCategory + 1;
         public override bool IsNumeric => true;
         public override UnitType UnitType => UnitType.Dimensionless;
         public override string Legend => "Allocated memory ratio distribution ([Current]/[Baseline])";

--- a/src/BenchmarkDotNet/Columns/BaselineAllocationRatioColumn.cs
+++ b/src/BenchmarkDotNet/Columns/BaselineAllocationRatioColumn.cs
@@ -80,7 +80,7 @@ namespace BenchmarkDotNet.Columns
         }
 
         public override ColumnCategory Category => ColumnCategory.Metric; //it should be displayed after Allocated column
-        public override int PriorityInCategory => GC.MaxGeneration + 2; //after AllocatedMemoryMetricDescriptor
+        public override int PriorityInCategory => AllocatedMemoryMetricDescriptor.Instance.PriorityInCategory + 1; //after AllocatedMemoryMetricDescriptor
         public override bool IsNumeric => true;
         public override UnitType UnitType => UnitType.Dimensionless;
         public override string Legend => "Allocated memory ratio distribution ([Current]/[Baseline])";

--- a/src/BenchmarkDotNet/Columns/BaselineCustomColumn.cs
+++ b/src/BenchmarkDotNet/Columns/BaselineCustomColumn.cs
@@ -34,7 +34,7 @@ namespace BenchmarkDotNet.Columns
 
         public bool IsAvailable(Summary summary) => summary.HasBaselines();
         public bool AlwaysShow => true;
-        public ColumnCategory Category => ColumnCategory.Baseline;
+        public virtual ColumnCategory Category => ColumnCategory.Baseline;
         public abstract int PriorityInCategory { get; }
         public abstract bool IsNumeric { get; }
         public abstract UnitType UnitType { get; }

--- a/src/BenchmarkDotNet/Columns/DefaultColumnProvider.cs
+++ b/src/BenchmarkDotNet/Columns/DefaultColumnProvider.cs
@@ -64,7 +64,7 @@ namespace BenchmarkDotNet.Columns
                     if (!hide)
                         yield return BaselineRatioColumn.RatioStdDev;
 
-                    if (HasDisassemblyDiagnoser(summary))
+                    if (HasMemoryDiagnoser(summary))
                     {
                         yield return new BaselineAllocationRatioColumn();
                     }
@@ -76,7 +76,7 @@ namespace BenchmarkDotNet.Columns
                 return summary.Reports != null && summary.Reports.Any(r => r.ResultStatistics != null && check(r.ResultStatistics));
             }
 
-            private static bool HasDisassemblyDiagnoser(Summary summary)
+            private static bool HasMemoryDiagnoser(Summary summary)
             {
                 return summary.BenchmarksCases.Any(c => c.Config.HasMemoryDiagnoser());
             }

--- a/src/BenchmarkDotNet/Columns/DefaultColumnProvider.cs
+++ b/src/BenchmarkDotNet/Columns/DefaultColumnProvider.cs
@@ -63,12 +63,22 @@ namespace BenchmarkDotNet.Columns
                     bool hide = stdDevColumnValues.All(value => value == "0.00" || value == "0.01");
                     if (!hide)
                         yield return BaselineRatioColumn.RatioStdDev;
+
+                    if (HasDisassemblyDiagnoser(summary))
+                    {
+                        yield return new BaselineAllocationRatioColumn();
+                    }
                 }
             }
 
             private static bool NeedToShow(Summary summary, Func<Statistics, bool> check)
             {
                 return summary.Reports != null && summary.Reports.Any(r => r.ResultStatistics != null && check(r.ResultStatistics));
+            }
+
+            private static bool HasDisassemblyDiagnoser(Summary summary)
+            {
+                return summary.BenchmarksCases.Any(c => c.Config.HasMemoryDiagnoser());
             }
         }
 

--- a/src/BenchmarkDotNet/Diagnosers/AllocatedMemoryMetricDescriptor.cs
+++ b/src/BenchmarkDotNet/Diagnosers/AllocatedMemoryMetricDescriptor.cs
@@ -6,6 +6,8 @@ namespace BenchmarkDotNet.Diagnosers
 {
     internal class AllocatedMemoryMetricDescriptor : IMetricDescriptor
     {
+        internal static readonly IMetricDescriptor Instance = new AllocatedMemoryMetricDescriptor();
+
         public string Id => "Allocated Memory";
         public string DisplayName => "Allocated";
         public string Legend => "Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)";

--- a/src/BenchmarkDotNet/Diagnosers/AllocatedMemoryMetricDescriptor.cs
+++ b/src/BenchmarkDotNet/Diagnosers/AllocatedMemoryMetricDescriptor.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Reports;
+
+namespace BenchmarkDotNet.Diagnosers
+{
+    internal class AllocatedMemoryMetricDescriptor : IMetricDescriptor
+    {
+        public string Id => "Allocated Memory";
+        public string DisplayName => "Allocated";
+        public string Legend => "Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)";
+        public string NumberFormat => "0.##";
+        public UnitType UnitType => UnitType.Size;
+        public string Unit => SizeUnit.B.Name;
+        public bool TheGreaterTheBetter => false;
+        public int PriorityInCategory => GC.MaxGeneration + 1;
+    }
+}

--- a/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
@@ -42,21 +42,7 @@ namespace BenchmarkDotNet.Diagnosers
             if (diagnoserResults.GcStats.Gen2Collections > 0 && Config.DisplayGenColumns)
                 yield return new Metric(GarbageCollectionsMetricDescriptor.Gen2, diagnoserResults.GcStats.Gen2Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
 
-            yield return new Metric(AllocatedMemoryMetricDescriptor.Instance, diagnoserResults.GcStats.GetBytesAllocatedPerOperation(diagnoserResults.BenchmarkCase));
-        }
-
-        private class AllocatedMemoryMetricDescriptor : IMetricDescriptor
-        {
-            internal static readonly IMetricDescriptor Instance = new AllocatedMemoryMetricDescriptor();
-
-            public string Id => "Allocated Memory";
-            public string DisplayName => "Allocated";
-            public string Legend => "Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)";
-            public string NumberFormat => "0.##";
-            public UnitType UnitType => UnitType.Size;
-            public string Unit => SizeUnit.B.Name;
-            public bool TheGreaterTheBetter => false;
-            public int PriorityInCategory => GC.MaxGeneration + 1;
+            yield return new Metric(new AllocatedMemoryMetricDescriptor(), diagnoserResults.GcStats.GetBytesAllocatedPerOperation(diagnoserResults.BenchmarkCase));
         }
 
         private class GarbageCollectionsMetricDescriptor : IMetricDescriptor

--- a/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/MemoryDiagnoser.cs
@@ -42,7 +42,7 @@ namespace BenchmarkDotNet.Diagnosers
             if (diagnoserResults.GcStats.Gen2Collections > 0 && Config.DisplayGenColumns)
                 yield return new Metric(GarbageCollectionsMetricDescriptor.Gen2, diagnoserResults.GcStats.Gen2Collections / (double)diagnoserResults.GcStats.TotalOperations * 1000);
 
-            yield return new Metric(new AllocatedMemoryMetricDescriptor(), diagnoserResults.GcStats.GetBytesAllocatedPerOperation(diagnoserResults.BenchmarkCase));
+            yield return new Metric(AllocatedMemoryMetricDescriptor.Instance, diagnoserResults.GcStats.GetBytesAllocatedPerOperation(diagnoserResults.BenchmarkCase));
         }
 
         private class GarbageCollectionsMetricDescriptor : IMetricDescriptor

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -72,7 +72,7 @@ namespace BenchmarkDotNet.Reports
                    && PrintUnitsInContent == other.PrintUnitsInContent
                    && PrintZeroValuesInContent == other.PrintZeroValuesInContent
                    && Equals(SizeUnit, other.SizeUnit)
-                   && Equals(SizeUnit, other.CodeSizeUnit)
+                   && Equals(CodeSizeUnit, other.CodeSizeUnit)
                    && Equals(TimeUnit, other.TimeUnit)
                    && MaxParameterColumnWidth == other.MaxParameterColumnWidth
                    && RatioStyle == other.RatioStyle;

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -72,7 +72,7 @@ namespace BenchmarkDotNet.Reports
                    && PrintUnitsInContent == other.PrintUnitsInContent
                    && PrintZeroValuesInContent == other.PrintZeroValuesInContent
                    && Equals(SizeUnit, other.SizeUnit)
-                   && Equals(CodeSizeUnit, other.CodeSizeUnit)
+                   && Equals(SizeUnit, other.CodeSizeUnit)
                    && Equals(TimeUnit, other.TimeUnit)
                    && MaxParameterColumnWidth == other.MaxParameterColumnWidth
                    && RatioStyle == other.RatioStyle;


### PR DESCRIPTION
fixes #722

![image](https://user-images.githubusercontent.com/19392641/144689788-b45b8e8b-87db-415b-95c1-4dbb5aff0ee4.png)
![image](https://user-images.githubusercontent.com/19392641/144689887-879f42ce-1045-4a51-a462-267f528e14de.png)
![image](https://user-images.githubusercontent.com/19392641/144689979-f5f525a0-e6a0-434a-a2dd-1354661c4f73.png)
It's an analog of [`BaselineRatioColumn`.](https://github.com/dotnet/BenchmarkDotNet/blob/63e28c100a42a6492d09a0b93a8a4c141061bb0d/src/BenchmarkDotNet/Columns/BaselineRatioColumn.cs)

Notes:

If it's a breaking change
```C#
    public virtual ColumnCategory Category => ColumnCategory.Baseline;
    //for 
    public override ColumnCategory Category => ColumnCategory.Metric; //it should be displayed after Allocated column

```

Then it can be done thought EIMI, but I think it's helpful extension for the future. 
```C#
    IColumn.ColumnCategory Category => ColumnCategory.Metric;
```

P.S. `ColumnCategory` is used for the outer sorting:
https://github.com/dotnet/BenchmarkDotNet/blob/63e28c100a42a6492d09a0b93a8a4c141061bb0d/src/BenchmarkDotNet/Reports/SummaryExtensions.cs#L13-L24

.

There are 2 ways how to find correct Metric: 
1) Move `AllocatedMemoryMetricDescriptor` from private to internal. There are exist few internal Descriptors (e.g [`AllocatedNativeMemoryDescriptor`](https://github.com/dotnet/BenchmarkDotNet/blob/f372668e028161d0d1bf675811a6168967175034/src/BenchmarkDotNet/Diagnosers/AllocatedNativeMemoryDescriptor.cs)). It creates one time per `Summary` creation now. `Equals` is called by `Id` in [`MetricDescriptorEqualityComparer`](https://github.com/dotnet/BenchmarkDotNet/blob/f372668e028161d0d1bf675811a6168967175034/src/BenchmarkDotNet/Reports/Metric.cs#L39-L47), so it seems to be safe.

Adam in #878 has changed `AllocatedMemoryMetricDescriptor.Id` from `typeof(AllocatedMemoryMetricDescriptor)` to `"Allocated Memory"`. So if class will be moved to new file, the history will be lost. Need add a comment explaining why only this Descriptor uses literal.


2) Incapsulate filtering by adding to `MemoryDiagnoser` (or to the new inner class in it) filter method):
```C#
public bool ICantThinkTheName(IMetricDescriptor d) => d is AllocatedMemoryMetricDescriptor;
```

....

The base class writes `?` to the cell when `Statistics` data are invalid (often for `Dry`, `Short`). I shouldn't inherit from this class?

https://github.com/dotnet/BenchmarkDotNet/blob/63e28c100a42a6492d09a0b93a8a4c141061bb0d/src/BenchmarkDotNet/Columns/BaselineCustomColumn.cs#L14-L29