### PR TITLE
Fix typo in WasmCsProj.txt

### DIFF
--- a/src/BenchmarkDotNet/Templates/WasmCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmCsProj.txt
@@ -12,7 +12,7 @@
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
     <PublishTrimmed>false</PublishTrimmed>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <WasmMainJSPath>$(RuntimeSrcDir)\src\mono\wasm\$MAINJS$/WasmMainJSPath>
+    <WasmMainJSPath>$(RuntimeSrcDir)\src\mono\wasm\$MAINJS$</WasmMainJSPath>
     <WasmGenerateRunV8Script>true</WasmGenerateRunV8Script>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     <WasmNativeWorkload>false</WasmNativeWorkload>


### PR DESCRIPTION
Get the wasm targets building again.

```BenchmarkDotNet.Autogenerated.csproj(21,5): error MSB4025: The project file could not be loaded. The 'WasmMainJSPath' start tag on line 15 position 6 does not match the end tag of 'PropertyGroup'. Line 21, position 5```