### PR TITLE
[NativeAOT] Set TrimmerDefaultAction to link 

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -25,7 +25,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             string runtimeFrameworkVersion, string targetFrameworkMoniker, string cliPath,
             string runtimeIdentifier, IReadOnlyDictionary<string, string> feeds, bool useNuGetClearTag,
             bool useTempFolderForRestore, string packagesRestorePath,
-            bool rootAllApplicationAssemblies, bool ilcGenerateCompleteTypeMetadata, bool ilcGenerateStackTraceData)
+            bool rootAllApplicationAssemblies, bool ilcGenerateCompleteTypeMetadata, bool ilcGenerateStackTraceData, string trimmerDefaultAction)
             : base(targetFrameworkMoniker, cliPath, GetPackagesDirectoryPath(useTempFolderForRestore, packagesRestorePath), runtimeFrameworkVersion)
         {
             this.ilCompilerVersion = ilCompilerVersion;
@@ -38,6 +38,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             this.rootAllApplicationAssemblies = rootAllApplicationAssemblies;
             this.ilcGenerateCompleteTypeMetadata = ilcGenerateCompleteTypeMetadata;
             this.ilcGenerateStackTraceData = ilcGenerateStackTraceData;
+            this.trimmerDefaultAction = trimmerDefaultAction;
         }
 
         private readonly string ilCompilerVersion;
@@ -51,6 +52,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         private readonly bool rootAllApplicationAssemblies;
         private readonly bool ilcGenerateCompleteTypeMetadata;
         private readonly bool ilcGenerateStackTraceData;
+        private readonly string trimmerDefaultAction;
 
         private bool IsNuGet => feeds.ContainsKey(NativeAotNuGetFeed) && !string.IsNullOrWhiteSpace(ilCompilerVersion);
 
@@ -188,9 +190,18 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 </Project>";
 
         private string GetTrimmingSettings()
-            => rootAllApplicationAssemblies
-                ? "<PublishTrimmed>false</PublishTrimmed>"
-                : "<TrimMode>link</TrimMode>";
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.AppendLine(rootAllApplicationAssemblies ? "<PublishTrimmed>false</PublishTrimmed>" : "<TrimMode>link</TrimMode>");
+
+            if (!string.IsNullOrEmpty(trimmerDefaultAction))
+            {
+                sb.Append($"<TrimmerDefaultAction>{trimmerDefaultAction}</TrimmerDefaultAction>");
+            }
+
+            return sb.ToString();
+        }
 
         /// <summary>
         /// mandatory to make it possible to call GC.GetAllocatedBytesForCurrentThread() using reflection (not part of .NET Standard)

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
@@ -28,11 +28,11 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             string runtimeFrameworkVersion, string targetFrameworkMoniker, string runtimeIdentifier,
             string customDotNetCliPath, string packagesRestorePath,
             Dictionary<string, string> feeds, bool useNuGetClearTag, bool useTempFolderForRestore,
-            bool rootAllApplicationAssemblies, bool ilcGenerateCompleteTypeMetadata, bool ilcGenerateStackTraceData)
+            bool rootAllApplicationAssemblies, bool ilcGenerateCompleteTypeMetadata, bool ilcGenerateStackTraceData, string trimmerDefaultAction)
             : base(displayName,
                 new Generator(ilCompilerVersion, useCppCodeGenerator, runtimeFrameworkVersion, targetFrameworkMoniker, customDotNetCliPath,
                     runtimeIdentifier, feeds, useNuGetClearTag, useTempFolderForRestore, packagesRestorePath,
-                    rootAllApplicationAssemblies, ilcGenerateCompleteTypeMetadata, ilcGenerateStackTraceData),
+                    rootAllApplicationAssemblies, ilcGenerateCompleteTypeMetadata, ilcGenerateStackTraceData, trimmerDefaultAction),
                 new DotNetCliPublisher(customDotNetCliPath, GetExtraArguments(useCppCodeGenerator, runtimeIdentifier), GetEnvironmentVariables(ilcPath)),
                 new Executor())
         {

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
@@ -20,6 +20,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         private bool ilcGenerateStackTraceData = true;
 
         private bool isIlCompilerConfigured;
+        private string trimmerDefaultAction = "link";
 
         /// <summary>
         /// creates a NativeAOT toolchain targeting NuGet build of Microsoft.DotNet.ILCompiler
@@ -124,6 +125,19 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             return this;
         }
 
+        /// <summary>
+        /// By using the default value ("link") this ensures that the trimmer only analyzes the parts of the library's dependencies that are used.
+        /// It tells the trimmer that any code that is not part of a "root" can be trimmed if it is unused.
+        /// </summary>
+        /// <remarks>Pass null or empty string to NOT set TrimmerDefaultAction to any value.</remarks>
+        [PublicAPI]
+        public NativeAotToolchainBuilder SeTrimmerDefaultAction(string value = "link")
+        {
+            trimmerDefaultAction = value;
+
+            return this;
+        }
+
         [PublicAPI]
         public override IToolchain ToToolchain()
         {
@@ -145,7 +159,8 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
                 useTempFolderForRestore: useTempFolderForRestore,
                 rootAllApplicationAssemblies: rootAllApplicationAssemblies,
                 ilcGenerateCompleteTypeMetadata: ilcGenerateCompleteTypeMetadata,
-                ilcGenerateStackTraceData: ilcGenerateStackTraceData
+                ilcGenerateStackTraceData: ilcGenerateStackTraceData,
+                trimmerDefaultAction: trimmerDefaultAction
             );
         }
     }


### PR DESCRIPTION
To ensure that trimmer only analyzes the parts of the dependencies that are used. With this setting, the build time for our samples project goes from 116 to 15 seconds! I've tested it with dotnet/performance microbenchmarks and everything works fine. In case it does not, users can still disable it:

```cs
builder.SeTrimmerDefaultAction("");
```

cc @MichalStrehovsky 