### PR TITLE
Executor: Don't use Process.ExitCode, unless the process has exited

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
@@ -62,7 +62,12 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
             var buildResult = BuildNoRestore();
             if (!buildResult.IsSuccess) // if we fail to do the full build, we try with --no-dependencies
+            {
+                Logger.WriteLineInfo(buildResult.StandardOutput);
+                Logger.WriteLineInfo(buildResult.StandardError);
+                Logger.WriteLineInfo("Build failed. Trying with --no-dependencies");
                 buildResult = BuildNoRestoreNoDependencies();
+            }
 
             return buildResult.ToBuildResult(GenerateResult);
         }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
@@ -91,7 +91,12 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
             var buildResult = BuildNoRestore();
             if (!buildResult.IsSuccess) // if we fail to do the full build, we try with --no-dependencies
+            {
+                Logger.WriteLineInfo(buildResult.StandardOutput);
+                Logger.WriteLineInfo(buildResult.StandardError);
+                Logger.WriteLineInfo("Build failed. Trying with --no-dependencies");
                 buildResult = BuildNoRestoreNoDependencies();
+            }
 
             if (!buildResult.IsSuccess)
                 return BuildResult.Failure(GenerateResult, buildResult.AllInformation);

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
@@ -62,12 +62,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
             var buildResult = BuildNoRestore();
             if (!buildResult.IsSuccess) // if we fail to do the full build, we try with --no-dependencies
-            {
-                Logger.WriteLineInfo(buildResult.StandardOutput);
-                Logger.WriteLineInfo(buildResult.StandardError);
-                Logger.WriteLineInfo("Build failed. Trying with --no-dependencies");
                 buildResult = BuildNoRestoreNoDependencies();
-            }
 
             return buildResult.ToBuildResult(GenerateResult);
         }
@@ -91,12 +86,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
             var buildResult = BuildNoRestore();
             if (!buildResult.IsSuccess) // if we fail to do the full build, we try with --no-dependencies
-            {
-                Logger.WriteLineInfo(buildResult.StandardOutput);
-                Logger.WriteLineInfo(buildResult.StandardError);
-                Logger.WriteLineInfo("Build failed. Trying with --no-dependencies");
                 buildResult = BuildNoRestoreNoDependencies();
-            }
 
             if (!buildResult.IsSuccess)
                 return BuildResult.Failure(GenerateResult, buildResult.AllInformation);

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -81,7 +81,12 @@ namespace BenchmarkDotNet.Toolchains
             if (loggerWithDiagnoser.LinesWithResults.Any(line => line.Contains("BadImageFormatException")))
                 logger.WriteLineError("You are probably missing <PlatformTarget>AnyCPU</PlatformTarget> in your .csproj file.");
 
-            return new ExecuteResult(true, process.ExitCode, process.Id, loggerWithDiagnoser.LinesWithResults, loggerWithDiagnoser.LinesWithExtraOutput, launchIndex);
+            return new ExecuteResult(true,
+                process.HasExited ? process.ExitCode : null,
+                process.Id,
+                loggerWithDiagnoser.LinesWithResults,
+                loggerWithDiagnoser.LinesWithExtraOutput,
+                launchIndex);
         }
 
         private ProcessStartInfo CreateStartInfo(BenchmarkCase benchmarkCase, ArtifactsPaths artifactsPaths, string args, IResolver resolver)


### PR DESCRIPTION
Once the `AfterAll` signal is received, and the process doesn't exit within 2s, we try to kill the process tree with SIGTERM. But the process might not immediately quit, so trying to access `process.ExitCode` with the process still running throws an exception:

```
[2022/03/17 05:48:51][INFO] // AfterAll
[2022/03/17 05:48:53][INFO] // The benchmarking process did not quit on time, it's going to get force killed now.
[2022/03/17 05:48:53][INFO] Unhandled exception. System.InvalidOperationException: Process must exit before requested information can be determined.
[2022/03/17 05:48:53][INFO]    at System.Diagnostics.Process.EnsureState(State state)
[2022/03/17 05:48:53][INFO]    at BenchmarkDotNet.Toolchains.Executor.Execute(Process process, BenchmarkCase benchmarkCase, SynchronousProcessOutputLoggerWithDiagnoser loggerWithDiagnoser, ILogger logger, ConsoleExitHandler consoleExitHandler, Int32 launchIndex)
[2022/03/17 05:48:53][INFO]    at BenchmarkDotNet.Toolchains.Executor.Execute(BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, ILogger logger, ArtifactsPaths artifactsPaths, String args, IDiagnoser diagnoser, IResolver resolver, Int32 launchIndex)
[2022/03/17 05:48:53][INFO]    at BenchmarkDotNet.Toolchains.Executor.Execute(ExecuteParameters executeParameters)
[2022/03/17 05:48:53][INFO]    at BenchmarkDotNet.Running.BenchmarkRunnerClean.RunExecute(ILogger logger, BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, IToolchain toolchain, BuildResult buildResult, IResolver resolver, IDiagnoser diagnoser, Int32 launchIndex)
[2022/03/17 05:48:53][INFO]    at BenchmarkDotNet.Running.BenchmarkRunnerClean.Execute(ILogger logger, BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, IToolchain toolchain, BuildResult buildResult, IResolver resolver)
[2022/03/17 05:48:53][INFO]    at BenchmarkDotNet.Running.BenchmarkRunnerClean.RunCore(BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, ILogger logger, IResolver resolver, BuildResult buildResult)
[2022/03/17 05:48:53][INFO]    at BenchmarkDotNet.Running.BenchmarkRunnerClean.Run(BenchmarkRunInfo benchmarkRunInfo, Dictionary`2 buildResults, IResolver resolver, ILogger logger, List`1 artifactsToCleanup, String resultsFolderPath, String logFilePath, Int32 totalBenchmarkCount, StartedClock& runsChronometer, Int32& benchmarksToRunCount)
[2022/03/17 05:48:53][INFO]    at BenchmarkDotNet.Running.BenchmarkRunnerClean.Run(BenchmarkRunInfo[] benchmarkRunInfos)
[2022/03/17 05:48:53][INFO]    at BenchmarkDotNet.Running.BenchmarkSwitcher.RunWithDirtyAssemblyResolveHelper(String[] args, IConfig config, Boolean askUserForInput)
[2022/03/17 05:48:53][INFO]    at BenchmarkDotNet.Running.BenchmarkSwitcher.Run(String[] args, IConfig config)
[2022/03/17 05:48:53][INFO]    at MicroBenchmarks.Program.Main(String[] args) in /home/helixbot/work/A60608D9/p/performance/src/benchmarks/micro/Program.cs:line 42
```