### PR TITLE
Remove CPP codegen for NativeAOT

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -21,7 +21,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
     {
         internal const string NativeAotNuGetFeed = "nativeAotNuGetFeed";
 
-        internal Generator(string ilCompilerVersion, bool useCppCodeGenerator,
+        internal Generator(string ilCompilerVersion,
             string runtimeFrameworkVersion, string targetFrameworkMoniker, string cliPath,
             string runtimeIdentifier, IReadOnlyDictionary<string, string> feeds, bool useNuGetClearTag,
             bool useTempFolderForRestore, string packagesRestorePath,
@@ -29,7 +29,6 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             : base(targetFrameworkMoniker, cliPath, GetPackagesDirectoryPath(useTempFolderForRestore, packagesRestorePath), runtimeFrameworkVersion)
         {
             this.ilCompilerVersion = ilCompilerVersion;
-            this.useCppCodeGenerator = useCppCodeGenerator;
             this.targetFrameworkMoniker = targetFrameworkMoniker;
             this.runtimeIdentifier = runtimeIdentifier;
             this.feeds = feeds;
@@ -42,7 +41,6 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         }
 
         private readonly string ilCompilerVersion;
-        private readonly bool useCppCodeGenerator;
         [SuppressMessage("ReSharper", "NotAccessedField.Local")]
         private readonly string targetFrameworkMoniker;
         private readonly string runtimeIdentifier;
@@ -68,7 +66,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
 
         protected override void GenerateBuildScript(BuildPartition buildPartition, ArtifactsPaths artifactsPaths)
         {
-            string extraArguments = NativeAotToolchain.GetExtraArguments(useCppCodeGenerator, runtimeIdentifier);
+            string extraArguments = NativeAotToolchain.GetExtraArguments(runtimeIdentifier);
 
             var content = new StringBuilder(300)
                 .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetRestoreCommand(artifactsPaths, buildPartition, extraArguments)}")

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
@@ -24,16 +24,16 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             => CreateBuilder().UseNuGet("6.0.0-*", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json");
 
         internal NativeAotToolchain(string displayName,
-            string ilCompilerVersion, string ilcPath, bool useCppCodeGenerator,
+            string ilCompilerVersion, string ilcPath,
             string runtimeFrameworkVersion, string targetFrameworkMoniker, string runtimeIdentifier,
             string customDotNetCliPath, string packagesRestorePath,
             Dictionary<string, string> feeds, bool useNuGetClearTag, bool useTempFolderForRestore,
             bool rootAllApplicationAssemblies, bool ilcGenerateCompleteTypeMetadata, bool ilcGenerateStackTraceData, string trimmerDefaultAction)
             : base(displayName,
-                new Generator(ilCompilerVersion, useCppCodeGenerator, runtimeFrameworkVersion, targetFrameworkMoniker, customDotNetCliPath,
+                new Generator(ilCompilerVersion, runtimeFrameworkVersion, targetFrameworkMoniker, customDotNetCliPath,
                     runtimeIdentifier, feeds, useNuGetClearTag, useTempFolderForRestore, packagesRestorePath,
                     rootAllApplicationAssemblies, ilcGenerateCompleteTypeMetadata, ilcGenerateStackTraceData, trimmerDefaultAction),
-                new DotNetCliPublisher(customDotNetCliPath, GetExtraArguments(useCppCodeGenerator, runtimeIdentifier), GetEnvironmentVariables(ilcPath)),
+                new DotNetCliPublisher(customDotNetCliPath, GetExtraArguments(runtimeIdentifier), GetEnvironmentVariables(ilcPath)),
                 new Executor())
         {
             IlcPath = ilcPath;
@@ -43,8 +43,8 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
 
         public static NativeAotToolchainBuilder CreateBuilder() => NativeAotToolchainBuilder.Create();
 
-        public static string GetExtraArguments(bool useCppCodeGenerator, string runtimeIdentifier)
-            => useCppCodeGenerator ? $"-r {runtimeIdentifier} /p:NativeCodeGen=cpp" : $"-r {runtimeIdentifier}";
+        public static string GetExtraArguments(string runtimeIdentifier)
+            => $"-r {runtimeIdentifier}";
 
         // https://github.com/dotnet/corert/blob/7f902d4d8b1c3280e60f5e06c71951a60da173fb/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md#compiling-source-to-native-code-using-the-ilcompiler-you-built
         // we have to pass IlcPath env var to get it working

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
@@ -12,7 +12,6 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
 
         private string ilCompilerVersion;
         private string ilcPath;
-        private bool useCppCodeGenerator;
         private string packagesRestorePath;
         // we set those default values on purpose https://github.com/dotnet/BenchmarkDotNet/pull/1057#issuecomment-461832612
         private bool rootAllApplicationAssemblies;
@@ -55,19 +54,6 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             useTempFolderForRestore = true;
 
             isIlCompilerConfigured = true;
-
-            return this;
-        }
-
-        /// <summary>
-        /// "This approach uses transpiler to convert IL to C++, and then uses platform specific C++ compiler and linker for compiling/linking the application.
-        /// The transpiler is a lot less mature than the RyuJIT path. If you came here to give CoreRT a try" please don't use this option.
-        /// Based on https://github.com/dotnet/corert/blob/7f902d4d8b1c3280e60f5e06c71951a60da173fb/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md#using-cpp-code-generator
-        /// </summary>
-        [PublicAPI]
-        public NativeAotToolchainBuilder UseCppCodeGenerator()
-        {
-            useCppCodeGenerator = true;
 
             return this;
         }
@@ -148,7 +134,6 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
                 displayName: displayName ?? (ilCompilerVersion != null ? $"ILCompiler {ilCompilerVersion}" : "local ILCompiler build"),
                 ilCompilerVersion: ilCompilerVersion,
                 ilcPath: ilcPath,
-                useCppCodeGenerator: useCppCodeGenerator,
                 runtimeFrameworkVersion: runtimeFrameworkVersion,
                 targetFrameworkMoniker: GetTargetFrameworkMoniker(),
                 runtimeIdentifier: runtimeIdentifier ?? GetPortableRuntimeIdentifier(),

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/LocalNativeAotToolchainTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/LocalNativeAotToolchainTests.cs
@@ -37,21 +37,6 @@ namespace BenchmarkDotNet.IntegrationTests.ManualRunning
 
             CanExecute<NativeAotBenchmark>(config);
         }
-
-        [Fact]
-        public void CanBenchmarkLocalBuildUsingCppCodeGen()
-        {
-            var config = ManualConfig.CreateEmpty()
-                .AddJob(Job.Dry
-                    .WithRuntime(NativeAotRuntime.Net50)
-                    .WithToolchain(
-                        NativeAotToolchain.CreateBuilder()
-                            .UseLocalBuild(IlcPath)
-                            .UseCppCodeGenerator() // https://github.com/dotnet/corert/blob/7f902d4d8b1c3280e60f5e06c71951a60da173fb/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md#using-cpp-code-generator
-                            .ToToolchain()));
-
-            CanExecute<NativeAotBenchmark>(config);
-        }
     }
 
     [KeepBenchmarkFiles]


### PR DESCRIPTION
Cpp codegeneration was never part of NativeAOT, and CoreRT is not tested/used in BDN right now, so I remove that option.