### PR TITLE
[WASM] Fix rename of main.js to test-main.js

### DIFF
--- a/docs/articles/guides/console-args.md
+++ b/docs/articles/guides/console-args.md
@@ -222,6 +222,6 @@ dotnet run -c Release -- --filter * --runtimes netcoreapp2.0 netcoreapp2.1 --sta
 * `--runOncePerIteration` run the benchmark exactly once per iteration.
 * `--buildTimeout` build timeout in seconds.
 * `--wasmEngine` full path to a java script engine used to run the benchmarks, used by Wasm toolchain.
-* `--wasmMainJS` path to the main.js file used by Wasm toolchain. Mandatory when using \"--runtimes wasm\"
+* `--wasmMainJS` path to the test-main.js file used by Wasm toolchain. Mandatory when using \"--runtimes wasm\"
 * `--expose_wasm` arguments for the JavaScript engine used by Wasm toolchain.
 * `--customRuntimePack` specify the path to a custom runtime pack. Only used for wasm currently.

--- a/src/BenchmarkDotNet/Templates/WasmAotCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmAotCsProj.txt
@@ -13,7 +13,7 @@
     <PublishTrimmed>true</PublishTrimmed>
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
     <RunAOTCompilation>true</RunAOTCompilation>
-    <WasmMainJSPath>$(RuntimeSrcDir)\src\mono\wasm\test-main.js</WasmMainJSPath>
+    <WasmMainJSPath>$(RuntimeSrcDir)\src\mono\wasm\$MAINJS$</WasmMainJSPath>
     <WasmGenerateRunV8Script>true</WasmGenerateRunV8Script>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     <WasmNativeWorkload>false</WasmNativeWorkload>

--- a/src/BenchmarkDotNet/Templates/WasmCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmCsProj.txt
@@ -12,7 +12,7 @@
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
     <PublishTrimmed>false</PublishTrimmed>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <WasmMainJSPath>$(RuntimeSrcDir)\src\mono\wasm\test-main.js</WasmMainJSPath>
+    <WasmMainJSPath>$(RuntimeSrcDir)\src\mono\wasm\$MAINJS$/WasmMainJSPath>
     <WasmGenerateRunV8Script>true</WasmGenerateRunV8Script>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     <WasmNativeWorkload>false</WasmNativeWorkload>

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -117,7 +117,7 @@ namespace BenchmarkDotNet.Toolchains
                     start.FileName = wasm.JavaScriptEngine;
                     start.RedirectStandardInput = false;
 
-                    string main_js = (runtime.RuntimeMoniker == RuntimeMoniker.WasmNet60 || runtime.RuntimeMoniker == RuntimeMoniker.WasmNet50)? "main.js" : "test-main.js";
+                    string main_js = runtime.RuntimeMoniker < RuntimeMoniker.WasmNet70 ? "main.js" : "test-main.js";
 
                     start.Arguments = $"{wasm.JavaScriptEngineArguments} {main_js} -- --run {artifactsPaths.ProgramName}.dll {args} ";
                     start.WorkingDirectory = artifactsPaths.BinariesDirectoryPath;

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -116,7 +116,7 @@ namespace BenchmarkDotNet.Toolchains
                 case WasmRuntime wasm:
                     start.FileName = wasm.JavaScriptEngine;
                     start.RedirectStandardInput = false;
-                    start.Arguments = $"{wasm.JavaScriptEngineArguments} main.js -- --run {artifactsPaths.ProgramName}.dll {args} ";
+                    start.Arguments = $"{wasm.JavaScriptEngineArguments} test-main.js -- --run {artifactsPaths.ProgramName}.dll {args} ";
                     start.WorkingDirectory = artifactsPaths.BinariesDirectoryPath;
                     break;
                 case MonoAotLLVMRuntime _:

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -116,7 +116,10 @@ namespace BenchmarkDotNet.Toolchains
                 case WasmRuntime wasm:
                     start.FileName = wasm.JavaScriptEngine;
                     start.RedirectStandardInput = false;
-                    start.Arguments = $"{wasm.JavaScriptEngineArguments} test-main.js -- --run {artifactsPaths.ProgramName}.dll {args} ";
+
+                    string main_js = (runtime.RuntimeMoniker == RuntimeMoniker.WasmNet60 || runtime.RuntimeMoniker == RuntimeMoniker.WasmNet50)? "main.js" : "test-main.js";
+
+                    start.Arguments = $"{wasm.JavaScriptEngineArguments} {main_js} -- --run {artifactsPaths.ProgramName}.dll {args} ";
                     start.WorkingDirectory = artifactsPaths.BinariesDirectoryPath;
                     break;
                 case MonoAotLLVMRuntime _:

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -13,12 +13,14 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
     {
         private readonly string CustomRuntimePack;
         private readonly bool Aot;
+        private readonly string MainJS;
 
         public WasmGenerator(string targetFrameworkMoniker, string cliPath, string packagesPath, string customRuntimePack, bool aot)
             : base(targetFrameworkMoniker, cliPath, packagesPath, runtimeFrameworkVersion: null)
         {
             Aot = aot;
             CustomRuntimePack = customRuntimePack;
+            MainJS = (targetFrameworkMoniker == "net5.0" || targetFrameworkMoniker == "net6.0") ? "main.js" : "test-main.js";
         }
 
         protected override void GenerateProject(BuildPartition buildPartition, ArtifactsPaths artifactsPaths, ILogger logger)
@@ -56,6 +58,7 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
                     .Replace("$COPIEDSETTINGS$", customProperties)
                     .Replace("$CONFIGURATIONNAME$", buildPartition.BuildConfiguration)
                     .Replace("$SDKNAME$", sdkName)
+                    .Replace("$MAINJS$", MainJS)
                     .ToString();
 
                 File.WriteAllText(artifactsPaths.ProjectFilePath, content);
@@ -84,6 +87,7 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
                     .Replace("$CONFIGURATIONNAME$", buildPartition.BuildConfiguration)
                     .Replace("$SDKNAME$", sdkName)
                     .Replace("$RUNTIMEPACK$", CustomRuntimePack ?? "")
+                    .Replace("$MAINJS$", MainJS)
                     .Replace("$TARGET$", CustomRuntimePack != null ? "PublishWithCustomRuntimePack" : "Publish")
                 .ToString();
 
@@ -91,7 +95,7 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
             }
         }
 
-        protected override string GetExecutablePath(string binariesDirectoryPath, string programName) => Path.Combine(binariesDirectoryPath, "test-main.js");
+        protected override string GetExecutablePath(string binariesDirectoryPath, string programName) => Path.Combine(binariesDirectoryPath, MainJS);
 
         protected override string GetBinariesDirectoryPath(string buildArtifactsDirectoryPath, string configuration)
         {

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -91,7 +91,7 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
             }
         }
 
-        protected override string GetExecutablePath(string binariesDirectoryPath, string programName) => Path.Combine(binariesDirectoryPath, "main.js");
+        protected override string GetExecutablePath(string binariesDirectoryPath, string programName) => Path.Combine(binariesDirectoryPath, "test-main.js");
 
         protected override string GetBinariesDirectoryPath(string buildArtifactsDirectoryPath, string configuration)
         {


### PR DESCRIPTION
This file generated by wasm apps changed names; this fix makes bdn  use the new name.

Fixes: https://github.com/dotnet/runtime/issues/64553