### PR TITLE
add possibility to enable build output logging via command line args

### DIFF
--- a/docs/articles/guides/troubleshooting.md
+++ b/docs/articles/guides/troubleshooting.md
@@ -31,7 +31,7 @@ If the error message is not clear enough, you need to investigate it further.
 
 How to troubleshoot the build process:
 
-1. Run the benchmarks.
+1. Run the benchmarks with `--logBuildOutput` command line argument.
 2. Read the error message. If it does not contain the answer to your problem, please continue to the next step.
 3. Go to the build artifacts folder (path printed by BDN).
 4. The folder should contain: 

--- a/src/BenchmarkDotNet/Configs/ConfigOptions.cs
+++ b/src/BenchmarkDotNet/Configs/ConfigOptions.cs
@@ -32,7 +32,11 @@ namespace BenchmarkDotNet.Configs
         /// <summary>
         /// Determines if the log file should be disabled.
         /// </summary>
-        DisableLogFile = 1 << 5
+        DisableLogFile = 1 << 5,
+        /// <summary>
+        /// Determines whether build output should be logged.
+        /// </summary>
+        LogBuildOutput = 1 << 6
     }
 
     internal static class ConfigOptionsExtensions

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -151,6 +151,9 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option("disasmDiff", Required = false, Default = false, HelpText = "Generates diff reports for the disassembler.")]
         public bool DisassemblerDiff { get; set; }
 
+        [Option("logBuildOutput", Required = false, HelpText = "Log Build output.")]
+        public bool LogBuildOutput { get; set; }
+
         [Option("buildTimeout", Required = false, HelpText = "Build timeout in seconds.")]
         public int? TimeOutInSeconds { get; set; }
 

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -244,6 +244,7 @@ namespace BenchmarkDotNet.ConsoleArguments
             config.WithOption(ConfigOptions.DontOverwriteResults, options.DontOverwriteResults);
             config.WithOption(ConfigOptions.StopOnFirstError, options.StopOnFirstError);
             config.WithOption(ConfigOptions.DisableLogFile, options.DisableLogFile);
+            config.WithOption(ConfigOptions.LogBuildOutput, options.LogBuildOutput);
 
             if (options.MaxParameterColumnWidth.HasValue)
                 config.WithSummaryStyle(SummaryStyle.Default.WithMaxParameterColumnWidth(options.MaxParameterColumnWidth.Value));

--- a/src/BenchmarkDotNet/Running/BuildPartition.cs
+++ b/src/BenchmarkDotNet/Running/BuildPartition.cs
@@ -23,6 +23,7 @@ namespace BenchmarkDotNet.Running
             RepresentativeBenchmarkCase = benchmarks[0].BenchmarkCase;
             Benchmarks = benchmarks;
             ProgramName = benchmarks[0].Config.Options.IsSet(ConfigOptions.KeepBenchmarkFiles) ? RepresentativeBenchmarkCase.Job.FolderInfo : Guid.NewGuid().ToString();
+            LogBuildOutput = benchmarks[0].Config.Options.IsSet(ConfigOptions.LogBuildOutput);
         }
 
         public BenchmarkBuildInfo[] Benchmarks { get; }
@@ -65,6 +66,8 @@ namespace BenchmarkDotNet.Running
         public TimeSpan Timeout => IsCoreRT && RepresentativeBenchmarkCase.Config.BuildTimeout == DefaultConfig.Instance.BuildTimeout
             ? TimeSpan.FromMinutes(5) // downloading all CoreRT dependencies can take a LOT of time
             : RepresentativeBenchmarkCase.Config.BuildTimeout;
+
+        public bool LogBuildOutput { get; }
 
         public bool NoAcknowledgments
             => !Benchmarks

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
@@ -40,7 +40,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             BuildPartition = buildPartition;
             EnvironmentVariables = environmentVariables;
             Timeout = timeout;
-            LogOutput = logOutput;
+            LogOutput = logOutput || buildPartition.LogBuildOutput;
         }
 
         public DotNetCliCommand WithArguments(string arguments)

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -238,6 +238,7 @@ namespace BenchmarkDotNet.Tests
         [InlineData(ConfigOptions.DontOverwriteResults, "--noOverwrite")]
         [InlineData(ConfigOptions.StopOnFirstError, "--stopOnFirstError")]
         [InlineData(ConfigOptions.DisableLogFile, "--disableLogFile" )]
+        [InlineData(ConfigOptions.LogBuildOutput, "--logBuildOutput")]
         [InlineData(
             ConfigOptions.JoinSummary |
             ConfigOptions.KeepBenchmarkFiles |
@@ -253,6 +254,13 @@ namespace BenchmarkDotNet.Tests
             var config = ConfigParser.Parse(configOptionArgs, new OutputLogger(Output)).config;
             Assert.Equal(expectedConfigOption, config.Options);
             Assert.NotEqual(ConfigOptions.Default, config.Options);
+        }
+
+        [Fact]
+        public void WhenConfigOptionsFlagsAreNotSpecifiedTheyAreNotSet()
+        {
+            var config = ConfigParser.Parse(Array.Empty<string>(), new OutputLogger(Output)).config;
+            Assert.Equal(ConfigOptions.Default, config.Options);
         }
 
         [Fact]


### PR DESCRIPTION
In #1950 @radical has added the possibility to log build output to the console. This PR exposes this feature via `--logBuildOutput` command line arg.