### PR TITLE
Cleaning up argument spacing in CLI calls. Add output path for publish. CoreRT

### DIFF
--- a/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
@@ -129,6 +129,6 @@ namespace BenchmarkDotNet.Extensions
         /// <param name="argument">The argument to append to this string builder</param>
         /// <returns>The string builder with the arguments added</returns>
         internal static StringBuilder AppendArgument(this StringBuilder stringBuilder, object argument)
-            => argument ?? stringBuilder : AppendArgument(stringBuilder, argument.ToString());
+            => argument == null ? stringBuilder : AppendArgument(stringBuilder, argument.ToString());
     }
 }

--- a/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
@@ -103,5 +103,38 @@ namespace BenchmarkDotNet.Extensions
         {
             return path.Replace(directory, string.Empty).Trim('/', '\\');
         }
+
+        /// <summary>
+        /// Standardizes the whitespace before/after arguments so that all arguments are separated by a single space
+        /// </summary>
+        /// <param name="stringBuilder">The string builder that will hold the arguments</param>
+        /// <param name="argument">The argument to append to this string builder</param>
+        /// <returns>The string builder with the arguments added</returns>
+        internal static StringBuilder AppendArgument(this StringBuilder stringBuilder, string argument)
+        {
+            if (string.IsNullOrWhiteSpace(argument))
+            {
+                return stringBuilder;
+            }
+            argument = " " + argument.Trim();
+            stringBuilder.Append(argument);
+
+            return stringBuilder;
+        }
+
+        /// <summary>
+        /// Standardizes the whitespace before/after arguments so that all arguments are separated by a single space
+        /// </summary>
+        /// <param name="stringBuilder">The string builder that will hold the arguments</param>
+        /// <param name="argument">The argument to append to this string builder</param>
+        /// <returns>The string builder with the arguments added</returns>
+        internal static StringBuilder AppendArgument(this StringBuilder stringBuilder, object argument)
+        {
+            if (argument == null)
+            {
+                return stringBuilder;
+            }
+            return AppendArgument(stringBuilder, argument.ToString());
+        }
     }
 }

--- a/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
@@ -129,12 +129,6 @@ namespace BenchmarkDotNet.Extensions
         /// <param name="argument">The argument to append to this string builder</param>
         /// <returns>The string builder with the arguments added</returns>
         internal static StringBuilder AppendArgument(this StringBuilder stringBuilder, object argument)
-        {
-            if (argument == null)
-            {
-                return stringBuilder;
-            }
-            return AppendArgument(stringBuilder, argument.ToString());
-        }
+            => argument ?? stringBuilder : AppendArgument(stringBuilder, argument.ToString());
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
@@ -60,7 +60,7 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
 
         public static CoreRtToolchainBuilder CreateBuilder() => CoreRtToolchainBuilder.Create();
 
-        private static string GetExtraArguments(bool useCppCodeGenerator, string runtimeIdentifier)
+        public static string GetExtraArguments(bool useCppCodeGenerator, string runtimeIdentifier)
             => useCppCodeGenerator ? $"-r {runtimeIdentifier} /p:NativeCodeGen=cpp" : $"-r {runtimeIdentifier}";
 
         // https://github.com/dotnet/corert/blob/7f902d4d8b1c3280e60f5e06c71951a60da173fb/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md#compiling-source-to-native-code-using-the-ilcompiler-you-built

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/Generator.cs
@@ -66,12 +66,12 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
 
         protected override void GenerateBuildScript(BuildPartition buildPartition, ArtifactsPaths artifactsPaths)
         {
-            string extraArguments = useCppCodeGenerator ? $"-r {runtimeIdentifier} /p:NativeCodeGen=cpp" : $"-r {runtimeIdentifier}";
+            string extraArguments = CoreRtToolchain.GetExtraArguments(useCppCodeGenerator, runtimeIdentifier);
 
             var content = new StringBuilder(300)
-                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetRestoreCommand(artifactsPaths, buildPartition)} {extraArguments}")
-                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetBuildCommand(artifactsPaths, buildPartition)} {extraArguments}")
-                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetPublishCommand(artifactsPaths, buildPartition)} {extraArguments}")
+                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetRestoreCommand(artifactsPaths, buildPartition, extraArguments)}")
+                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetBuildCommand(artifactsPaths, buildPartition, extraArguments)}")
+                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetPublishCommand(artifactsPaths, buildPartition, extraArguments)}")
                 .ToString();
 
             File.WriteAllText(artifactsPaths.BuildScriptFilePath, content);

--- a/tests/BenchmarkDotNet.Tests/StringExtensionsTests.cs
+++ b/tests/BenchmarkDotNet.Tests/StringExtensionsTests.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Text;
 using BenchmarkDotNet.Extensions;
 using Xunit;
 
@@ -28,6 +30,41 @@ namespace BenchmarkDotNet.Tests
             string html = "<'>\"&shouldntchange";
 
             Assert.Equal(expectedHtml, html.HtmlEncode());
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData(" ", "")]
+        [InlineData("-n win-x64", " -n win-x64")]
+        [InlineData(" -n win-x64", " -n win-x64")]
+        [InlineData("-n win-x64 ", " -n win-x64")]
+        [InlineData(" -n Win-x64 ", " -n Win-x64")]
+        [InlineData(" a ", " a")]
+        [InlineData("        a        ", " a")]
+        [InlineData("   \r\n  a   \r\n", " a")]
+        public void AppendArgumentMakesSureOneSpaceBeforeStringArgument(string input, string expectedOutput)
+        {
+            var stringBuilder = new StringBuilder();
+            var result = stringBuilder.AppendArgument(input).ToString();
+
+            Assert.Equal(expectedOutput, result);
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("http://test.com/", " http://test.com/")]
+        [InlineData(" http://test.com/", " http://test.com/")]
+        [InlineData("http://test.com/ ", " http://test.com/")]
+        [InlineData(" http://test.com/ ", " http://test.com/")]
+        [InlineData("\r\n  http://test.com/  \r\n", " http://test.com/")]
+        public void AppendArgumentMakesSureOneSpaceBeforeObjectArgument(string input, string expectedOutput)
+        {
+            Uri uri = input != null ? new Uri(input) : null; // Use Uri for our object type since that is what is used in code
+            var stringBuilder = new StringBuilder();
+            var result = stringBuilder.AppendArgument(uri).ToString();
+
+            Assert.Equal(expectedOutput, result);
         }
     }
 }


### PR DESCRIPTION
Previous discussion here: https://github.com/dotnet/BenchmarkDotNet/pull/1951 (and https://github.com/dotnet/BenchmarkDotNet/pull/1952)

This was tested locally by manually pointing dotnet/performance to this code and running a CoreRT benchmark against it. 

This fixes 2 different issues:
1. The architecture flag "-r" didn't have a leading space and therefore was combine with the string in front of it, causing it not to be passed to the dotnet restore/build/publish commands. Would look like this: `dotnet restore /p:DebugType=portable -bl:benchmarkdotnet.binlog-r win-x64 /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true and dotnet fails to restore/build/publish`

2. The output directory of CoreRT publishes wasn't specified and if running the test project inside another project seemed to output to the first bin directory found from the root of the drive.

### Output path
When benchmarking CoreRT (like from https://github.com/dotnet/performance ) the publish directory ends up being inside of the bin directory of the host console app, and not the sub-directory bin directory of the generated project.

For example when the publish command is this (before this change): start dotnet publish -c Release /p:DebugType=portable -bl:benchmarkdotnet.binlog -r win-x64 --no-build --no-restore /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true in C:\Code\Local Spikes\performance\performance\artifacts\bin\MicroBenchmarks\Debug\net6.0\Job-PALSMU

Then it will result in this: Executable C:\Code\Local Spikes\performance\performance\artifacts\bin\MicroBenchmarks\Debug\net6.0\Job-PALSMU\bin\Release\net6.0\win-x64\publish\Job-PALSMU.exe not found

because the executable was actually published to C:\Code\Local Spikes\performance\performance\artifacts\bin\BenchmarkDotNet.Autogenerated\Release\net6.0\win-x64\publish
