### PR TITLE
fix Markdown output to escape pipe character

### DIFF
--- a/src/BenchmarkDotNet/Exporters/MarkdownExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/MarkdownExporter.cs
@@ -51,7 +51,8 @@ namespace BenchmarkDotNet.Exporters
             CodeBlockStart = "``` ini",
             StartOfGroupHighlightStrategy = MarkdownHighlightStrategy.Bold,
             ColumnsStartWithSeparator = true,
-            EscapeHtml = true
+            EscapeHtml = true,
+            EscapePipe = true
         };
 
         public static readonly IExporter Atlassian = new MarkdownExporter
@@ -71,7 +72,8 @@ namespace BenchmarkDotNet.Exporters
         internal static readonly IExporter Mock = new MarkdownExporter
         {
             Dialect = nameof(Mock),
-            StartOfGroupHighlightStrategy = MarkdownHighlightStrategy.Marker
+            StartOfGroupHighlightStrategy = MarkdownHighlightStrategy.Marker,
+            EscapePipe = true
         };
 
         [PublicAPI] protected string Prefix = string.Empty;
@@ -85,6 +87,7 @@ namespace BenchmarkDotNet.Exporters
         [PublicAPI] protected bool ColumnsStartWithSeparator;
         [PublicAPI] protected string BoldMarkupFormat = "**{0}**";
         [PublicAPI] protected bool EscapeHtml;
+        [PublicAPI] protected bool EscapePipe;
 
         private MarkdownExporter() { }
 
@@ -170,13 +173,13 @@ namespace BenchmarkDotNet.Exporters
             var separatorLine = Enumerable.Range(0, table.ColumnCount).Select(_ => "").ToArray();
             foreach (var line in table.FullContent)
             {
-                if (rowCounter > 0 && table.FullContentStartOfLogicalGroup[rowCounter] && table.SeparateLogicalGroups)
+               if (rowCounter > 0 && table.FullContentStartOfLogicalGroup[rowCounter] && table.SeparateLogicalGroups)
                 {
                     // Print logical separator
                     if (ColumnsStartWithSeparator)
                         logger.WriteStatistic(TableColumnSeparator.TrimStart());
                     table.PrintLine(separatorLine, logger, string.Empty, TableColumnSeparator, highlightRow, false, StartOfGroupHighlightStrategy,
-                        BoldMarkupFormat, false);
+                        BoldMarkupFormat, false, false);
                 }
 
                 // Each time we hit the start of a new group, alternative the color (in the console) or display bold in Markdown
@@ -189,7 +192,7 @@ namespace BenchmarkDotNet.Exporters
                     logger.WriteStatistic(TableColumnSeparator.TrimStart());
 
                 table.PrintLine(line, logger, string.Empty, TableColumnSeparator, highlightRow, table.FullContentStartOfHighlightGroup[rowCounter],
-                    StartOfGroupHighlightStrategy, BoldMarkupFormat, EscapeHtml);
+                    StartOfGroupHighlightStrategy, BoldMarkupFormat, EscapeHtml, EscapePipe);
                 rowCounter++;
             }
         }

--- a/src/BenchmarkDotNet/Reports/SummaryTableExtensions.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTableExtensions.cs
@@ -48,7 +48,7 @@ namespace BenchmarkDotNet.Reports
         }
 
         public static void PrintLine(this SummaryTable table, string[] line, ILogger logger, string leftDel, string rightDel,
-                                     bool highlightRow, bool startOfGroup, MarkdownExporter.MarkdownHighlightStrategy startOfGroupHighlightStrategy, string boldMarkupFormat, bool escapeHtml)
+                                     bool highlightRow, bool startOfGroup, MarkdownExporter.MarkdownHighlightStrategy startOfGroupHighlightStrategy, string boldMarkupFormat, bool escapeHtml, bool escapePipe)
         {
             for (int columnIndex = 0; columnIndex < table.ColumnCount; columnIndex++)
             {
@@ -56,6 +56,9 @@ namespace BenchmarkDotNet.Reports
                 {
                     continue;
                 }
+
+                if (escapePipe)
+                    line[columnIndex] = line[columnIndex].Replace("|", "\\|");
 
                 string text = startOfGroup && startOfGroupHighlightStrategy == MarkdownExporter.MarkdownHighlightStrategy.Bold
                     ? BuildBoldText(table, line, leftDel, rightDel, columnIndex, boldMarkupFormat)

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.MethodBaseline_MethodsParamsEscaped.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.MethodBaseline_MethodsParamsEscaped.approved.txt
@@ -1,0 +1,20 @@
+﻿=== MethodBaseline_MethodsParamsEscaped ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+ Method |           Param |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank |                       LogicalGroup | Baseline |
+------- |---------------- |---------:|--------:|--------:|------:|--------:|-----:|----------------------------------- |--------- |
+   Base | ShouldNotEscape | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=ShouldNotEscape]-DefaultJob |      Yes | ^
+    Foo | ShouldNotEscape | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | [Param=ShouldNotEscape]-DefaultJob |       No |
+    Bar | ShouldNotEscape | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | [Param=ShouldNotEscape]-DefaultJob |       No |
+        |                 |          |         |         |       |         |      |                                    |          |
+   Base |  Should\|Escape | 402.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  [Param=Should\|Escape]-DefaultJob |      Yes | ^
+    Foo |  Should\|Escape | 502.0 ns | 6.09 ns | 1.58 ns |  1.25 |    0.00 |    2 |  [Param=Should\|Escape]-DefaultJob |       No |
+    Bar |  Should\|Escape | 602.0 ns | 6.09 ns | 1.58 ns |  1.50 |    0.00 |    3 |  [Param=Should\|Escape]-DefaultJob |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/MarkdownExporterApprovalTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Exporters/MarkdownExporterApprovalTests.cs
@@ -178,6 +178,16 @@ namespace BenchmarkDotNet.Tests.Exporters
             }
 
             [RankColumn, LogicalGroupColumn, BaselineColumn]
+            public class MethodBaseline_MethodsParamsEscaped
+            {
+                [Params("Should|Escape", "ShouldNotEscape"), UsedImplicitly] public string Param;
+
+                [Benchmark(Baseline = true)] public void Base() { }
+                [Benchmark] public void Foo() { }
+                [Benchmark] public void Bar() { }
+            }
+
+            [RankColumn, LogicalGroupColumn, BaselineColumn]
             [SimpleJob(id: "Job1"), SimpleJob(id: "Job2")]
             public class MethodBaseline_MethodsJobs
             {


### PR DESCRIPTION
Hello! Looking to get my feet wet contributing to open source. I've made changes here that should fix #1839. 

This will escape the pipe `` | `` character in markdown table cells by replacing it with ``\|`` so that the tables render properly.
Example before escaping:
![image](https://user-images.githubusercontent.com/23360919/151497698-46a68051-8883-40dd-a23a-e2f187975404.png)

And after:
![image](https://user-images.githubusercontent.com/23360919/151497790-11a9c87d-839d-42f1-9dc3-25db2cf7c105.png)
