### PR TITLE
make `install-from-source` more macOS friendly

### DIFF
--- a/templates/install-from-source.bat
+++ b/templates/install-from-source.bat
@@ -1,4 +1,4 @@
 dotnet build -c Release BenchmarkDotNet.Templates.csproj
 dotnet pack -c Release BenchmarkDotNet.Templates.csproj
 dotnet new -u BenchmarkDotNet.Templates
-dotnet new -i BenchmarkDotNet.Templates::0.0.0-* --nuget-source .\bin\Release\
+dotnet new -i bin/Release/BenchmarkDotNet.Templates.*


### PR DESCRIPTION
- fix / vs \
- fix `BenchmarkDotNet.Templates::0.0.0-* is not supported`