### PR TITLE
[wasm] Add a `--wasmDataDir` parameter

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -187,6 +187,9 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option("AOTCompilerMode", Required = false, Default = MonoAotCompilerMode.mini, HelpText = "Mono AOT compiler mode, either 'mini' or 'llvm'")]
         public MonoAotCompilerMode AOTCompilerMode { get; set; }
 
+        [Option("wasmDataDir", Required = false, HelpText = "Wasm data directory")]
+        public DirectoryInfo WasmDataDirectory { get; set; }
+
         internal bool UserProvidedFilters => Filters.Any() || AttributeNames.Any() || AllCategories.Any() || AnyCategories.Any();
 
         [Usage(ApplicationAlias = "")]

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -426,6 +426,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 javaScriptEngine: options.WasmJavascriptEngine?.FullName ?? "v8",
                 javaScriptEngineArguments: options.WasmJavaScriptEngineArguments,
                 aot: wasmAot,
+                wasmDataDir: options.WasmDataDirectory?.FullName,
                 moniker: moniker);
 
             var toolChain = WasmToolChain.From(new NetCoreAppSettings(

--- a/src/BenchmarkDotNet/Environments/Runtimes/WasmRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/WasmRuntime.cs
@@ -16,6 +16,8 @@ namespace BenchmarkDotNet.Environments
 
         public bool Aot { get;  }
 
+        public string WasmDataDir { get; }
+
         /// <summary>
         /// creates new instance of WasmRuntime
         /// </summary>
@@ -24,7 +26,8 @@ namespace BenchmarkDotNet.Environments
         /// <param name="msBuildMoniker">moniker, default: "net5.0"</param>
         /// <param name="displayName">default: "Wasm"</param>
         /// <param name="aot">Specifies whether AOT or Interpreter (default) project should be generated.</param>
-        public WasmRuntime(string msBuildMoniker = "net5.0", string displayName = "Wasm", string javaScriptEngine = "v8", string javaScriptEngineArguments = "--expose_wasm", bool aot = false, RuntimeMoniker moniker = RuntimeMoniker.Wasm) : base(moniker, msBuildMoniker, displayName)
+        /// <param name="wasmDataDir">Specifies a wasm data directory surfaced as $(WasmDataDir) for the project</param>
+        public WasmRuntime(string msBuildMoniker = "net5.0", string displayName = "Wasm", string javaScriptEngine = "v8", string javaScriptEngineArguments = "--expose_wasm", bool aot = false, string wasmDataDir = null, RuntimeMoniker moniker = RuntimeMoniker.Wasm) : base(moniker, msBuildMoniker, displayName)
         {
             if (!string.IsNullOrEmpty(javaScriptEngine) && javaScriptEngine != "v8" && !File.Exists(javaScriptEngine))
                 throw new FileNotFoundException($"Provided {nameof(javaScriptEngine)} file: \"{javaScriptEngine}\" doest NOT exist");
@@ -32,6 +35,7 @@ namespace BenchmarkDotNet.Environments
             JavaScriptEngine = javaScriptEngine;
             JavaScriptEngineArguments = javaScriptEngineArguments;
             Aot = aot;
+            WasmDataDir = wasmDataDir;
         }
 
         public override bool Equals(object obj)

--- a/src/BenchmarkDotNet/Templates/WasmCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmCsProj.txt
@@ -3,6 +3,8 @@
     <OriginalCSProjPath>$CSPROJPATH$</OriginalCSProjPath>
     <WasmPropsPath>$([System.IO.Path]::ChangeExtension('$(OriginalCSProjPath)', '.Wasm.props'))</WasmPropsPath>
     <WasmTargetsPath>$([System.IO.Path]::ChangeExtension('$(OriginalCSProjPath)', '.Wasm.targets'))</WasmTargetsPath>
+    <WasmDataDir>$WASMDATADIR$</WasmDataDir>
+    <WasmDataDir Condition="'$(WasmDataDir)' != ''">$([MSBuild]::NormalizeDirectory($(WasmDataDir)))</WasmDataDir>
   </PropertyGroup>
 
   <Import Project="$(WasmPropsPath)" Condition="Exists($(WasmPropsPath))" />

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -58,7 +58,7 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
                     .Replace("$COPIEDSETTINGS$", customProperties)
                     .Replace("$CONFIGURATIONNAME$", buildPartition.BuildConfiguration)
                     .Replace("$SDKNAME$", sdkName)
-                    .Replace("$MAINJS$", MainJS)
+                    .Replace("$WASMDATADIR$", runtime.WasmDataDir)
                     .Replace("$TARGET$", CustomRuntimePack != null ? "PublishWithCustomRuntimePack" : "Publish")
                 .ToString();
 


### PR DESCRIPTION
In an earlier commit, generated projects got support for importing
props/targets files from the benchmark projects. And that allows
customizing the build.

But there isn't a clean way to inject/add references to the build of the
project, like custom paths, or access to additional files, without
adding new command line parameters.

To solve that, `--wasmDataDir` param is added which is surfaced in the
generated project as the msbuild property - `$(WasmDataDir)`.

An example use case is to have the wasm js file added to this data dir,
and in the props file use:
`<WasmMainJSPath>$(WasmDataDir)test-main.js</WasmMainJSPath>`.