### PR TITLE
don't place DynamicallyAccessedMembers on an array

### DIFF
--- a/src/BenchmarkDotNet.Annotations/Attributes/GenericTypeArgumentsAttribute.cs
+++ b/src/BenchmarkDotNet.Annotations/Attributes/GenericTypeArgumentsAttribute.cs
@@ -12,6 +12,18 @@ namespace BenchmarkDotNet.Attributes
         // CLS-Compliant Code requires a constructor without an array in the argument list
         [PublicAPI] public GenericTypeArgumentsAttribute() => GenericTypeArguments = new Type[0];
 
-        public GenericTypeArgumentsAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] params Type[] genericTypeArguments) => GenericTypeArguments = genericTypeArguments;
+        public GenericTypeArgumentsAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
+            => GenericTypeArguments = new Type[] { type };
+
+        public GenericTypeArgumentsAttribute(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type2)
+            => GenericTypeArguments = new Type[] { type1, type2 };
+
+        public GenericTypeArgumentsAttribute(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type1,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type2,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type3)
+            => GenericTypeArguments = new Type[] { type1, type2, type3 };
     }
 }


### PR DESCRIPTION
it's a nop for NativeAOT and a bug for WASM. Instead of using `params` I've added ctors that accept 1, 2 and 3 types.

https://github.com/dotnet/BenchmarkDotNet/pull/1960#discussion_r832712652

cc @MichalStrehovsky @radical 