### PR TITLE
adjust defaultBenchmarkDotNetVersion on build

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -62,4 +62,28 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
+  <UsingTask TaskName="ReplaceFileText"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <InputFilename ParameterType="System.String" Required="true" />
+      <OutputFilename ParameterType="System.String" Required="true" />
+      <MatchExpression ParameterType="System.String" Required="true" />
+      <ReplacementText ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Text.RegularExpressions" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+            File.WriteAllText(
+                OutputFilename,
+                Regex.Replace(File.ReadAllText(InputFilename), MatchExpression, ReplacementText)
+                );
+          ]]>
+      </Code>
+    </Task>
+  </UsingTask>
 </Project>

--- a/templates/BenchmarkDotNet.Templates.csproj
+++ b/templates/BenchmarkDotNet.Templates.csproj
@@ -32,10 +32,5 @@
             OutputFilename="templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json"
             MatchExpression='("defaultValue": )"([\d+\.?]+)"'
             ReplacementText='${1}"$(VersionPrefix)"' />
-    <PropertyGroup>
-      <InputFile>templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json</InputFile>
-      <OutputFile>templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json</OutputFile>
-      <VersionRegex>"defaultValue" : ([\d+\.?]+)</VersionRegex>
-    </PropertyGroup>
   </Target>
 </Project>

--- a/templates/BenchmarkDotNet.Templates.csproj
+++ b/templates/BenchmarkDotNet.Templates.csproj
@@ -31,7 +31,7 @@
             InputFilename="templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json"
             OutputFilename="templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json"
             MatchExpression='("defaultValue": )"([\d+\.?]+)"'
-            ReplacementText='${1}"$(Major).$(Minor).$(Revision)"' />
+            ReplacementText='${1}"$(VersionPrefix)"' />
     <PropertyGroup>
       <InputFile>templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json</InputFile>
       <OutputFile>templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json</OutputFile>

--- a/templates/BenchmarkDotNet.Templates.csproj
+++ b/templates/BenchmarkDotNet.Templates.csproj
@@ -32,5 +32,17 @@
             OutputFilename="templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json"
             MatchExpression='("defaultValue": )"([\d+\.?]+)"'
             ReplacementText='${1}"$(VersionPrefix)"' />
+
+    <ReplaceFileText
+            InputFilename="templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json"
+            OutputFilename="templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json"
+            MatchExpression='("defaultValue": )"([\d+\.?]+)"'
+            ReplacementText='${1}"$(VersionPrefix)"' />
+
+    <ReplaceFileText
+            InputFilename="templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json"
+            OutputFilename="templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json"
+            MatchExpression='("defaultValue": )"([\d+\.?]+)"'
+            ReplacementText='${1}"$(VersionPrefix)"' />
   </Target>
 </Project>

--- a/templates/BenchmarkDotNet.Templates.csproj
+++ b/templates/BenchmarkDotNet.Templates.csproj
@@ -24,4 +24,18 @@
     <Compile Remove="**\*" />
     <None Remove="*.bat;.sh" />
   </ItemGroup>
+
+  <Target Name="Fix BenchmarkDotNetVersion"
+          BeforeTargets="Build">
+    <ReplaceFileText
+            InputFilename="templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json"
+            OutputFilename="templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json"
+            MatchExpression='("defaultValue": )"([\d+\.?]+)"'
+            ReplacementText='${1}"$(Major).$(Minor).$(Revision)"' />
+    <PropertyGroup>
+      <InputFile>templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json</InputFile>
+      <OutputFile>templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json</OutputFile>
+      <VersionRegex>"defaultValue" : ([\d+\.?]+)</VersionRegex>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/templates/install-from-source.sh
+++ b/templates/install-from-source.sh
@@ -1,4 +1,4 @@
-# Run only from the folder where the batch file is located!
+# Run only from the folder where the shell script is located!
 
 dotnet build BenchmarkDotNet.Templates.csproj -c Release
 dotnet pack BenchmarkDotNet.Templates.csproj -c Release

--- a/templates/install-from-source.sh
+++ b/templates/install-from-source.sh
@@ -1,0 +1,13 @@
+# Run only from the folder where the batch file is located!
+
+dotnet build BenchmarkDotNet.Templates.csproj -c Release
+dotnet pack BenchmarkDotNet.Templates.csproj -c Release
+
+#  If we install the templates via a folder path, then it will have a different ID (ID=folder path).
+#  It will conflict with BDN templates from nuget.
+#  We need to install the templates via a FILE path in order to update the template from nuget.
+
+nupkg_path=$(find . -name "BenchmarkDotNet.Templates*.nupkg")
+
+dotnet new uninstall "BenchmarkDotNet.Templates"
+dotnet new install $nupkg_path


### PR DESCRIPTION
Some automatization to reconcile BenchmarkDotNet version with default version in template

If it's good enough I will fix templates for VB and F# also. If not just close PR