### PR TITLE
AsyncProcessOutputReader: Use ConcurrentQueue instead of ConcurrentStack

### DIFF
--- a/src/BenchmarkDotNet/Loggers/AsyncProcessOutputReader.cs
+++ b/src/BenchmarkDotNet/Loggers/AsyncProcessOutputReader.cs
@@ -10,7 +10,7 @@ namespace BenchmarkDotNet.Loggers
     internal class AsyncProcessOutputReader : IDisposable
     {
         private readonly Process process;
-        private readonly ConcurrentStack<string> output, error;
+        private readonly ConcurrentQueue<string> output, error;
 
         private long status;
 
@@ -22,8 +22,8 @@ namespace BenchmarkDotNet.Loggers
                 throw new NotSupportedException("set RedirectStandardError to true first");
 
             this.process = process;
-            output = new ConcurrentStack<string>();
-            error = new ConcurrentStack<string>();
+            output = new ConcurrentQueue<string>();
+            error = new ConcurrentQueue<string>();
             status = (long)Status.Created;
         }
 
@@ -89,13 +89,13 @@ namespace BenchmarkDotNet.Loggers
         private void ProcessOnOutputDataReceived(object sender, DataReceivedEventArgs e)
         {
             if (!string.IsNullOrEmpty(e.Data))
-                output.Push(e.Data);
+                output.Enqueue(e.Data);
         }
 
         private void ProcessOnErrorDataReceived(object sender, DataReceivedEventArgs e)
         {
             if (!string.IsNullOrEmpty(e.Data))
-                error.Push(e.Data);
+                error.Enqueue(e.Data);
         }
 
         private T ReturnIfStopped<T>(Func<T> getter)


### PR DESCRIPTION
Using a `ConcurrentStack<string>` and converting it to a string
results in the output being in reverse order.

Eg:
```
[2022/03/11 18:50:56][INFO]  Standard error:
[2022/03/11 18:50:56][INFO]  Time Elapsed 00:00:04.52
[2022/03/11 18:50:56][INFO]     1 Error(s)
[2022/03/11 18:50:56][INFO]     1 Warning(s)
[2022/03/11 18:50:56][INFO] /home/helixbot/work/C1620A35/p/dotnet-wasm/src/mono/wasm/build/WasmApp.targets(273,5): error : File MainJS='/home/helixbot/work/C1620A35/p/dotnet-wasm/src/mono/wasm/main.js' doesn't exist. [/home/helixbot/work/C1620A35/p/performance/artifacts/bin/MicroBenchmarks/Release/net6.0/bad71138-a579-43c9-adcb-c1124d577ac6/BenchmarkDotNet.Autogenerated.csproj]
[2022/03/11 18:50:56][INFO] CSC : warning CS8002: Referenced assembly 'MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null' does not have a strong name. [/home/helixbot/work/C1620A35/p/performance/artifacts/bin/MicroBenchmarks/Release/net6.0/bad71138-a579-43c9-adcb-c1124d577ac6/BenchmarkDotNet.Autogenerated.csproj]
```