### PR TITLE
Set --llvm in MONO_ENV_OPTIONS for llvm.

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -410,7 +410,7 @@ namespace BenchmarkDotNet.ConsoleArguments
 
         private static Job MakeMonoAOTLLVMJob(Job baseJob, CommandLineOptions options, string msBuildMoniker)
         {
-            var monoAotLLVMRuntime = new MonoAotLLVMRuntime(aotCompilerPath: options.AOTCompilerPath, msBuildMoniker: msBuildMoniker);
+            var monoAotLLVMRuntime = new MonoAotLLVMRuntime(aotCompilerPath: options.AOTCompilerPath, aotCompilerMode: options.AOTCompilerMode, msBuildMoniker: msBuildMoniker);
 
             var toolChain = MonoAotLLVMToolChain.From(
             new NetCoreAppSettings(

--- a/src/BenchmarkDotNet/Environments/Runtimes/MonoAotLLVMRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/MonoAotLLVMRuntime.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.IO;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.MonoAotLLVM;
 
 namespace BenchmarkDotNet.Environments
 {
@@ -12,11 +13,12 @@ namespace BenchmarkDotNet.Environments
         internal static readonly MonoAotLLVMRuntime Default = new MonoAotLLVMRuntime();
 
         public FileInfo AOTCompilerPath { get; }
+        public MonoAotCompilerMode AOTCompilerMode { get;  }
 
         /// <summary>
         /// creates new instance of MonoAotLLVMRuntime
         /// </summary>
-        public MonoAotLLVMRuntime(FileInfo aotCompilerPath, string msBuildMoniker = "net6.0", string displayName = "MonoAOTLLVM") : base(RuntimeMoniker.MonoAOTLLVM, msBuildMoniker, displayName)
+        public MonoAotLLVMRuntime(FileInfo aotCompilerPath, MonoAotCompilerMode aotCompilerMode, string msBuildMoniker = "net6.0", string displayName = "MonoAOTLLVM") : base(RuntimeMoniker.MonoAOTLLVM, msBuildMoniker, displayName)
         {
             if (aotCompilerPath == null)
                 throw new ArgumentNullException(paramName: nameof(aotCompilerPath));
@@ -24,6 +26,7 @@ namespace BenchmarkDotNet.Environments
                 throw new FileNotFoundException($"Provided {nameof(aotCompilerPath)} file: \"{aotCompilerPath.FullName}\" doest NOT exist");
 
             AOTCompilerPath = aotCompilerPath;
+            AOTCompilerMode = aotCompilerMode;
         }
 
         // this ctor exists only for the purpose of having .Default property that returns something consumable by RuntimeInformation.GetCurrentRuntime()

--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -10,7 +10,9 @@ using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.CoreRun;
+using BenchmarkDotNet.Toolchains.MonoAotLLVM;
 using JetBrains.Annotations;
+
 
 namespace BenchmarkDotNet.Extensions
 {
@@ -131,6 +133,17 @@ namespace BenchmarkDotNet.Extensions
 
             if (!benchmarkCase.Job.HasValue(EnvironmentMode.EnvironmentVariablesCharacteristic))
                 return;
+
+            if (benchmarkCase.Job.Infrastructure.Toolchain is MonoAotLLVMToolChain)
+            {
+                MonoAotLLVMRuntime aotruntime = (MonoAotLLVMRuntime)benchmarkCase.GetRuntime();
+
+                if (aotruntime.AOTCompilerMode == MonoAotCompilerMode.llvm)
+                {
+                    start.EnvironmentVariables["MONO_ENV_OPTIONS"] = "--llvm";
+                }
+
+            }
 
             foreach (var environmentVariable in benchmarkCase.Job.Environment.EnvironmentVariables)
                 start.EnvironmentVariables[environmentVariable.Key] = environmentVariable.Value;


### PR DESCRIPTION
This sets the MONO_ENV_OPTIONS environment variable to "--llvm" when running the benchmarks. This correctly uses the llvm backend when running. 