### PR TITLE
ensure the default order of benchmarks is the same as declared in source code

### DIFF
--- a/src/BenchmarkDotNet.Annotations/Attributes/BenchmarkAttribute.cs
+++ b/src/BenchmarkDotNet.Annotations/Attributes/BenchmarkAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Attributes
@@ -7,10 +8,14 @@ namespace BenchmarkDotNet.Attributes
     [MeansImplicitUse]
     public class BenchmarkAttribute : Attribute
     {
+        public BenchmarkAttribute([CallerLineNumber] int sourceCodeLineNumber = 0) => SourceCodeLineNumber = sourceCodeLineNumber;
+
         public string Description { get; set; }
 
         public bool Baseline { get; set; }
 
         public int OperationsPerInvoke { get; set; } = 1;
+
+        public int SourceCodeLineNumber { get; }
     }
 }

--- a/src/BenchmarkDotNet.Annotations/Attributes/BenchmarkAttribute.cs
+++ b/src/BenchmarkDotNet.Annotations/Attributes/BenchmarkAttribute.cs
@@ -8,7 +8,11 @@ namespace BenchmarkDotNet.Attributes
     [MeansImplicitUse]
     public class BenchmarkAttribute : Attribute
     {
-        public BenchmarkAttribute([CallerLineNumber] int sourceCodeLineNumber = 0) => SourceCodeLineNumber = sourceCodeLineNumber;
+        public BenchmarkAttribute([CallerLineNumber] int sourceCodeLineNumber = 0, [CallerFilePath] string sourceCodeFile = "")
+        {
+            SourceCodeLineNumber = sourceCodeLineNumber;
+            SourceCodeFile = sourceCodeFile;
+        }
 
         public string Description { get; set; }
 
@@ -17,5 +21,7 @@ namespace BenchmarkDotNet.Attributes
         public int OperationsPerInvoke { get; set; } = 1;
 
         public int SourceCodeLineNumber { get; }
+
+        public string SourceCodeFile { get; }
     }
 }

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -23,7 +23,11 @@ namespace BenchmarkDotNet.Running
 
             // We should check all methods including private to notify users about private methods with the [Benchmark] attribute
             var bindingFlags = BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-            var benchmarkMethods = type.GetMethods(bindingFlags).Where(method => method.HasAttribute<BenchmarkAttribute>()).ToArray();
+            var benchmarkMethods = type
+                .GetMethods(bindingFlags)
+                .Where(method => method.HasAttribute<BenchmarkAttribute>())
+                .OrderBy(method => method.ResolveAttribute<BenchmarkAttribute>().SourceCodeLineNumber)
+                .ToArray();
 
             return MethodsToBenchmarksWithFullConfig(type, benchmarkMethods, config);
         }

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -115,7 +115,6 @@ namespace BenchmarkDotNet.Running
             Tuple<MethodInfo, TargetedAttribute>[] iterationCleanupMethods)
         {
             return targetMethods
-                .Where(m => m.HasAttribute<BenchmarkAttribute>())
                 .Select(methodInfo => CreateDescriptor(type,
                                                    GetTargetedMatchingMethod(methodInfo, globalSetupMethods),
                                                    methodInfo,

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -25,8 +25,11 @@ namespace BenchmarkDotNet.Running
             var bindingFlags = BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
             var benchmarkMethods = type
                 .GetMethods(bindingFlags)
-                .Where(method => method.HasAttribute<BenchmarkAttribute>())
-                .OrderBy(method => method.ResolveAttribute<BenchmarkAttribute>().SourceCodeLineNumber)
+                .Select(method => (method, attribute: method.ResolveAttribute<BenchmarkAttribute>()))
+                .Where(pair => pair.attribute is not null)
+                .OrderBy(pair => pair.attribute.SourceCodeFile)
+                .ThenBy(pair => pair.attribute.SourceCodeLineNumber)
+                .Select(pair => pair.method)
                 .ToArray();
 
             return MethodsToBenchmarksWithFullConfig(type, benchmarkMethods, config);

--- a/src/BenchmarkDotNet/Running/TypeFilter.cs
+++ b/src/BenchmarkDotNet/Running/TypeFilter.cs
@@ -9,9 +9,9 @@ using BenchmarkDotNet.Loggers;
 
 namespace BenchmarkDotNet.Running
 {
-    internal static class TypeFilter
+    public static class TypeFilter
     {
-        internal static (bool allTypesValid, IReadOnlyList<Type> runnable) GetTypesWithRunnableBenchmarks(IEnumerable<Type> types, IEnumerable<Assembly> assemblies, ILogger logger)
+        public static (bool allTypesValid, IReadOnlyList<Type> runnable) GetTypesWithRunnableBenchmarks(IEnumerable<Type> types, IEnumerable<Assembly> assemblies, ILogger logger)
         {
             var validRunnableTypes = new List<Type>();
 
@@ -37,7 +37,7 @@ namespace BenchmarkDotNet.Running
             return (true, validRunnableTypes);
         }
 
-        internal static BenchmarkRunInfo[] Filter(IConfig effectiveConfig, IEnumerable<Type> types)
+        public static BenchmarkRunInfo[] Filter(IConfig effectiveConfig, IEnumerable<Type> types)
             => types
                 .Select(type => BenchmarkConverter.TypeToBenchmarks(type, effectiveConfig))
                 .Where(info => info.BenchmarksCases.Any())

--- a/tests/BenchmarkDotNet.Tests/Running/BenchmarkConverterTests.BAC_Partial_DifferentFiles.cs
+++ b/tests/BenchmarkDotNet.Tests/Running/BenchmarkConverterTests.BAC_Partial_DifferentFiles.cs
@@ -1,0 +1,12 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace BenchmarkDotNet.Tests.Running
+{
+    public partial class BenchmarkConverterTests
+    {
+        public partial class BAC_Partial_DifferentFiles
+        {
+            [Benchmark] public void B() { }
+        }
+    }
+}


### PR DESCRIPTION
The story behind this fix is quite long.

In the dotnet/performance repo we have a single type that allows for partitioning benchmarks. The idea is quite simple: it's a filter that takes partition index and count and performs modulo operation to check whether current benchmark belongs to given partition (and should be executed).

Entire [logic](https://github.com/dotnet/performance/blob/main/src/harness/BenchmarkDotNet.Extensions/PartitionFilter.cs#L25):

```cs
public bool Predicate(BenchmarkCase benchmarkCase)
    => _counter++ % _partitionsCount == _partitionIndex; // will return true only for benchmarks that belong to it’s partition
```

Some time ago @DrewScoggins has realized that some of the benchmarks in our Reporting System seem to be missing data from time to time. In the example below you can see no new uploads since december:

![image](https://user-images.githubusercontent.com/6011991/152042136-5b95c911-d2d0-4476-bc07-4d72ea79f437.png)


I believe that it's most likely caused by lack of deterministic order in the reflection APIs (https://github.com/dotnet/runtime/issues/46272). There is no guarantee that the value of `_counter` will be the same for the same benchmark if we compile and run exactly the same source code multiple times. 

Example: let's say that we have 4 benchmarks: A, B, C and D.
Usually they are provided to the filter (which uses their index for filtering) as A, B, C, D.
But sometimes they are ordered as A, B, D, C.

So if we have 2 partitions, and run the process with:
--partition-count 2 --partition-index 0: for **A**B**C**D it decides to run benchmark A and C
--partition-count 2 --partition-index 1: for A**B**D**C** it decides to run benchmark B and C.

As you can see, benchmark D was never executed because the index changed between two runs of exactly same code.

The types are already sorted by name:

https://github.com/dotnet/BenchmarkDotNet/blob/c3fb7b9724a62048d27ef5bcaec616117d68b934/src/BenchmarkDotNet/Extensions/ReflectionExtensions.cs#L132-L138

But we can't sort the methods by names as our users are used to the fact that BDN by default runs the benchmarks in the declaration order.

My proposal is to include the source code line provided by the compiler in the `[BenchmarkAttribute]` and just use the value for ordering.

I have not added any tests as it's super hard to repro this bug.
I am aware of the fact that the partition filter referenced above is fragile.