### PR TITLE
JitDiagnosers should print an error when run on non-Windows OS

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.Windows/JitDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/JitDiagnoser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Validators;
@@ -30,7 +31,13 @@ namespace BenchmarkDotNet.Diagnostics.Windows
 
         public virtual IEnumerable<Metric> ProcessResults(DiagnoserResults results) => Array.Empty<Metric>();
 
-        public IEnumerable<ValidationError> Validate(ValidationParameters validationParameters) => Array.Empty<ValidationError>();
+        public IEnumerable<ValidationError> Validate(ValidationParameters validationParameters)
+        {
+            if (!RuntimeInformation.IsWindows())
+            {
+                yield return new ValidationError(true, $"{GetType().Name} is supported only on Windows");
+            }
+        }
 
         public void DisplayResults(ILogger outputLogger)
         {


### PR DESCRIPTION
fixes #1857