### PR TITLE
Fixed FreeBSD shared library extension in MonoAOTLLVM tool chain.

### DIFF
--- a/src/BenchmarkDotNet/Templates/MonoAOTLLVMCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/MonoAOTLLVMCsProj.txt
@@ -42,8 +42,7 @@
       <PublishDirFullPath>$([System.IO.Path]::GetFullPath($(PublishDir)))</PublishDirFullPath>
       <SharedLibraryType Condition="$([MSBuild]::IsOSPlatform('OSX'))">Dylib</SharedLibraryType>
       <SharedLibraryType Condition="$([MSBuild]::IsOSPlatform('Windows'))">Dll</SharedLibraryType>
-      <SharedLibraryType Condition="$([MSBuild]::IsOSPlatform('Linux'))">So</SharedLibraryType>
-      <SharedLibraryType Condition="$([MSBuild]::IsOSPlatform('FreeBSD'))">So</SharedLibraryType>
+      <SharedLibraryType Condition="'$(SharedLibraryType)' == ''">So</SharedLibraryType>
    </PropertyGroup>
 
    <ItemGroup>

--- a/src/BenchmarkDotNet/Templates/MonoAOTLLVMCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/MonoAOTLLVMCsProj.txt
@@ -43,7 +43,7 @@
       <SharedLibraryType Condition="$([MSBuild]::IsOSPlatform('OSX'))">Dylib</SharedLibraryType>
       <SharedLibraryType Condition="$([MSBuild]::IsOSPlatform('Windows'))">Dll</SharedLibraryType>
       <SharedLibraryType Condition="$([MSBuild]::IsOSPlatform('Linux'))">So</SharedLibraryType>
-      <SharedLibraryType Condition="$([MSBuild]::IsOSPlatform('FreeBSD'))">Dll</SharedLibraryType>
+      <SharedLibraryType Condition="$([MSBuild]::IsOSPlatform('FreeBSD'))">So</SharedLibraryType>
    </PropertyGroup>
 
    <ItemGroup>


### PR DESCRIPTION
The library extension of FreeBSD is wrong for the MonoAOTLLVM tool chain.