### PR TITLE
fix broken pipe issue

### DIFF
--- a/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
+++ b/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs
@@ -15,11 +15,12 @@ namespace BenchmarkDotNet.Loggers
         private readonly IDiagnoser diagnoser;
         private readonly DiagnoserActionParameters diagnoserActionParameters;
 
-        public SynchronousProcessOutputLoggerWithDiagnoser(ILogger logger, Process process, IDiagnoser diagnoser, BenchmarkCase benchmarkCase, BenchmarkId benchmarkId)
+        public SynchronousProcessOutputLoggerWithDiagnoser(ILogger logger, Process process, IDiagnoser diagnoser,
+            BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, bool noAcknowledgments)
         {
             if (!process.StartInfo.RedirectStandardOutput)
                 throw new NotSupportedException("set RedirectStandardOutput to true first");
-            if (!(process.StartInfo.RedirectStandardInput || benchmarkCase.GetRuntime() is WasmRuntime))
+            if (!(process.StartInfo.RedirectStandardInput || benchmarkCase.GetRuntime() is WasmRuntime || noAcknowledgments))
                 throw new NotSupportedException("set RedirectStandardInput to true first");
 
             this.logger = logger;

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
@@ -43,7 +43,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                     executeParameters.Diagnoser,
                     Path.GetFileName(executeParameters.BuildResult.ArtifactsPaths.ExecutablePath),
                     executeParameters.Resolver,
-                    executeParameters.LaunchIndex);
+                    executeParameters.LaunchIndex,
+                    executeParameters.BuildResult.NoAcknowledgments);
             }
             finally
             {
@@ -60,13 +61,14 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                                       IDiagnoser diagnoser,
                                       string executableName,
                                       IResolver resolver,
-                                      int launchIndex)
+                                      int launchIndex,
+                                      bool noAcknowledgments)
         {
             var startInfo = DotNetCliCommandExecutor.BuildStartInfo(
                 CustomDotNetCliPath,
                 artifactsPaths.BinariesDirectoryPath,
                 $"{executableName.Escape()} {benchmarkId.ToArguments()}",
-                redirectStandardInput: true,
+                redirectStandardInput: !noAcknowledgments,
                 redirectStandardError: false); // #1629
 
             startInfo.SetEnvironmentVariables(benchmarkCase, resolver);
@@ -74,7 +76,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             using (var process = new Process { StartInfo = startInfo })
             using (var consoleExitHandler = new ConsoleExitHandler(process, logger))
             {
-                var loggerWithDiagnoser = new SynchronousProcessOutputLoggerWithDiagnoser(logger, process, diagnoser, benchmarkCase, benchmarkId);
+                var loggerWithDiagnoser = new SynchronousProcessOutputLoggerWithDiagnoser(logger, process, diagnoser, benchmarkCase, benchmarkId, noAcknowledgments);
 
                 logger.WriteLineInfo($"// Execute: {process.StartInfo.FileName} {process.StartInfo.Arguments} in {process.StartInfo.WorkingDirectory}");
 

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -32,18 +32,18 @@ namespace BenchmarkDotNet.Toolchains
             }
 
             return Execute(executeParameters.BenchmarkCase, executeParameters.BenchmarkId, executeParameters.Logger, executeParameters.BuildResult.ArtifactsPaths,
-                args, executeParameters.Diagnoser, executeParameters.Resolver, executeParameters.LaunchIndex);
+                args, executeParameters.Diagnoser, executeParameters.Resolver, executeParameters.LaunchIndex, executeParameters.BuildResult.NoAcknowledgments);
         }
 
         private ExecuteResult Execute(BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, ILogger logger, ArtifactsPaths artifactsPaths,
-            string args, IDiagnoser diagnoser, IResolver resolver, int launchIndex)
+            string args, IDiagnoser diagnoser, IResolver resolver, int launchIndex, bool noAcknowledgments)
         {
             try
             {
-                using (var process = new Process { StartInfo = CreateStartInfo(benchmarkCase, artifactsPaths, args, resolver) })
+                using (var process = new Process { StartInfo = CreateStartInfo(benchmarkCase, artifactsPaths, args, resolver, noAcknowledgments) })
                 using (var consoleExitHandler = new ConsoleExitHandler(process, logger))
                 {
-                    var loggerWithDiagnoser = new SynchronousProcessOutputLoggerWithDiagnoser(logger, process, diagnoser, benchmarkCase, benchmarkId);
+                    var loggerWithDiagnoser = new SynchronousProcessOutputLoggerWithDiagnoser(logger, process, diagnoser, benchmarkCase, benchmarkId, noAcknowledgments);
 
                     diagnoser?.Handle(HostSignal.BeforeProcessStart, new DiagnoserActionParameters(process, benchmarkCase, benchmarkId));
 
@@ -89,13 +89,14 @@ namespace BenchmarkDotNet.Toolchains
                 launchIndex);
         }
 
-        private ProcessStartInfo CreateStartInfo(BenchmarkCase benchmarkCase, ArtifactsPaths artifactsPaths, string args, IResolver resolver)
+        private ProcessStartInfo CreateStartInfo(BenchmarkCase benchmarkCase, ArtifactsPaths artifactsPaths,
+            string args, IResolver resolver, bool noAcknowledgments)
         {
             var start = new ProcessStartInfo
             {
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
-                RedirectStandardInput = true,
+                RedirectStandardInput = !noAcknowledgments,
                 RedirectStandardError = false, // #1629
                 CreateNoWindow = true,
                 StandardOutputEncoding = Encoding.UTF8, // #1713

--- a/src/BenchmarkDotNet/Toolchains/GeneratorBase.cs
+++ b/src/BenchmarkDotNet/Toolchains/GeneratorBase.cs
@@ -29,7 +29,7 @@ namespace BenchmarkDotNet.Toolchains
                 GenerateProject(buildPartition, artifactsPaths, logger);
                 GenerateBuildScript(buildPartition, artifactsPaths);
 
-                return GenerateResult.Success(artifactsPaths, GetArtifactsToCleanup(artifactsPaths));
+                return GenerateResult.Success(artifactsPaths, GetArtifactsToCleanup(artifactsPaths), buildPartition.NoAcknowledgments);
             }
             catch (Exception ex)
             {

--- a/src/BenchmarkDotNet/Toolchains/InProcess.Emit/InProcessEmitBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.Emit/InProcessEmitBuilder.cs
@@ -29,7 +29,8 @@ namespace BenchmarkDotNet.Toolchains.InProcess.Emit
             return BuildResult.Success(
                 GenerateResult.Success(
                     new InProcessEmitArtifactsPath(assembly, generateResult.ArtifactsPaths),
-                    generateResult.ArtifactsToCleanup));
+                    generateResult.ArtifactsToCleanup,
+                    generateResult.NoAcknowledgments));
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/InProcess.Emit/InProcessEmitGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.Emit/InProcessEmitGenerator.cs
@@ -20,7 +20,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess.Emit
             {
                 artifactsPaths = GetArtifactsPaths(buildPartition, rootArtifactsFolderPath);
 
-                return GenerateResult.Success(artifactsPaths, new List<string>());
+                return GenerateResult.Success(artifactsPaths, new List<string>(), buildPartition.NoAcknowledgments);
             }
             catch (Exception ex)
             {

--- a/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitGenerator.cs
@@ -13,6 +13,6 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
     {
         /// <summary>returns a success</summary>
         public GenerateResult GenerateProject(BuildPartition buildPartition, ILogger logger, string rootArtifactsFolderPath)
-            => GenerateResult.Success(null, Array.Empty<string>());
+            => GenerateResult.Success(null, Array.Empty<string>(), buildPartition.NoAcknowledgments);
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/InProcess/InProcessGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/InProcessGenerator.cs
@@ -13,6 +13,6 @@ namespace BenchmarkDotNet.Toolchains.InProcess
     {
         /// <summary>returns a success</summary>
         public GenerateResult GenerateProject(BuildPartition buildPartition, ILogger logger, string rootArtifactsFolderPath)
-            => GenerateResult.Success(null, Array.Empty<string>());
+            => GenerateResult.Success(null, Array.Empty<string>(), buildPartition.NoAcknowledgments);
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/Results/BuildResult.cs
+++ b/src/BenchmarkDotNet/Toolchains/Results/BuildResult.cs
@@ -11,7 +11,7 @@ namespace BenchmarkDotNet.Toolchains.Results
         public string ErrorMessage { get; }
 
         private BuildResult(GenerateResult generateResult, bool isBuildSuccess, string errorMessage)
-            : base(generateResult.ArtifactsPaths, generateResult.IsGenerateSuccess, generateResult.GenerateException, generateResult.ArtifactsToCleanup)
+            : base(generateResult.ArtifactsPaths, generateResult.IsGenerateSuccess, generateResult.GenerateException, generateResult.ArtifactsToCleanup, generateResult.NoAcknowledgments)
         {
             IsBuildSuccess = isBuildSuccess;
             ErrorMessage = errorMessage;

--- a/src/BenchmarkDotNet/Toolchains/Results/GenerateResult.cs
+++ b/src/BenchmarkDotNet/Toolchains/Results/GenerateResult.cs
@@ -9,20 +9,23 @@ namespace BenchmarkDotNet.Toolchains.Results
         public bool IsGenerateSuccess { get; }
         public Exception GenerateException { get; }
         public IReadOnlyCollection<string> ArtifactsToCleanup { get; }
+        public bool NoAcknowledgments { get; }
 
-        public GenerateResult(ArtifactsPaths artifactsPaths, bool isGenerateSuccess, Exception generateException, IReadOnlyCollection<string> artifactsToCleanup)
+        public GenerateResult(ArtifactsPaths artifactsPaths, bool isGenerateSuccess, Exception generateException,
+            IReadOnlyCollection<string> artifactsToCleanup, bool noAcknowledgments)
         {
             ArtifactsPaths = artifactsPaths;
             IsGenerateSuccess = isGenerateSuccess;
             GenerateException = generateException;
             ArtifactsToCleanup = artifactsToCleanup;
+            NoAcknowledgments = noAcknowledgments;
         }
 
-        public static GenerateResult Success(ArtifactsPaths artifactsPaths, IReadOnlyCollection<string> artifactsToCleanup)
-            => new GenerateResult(artifactsPaths, true, null, artifactsToCleanup);
+        public static GenerateResult Success(ArtifactsPaths artifactsPaths, IReadOnlyCollection<string> artifactsToCleanup, bool noAcknowledgments)
+            => new GenerateResult(artifactsPaths, true, null, artifactsToCleanup, noAcknowledgments);
 
         public static GenerateResult Failure(ArtifactsPaths artifactsPaths, IReadOnlyCollection<string> artifactsToCleanup, Exception exception = null)
-            => new GenerateResult(artifactsPaths, false, exception, artifactsToCleanup);
+            => new GenerateResult(artifactsPaths, false, exception, artifactsToCleanup, false);
 
         public override string ToString() => "GenerateResult: " + (IsGenerateSuccess ? "Success" : "Fail");
     }

--- a/tests/BenchmarkDotNet.IntegrationTests/ToolchainTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ToolchainTest.cs
@@ -25,7 +25,7 @@ namespace BenchmarkDotNet.IntegrationTests
             {
                 logger.WriteLine("Generating");
                 Done = true;
-                return new GenerateResult(null, true, null, Array.Empty<string>());
+                return new GenerateResult(null, true, null, Array.Empty<string>(), false);
             }
         }
 

--- a/tests/BenchmarkDotNet.Tests/BuildResultTests.cs
+++ b/tests/BenchmarkDotNet.Tests/BuildResultTests.cs
@@ -54,7 +54,7 @@ namespace BenchmarkDotNet.Tests
         [AssertionMethod]
         private void Verify(string msbuildError, bool expectedResult, string expectedReason)
         {
-            var sut = BuildResult.Failure(GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>()), msbuildError);
+            var sut = BuildResult.Failure(GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>(), false), msbuildError);
 
             Assert.Equal(expectedResult, sut.TryToExplainFailureReason(out string reason));
             Assert.Equal(expectedReason, reason);

--- a/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
+++ b/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
@@ -63,7 +63,7 @@ namespace BenchmarkDotNet.Tests.Mocks
 
         private static BenchmarkReport CreateReport(BenchmarkCase benchmarkCase, int n, double nanoseconds)
         {
-            var buildResult = BuildResult.Success(GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>()));
+            var buildResult = BuildResult.Success(GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>(), false));
             var measurements = Enumerable.Range(0, n)
                 .Select(index => new Measurement(1, IterationMode.Workload, IterationStage.Result, index + 1, 1, nanoseconds + index).ToString())
                 .ToList();
@@ -73,7 +73,7 @@ namespace BenchmarkDotNet.Tests.Mocks
 
         private static BenchmarkReport CreateReport(BenchmarkCase benchmarkCase, bool hugeSd, Metric[] metrics)
         {
-            var buildResult = BuildResult.Success(GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>()));
+            var buildResult = BuildResult.Success(GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>(), false));
             bool isFoo = benchmarkCase.Descriptor.WorkloadMethodDisplayInfo == "Foo";
             bool isBar = benchmarkCase.Descriptor.WorkloadMethodDisplayInfo == "Bar";
             var measurements = new List<Measurement>

--- a/tests/BenchmarkDotNet.Tests/Reports/RatioPrecisionTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/RatioPrecisionTests.cs
@@ -80,7 +80,7 @@ namespace BenchmarkDotNet.Tests.Reports
 
         private static BenchmarkReport CreateReport(BenchmarkCase benchmarkCase, int measurementValue)
         {
-            var buildResult = BuildResult.Success(GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>()));
+            var buildResult = BuildResult.Success(GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>(), false));
             var measurements = new List<Measurement>
                 {
                     new Measurement(1, IterationMode.Workload, IterationStage.Result, 1, 1, measurementValue),

--- a/tests/BenchmarkDotNet.Tests/Reports/RatioStyleTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/RatioStyleTests.cs
@@ -101,7 +101,7 @@ namespace BenchmarkDotNet.Tests.Reports
 
         private static BenchmarkReport CreateReport(BenchmarkCase benchmarkCase, int measurementValue, int noise)
         {
-            var buildResult = BuildResult.Success(GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>()));
+            var buildResult = BuildResult.Success(GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>(), false));
             var measurements = new List<Measurement>
             {
                 new Measurement(1, IterationMode.Workload, IterationStage.Result, 1, 1, measurementValue),

--- a/tests/BenchmarkDotNet.Tests/Reports/SummaryTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/SummaryTests.cs
@@ -64,7 +64,7 @@ namespace BenchmarkDotNet.Tests.Reports
 
         private static BenchmarkReport CreateSuccessReport(BenchmarkCase benchmark)
         {
-            GenerateResult generateResult = GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>());
+            GenerateResult generateResult = GenerateResult.Success(ArtifactsPaths.Empty, Array.Empty<string>(), false);
             BuildResult buildResult = BuildResult.Success(generateResult);
             var metrics = new[] { new Metric(new FakeMetricDescriptor(), Math.E) };
             return new BenchmarkReport(true, benchmark, generateResult, buildResult, Array.Empty<ExecuteResult>(), metrics);


### PR DESCRIPTION
This PR fixes a bug that I've introduced in https://github.com/dotnet/BenchmarkDotNet/pull/1940

In #1940 I've changed the benchmark process code to not wait for a blocking acknowledgment if there is no need to.

But he thost process was still writing the acknowledgments (which were just ignored by the benchmark process). In cases when  benchmark process has managed to already quit, it's std in was closed and host was failing with "broken pipe":

```log
at System.IO.FileStream.WriteNative(ReadOnlySpan`1 source)
   at System.IO.FileStream.FlushWriteBuffer()
   at System.IO.FileStream.Flush(Boolean flushToDisk)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.IO.StreamWriter.WriteLine(String value)
   at BenchmarkDotNet.Loggers.SynchronousProcessOutputLoggerWithDiagnoser.ProcessInput() in /Users/runner/work/1/s/src/BenchmarkDotNet/Loggers/SynchronousProcessOutputLoggerWithDiagnoser.cs:line 57
   at BenchmarkDotNet.Toolchains.Executor.Execute(Process process, BenchmarkCase benchmarkCase, SynchronousProcessOutputLoggerWithDiagnoser loggerWithDiagnoser, ILogger logger, ConsoleExitHandler consoleExitHandler, Int32 launchIndex) in /Users/runner/work/1/s/src/BenchmarkDotNet/Toolchains/Executor.cs:line 72
   at BenchmarkDotNet.Toolchains.Executor.Execute(BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, ILogger logger, ArtifactsPaths artifactsPaths, String args, IDiagnoser diagnoser, IResolver resolver, Int32 launchIndex) in /Users/runner/work/1/s/src/BenchmarkDotNet/Toolchains/Executor.cs:line 50
   at BenchmarkDotNet.Toolchains.Executor.Execute(ExecuteParameters executeParameters) in /Users/runner/work/1/s/src/BenchmarkDotNet/Toolchains/Executor.cs:line 34
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.RunExecute(ILogger logger, BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, IToolchain toolchain, BuildResult buildResult, IResolver resolver, IDiagnoser diagnoser, Int32 launchIndex) in /Users/runner/work/1/s/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs:line 514
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.Execute(ILogger logger, BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, IToolchain toolchain, BuildResult buildResult, IResolver resolver) in /Users/runner/work/1/s/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs:line 414
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.RunCore(BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, ILogger logger, IResolver resolver, BuildResult buildResult) in /Users/runner/work/1/s/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs:line 385
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.Run(BenchmarkRunInfo benchmarkRunInfo, Dictionary`2 buildResults, IResolver resolver, ILogger logger, List`1 artifactsToCleanup, String resultsFolderPath, String logFilePath, Int32 totalBenchmarkCount, StartedClock& runsChronometer, Int32& benchmarksToRunCount) in /Users/runner/work/1/s/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs:line 164
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.Run(BenchmarkRunInfo[] benchmarkRunInfos) in /Users/runner/work/1/s/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs:line 79
   at BenchmarkDotNet.Running.BenchmarkRunner.RunWithDirtyAssemblyResolveHelper(Type type, IConfig config, String[] args) in /Users/runner/work/1/s/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs:line 84
   at BenchmarkDotNet.Running.BenchmarkRunner.RunWithExceptionHandling(Func`1 run) in /Users/runner/work/1/s/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs:line 132
   at BenchmarkDotNet.Running.BenchmarkRunner.Run(Type type, IConfig config, String[] args) in /Users/runner/work/1/s/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs:line 31
   at BenchmarkDotNet.IntegrationTests.BenchmarkTestExecutor.CanExecute(Type type, IConfig config, Boolean fullValidation) in /Users/runner/work/1/s/tests/BenchmarkDotNet.IntegrationTests/BenchmarkTestExecutor.cs:line 53
   at BenchmarkDotNet.IntegrationTests.CoreRtTests.LatestCoreRtVersionIsSupported() in /Users/runner/work/1/s/tests/BenchmarkDotNet.IntegrationTests/CoreRtTests.cs:line 26
```

The fix is stop redirect standard input and writing acks when nobody needs them.

fixes #1957

cc @radical @DrewScoggins who has most likely hit it in the last few days