### PR TITLE
DotNetCli*: Allow logging command output

### DIFF
--- a/src/BenchmarkDotNet/Loggers/AsyncProcessOutputReader.cs
+++ b/src/BenchmarkDotNet/Loggers/AsyncProcessOutputReader.cs
@@ -16,7 +16,7 @@ namespace BenchmarkDotNet.Loggers
         private bool logOutput;
         private ILogger logger;
 
-        internal AsyncProcessOutputReader(Process process, bool logOutput=false, ILogger logger=null)
+        internal AsyncProcessOutputReader(Process process, bool logOutput = false, ILogger logger = null)
         {
             if (!process.StartInfo.RedirectStandardOutput)
                 throw new NotSupportedException("set RedirectStandardOutput to true first");
@@ -98,7 +98,7 @@ namespace BenchmarkDotNet.Loggers
             {
                 output.Enqueue(e.Data);
                 if (logOutput)
-                    logger.WriteLineInfo(e.Data);
+                    logger.WriteLine(e.Data);
             }
         }
 
@@ -108,7 +108,7 @@ namespace BenchmarkDotNet.Loggers
             {
                 error.Enqueue(e.Data);
                 if (logOutput)
-                    logger.WriteLineInfo(e.Data);
+                    logger.WriteLineError(e.Data);
             }
         }
 

--- a/src/BenchmarkDotNet/Loggers/AsyncProcessOutputReader.cs
+++ b/src/BenchmarkDotNet/Loggers/AsyncProcessOutputReader.cs
@@ -13,18 +13,24 @@ namespace BenchmarkDotNet.Loggers
         private readonly ConcurrentQueue<string> output, error;
 
         private long status;
+        private bool logOutput;
+        private ILogger logger;
 
-        internal AsyncProcessOutputReader(Process process)
+        internal AsyncProcessOutputReader(Process process, bool logOutput=false, ILogger logger=null)
         {
             if (!process.StartInfo.RedirectStandardOutput)
                 throw new NotSupportedException("set RedirectStandardOutput to true first");
             if (!process.StartInfo.RedirectStandardError)
                 throw new NotSupportedException("set RedirectStandardError to true first");
+            if (logOutput && logger == null)
+                throw new ArgumentException($"{nameof(logger)} cannot be null when {nameof(logOutput)} is true");
 
             this.process = process;
             output = new ConcurrentQueue<string>();
             error = new ConcurrentQueue<string>();
             status = (long)Status.Created;
+            this.logOutput = logOutput;
+            this.logger = logger;
         }
 
         public void Dispose()
@@ -89,13 +95,21 @@ namespace BenchmarkDotNet.Loggers
         private void ProcessOnOutputDataReceived(object sender, DataReceivedEventArgs e)
         {
             if (!string.IsNullOrEmpty(e.Data))
+            {
                 output.Enqueue(e.Data);
+                if (logOutput)
+                    logger.WriteLineInfo(e.Data);
+            }
         }
 
         private void ProcessOnErrorDataReceived(object sender, DataReceivedEventArgs e)
         {
             if (!string.IsNullOrEmpty(e.Data))
+            {
                 error.Enqueue(e.Data);
+                if (logOutput)
+                    logger.WriteLineInfo(e.Data);
+            }
         }
 
         private T ReturnIfStopped<T>(Func<T> getter)

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
@@ -13,12 +13,14 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         private string TargetFrameworkMoniker { get; }
 
         private string CustomDotNetCliPath { get; }
+        private bool LogOutput { get; }
 
         [PublicAPI]
-        public DotNetCliBuilder(string targetFrameworkMoniker, string customDotNetCliPath = null)
+        public DotNetCliBuilder(string targetFrameworkMoniker, string customDotNetCliPath = null, bool logOutput = false)
         {
             TargetFrameworkMoniker = targetFrameworkMoniker;
             CustomDotNetCliPath = customDotNetCliPath;
+            LogOutput = logOutput;
         }
 
         public BuildResult Build(GenerateResult generateResult, BuildPartition buildPartition, ILogger logger)
@@ -29,7 +31,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                     logger,
                     buildPartition,
                     Array.Empty<EnvironmentVariable>(),
-                    buildPartition.Timeout)
+                    buildPartition.Timeout,
+                    logOutput: LogOutput)
                 .RestoreThenBuild();
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
@@ -28,8 +28,10 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
         [PublicAPI] public TimeSpan Timeout { get; }
 
+        [PublicAPI] public bool LogOutput { get; }
+
         public DotNetCliCommand(string cliPath, string arguments, GenerateResult generateResult, ILogger logger,
-            BuildPartition buildPartition, IReadOnlyList<EnvironmentVariable> environmentVariables, TimeSpan timeout)
+            BuildPartition buildPartition, IReadOnlyList<EnvironmentVariable> environmentVariables, TimeSpan timeout, bool logOutput = false)
         {
             CliPath = cliPath ?? DotNetCliCommandExecutor.DefaultDotNetCliPath.Value;
             Arguments = arguments;
@@ -38,10 +40,11 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             BuildPartition = buildPartition;
             EnvironmentVariables = environmentVariables;
             Timeout = timeout;
+            this.LogOutput = logOutput;
         }
 
         public DotNetCliCommand WithArguments(string arguments)
-            => new DotNetCliCommand(CliPath, arguments, GenerateResult, Logger, BuildPartition, EnvironmentVariables, Timeout);
+            => new (CliPath, arguments, GenerateResult, Logger, BuildPartition, EnvironmentVariables, Timeout, logOutput: LogOutput);
 
         [PublicAPI]
         public BuildResult RestoreThenBuild()

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
@@ -49,6 +49,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         [PublicAPI]
         public BuildResult RestoreThenBuild()
         {
+            DotNetCliCommandExecutor.LogEnvVars(WithArguments(null));
+
             var packagesResult = AddPackages();
             if (!packagesResult.IsSuccess)
                 return BuildResult.Failure(GenerateResult, packagesResult.AllInformation);
@@ -73,6 +75,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         [PublicAPI]
         public BuildResult RestoreThenBuildThenPublish()
         {
+            DotNetCliCommandExecutor.LogEnvVars(WithArguments(null));
+
             var packagesResult = AddPackages();
             if (!packagesResult.IsSuccess)
                 return BuildResult.Failure(GenerateResult, packagesResult.AllInformation);

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
@@ -40,7 +40,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             BuildPartition = buildPartition;
             EnvironmentVariables = environmentVariables;
             Timeout = timeout;
-            this.LogOutput = logOutput;
+            LogOutput = logOutput;
         }
 
         public DotNetCliCommand WithArguments(string arguments)

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
@@ -93,7 +93,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                 command.Logger.WriteLineInfo("// Environment Variables:");
                 foreach (string name in startInfo.EnvironmentVariables.Keys)
                 {
-                    command.Logger.WriteLine($"\t[{name}] = {startInfo.EnvironmentVariables[name]}");
+                    command.Logger.WriteLine($"\t[{name}] = \"{startInfo.EnvironmentVariables[name]}\"");
                 }
             }
         }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
@@ -30,13 +30,6 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
                 var stopwatch = Stopwatch.StartNew();
 
-                if (parameters.LogOutput && process.StartInfo.EnvironmentVariables.Keys.Count > 0)
-                {
-                    parameters.Logger.WriteLineInfo("Environment Variables:");
-                    foreach (string name in process.StartInfo.EnvironmentVariables.Keys)
-                        parameters.Logger.WriteLineInfo($"\t[{name}] = {process.StartInfo.EnvironmentVariables[name]}");
-                }
-
                 process.Start();
                 outputReader.BeginRead();
 
@@ -82,6 +75,26 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                 // first line contains something like ".NET Command Line Tools (1.0.0-beta-001603)"
                 return Regex.Split(output, Environment.NewLine, RegexOptions.Compiled)
                     .FirstOrDefault(line => !string.IsNullOrEmpty(line));
+            }
+        }
+
+        internal static void LogEnvVars(DotNetCliCommand command)
+        {
+            if (!command.LogOutput)
+            {
+                return;
+            }
+
+            ProcessStartInfo startInfo = BuildStartInfo(
+                command.CliPath, command.GenerateResult.ArtifactsPaths.BuildArtifactsDirectoryPath, command.Arguments, command.EnvironmentVariables);
+
+            if (startInfo.EnvironmentVariables.Keys.Count > 0)
+            {
+                command.Logger.WriteLineInfo("// Environment Variables:");
+                foreach (string name in startInfo.EnvironmentVariables.Keys)
+                {
+                    command.Logger.WriteLine($"\t[{name}] = {startInfo.EnvironmentVariables[name]}");
+                }
             }
         }
 

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmToolChain.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmToolChain.cs
@@ -41,7 +41,9 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
                         netCoreAppSettings.CustomRuntimePack,
                         netCoreAppSettings.AOTCompilerMode == MonoAotLLVM.MonoAotCompilerMode.wasm),
                     new DotNetCliBuilder(netCoreAppSettings.TargetFrameworkMoniker,
-                        netCoreAppSettings.CustomDotNetCliPath),
+                        netCoreAppSettings.CustomDotNetCliPath,
+                        // aot builds can be very slow
+                        logOutput: netCoreAppSettings.AOTCompilerMode == MonoAotLLVM.MonoAotCompilerMode.wasm),
                     new Executor(),
                     netCoreAppSettings.CustomDotNetCliPath);
     }


### PR DESCRIPTION
This is useful when building wasm/aot projects, which can take
10-20mins. Being able to see the progress helps, for example, with
diagnosing issues when the whole thing might timeout, or when running
locally.

This enables it by default for wasm/aot builds.