### PR TITLE
Fix optimization of action methods for coreclr

### DIFF
--- a/src/BenchmarkDotNet/Templates/BenchmarkType.txt
+++ b/src/BenchmarkDotNet/Templates/BenchmarkType.txt
@@ -113,6 +113,9 @@
 
         private BenchmarkDotNet.Engines.Consumer consumer = new BenchmarkDotNet.Engines.Consumer();
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -122,6 +125,9 @@
             }
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -131,6 +137,9 @@
             }
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -140,6 +149,9 @@
             }
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -163,6 +175,9 @@
 
 #elif RETURNS_NON_CONSUMABLE_STRUCT_$ID$
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -174,6 +189,9 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(result);
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -185,6 +203,9 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(result);
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -196,6 +217,9 @@
             NonGenericKeepAliveWithoutBoxing(result);
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -226,6 +250,9 @@
 
 #elif RETURNS_BYREF_$ID$
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -237,6 +264,9 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(value);
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -250,6 +280,9 @@
 
         private $WorkloadMethodReturnType$ workloadDefaultValueHolder = default($WorkloadMethodReturnType$);
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -260,7 +293,10 @@
             }
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(ref alias);
         }
-        
+
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -285,6 +321,9 @@
         }
 #elif RETURNS_BYREF_READONLY_$ID$
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -296,6 +335,9 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(value);
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -309,6 +351,9 @@
 
         private $WorkloadMethodReturnType$ workloadDefaultValueHolder = default($WorkloadMethodReturnType$);
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -319,7 +364,10 @@
             }
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxingReadonly(alias);
         }
-        
+
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -344,6 +392,9 @@
         }
 #elif RETURNS_VOID_$ID$
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -353,6 +404,9 @@
             }
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -362,6 +416,9 @@
             }
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -371,6 +428,9 @@
             }
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
+#endif
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$


### PR DESCRIPTION
Not sure this is sufficient to catch all the cases where these methods are generated, but this is the rough idea.

Fixes #1934