### PR TITLE
[Mono] Change AOT mode to Normal AOT with LLVM JIT fall back

### DIFF
--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -137,7 +137,7 @@ namespace BenchmarkDotNet.Extensions
 
                 if (aotruntime.AOTCompilerMode == MonoAotCompilerMode.llvm)
                 {
-                    start.EnvironmentVariables["MONO_ENV_OPTIONS"] = "--full-aot";
+                    start.EnvironmentVariables["MONO_ENV_OPTIONS"] = "--llvm";
                 }
             }
 

--- a/src/BenchmarkDotNet/Templates/MonoAOTLLVMCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/MonoAOTLLVMCsProj.txt
@@ -47,15 +47,14 @@
 
    <ItemGroup>
      <AotInputAssemblies Include="$(PublishDirFullPath)\*.dll">
-        <AotArguments>@(MonoAOTCompilerDefaultAotArguments, ';');mcpu=native</AotArguments>
-        <ProcessArguments>@(MonoAOTCompilerDefaultProcessArguments, ';')</ProcessArguments>
+        <AotArguments>mcpu=native</AotArguments>
      </AotInputAssemblies>
    </ItemGroup>
 
 
    <MonoAOTCompiler
         CompilerBinaryPath="$COMPILERBINARYPATH$"
-        Mode="Full"
+        Mode="Normal"
         OutputType="Library"
         LibraryFormat="$(SharedLibraryType)"
         Assemblies="@(AotInputAssemblies)"


### PR DESCRIPTION
Some of the microbenchmarks use generic type, where Mono full AOT would emit a generic function to handle various types, which is very slow and doesn't worth benchmarking. This is one example:
https://github.com/dotnet/performance/blob/main/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_VectorOfT.cs

This PR will change the AOT mode to Normal LLVM AOT with LLVM JIT fallback. Because Normal AOT leaves the generic type cases for JIT to handle. That way optimized code will be emitted.

Additionally, Maui Android is using Profiled AOT with JIT fallback, which is similar to Normal AOT with JIT fallback. Ideally, they would like to leverage LLVM too at some point.

cc: @naricc 