### PR TITLE
Make FromUrl and FromSource more friendly

### DIFF
--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -19,7 +19,7 @@ namespace BenchmarkDotNet.Running
         public static BenchmarkRunInfo TypeToBenchmarks(Type type, IConfig config = null)
         {
             if (type.IsGenericTypeDefinition)
-                throw new ArgumentException($"{type.Name} is generic type definition, use BenchmarkSwitcher for it"); // for "open generic types" should be used BenchmarkSwitcher
+                throw new InvalidBenchmarkDeclarationException($"{type.Name} is generic type definition, use BenchmarkSwitcher for it"); // for "open generic types" should be used BenchmarkSwitcher
 
             // We should check all methods including private to notify users about private methods with the [Benchmark] attribute
             var bindingFlags = BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs
@@ -65,6 +65,9 @@ namespace BenchmarkDotNet.Running
                 return RunWithExceptionHandling(() => RunWithDirtyAssemblyResolveHelper(benchmarkRunInfos));
         }
 
+        /// <summary>
+        /// Supported only on Full .NET Framework. Not recommended.
+        /// </summary>
         [PublicAPI]
         public static Summary RunUrl(string url, IConfig config = null)
         {
@@ -72,6 +75,9 @@ namespace BenchmarkDotNet.Running
                 return RunWithExceptionHandling(() => RunUrlWithDirtyAssemblyResolveHelper(url, config));
         }
 
+        /// <summary>
+        /// Supported only on Full .NET Framework. Not recommended.
+        /// </summary>
         [PublicAPI]
         public static Summary RunSource(string source, IConfig config = null)
         {
@@ -110,13 +116,13 @@ namespace BenchmarkDotNet.Running
         private static Summary RunUrlWithDirtyAssemblyResolveHelper(string url, IConfig config = null)
             => RuntimeInformation.IsFullFramework
                 ? BenchmarkRunnerClean.Run(BenchmarkConverter.UrlToBenchmarks(url, config)).Single()
-                : throw new NotSupportedException("Supported only on Full .NET Framework");
+                : throw new InvalidBenchmarkDeclarationException("Supported only on Full .NET Framework");
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Summary RunSourceWithDirtyAssemblyResolveHelper(string source, IConfig config = null)
             => RuntimeInformation.IsFullFramework
                 ? BenchmarkRunnerClean.Run(BenchmarkConverter.SourceToBenchmarks(source, config)).Single()
-                : throw new NotSupportedException("Supported only on Full .NET Framework");
+                : throw new InvalidBenchmarkDeclarationException("Supported only on Full .NET Framework");
 
         private static Summary RunWithExceptionHandling(Func<Summary> run)
         {

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -69,6 +70,7 @@ namespace BenchmarkDotNet.Running
         /// Supported only on Full .NET Framework. Not recommended.
         /// </summary>
         [PublicAPI]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static Summary RunUrl(string url, IConfig config = null)
         {
             using (DirtyAssemblyResolveHelper.Create())
@@ -79,6 +81,7 @@ namespace BenchmarkDotNet.Running
         /// Supported only on Full .NET Framework. Not recommended.
         /// </summary>
         [PublicAPI]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static Summary RunSource(string source, IConfig config = null)
         {
             using (DirtyAssemblyResolveHelper.Create())

--- a/src/BenchmarkDotNet/Running/ClassicBenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/ClassicBenchmarkConverter.cs
@@ -7,6 +7,7 @@ using System.Net;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Portability;
 using Microsoft.CSharp;
 
 namespace BenchmarkDotNet.Running
@@ -15,6 +16,9 @@ namespace BenchmarkDotNet.Running
     {
         public static BenchmarkRunInfo[] UrlToBenchmarks(string url, IConfig config = null)
         {
+            if (!RuntimeInformation.IsFullFramework)
+                throw new NotSupportedException("Supported only on Full .NET Framework.");
+
             var logger = HostEnvironmentInfo.FallbackLogger;
 
             url = GetRawUrl(url);
@@ -49,6 +53,9 @@ namespace BenchmarkDotNet.Running
 
         public static BenchmarkRunInfo[] SourceToBenchmarks(string source, IConfig config = null)
         {
+            if (!RuntimeInformation.IsFullFramework)
+                throw new NotSupportedException("Supported only on Full .NET Framework.");
+
             string benchmarkContent = source;
             CompilerResults compilerResults;
             using (var cSharpCodeProvider = new CSharpCodeProvider()) {


### PR DESCRIPTION
### 1st commit
Change unhandled exception with message exception.
Add Unsupported checking directly to the methods, because It fails in .NET core (and they are public).

### 2nd commit
Hide it from IntelliSense cuz it not working and not recommended. Feel free to drop the commit if it isn't desired.

### 3rd commit
Change unhandled exception with message-exception for the case:
```C#
BenchmarkRunner.Run(typeof(GenericBenchmarkType<>));
````

#1908