### PR TITLE
Don't run Analyzers for the generated project + Roslyn workaround

### DIFF
--- a/src/BenchmarkDotNet/Templates/CsProj.txt
+++ b/src/BenchmarkDotNet/Templates/CsProj.txt
@@ -11,8 +11,9 @@
     <OutputType>Exe</OutputType>
     <OutputPath>bin\$CONFIGURATIONNAME$</OutputPath>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
-    <DebugType>pdbonly</DebugType>
-    <DebugSymbols>true</DebugSymbols>
+    <!-- nice to have for EtwProfiler, but not mandatory. On x86 and ARM disabled due to bug in Roslyn. -->
+    <DebugType Condition=" '$(PlatformTarget)' != 'x86' And '$(PlatformTarget)' != 'ARM' ">pdbonly</DebugType>
+    <DebugSymbols Condition=" '$(PlatformTarget)' != 'x86' And '$(PlatformTarget)' != 'ARM' ">true</DebugSymbols>
     <UseSharedCompilation>false</UseSharedCompilation>
     <CodeAnalysisRuleSet></CodeAnalysisRuleSet>
     <RunAnalyzers>false</RunAnalyzers>

--- a/src/BenchmarkDotNet/Templates/CsProj.txt
+++ b/src/BenchmarkDotNet/Templates/CsProj.txt
@@ -15,6 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
     <UseSharedCompilation>false</UseSharedCompilation>
     <CodeAnalysisRuleSet></CodeAnalysisRuleSet>
+    <RunAnalyzers>false</RunAnalyzers>
     <Deterministic>true</Deterministic>
     <!-- needed for custom build configurations (only "Release" builds are optimized by default) -->
     <Optimize Condition=" '$(Configuration)' != 'Debug' ">true</Optimize>


### PR DESCRIPTION
https://github.com/dotnet/roslyn/issues/59240