### PR TITLE
don't use diagnosers when running the benchmark has failed

### DIFF
--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -475,7 +475,7 @@ namespace BenchmarkDotNet.Running
 
             // Do a "Diagnostic" run, but DISCARD the results, so that the overhead of Diagnostics doesn't skew the overall results
             var extraRunCompositeDiagnoser = benchmarkCase.Config.GetCompositeDiagnoser(benchmarkCase, Diagnosers.RunMode.ExtraRun);
-            if (extraRunCompositeDiagnoser != null)
+            if (extraRunCompositeDiagnoser != null && success)
             {
                 logger.WriteLineInfo("// Run, Diagnostic");
 
@@ -499,7 +499,7 @@ namespace BenchmarkDotNet.Running
             }
 
             var separateLogicCompositeDiagnoser = benchmarkCase.Config.GetCompositeDiagnoser(benchmarkCase, Diagnosers.RunMode.SeparateLogic);
-            if (separateLogicCompositeDiagnoser != null)
+            if (separateLogicCompositeDiagnoser != null && success)
             {
                 logger.WriteLineInfo("// Run, Diagnostic [SeparateLogic]");
 

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -444,6 +444,11 @@ namespace BenchmarkDotNet.Running
                     break;
                 }
 
+                if (!success && benchmarkCase.Config.Options.IsSet(ConfigOptions.StopOnFirstError))
+                {
+                    break;
+                }
+
                 if (useDiagnoser)
                 {
                     if (benchmarkCase.Config.HasMemoryDiagnoser())
@@ -464,11 +469,6 @@ namespace BenchmarkDotNet.Running
                     double workloadApprox = new Statistics(measurements.Where(m => m.Is(IterationMode.Workload, IterationStage.Actual)).Select(m => m.Nanoseconds)).Median;
                     double percent = overheadApprox / workloadApprox * 100;
                     launchCount = (int)Math.Round(Math.Max(2, 2 + (percent - 1) / 3)); // an empirical formula
-                }
-
-                if (!success && benchmarkCase.Config.Options.IsSet(ConfigOptions.StopOnFirstError))
-                {
-                    break;
                 }
             }
             logger.WriteLine();

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -452,10 +452,16 @@ namespace BenchmarkDotNet.Running
                 if (useDiagnoser)
                 {
                     if (benchmarkCase.Config.HasMemoryDiagnoser())
-                        gcStats = GcStats.Parse(executeResult.Data.Last(line => !string.IsNullOrEmpty(line) && line.StartsWith(GcStats.ResultsLinePrefix)));
+                    {
+                        string resultsLine = executeResult.Data.LastOrDefault(line => !string.IsNullOrEmpty(line) && line.StartsWith(GcStats.ResultsLinePrefix));
+                        gcStats = resultsLine is not null ? GcStats.Parse(resultsLine) : default;
+                    }
 
                     if (benchmarkCase.Config.HasThreadingDiagnoser())
-                        threadingStats = ThreadingStats.Parse(executeResult.Data.Last(line => !string.IsNullOrEmpty(line) && line.StartsWith(ThreadingStats.ResultsLinePrefix)));
+                    {
+                        string resultsLine = executeResult.Data.LastOrDefault(line => !string.IsNullOrEmpty(line) && line.StartsWith(ThreadingStats.ResultsLinePrefix));
+                        threadingStats = resultsLine is not null ? ThreadingStats.Parse(resultsLine) : default;
+                    }
 
                     metrics.AddRange(
                         noOverheadCompositeDiagnoser.ProcessResults(

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -436,7 +436,7 @@ namespace BenchmarkDotNet.Running
                     .Where(r => r.IterationMode != IterationMode.Unknown)
                     .ToArray();
 
-                if (!measurements.Any())
+                if (!measurements.Any(measurement => measurement.IsWorkload()))
                 {
                     // Something went wrong during the benchmark, don't bother doing more runs
                     logger.WriteLineError("No more Benchmark runs will be launched as NO measurements were obtained from the previous run!");

--- a/tests/BenchmarkDotNet.IntegrationTests/ExceptionHandlingTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ExceptionHandlingTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
@@ -110,6 +112,40 @@ namespace BenchmarkDotNet.IntegrationTests
             public void Bar1() { }
             [Benchmark]
             public void Bar2() => throw new Exception();
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void StopOnFirstErrorIsRespected(bool value)
+        {
+            var config = ManualConfig.CreateEmpty()
+                .AddJob(Job.Dry)
+                .AddDiagnoser(MemoryDiagnoser.Default) // crucial to repro the bug
+                .WithOption(ConfigOptions.StopOnFirstError, value);
+
+            var summary = CanExecute<MoreThanOneNonThrowingBenchmark>(config, fullValidation: false);
+
+            if (value)
+            {
+                Assert.Equal(1, summary.Reports.Count(report => !report.Success));
+            }
+            else
+            {
+                Assert.Equal(3, summary.Reports.Count(report => report.Success));
+                Assert.Equal(4, summary.Reports.Count(report => !report.Success));
+            }
+        }
+
+        public class MoreThanOneNonThrowingBenchmark
+        {
+            [Benchmark] public void Ok1() { }
+            [Benchmark] public void Throw1() => throw new Exception(BenchmarkExceptionMessage);
+            [Benchmark] public void Ok2() { }
+            [Benchmark] public void Throw2() => throw new Exception(BenchmarkExceptionMessage);
+            [Benchmark] public void Ok3() { }
+            [Benchmark] public void Throw3() => throw new Exception(BenchmarkExceptionMessage);
+            [Benchmark] public void Throw4() => throw new Exception(BenchmarkExceptionMessage);
         }
     }
 }


### PR DESCRIPTION
Fixes few issues:

* when `OverheadJitting` succeeds, but workload fails there are some measurements reported. I've improved the check to take this into account:

```diff
- if (!measurements.Any())
+ if (!measurements.Any(measurement => measurement.IsWorkload()))
```

* when few iterations run OK, but then some fail the `MemoryDiagnoser` (which runs at the end) is not collecting any data, hence there is nothing to parse. I've changed `lines.Last` to `lines.LastOrDefault` to account for that

* when we know that the benchmarking has failed, we should not try to run any diagnosers

fixes #1803

cc @jeffhandley who has reported this bug offline