### PR TITLE
Improve support for NativeAOT

### DIFF
--- a/src/BenchmarkDotNet.Annotations/Attributes/DynamicallyAccessedMemberTypes.cs
+++ b/src/BenchmarkDotNet.Annotations/Attributes/DynamicallyAccessedMemberTypes.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Specifies the types of members that are dynamically accessed.
+    ///
+    /// This enumeration has a <see cref="FlagsAttribute"/> attribute that allows a
+    /// bitwise combination of its member values.
+    /// </summary>
+    [Flags]
+    internal enum DynamicallyAccessedMemberTypes
+    {
+        /// <summary>
+        /// Specifies no members.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Specifies the default, parameterless public constructor.
+        /// </summary>
+        PublicParameterlessConstructor = 0x0001,
+
+        /// <summary>
+        /// Specifies all public constructors.
+        /// </summary>
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+
+        /// <summary>
+        /// Specifies all non-public constructors.
+        /// </summary>
+        NonPublicConstructors = 0x0004,
+
+        /// <summary>
+        /// Specifies all public methods.
+        /// </summary>
+        PublicMethods = 0x0008,
+
+        /// <summary>
+        /// Specifies all non-public methods.
+        /// </summary>
+        NonPublicMethods = 0x0010,
+
+        /// <summary>
+        /// Specifies all public fields.
+        /// </summary>
+        PublicFields = 0x0020,
+
+        /// <summary>
+        /// Specifies all non-public fields.
+        /// </summary>
+        NonPublicFields = 0x0040,
+
+        /// <summary>
+        /// Specifies all public nested types.
+        /// </summary>
+        PublicNestedTypes = 0x0080,
+
+        /// <summary>
+        /// Specifies all non-public nested types.
+        /// </summary>
+        NonPublicNestedTypes = 0x0100,
+
+        /// <summary>
+        /// Specifies all public properties.
+        /// </summary>
+        PublicProperties = 0x0200,
+
+        /// <summary>
+        /// Specifies all non-public properties.
+        /// </summary>
+        NonPublicProperties = 0x0400,
+
+        /// <summary>
+        /// Specifies all public events.
+        /// </summary>
+        PublicEvents = 0x0800,
+
+        /// <summary>
+        /// Specifies all non-public events.
+        /// </summary>
+        NonPublicEvents = 0x1000,
+
+        /// <summary>
+        /// Specifies all members.
+        /// </summary>
+        All = ~None
+    }
+}

--- a/src/BenchmarkDotNet.Annotations/Attributes/DynamicallyAccessedMembersAttribute.cs
+++ b/src/BenchmarkDotNet.Annotations/Attributes/DynamicallyAccessedMembersAttribute.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that certain members on a specified <see cref="Type"/> are accessed dynamically,
+    /// for example through <see cref="System.Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which members are being accessed during the execution
+    /// of a program.
+    ///
+    /// This attribute is valid on members whose type is <see cref="Type"/> or <see cref="string"/>.
+    ///
+    /// When this attribute is applied to a location of type <see cref="string"/>, the assumption is
+    /// that the string represents a fully qualified type name.
+    ///
+    /// If the attribute is applied to a method it's treated as a special case and it implies
+    /// the attribute should be applied to the "this" parameter of the method. As such the attribute
+    /// should only be used on instance methods of types assignable to System.Type (or string, but no methods
+    /// will use it there).
+    /// </remarks>
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method,
+        Inherited = false)]
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// with the specified member types.
+        /// </summary>
+        /// <param name="memberTypes">The types of members dynamically accessed.</param>
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members dynamically accessed.
+        /// </summary>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+}

--- a/src/BenchmarkDotNet.Annotations/Attributes/GenericTypeArgumentsAttribute.cs
+++ b/src/BenchmarkDotNet.Annotations/Attributes/GenericTypeArgumentsAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace BenchmarkDotNet.Attributes
 {
@@ -11,6 +12,6 @@ namespace BenchmarkDotNet.Attributes
         // CLS-Compliant Code requires a constructor without an array in the argument list
         [PublicAPI] public GenericTypeArgumentsAttribute() => GenericTypeArguments = new Type[0];
 
-        public GenericTypeArgumentsAttribute(params Type[] genericTypeArguments) => GenericTypeArguments = genericTypeArguments;
+        public GenericTypeArgumentsAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] params Type[] genericTypeArguments) => GenericTypeArguments = genericTypeArguments;
     }
 }

--- a/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
+++ b/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
@@ -106,9 +106,9 @@ namespace BenchmarkDotNet.Jobs
         CoreRt60,
 
         /// <summary>
-        /// CoreRT compiled as net7.0
+        /// NativeAOT compiled as net7.0
         /// </summary>
-        CoreRt70,
+        NativeAot70,
 
         /// <summary>
         /// WebAssembly with default .Net version

--- a/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
+++ b/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
@@ -96,31 +96,6 @@ namespace BenchmarkDotNet.Jobs
         Net70,
 
         /// <summary>
-        /// CoreRT compiled as netcoreapp2.0
-        /// </summary>
-        CoreRt20,
-
-        /// <summary>
-        /// CoreRT compiled as netcoreapp2.1
-        /// </summary>
-        CoreRt21,
-
-        /// <summary>
-        /// CoreRT compiled as netcoreapp2.2
-        /// </summary>
-        CoreRt22,
-
-        /// <summary>
-        /// CoreRT compiled as netcoreapp3.0
-        /// </summary>
-        CoreRt30,
-
-        /// <summary>
-        /// CoreRT compiled as netcoreapp3.1
-        /// </summary>
-        CoreRt31,
-
-        /// <summary>
         /// CoreRT compiled as net5.0
         /// </summary>
         CoreRt50,

--- a/src/BenchmarkDotNet/Attributes/Filters/AotFilterAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/Filters/AotFilterAttribute.cs
@@ -1,0 +1,12 @@
+﻿using BenchmarkDotNet.Filters;
+
+namespace BenchmarkDotNet.Attributes.Filters
+{
+    public class AotFilterAttribute : FilterConfigBaseAttribute
+    {
+        public AotFilterAttribute(string reason = null)
+            : base(new SimpleFilter(benchmark => !benchmark.GetRuntime().IsAOT))
+        {
+        }
+    }
+}

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -94,8 +94,8 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option("clrVersion", Required = false, HelpText = "Optional version of private CLR build used as the value of COMPLUS_Version env var.")]
         public string ClrVersion { get; set; }
 
-        [Option("coreRtVersion", Required = false, HelpText = "Optional version of Microsoft.DotNet.ILCompiler which should be used to run with CoreRT. Example: \"1.0.0-alpha-26414-01\"")]
-        public string CoreRtVersion { get; set; }
+        [Option("ilCompilerVersion", Required = false, HelpText = "Optional version of Microsoft.DotNet.ILCompiler which should be used to run with CoreRT/NativeAOT. Example: \"7.0.0-preview.3.22123.2\"")]
+        public string ILCompilerVersion { get; set; }
 
         [Option("ilcPath", Required = false, HelpText = "Optional IlcPath which should be used to run with private CoreRT build.")]
         public DirectoryInfo CoreRtPath { get; set; }

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -363,11 +363,6 @@ namespace BenchmarkDotNet.ConsoleArguments
                         .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings(runtimeId, null, runtimeId, options.CliPath?.FullName, options.RestorePath?.FullName)));
                 case RuntimeMoniker.Mono:
                     return baseJob.WithRuntime(new MonoRuntime("Mono", options.MonoPath?.FullName));
-                case RuntimeMoniker.CoreRt20:
-                case RuntimeMoniker.CoreRt21:
-                case RuntimeMoniker.CoreRt22:
-                case RuntimeMoniker.CoreRt30:
-                case RuntimeMoniker.CoreRt31:
                 case RuntimeMoniker.CoreRt50:
                 case RuntimeMoniker.CoreRt60:
                 case RuntimeMoniker.CoreRt70:

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -365,25 +365,9 @@ namespace BenchmarkDotNet.ConsoleArguments
                     return baseJob.WithRuntime(new MonoRuntime("Mono", options.MonoPath?.FullName));
                 case RuntimeMoniker.CoreRt50:
                 case RuntimeMoniker.CoreRt60:
-                case RuntimeMoniker.CoreRt70:
-                    var builder = CoreRtToolchain.CreateBuilder();
-
-                    if (options.CliPath != null)
-                        builder.DotNetCli(options.CliPath.FullName);
-                    if (options.RestorePath != null)
-                        builder.PackagesRestorePath(options.RestorePath.FullName);
-
-                    if (options.CoreRtPath != null)
-                        builder.UseCoreRtLocal(options.CoreRtPath.FullName);
-                    else if (!string.IsNullOrEmpty(options.CoreRtVersion))
-                        builder.UseCoreRtNuGet(options.CoreRtVersion);
-                    else
-                        builder.UseCoreRtNuGet();
-
-                    var runtime = runtimeMoniker.GetRuntime();
-                    builder.TargetFrameworkMoniker(runtime.MsBuildMoniker);
-
-                    return baseJob.WithRuntime(runtime).WithToolchain(builder.ToToolchain());
+                    return CreateAotJob(baseJob, options, runtimeMoniker, "6.0.0-*", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json");
+                case RuntimeMoniker.NativeAot70:
+                    return CreateAotJob(baseJob, options, runtimeMoniker, "7.0.0-*", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json");
                 case RuntimeMoniker.Wasm:
                     return MakeWasmJob(baseJob, options, RuntimeInformation.IsNetCore ? CoreRuntime.GetCurrentVersion().MsBuildMoniker : "net5.0", runtimeMoniker);
                 case RuntimeMoniker.WasmNet50:
@@ -401,6 +385,28 @@ namespace BenchmarkDotNet.ConsoleArguments
                 default:
                     throw new NotSupportedException($"Runtime {runtimeId} is not supported");
             }
+        }
+
+        private static Job CreateAotJob(Job baseJob, CommandLineOptions options, RuntimeMoniker runtimeMoniker, string ilCompilerVersion, string nuGetFeedUrl)
+        {
+            var builder = CoreRtToolchain.CreateBuilder();
+
+            if (options.CliPath != null)
+                builder.DotNetCli(options.CliPath.FullName);
+            if (options.RestorePath != null)
+                builder.PackagesRestorePath(options.RestorePath.FullName);
+
+            if (options.CoreRtPath != null)
+                builder.UseCoreRtLocal(options.CoreRtPath.FullName);
+            else if (!string.IsNullOrEmpty(options.ILCompilerVersion))
+                builder.UseCoreRtNuGet(options.ILCompilerVersion, nuGetFeedUrl);
+            else
+                builder.UseCoreRtNuGet(ilCompilerVersion, nuGetFeedUrl);
+
+            var runtime = runtimeMoniker.GetRuntime();
+            builder.TargetFrameworkMoniker(runtime.MsBuildMoniker);
+
+            return baseJob.WithRuntime(runtime).WithToolchain(builder.ToToolchain());
         }
 
         private static Job MakeMonoAOTLLVMJob(Job baseJob, CommandLineOptions options, string msBuildMoniker)

--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRtRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRtRuntime.cs
@@ -14,10 +14,6 @@ namespace BenchmarkDotNet.Environments
         /// CoreRT compiled as net6.0
         /// </summary>
         public static readonly CoreRtRuntime CoreRt60 = new CoreRtRuntime(RuntimeMoniker.CoreRt60, "net6.0", "CoreRT 6.0");
-        /// <summary>
-        /// CoreRT compiled as net7.0
-        /// </summary>
-        public static readonly CoreRtRuntime CoreRt70 = new CoreRtRuntime(RuntimeMoniker.CoreRt70, "net7.0", "CoreRT 7.0");
 
         public override bool IsAOT => true;
 
@@ -42,7 +38,6 @@ namespace BenchmarkDotNet.Environments
             {
                 case Version v when v.Major == 5 && v.Minor == 0: return CoreRt50;
                 case Version v when v.Major == 6 && v.Minor == 0: return CoreRt60;
-                case Version v when v.Major == 7 && v.Minor == 0: return CoreRt70;
                 default:
                     return new CoreRtRuntime(RuntimeMoniker.NotRecognized, $"net{version.Major}.{version.Minor}", $"CoreRT {version.Major}.{version.Minor}");
             }

--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRtRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRtRuntime.cs
@@ -1,7 +1,6 @@
 ﻿using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Portability;
 using System;
-using System.Linq;
 
 namespace BenchmarkDotNet.Environments
 {
@@ -39,6 +38,8 @@ namespace BenchmarkDotNet.Environments
         /// CoreRT compiled as net7.0
         /// </summary>
         public static readonly CoreRtRuntime CoreRt70 = new CoreRtRuntime(RuntimeMoniker.CoreRt70, "net7.0", "CoreRT 7.0");
+
+        public override bool IsAOT => true;
 
         private CoreRtRuntime(RuntimeMoniker runtimeMoniker, string msBuildMoniker, string displayName)
             : base(runtimeMoniker, msBuildMoniker, displayName)

--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRtRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRtRuntime.cs
@@ -7,26 +7,6 @@ namespace BenchmarkDotNet.Environments
     public class CoreRtRuntime : Runtime
     {
         /// <summary>
-        /// CoreRT compiled as netcoreapp2.0
-        /// </summary>
-        public static readonly CoreRtRuntime CoreRt20 = new CoreRtRuntime(RuntimeMoniker.CoreRt20, "netcoreapp2.0", "CoreRT 2.0");
-        /// <summary>
-        /// CoreRT compiled as netcoreapp2.1
-        /// </summary>
-        public static readonly CoreRtRuntime CoreRt21 = new CoreRtRuntime(RuntimeMoniker.CoreRt21, "netcoreapp2.1", "CoreRT 2.1");
-        /// <summary>
-        /// CoreRT compiled as netcoreapp2.2
-        /// </summary>
-        public static readonly CoreRtRuntime CoreRt22 = new CoreRtRuntime(RuntimeMoniker.CoreRt22, "netcoreapp2.2", "CoreRT 2.2");
-        /// <summary>
-        /// CoreRT compiled as netcoreapp3.0
-        /// </summary>
-        public static readonly CoreRtRuntime CoreRt30 = new CoreRtRuntime(RuntimeMoniker.CoreRt30, "netcoreapp3.0", "CoreRT 3.0");
-        /// <summary>
-        /// CoreRT compiled as netcoreapp3.1
-        /// </summary>
-        public static readonly CoreRtRuntime CoreRt31 = new CoreRtRuntime(RuntimeMoniker.CoreRt31, "netcoreapp3.1", "CoreRT 3.1");
-        /// <summary>
         /// CoreRT compiled as net5.0
         /// </summary>
         public static readonly CoreRtRuntime CoreRt50 = new CoreRtRuntime(RuntimeMoniker.CoreRt50, "net5.0", "CoreRT 5.0");
@@ -60,11 +40,6 @@ namespace BenchmarkDotNet.Environments
 
             switch (version)
             {
-                case Version v when v.Major == 2 && v.Minor == 0: return CoreRt20;
-                case Version v when v.Major == 2 && v.Minor == 1: return CoreRt21;
-                case Version v when v.Major == 2 && v.Minor == 2: return CoreRt22;
-                case Version v when v.Major == 3 && v.Minor == 0: return CoreRt30;
-                case Version v when v.Major == 3 && v.Minor == 1: return CoreRt31;
                 case Version v when v.Major == 5 && v.Minor == 0: return CoreRt50;
                 case Version v when v.Major == 6 && v.Minor == 0: return CoreRt60;
                 case Version v when v.Major == 7 && v.Minor == 0: return CoreRt70;

--- a/src/BenchmarkDotNet/Environments/Runtimes/MonoAotLLVMRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/MonoAotLLVMRuntime.cs
@@ -13,6 +13,8 @@ namespace BenchmarkDotNet.Environments
 
         public FileInfo AOTCompilerPath { get; }
 
+        public override bool IsAOT => true;
+
         /// <summary>
         /// creates new instance of MonoAotLLVMRuntime
         /// </summary>

--- a/src/BenchmarkDotNet/Environments/Runtimes/MonoRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/MonoRuntime.cs
@@ -11,6 +11,8 @@ namespace BenchmarkDotNet.Environments
 
         public string AotArgs { get; }
 
+        public override bool IsAOT => !string.IsNullOrEmpty(AotArgs);
+
         public string MonoBclPath { get; }
 
         private MonoRuntime(string name) : base(RuntimeMoniker.Mono, "mono", name) { }

--- a/src/BenchmarkDotNet/Environments/Runtimes/NativeAotRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/NativeAotRuntime.cs
@@ -1,0 +1,41 @@
+﻿using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Portability;
+using System;
+
+namespace BenchmarkDotNet.Environments
+{
+    public class NativeAotRuntime : Runtime
+    {
+        /// <summary>
+        /// NativeAOT compiled as net7.0
+        /// </summary>
+        public static readonly NativeAotRuntime NativeAot70 = new NativeAotRuntime(RuntimeMoniker.NativeAot70, "net7.0", "NativeAOT 7.0");
+
+        public override bool IsAOT => true;
+
+        private NativeAotRuntime(RuntimeMoniker runtimeMoniker, string msBuildMoniker, string displayName)
+            : base(runtimeMoniker, msBuildMoniker, displayName)
+        {
+        }
+
+        public static NativeAotRuntime GetCurrentVersion()
+        {
+            if (!RuntimeInformation.IsNetCore && !RuntimeInformation.IsNativeAOT)
+            {
+                throw new NotSupportedException("It's impossible to reliably detect the version of NativeAOT if the process is not a .NET or NativeAOT process!");
+            }
+
+            if (!CoreRuntime.TryGetVersion(out var version))
+            {
+                throw new NotSupportedException("Failed to recognize NativeAOT version");
+            }
+
+            switch (version)
+            {
+                case Version v when v.Major == 7 && v.Minor == 0: return NativeAot70;
+                default:
+                    return new NativeAotRuntime(RuntimeMoniker.NotRecognized, $"net{version.Major}.{version.Minor}", $"NativeAOT {version.Major}.{version.Minor}");
+            }
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Environments/Runtimes/Runtime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/Runtime.cs
@@ -22,6 +22,8 @@ namespace BenchmarkDotNet.Environments
         /// </summary>
         public string MsBuildMoniker { get; }
 
+        public virtual bool IsAOT => false;
+
         protected Runtime(RuntimeMoniker runtimeMoniker, string msBuildMoniker, string displayName)
         {
             if (string.IsNullOrEmpty(displayName)) throw new ArgumentNullException(nameof(displayName));

--- a/src/BenchmarkDotNet/Environments/Runtimes/Runtime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/Runtime.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using BenchmarkDotNet.Jobs;
 using JetBrains.Annotations;
 
@@ -7,22 +6,6 @@ namespace BenchmarkDotNet.Environments
 {
     public abstract class Runtime : IEquatable<Runtime>
     {
-        [Obsolete("Please use ClrRuntime.Net$Version instead", true)]
-        [EditorBrowsable(EditorBrowsableState.Never)] // hide from intellisense
-        public static readonly Runtime Clr;
-
-        [Obsolete("Please use new MonoRuntime() instead", true)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly Runtime Mono;
-
-        [Obsolete("Please use CoreRuntime.Core$Version instead", true)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly Runtime Core;
-
-        [Obsolete("Please use CoreRtRuntime.CoreRt$Version instead", true)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly Runtime CoreRT;
-
         /// <summary>
         /// Display name
         /// </summary>

--- a/src/BenchmarkDotNet/Environments/Runtimes/WasmRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/WasmRuntime.cs
@@ -27,6 +27,7 @@ namespace BenchmarkDotNet.Environments
         /// <param name="displayName">default: "Wasm"</param>
         /// <param name="aot">Specifies whether AOT or Interpreter (default) project should be generated.</param>
         /// <param name="wasmDataDir">Specifies a wasm data directory surfaced as $(WasmDataDir) for the project</param>
+        /// <param name="moniker">Runtime moniker</param>
         public WasmRuntime(string msBuildMoniker = "net5.0", string displayName = "Wasm", string javaScriptEngine = "v8", string javaScriptEngineArguments = "--expose_wasm", bool aot = false, string wasmDataDir = null, RuntimeMoniker moniker = RuntimeMoniker.Wasm) : base(moniker, msBuildMoniker, displayName)
         {
             if (!string.IsNullOrEmpty(javaScriptEngine) && javaScriptEngine != "v8" && !File.Exists(javaScriptEngine))

--- a/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
@@ -47,8 +47,8 @@ namespace BenchmarkDotNet.Extensions
                     return CoreRtRuntime.CoreRt50;
                 case RuntimeMoniker.CoreRt60:
                     return CoreRtRuntime.CoreRt60;
-                case RuntimeMoniker.CoreRt70:
-                    return CoreRtRuntime.CoreRt70;
+                case RuntimeMoniker.NativeAot70:
+                    return NativeAotRuntime.NativeAot70;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(runtimeMoniker), runtimeMoniker, "Runtime Moniker not supported");
             }

--- a/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
@@ -43,16 +43,6 @@ namespace BenchmarkDotNet.Extensions
                     return CoreRuntime.Core70;
                 case RuntimeMoniker.Mono:
                     return MonoRuntime.Default;
-                case RuntimeMoniker.CoreRt20:
-                    return CoreRtRuntime.CoreRt20;
-                case RuntimeMoniker.CoreRt21:
-                    return CoreRtRuntime.CoreRt21;
-                case RuntimeMoniker.CoreRt22:
-                    return CoreRtRuntime.CoreRt22;
-                case RuntimeMoniker.CoreRt30:
-                    return CoreRtRuntime.CoreRt30;
-                case RuntimeMoniker.CoreRt31:
-                    return CoreRtRuntime.CoreRt31;
                 case RuntimeMoniker.CoreRt50:
                     return CoreRtRuntime.CoreRt50;
                 case RuntimeMoniker.CoreRt60:

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -39,7 +39,7 @@ namespace BenchmarkDotNet.Portability
         /// "The north star for CoreRT is to be a flavor of .NET Core" -> CoreRT reports .NET Core everywhere
         /// </summary>
         public static bool IsCoreRT
-            => ((Environment.Version.Major >= 5) || FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase))
+            => ((Environment.Version.Major >= 5 && Environment.Version.Major <= 6) || FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase))
                && string.IsNullOrEmpty(typeof(object).Assembly.Location); // but it's merged to a single .exe and .Location returns null here ;)
 
         public static bool IsNativeAOT

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
@@ -10,19 +10,17 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
         /// <summary>
         /// compiled as net5.0, targets experimental 6.0.0-* CoreRT build from the https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
         /// </summary>
-        public static readonly IToolchain Core50 = GetBuilderForOldDefaults().TargetFrameworkMoniker("net5.0").ToToolchain();
+        public static readonly IToolchain Core50 = GetBuilderForOldExperimentalFeed().TargetFrameworkMoniker("net5.0").ToToolchain();
         /// <summary>
         /// compiled as net6.0, targets experimental 6.0.0-* CoreRT build from the https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
         /// </summary>
-        public static readonly IToolchain Core60 = GetBuilderForOldDefaults().TargetFrameworkMoniker("net6.0").ToToolchain();
+        public static readonly IToolchain Core60 = GetBuilderForOldExperimentalFeed().TargetFrameworkMoniker("net6.0").ToToolchain();
         /// <summary>
         /// compiled as net7.0, targets latest (7.0.0-*) NativeAOT build from the .NET 7 feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json
         /// </summary>
-        /// <summary>
-        /// compiled as net7.0, targets latest (6.0.0-*) CoreRT build from the new feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
-        /// </summary>
         public static readonly IToolchain Core70 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("net7.0").ToToolchain();
-        private static CoreRtToolchainBuilder GetBuilderForOldDefaults()
+
+        private static CoreRtToolchainBuilder GetBuilderForOldExperimentalFeed()
             => CreateBuilder().UseCoreRtNuGet("6.0.0-*", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json");
 
         internal CoreRtToolchain(string displayName,

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
@@ -8,37 +8,22 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
     public class CoreRtToolchain : Toolchain
     {
         /// <summary>
-        /// compiled as netcoreapp2.0, targets latest (6.0.0-*) CoreRT build from the new feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
+        /// compiled as net5.0, targets experimental 6.0.0-* CoreRT build from the https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
         /// </summary>
-        public static readonly IToolchain Core20 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("netcoreapp2.0").ToToolchain();
+        public static readonly IToolchain Core50 = GetBuilderForOldDefaults().TargetFrameworkMoniker("net5.0").ToToolchain();
         /// <summary>
-        /// compiled as netcoreapp2.1, targets latest (6.0.0-*) CoreRT build from the new feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
+        /// compiled as net6.0, targets experimental 6.0.0-* CoreRT build from the https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
         /// </summary>
-        public static readonly IToolchain Core21 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("netcoreapp2.1").ToToolchain();
+        public static readonly IToolchain Core60 = GetBuilderForOldDefaults().TargetFrameworkMoniker("net6.0").ToToolchain();
         /// <summary>
-        /// compiled as netcoreapp2.2, targets latest (6.0.0-*) CoreRT build from the new feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
+        /// compiled as net7.0, targets latest (7.0.0-*) NativeAOT build from the .NET 7 feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json
         /// </summary>
-        public static readonly IToolchain Core22 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("netcoreapp2.2").ToToolchain();
-        /// <summary>
-        /// compiled as netcoreapp3.0, targets latest (6.0.0-*) CoreRT build from the new feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
-        /// </summary>
-        public static readonly IToolchain Core30 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("netcoreapp3.0").ToToolchain();
-        /// <summary>
-        /// compiled as netcoreapp3.1, targets latest (6.0.0-*) CoreRT build from the new feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
-        /// </summary>
-        public static readonly IToolchain Core31 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("netcoreapp3.1").ToToolchain();
-        /// <summary>
-        /// compiled as net5.0, targets latest (6.0.0-*) CoreRT build from the new feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
-        /// </summary>
-        public static readonly IToolchain Core50 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("net5.0").ToToolchain();
-        /// <summary>
-        /// compiled as net6.0, targets latest (6.0.0-*) CoreRT build from the new feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
-        /// </summary>
-        public static readonly IToolchain Core60 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("net6.0").ToToolchain();
         /// <summary>
         /// compiled as net7.0, targets latest (6.0.0-*) CoreRT build from the new feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
         /// </summary>
         public static readonly IToolchain Core70 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("net7.0").ToToolchain();
+        private static CoreRtToolchainBuilder GetBuilderForOldDefaults()
+            => CreateBuilder().UseCoreRtNuGet("6.0.0-*", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json");
 
         internal CoreRtToolchain(string displayName,
             string coreRtVersion, string ilcPath, bool useCppCodeGenerator,

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchainBuilder.cs
@@ -10,7 +10,7 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
     {
         public static CoreRtToolchainBuilder Create() => new CoreRtToolchainBuilder();
 
-        private string coreRtVersion;
+        private string ilCompilerVersion;
         private string ilcPath;
         private bool useCppCodeGenerator;
         private string packagesRestorePath;
@@ -22,15 +22,15 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
         private bool isCoreRtConfigured;
 
         /// <summary>
-        /// creates a CoreRT toolchain targeting NuGet build of CoreRT
+        /// creates a NativeAOT (CoreRT) toolchain targeting NuGet build of Microsoft.DotNet.ILCompiler
         /// Based on https://github.com/dotnet/runtimelab/blob/d0a37893a67c125f9b0cd8671846ff7d867df241/samples/HelloWorld/README.md#add-corert-to-your-project
         /// </summary>
-        /// <param name="microsoftDotNetILCompilerVersion">the version of Microsoft.DotNet.ILCompiler which should be used. The default is: "6.0.0-*"</param>
-        /// <param name="nuGetFeedUrl">url to NuGet CoreRT feed, The default is: "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json"</param>
+        /// <param name="microsoftDotNetILCompilerVersion">the version of Microsoft.DotNet.ILCompiler which should be used. The default is: "7.0.0-*"</param>
+        /// <param name="nuGetFeedUrl">url to NuGet feed, The default is: "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json"</param>
         [PublicAPI]
-        public CoreRtToolchainBuilder UseCoreRtNuGet(string microsoftDotNetILCompilerVersion = "6.0.0-*", string nuGetFeedUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json")
+        public CoreRtToolchainBuilder UseCoreRtNuGet(string microsoftDotNetILCompilerVersion = "7.0.0-*", string nuGetFeedUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json")
         {
-            coreRtVersion = microsoftDotNetILCompilerVersion ?? throw new ArgumentNullException(nameof(microsoftDotNetILCompilerVersion));
+            ilCompilerVersion = microsoftDotNetILCompilerVersion ?? throw new ArgumentNullException(nameof(microsoftDotNetILCompilerVersion));
 
             Feeds[Generator.CoreRtNuGetFeed] = nuGetFeedUrl ?? throw new ArgumentNullException(nameof(nuGetFeedUrl));
 
@@ -38,7 +38,6 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
 
             return this;
         }
-
 
         /// <summary>
         /// creates a CoreRT toolchain targeting local build for CoreRT
@@ -132,8 +131,8 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
                 throw new InvalidOperationException("You need to use one of the UseCoreRt* methods to tell us which CoreRT to use.");
 
             return new CoreRtToolchain(
-                displayName: displayName ?? (coreRtVersion != null ? $"Core RT {coreRtVersion}" : "local Core RT"),
-                coreRtVersion: coreRtVersion,
+                displayName: displayName ?? (ilCompilerVersion != null ? $"ILCompiler {ilCompilerVersion}" : "local Core RT"),
+                coreRtVersion: ilCompilerVersion,
                 ilcPath: ilcPath,
                 useCppCodeGenerator: useCppCodeGenerator,
                 runtimeFrameworkVersion: runtimeFrameworkVersion,

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -115,6 +115,7 @@ namespace BenchmarkDotNet.Toolchains
                 case ClrRuntime _:
                 case CoreRuntime _:
                 case CoreRtRuntime _:
+                case NativeAotRuntime _:
                     start.FileName = exePath;
                     start.Arguments = args;
                     break;

--- a/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
@@ -112,7 +112,7 @@ namespace BenchmarkDotNet.Toolchains
                     return CoreRtToolchain.Core50;
                 case RuntimeMoniker.CoreRt60:
                     return CoreRtToolchain.Core60;
-                case RuntimeMoniker.CoreRt70:
+                case RuntimeMoniker.NativeAot70:
                     return CoreRtToolchain.Core70;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(runtimeMoniker), runtimeMoniker, "RuntimeMoniker not supported");

--- a/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
@@ -108,16 +108,6 @@ namespace BenchmarkDotNet.Toolchains
                     return CsProjCoreToolchain.NetCoreApp60;
                 case RuntimeMoniker.Net70:
                     return CsProjCoreToolchain.NetCoreApp70;
-                case RuntimeMoniker.CoreRt20:
-                    return CoreRtToolchain.Core20;
-                case RuntimeMoniker.CoreRt21:
-                    return CoreRtToolchain.Core21;
-                case RuntimeMoniker.CoreRt22:
-                    return CoreRtToolchain.Core22;
-                case RuntimeMoniker.CoreRt30:
-                    return CoreRtToolchain.Core30;
-                case RuntimeMoniker.CoreRt31:
-                    return CoreRtToolchain.Core31;
                 case RuntimeMoniker.CoreRt50:
                     return CoreRtToolchain.Core50;
                 case RuntimeMoniker.CoreRt60:

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -207,7 +207,7 @@ namespace BenchmarkDotNet.Tests
         public void CoreRtPathParsedCorrectly()
         {
             var fakeCoreRtPath =  new FileInfo(typeof(ConfigParserTests).Assembly.Location).Directory;
-            var config = ConfigParser.Parse(new[] { "-r", "corert30", "--ilcPath", fakeCoreRtPath.FullName }, new OutputLogger(Output)).config;
+            var config = ConfigParser.Parse(new[] { "-r", "corert50", "--ilcPath", fakeCoreRtPath.FullName }, new OutputLogger(Output)).config;
 
             Assert.Single(config.GetJobs());
             CoreRtToolchain toolchain = config.GetJobs().Single().GetToolchain() as CoreRtToolchain;

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -344,13 +344,14 @@ namespace BenchmarkDotNet.Tests
         [Fact]
         public void CanCompareFewDifferentRuntimes()
         {
-            var config = ConfigParser.Parse(new[] { "--runtimes", "net461", "MONO", "netcoreapp3.0", "CoreRT30"}, new OutputLogger(Output)).config;
+            var config = ConfigParser.Parse(new[] { "--runtimes", "net461", "MONO", "netcoreapp3.0", "coreRT6.0", "nativeAOT7.0"}, new OutputLogger(Output)).config;
 
             Assert.True(config.GetJobs().First().Meta.Baseline); // when the user provides multiple runtimes the first one should be marked as baseline
             Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is ClrRuntime clrRuntime && clrRuntime.MsBuildMoniker == "net461"));
             Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is MonoRuntime));
             Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is CoreRuntime coreRuntime && coreRuntime.MsBuildMoniker == "netcoreapp3.0" && coreRuntime.RuntimeMoniker == RuntimeMoniker.NetCoreApp30));
-            Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is CoreRtRuntime coreRtRuntime && coreRtRuntime.MsBuildMoniker == "netcoreapp3.0" && coreRtRuntime.RuntimeMoniker == RuntimeMoniker.CoreRt30));
+            Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is CoreRtRuntime coreRtRuntime && coreRtRuntime.MsBuildMoniker == "net6.0" && coreRtRuntime.RuntimeMoniker == RuntimeMoniker.CoreRt60));
+            Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is NativeAotRuntime nativeAOTRuntime && nativeAOTRuntime.MsBuildMoniker == "net7.0" && nativeAOTRuntime.RuntimeMoniker == RuntimeMoniker.NativeAot70));
         }
 
         [Theory]


### PR DESCRIPTION
With the following 3 recent fixes:

* https://github.com/dotnet/runtime/pull/66290 (https://github.com/dotnet/runtime/issues/66028) 
* https://github.com/dotnet/runtime/pull/66650 (https://github.com/dotnet/runtime/issues/66637)
* https://github.com/dotnet/BenchmarkDotNet/pull/1955

It required very little work to improve the NativeAOT support. Main changes:

* CoreRT and NativeAOT are treated as two different runtimes, mostly to be able to run .NET 6 with CoreRT vs .NET 7 with NativeAOT
* `--runtimes` no longer supports `corert70`. The proper name is `nativeaot70` (case and dots are ignored, so you can use `NativeAOT7.0` as well)
* the default feed for the `CoreRtToolchainBuilder` has been upgraded to .NET 7 feed
* the default ILCompiler for the `CoreRtToolchainBuilder` has been upgraded to `7.0.0-*`
* I've renamed `--coreRtVersion` to `--ilCompilerVersion` as it specifies the ILCompiler version. Sample command:
```cmd
dotnet run -c Release -f net5.0 --filter *Basic* --runtimes nativeaot70 --ilcompilerversion 7.0.0-preview.3.22123.2
```


Demo:

```cmd
dotnet run -c Release -f net5.0 --filter *Basic* --runtimes net50 corert60 nativeaot70
```

![image](https://user-images.githubusercontent.com/6011991/159509674-2fd9627f-26db-4ad8-9a36-e4b2034f65d2.png)

In the meantime I am working on getting all dotnet/performance microbenchmarks running with NativeAOT

cc @jkotas @MichalStrehovsky @hez2010 @Beau-Gosse-dev

