### PR TITLE
[wasm] Set the right runtime moniker

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -97,7 +97,8 @@ namespace BenchmarkDotNet.ConsoleArguments
                 settings.MaximumDisplayWidth = Math.Max(MinimumDisplayWidth, GetMaximumDisplayWidth());
             });
 
-        private static bool MonikerIsWasm (RuntimeMoniker moniker)
+        private static bool MonikerIsWasm(RuntimeMoniker moniker)
+
         {
             switch (moniker)
             {
@@ -130,7 +131,8 @@ namespace BenchmarkDotNet.ConsoleArguments
                 {
                      logger.WriteLineError($"The provided {nameof(options.AOTCompilerPath)} \"{ options.AOTCompilerPath }\" does NOT exist. It MUST be provided.");
                 }
-                else if (MonikerIsWasm (runtimeMoniker) && (options.RuntimeSrcDir == null || options.RuntimeSrcDir.IsNotNullButDoesNotExist()))
+                else if (MonikerIsWasm(runtimeMoniker) && (options.RuntimeSrcDir == null || options.RuntimeSrcDir.IsNotNullButDoesNotExist()))
+
                 {
                     logger.WriteLineError($"The provided {nameof(options.RuntimeSrcDir)} \"{options.RuntimeSrcDir}\" does NOT exist. It MUST be provided for wasm-aot.");
                     return false;

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -97,6 +97,20 @@ namespace BenchmarkDotNet.ConsoleArguments
                 settings.MaximumDisplayWidth = Math.Max(MinimumDisplayWidth, GetMaximumDisplayWidth());
             });
 
+        private static bool MonikerIsWasm (RuntimeMoniker moniker)
+        {
+            switch (moniker)
+            {
+                case RuntimeMoniker.Wasm:
+                case RuntimeMoniker.WasmNet50:
+                case RuntimeMoniker.WasmNet60:
+                case RuntimeMoniker.WasmNet70:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         private static bool Validate(CommandLineOptions options, ILogger logger)
         {
             if (!AvailableJobs.ContainsKey(options.BaseJob))
@@ -116,7 +130,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 {
                      logger.WriteLineError($"The provided {nameof(options.AOTCompilerPath)} \"{ options.AOTCompilerPath }\" does NOT exist. It MUST be provided.");
                 }
-                else if (runtimeMoniker == RuntimeMoniker.Wasm && (options.RuntimeSrcDir == null || options.RuntimeSrcDir.IsNotNullButDoesNotExist()))
+                else if (MonikerIsWasm (runtimeMoniker) && (options.RuntimeSrcDir == null || options.RuntimeSrcDir.IsNotNullButDoesNotExist()))
                 {
                     logger.WriteLineError($"The provided {nameof(options.RuntimeSrcDir)} \"{options.RuntimeSrcDir}\" does NOT exist. It MUST be provided for wasm-aot.");
                     return false;
@@ -386,13 +400,13 @@ namespace BenchmarkDotNet.ConsoleArguments
 
                     return baseJob.WithRuntime(runtime).WithToolchain(builder.ToToolchain());
                 case RuntimeMoniker.Wasm:
-                    return MakeWasmJob(baseJob, options, RuntimeInformation.IsNetCore ? CoreRuntime.GetCurrentVersion().MsBuildMoniker : "net5.0");
+                    return MakeWasmJob(baseJob, options, RuntimeInformation.IsNetCore ? CoreRuntime.GetCurrentVersion().MsBuildMoniker : "net5.0", runtimeMoniker);
                 case RuntimeMoniker.WasmNet50:
-                    return MakeWasmJob(baseJob, options, "net5.0");
+                    return MakeWasmJob(baseJob, options, "net5.0", runtimeMoniker);
                 case RuntimeMoniker.WasmNet60:
-                    return MakeWasmJob(baseJob, options, "net6.0");
+                    return MakeWasmJob(baseJob, options, "net6.0", runtimeMoniker);
                 case RuntimeMoniker.WasmNet70:
-                    return MakeWasmJob(baseJob, options, "net7.0");
+                    return MakeWasmJob(baseJob, options, "net7.0", runtimeMoniker);
                 case RuntimeMoniker.MonoAOTLLVM:
                     return MakeMonoAOTLLVMJob(baseJob, options, RuntimeInformation.IsNetCore ? CoreRuntime.GetCurrentVersion().MsBuildMoniker : "net6.0");
                 case RuntimeMoniker.MonoAOTLLVMNet60:
@@ -422,7 +436,7 @@ namespace BenchmarkDotNet.ConsoleArguments
             return baseJob.WithRuntime(monoAotLLVMRuntime).WithToolchain(toolChain);
         }
 
-        private static Job MakeWasmJob(Job baseJob, CommandLineOptions options, string msBuildMoniker)
+        private static Job MakeWasmJob(Job baseJob, CommandLineOptions options, string msBuildMoniker, RuntimeMoniker moniker)
         {
             bool wasmAot = options.AOTCompilerMode == MonoAotCompilerMode.wasm;
 
@@ -431,7 +445,8 @@ namespace BenchmarkDotNet.ConsoleArguments
                 javaScriptEngine: options.WasmJavascriptEngine?.FullName ?? "v8",
                 javaScriptEngineArguments: options.WasmJavaScriptEngineArguments,
                 aot: wasmAot,
-                runtimeSrcDir: options.RuntimeSrcDir);
+                runtimeSrcDir: options.RuntimeSrcDir,
+                moniker: moniker);
 
             var toolChain = WasmToolChain.From(new NetCoreAppSettings(
                 targetFrameworkMoniker: wasmRuntime.MsBuildMoniker,

--- a/src/BenchmarkDotNet/Environments/Runtimes/WasmRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/WasmRuntime.cs
@@ -27,7 +27,7 @@ namespace BenchmarkDotNet.Environments
         /// <param name="displayName">default: "Wasm"</param>
         /// <param name="aot">Specifies whether AOT or Interpreter (default) project should be generated.</param>
         /// <param name="runtimeSrcDir">The path to runtime source directory.</param>
-        public WasmRuntime(string msBuildMoniker = "net5.0", string displayName = "Wasm", string javaScriptEngine = "v8", string javaScriptEngineArguments = "--expose_wasm", bool aot = false, DirectoryInfo runtimeSrcDir = null) : base(RuntimeMoniker.Wasm, msBuildMoniker, displayName)
+        public WasmRuntime(string msBuildMoniker = "net5.0", string displayName = "Wasm", string javaScriptEngine = "v8", string javaScriptEngineArguments = "--expose_wasm", bool aot = false, DirectoryInfo runtimeSrcDir = null, RuntimeMoniker moniker = RuntimeMoniker.Wasm) : base(moniker, msBuildMoniker, displayName)
         {
             if (!string.IsNullOrEmpty(javaScriptEngine) && javaScriptEngine != "v8" && !File.Exists(javaScriptEngine))
                 throw new FileNotFoundException($"Provided {nameof(javaScriptEngine)} file: \"{javaScriptEngine}\" doest NOT exist");


### PR DESCRIPTION
Fix https://github.com/dotnet/performance/issues/2250

Commit 80f45cedc started using the runtime moniker to decide, which
main JS file to use. We use `test-main.js` in net7.0, while we were
using `main.js` in older versions.

To make that work, let set the right runtime moniker to `WasmRuntime`. So
that later in `Executor::ProcessStartInfo` we select the right file.