### PR TITLE
Reduce generated code size

### DIFF
--- a/src/BenchmarkDotNet/Code/CodeGenerator.cs
+++ b/src/BenchmarkDotNet/Code/CodeGenerator.cs
@@ -122,6 +122,7 @@ namespace BenchmarkDotNet.Code
             const string unrollDirective = "@Unroll@";
             const string dummyUnrollDirective = "@DummyUnroll@";
             const int dummyUnrollFactor = 1 << 6;
+            string dummyUnrolled = string.Join("", Enumerable.Repeat("dummyVar++;", dummyUnrollFactor));
             var oldLines = text.Split('\n');
             var newLines = new List<string>();
             foreach (string line in oldLines)
@@ -134,9 +135,7 @@ namespace BenchmarkDotNet.Code
                 }
                 else if (line.Contains(dummyUnrollDirective))
                 {
-                    string newLine = line.Replace(dummyUnrollDirective, "");
-                    for (int i = 0; i < dummyUnrollFactor; i++)
-                        newLines.Add(newLine);
+                    newLines.Add(line.Replace(dummyUnrollDirective, dummyUnrolled));
                 }
                 else
                     newLines.Add(line);

--- a/src/BenchmarkDotNet/Code/DeclarationsProvider.cs
+++ b/src/BenchmarkDotNet/Code/DeclarationsProvider.cs
@@ -30,7 +30,7 @@ namespace BenchmarkDotNet.Code
 
         public string IterationCleanupMethodName => Descriptor.IterationCleanupMethod?.Name ?? EmptyAction;
 
-        public abstract string ExtraDefines { get; }
+        public abstract string ReturnsDefinition { get; }
 
         protected virtual Type WorkloadMethodReturnType => Descriptor.WorkloadMethod.ReturnType;
 
@@ -74,7 +74,7 @@ namespace BenchmarkDotNet.Code
     {
         public VoidDeclarationsProvider(Descriptor descriptor) : base(descriptor) { }
 
-        public override string ExtraDefines => "#define RETURNS_VOID";
+        public override string ReturnsDefinition => "RETURNS_VOID";
 
         protected override Type OverheadMethodReturnType => typeof(void);
 
@@ -113,10 +113,10 @@ namespace BenchmarkDotNet.Code
             }
         }
 
-        public override string ExtraDefines
+        public override string ReturnsDefinition
             => Consumer.IsConsumable(WorkloadMethodReturnType) || Consumer.HasConsumableField(WorkloadMethodReturnType, out _)
-                ? "#define RETURNS_CONSUMABLE"
-                : "#define RETURNS_NON_CONSUMABLE_STRUCT";
+                ? "RETURNS_CONSUMABLE"
+                : "RETURNS_NON_CONSUMABLE_STRUCT";
     }
 
     internal class ByRefDeclarationsProvider : NonVoidDeclarationsProvider
@@ -131,7 +131,7 @@ namespace BenchmarkDotNet.Code
 
         public override string OverheadImplementation => $"return default(System.{nameof(IntPtr)});";
 
-        public override string ExtraDefines => "#define RETURNS_BYREF";
+        public override string ReturnsDefinition => "RETURNS_BYREF";
 
         public override string WorkloadMethodReturnTypeModifiers => "ref";
     }
@@ -140,7 +140,7 @@ namespace BenchmarkDotNet.Code
     {
         public ByReadOnlyRefDeclarationsProvider(Descriptor descriptor) : base(descriptor) { }
 
-        public override string ExtraDefines => "#define RETURNS_BYREF_READONLY";
+        public override string ReturnsDefinition => "RETURNS_BYREF_READONLY";
 
         public override string WorkloadMethodReturnTypeModifiers => "ref readonly";
     }

--- a/src/BenchmarkDotNet/Templates/BenchmarkType.txt
+++ b/src/BenchmarkDotNet/Templates/BenchmarkType.txt
@@ -89,19 +89,19 @@
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private void Dummy1()
         {
-            dummyVar++;@DummyUnroll@
+            @DummyUnroll@
         }
 
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private void Dummy2()
         {
-            dummyVar++;@DummyUnroll@
+            @DummyUnroll@
         }
 
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private void Dummy3()
         {
-            dummyVar++;@DummyUnroll@
+            @DummyUnroll@
         }
 
         private $OverheadMethodReturnTypeName$ __Overhead($ArgumentsDefinition$) // __ is to avoid possible name conflict

--- a/src/BenchmarkDotNet/Templates/BenchmarkType.txt
+++ b/src/BenchmarkDotNet/Templates/BenchmarkType.txt
@@ -449,5 +449,5 @@
                 $WorkloadMethodCall$;
             }
         }
-#endif
+#endif // RETURNS
     }


### PR DESCRIPTION
We are getting OOM from x86 Roslyn in dotnet/performance as the generated source file is 3 128 078 lines long (116 MB).

With this PR we are getting code that does exactly the same thing, but using 832 679 lines of code (46 MB)

Partially addresses https://github.com/dotnet/performance/issues/2350