### PR TITLE
Specify output path for "dotnet publish"

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
@@ -160,6 +160,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                 .Append(extraArguments)
                 .Append(GetMandatoryMsBuildSettings(buildPartition.BuildConfiguration))
                 .Append(string.IsNullOrEmpty(artifactsPaths.PackagesDirectoryName) ? string.Empty : $" /p:NuGetPackageRoot=\"{artifactsPaths.PackagesDirectoryName}\"")
+                .Append($" --output \"{artifactsPaths.BinariesDirectoryPath}\"")
                 .ToString();
 
         private static string GetCustomMsBuildArguments(BenchmarkCase benchmarkCase, IResolver resolver)


### PR DESCRIPTION
Without this, when benchmarking CoreRT (like from https://github.com/dotnet/performance ) the publish directory ends up being inside of the bin directory of the host console app, and not the sub-directory bin directory of the generated project.

For example when the publish command is this (before this change): ```start dotnet publish -c Release /p:DebugType=portable -bl:benchmarkdotnet.binlog -r win-x64 --no-build --no-restore /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true in C:\Code\Local Spikes\performance\performance\artifacts\bin\MicroBenchmarks\Debug\net6.0\Job-PALSMU```

Then it will result in this: ```Executable C:\Code\Local Spikes\performance\performance\artifacts\bin\MicroBenchmarks\Debug\net6.0\Job-PALSMU\bin\Release\net6.0\win-x64\publish\Job-PALSMU.exe not found``` 

because the executable was actually published to ```C:\Code\Local Spikes\performance\performance\artifacts\bin\BenchmarkDotNet.Autogenerated\Release\net6.0\win-x64\publish```