### PR TITLE
NativeAOT: IlcOptimizationPreference & IlcInstructionSet

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -26,7 +26,8 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             string runtimeFrameworkVersion, string targetFrameworkMoniker, string cliPath,
             string runtimeIdentifier, IReadOnlyDictionary<string, string> feeds, bool useNuGetClearTag,
             bool useTempFolderForRestore, string packagesRestorePath,
-            bool rootAllApplicationAssemblies, bool ilcGenerateCompleteTypeMetadata, bool ilcGenerateStackTraceData)
+            bool rootAllApplicationAssemblies, bool ilcGenerateCompleteTypeMetadata, bool ilcGenerateStackTraceData,
+            string ilcOptimizationPreference)
             : base(targetFrameworkMoniker, cliPath, GetPackagesDirectoryPath(useTempFolderForRestore, packagesRestorePath), runtimeFrameworkVersion)
         {
             this.ilCompilerVersion = ilCompilerVersion;
@@ -38,6 +39,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             this.rootAllApplicationAssemblies = rootAllApplicationAssemblies;
             this.ilcGenerateCompleteTypeMetadata = ilcGenerateCompleteTypeMetadata;
             this.ilcGenerateStackTraceData = ilcGenerateStackTraceData;
+            this.ilcOptimizationPreference = ilcOptimizationPreference;
         }
 
         private readonly string ilCompilerVersion;
@@ -50,6 +52,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         private readonly bool rootAllApplicationAssemblies;
         private readonly bool ilcGenerateCompleteTypeMetadata;
         private readonly bool ilcGenerateStackTraceData;
+        private readonly string ilcOptimizationPreference;
 
         private bool IsNuGet => feeds.ContainsKey(NativeAotNuGetFeed) && !string.IsNullOrWhiteSpace(ilCompilerVersion);
 
@@ -132,6 +135,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <UseSharedCompilation>false</UseSharedCompilation>
     <Deterministic>true</Deterministic>
     <RunAnalyzers>false</RunAnalyzers>
+    <IlcOptimizationPreference>{ilcOptimizationPreference}</IlcOptimizationPreference>
     {GetTrimmingSettings()}
     <IlcGenerateCompleteTypeMetadata>{ilcGenerateCompleteTypeMetadata}</IlcGenerateCompleteTypeMetadata>
     <IlcGenerateStackTraceData>{ilcGenerateStackTraceData}</IlcGenerateStackTraceData>
@@ -167,6 +171,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <UseSharedCompilation>false</UseSharedCompilation>
     <Deterministic>true</Deterministic>
     <RunAnalyzers>false</RunAnalyzers>
+    <IlcOptimizationPreference>{ilcOptimizationPreference}</IlcOptimizationPreference>
     {GetTrimmingSettings()}
     <IlcGenerateCompleteTypeMetadata>{ilcGenerateCompleteTypeMetadata}</IlcGenerateCompleteTypeMetadata>
     <IlcGenerateStackTraceData>{ilcGenerateStackTraceData}</IlcGenerateStackTraceData>

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
+using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Running;
@@ -132,6 +133,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <AssemblyName>{artifactsPaths.ProgramName}</AssemblyName>
     <AssemblyTitle>{artifactsPaths.ProgramName}</AssemblyTitle>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PlatformTarget>{buildPartition.Platform.ToConfig()}</PlatformTarget>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <DebugSymbols>false</DebugSymbols>
     <UseSharedCompilation>false</UseSharedCompilation>
@@ -171,6 +173,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <AssemblyName>{artifactsPaths.ProgramName}</AssemblyName>
     <AssemblyTitle>{artifactsPaths.ProgramName}</AssemblyTitle>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PlatformTarget>{buildPartition.Platform.ToConfig()}</PlatformTarget>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <DebugSymbols>false</DebugSymbols>
     <UseSharedCompilation>false</UseSharedCompilation>

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -266,6 +266,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
         private string GetCurrentInstructionSet(Platform platform)
             => string.Join(",", GetHostProcessInstructionSets(platform));
 
+        // based on https://github.com/dotnet/runtime/blob/ce61c09a5f6fc71d8f717d3fc4562f42171869a0/src/coreclr/tools/Common/JitInterface/CorInfoInstructionSet.cs#L727
         private static IEnumerable<string> GetHostProcessInstructionSets(Platform platform)
         {
             switch (platform)

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
@@ -29,11 +29,12 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             string customDotNetCliPath, string packagesRestorePath,
             Dictionary<string, string> feeds, bool useNuGetClearTag, bool useTempFolderForRestore,
             bool rootAllApplicationAssemblies, bool ilcGenerateCompleteTypeMetadata, bool ilcGenerateStackTraceData,
-            string ilcOptimizationPreference)
+            string ilcOptimizationPreference, string ilcInstructionSet)
             : base(displayName,
                 new Generator(ilCompilerVersion, runtimeFrameworkVersion, targetFrameworkMoniker, customDotNetCliPath,
                     runtimeIdentifier, feeds, useNuGetClearTag, useTempFolderForRestore, packagesRestorePath,
-                    rootAllApplicationAssemblies, ilcGenerateCompleteTypeMetadata, ilcGenerateStackTraceData, ilcOptimizationPreference),
+                    rootAllApplicationAssemblies, ilcGenerateCompleteTypeMetadata, ilcGenerateStackTraceData,
+                    ilcOptimizationPreference, ilcInstructionSet),
                 new DotNetCliPublisher(customDotNetCliPath, GetExtraArguments(runtimeIdentifier), GetEnvironmentVariables(ilcPath)),
                 new Executor())
         {

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
@@ -28,11 +28,12 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             string runtimeFrameworkVersion, string targetFrameworkMoniker, string runtimeIdentifier,
             string customDotNetCliPath, string packagesRestorePath,
             Dictionary<string, string> feeds, bool useNuGetClearTag, bool useTempFolderForRestore,
-            bool rootAllApplicationAssemblies, bool ilcGenerateCompleteTypeMetadata, bool ilcGenerateStackTraceData)
+            bool rootAllApplicationAssemblies, bool ilcGenerateCompleteTypeMetadata, bool ilcGenerateStackTraceData,
+            string ilcOptimizationPreference)
             : base(displayName,
                 new Generator(ilCompilerVersion, runtimeFrameworkVersion, targetFrameworkMoniker, customDotNetCliPath,
                     runtimeIdentifier, feeds, useNuGetClearTag, useTempFolderForRestore, packagesRestorePath,
-                    rootAllApplicationAssemblies, ilcGenerateCompleteTypeMetadata, ilcGenerateStackTraceData),
+                    rootAllApplicationAssemblies, ilcGenerateCompleteTypeMetadata, ilcGenerateStackTraceData, ilcOptimizationPreference),
                 new DotNetCliPublisher(customDotNetCliPath, GetExtraArguments(runtimeIdentifier), GetEnvironmentVariables(ilcPath)),
                 new Executor())
         {

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
@@ -18,6 +18,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         private bool ilcGenerateCompleteTypeMetadata = true;
         private bool ilcGenerateStackTraceData = true;
         private string ilcOptimizationPreference = "Speed";
+        private string ilcInstructionSet;
 
         private bool isIlCompilerConfigured;
 
@@ -123,6 +124,23 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             return this;
         }
 
+        /// <summary>
+        /// By default, the compiler targets the minimum instruction set supported by the target OS and architecture.
+        /// This option allows targeting newer instruction sets for better performance.
+        /// The native binary will require the instruction sets to be supported by the hardware in order to run.
+        /// For example, `avx2,bmi2,fma,pclmul,popcnt,aes` will produce binary that takes advantage of instruction sets
+        /// that are typically present on current Intel and AMD processors. Run `ilc.exe --help` for the full list of available instruction sets
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        [PublicAPI]
+        public NativeAotToolchainBuilder IlcInstructionSet(string value)
+        {
+            ilcInstructionSet = value;
+
+            return this;
+        }
+
         [PublicAPI]
         public override IToolchain ToToolchain()
         {
@@ -144,7 +162,8 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
                 rootAllApplicationAssemblies: rootAllApplicationAssemblies,
                 ilcGenerateCompleteTypeMetadata: ilcGenerateCompleteTypeMetadata,
                 ilcGenerateStackTraceData: ilcGenerateStackTraceData,
-                ilcOptimizationPreference: ilcOptimizationPreference
+                ilcOptimizationPreference: ilcOptimizationPreference,
+                ilcInstructionSet: ilcInstructionSet
             );
         }
     }

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
@@ -131,7 +131,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         /// For example, `avx2,bmi2,fma,pclmul,popcnt,aes` will produce binary that takes advantage of instruction sets
         /// that are typically present on current Intel and AMD processors.
         /// </summary>
-        /// <param name="value">Specify null to use the defaults.</param>
+        /// <param name="value">Specify empty string ("", not null) to use the defaults.</param>
         [PublicAPI]
         public NativeAotToolchainBuilder IlcInstructionSet(string value)
         {

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
@@ -18,7 +18,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         private bool ilcGenerateCompleteTypeMetadata = true;
         private bool ilcGenerateStackTraceData = true;
         private string ilcOptimizationPreference = "Speed";
-        private string ilcInstructionSet;
+        private string ilcInstructionSet = null;
 
         private bool isIlCompilerConfigured;
 
@@ -129,10 +129,9 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         /// This option allows targeting newer instruction sets for better performance.
         /// The native binary will require the instruction sets to be supported by the hardware in order to run.
         /// For example, `avx2,bmi2,fma,pclmul,popcnt,aes` will produce binary that takes advantage of instruction sets
-        /// that are typically present on current Intel and AMD processors. Run `ilc.exe --help` for the full list of available instruction sets
+        /// that are typically present on current Intel and AMD processors.
         /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        /// <param name="value">Specify null to use the defaults.</param>
         [PublicAPI]
         public NativeAotToolchainBuilder IlcInstructionSet(string value)
         {

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
@@ -17,6 +17,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         private bool rootAllApplicationAssemblies;
         private bool ilcGenerateCompleteTypeMetadata = true;
         private bool ilcGenerateStackTraceData = true;
+        private string ilcOptimizationPreference = "Speed";
 
         private bool isIlCompilerConfigured;
 
@@ -110,6 +111,18 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             return this;
         }
 
+        /// <summary>
+        /// Options related to code generation.
+        /// </summary>
+        /// <param name="value">"Speed" to favor code execution speed (default), "Size" to favor smaller code size</param>
+        [PublicAPI]
+        public NativeAotToolchainBuilder IlcOptimizationPreference(string value = "Speed")
+        {
+            ilcOptimizationPreference = value;
+
+            return this;
+        }
+
         [PublicAPI]
         public override IToolchain ToToolchain()
         {
@@ -130,7 +143,8 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
                 useTempFolderForRestore: useTempFolderForRestore,
                 rootAllApplicationAssemblies: rootAllApplicationAssemblies,
                 ilcGenerateCompleteTypeMetadata: ilcGenerateCompleteTypeMetadata,
-                ilcGenerateStackTraceData: ilcGenerateStackTraceData
+                ilcGenerateStackTraceData: ilcGenerateStackTraceData,
+                ilcOptimizationPreference: ilcOptimizationPreference
             );
         }
     }

--- a/tests/BenchmarkDotNet.IntegrationTests/NativeAotTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/NativeAotTests.cs
@@ -5,6 +5,7 @@ using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Tests.XUnit;
+using BenchmarkDotNet.Toolchains.NativeAot;
 using Xunit.Abstractions;
 
 namespace BenchmarkDotNet.IntegrationTests
@@ -23,21 +24,40 @@ namespace BenchmarkDotNet.IntegrationTests
             if (ContinuousIntegration.IsAppVeyorOnWindows()) // too time consuming for AppVeyor (1h limit)
                 return;
 
+            var toolchain = NativeAotToolchain.CreateBuilder().UseNuGet().IlcInstructionSet(IsAvx2Supported() ? "avx2" : "").ToToolchain();
+
             var config = ManualConfig.CreateEmpty()
                 .AddJob(Job.Dry
-                    .WithRuntime(NativeAotRuntime.GetCurrentVersion())); // we test against latest version for current TFM to make sure we avoid issues like #1055
+                    .WithRuntime(NativeAotRuntime.GetCurrentVersion()) // we test against latest version for current TFM to make sure we avoid issues like #1055
+                    .WithToolchain(toolchain)
+                    .WithEnvironmentVariable(NativeAotBenchmark.EnvVarKey, IsAvx2Supported().ToString().ToLower()));
 
             CanExecute<NativeAotBenchmark>(config);
+        }
+
+        private bool IsAvx2Supported()
+        {
+#if NET6_0_OR_GREATER
+            return System.Runtime.Intrinsics.X86.Avx2.IsSupported;
+#else
+            return false;
+#endif
         }
     }
 
     public class NativeAotBenchmark
     {
+        internal const string EnvVarKey = "AVX2_IsSupported";
+
         [Benchmark]
         public void Check()
         {
             if (!RuntimeInformation.IsNativeAOT)
                 throw new Exception("This is NOT NativeAOT");
+#if NET6_0_OR_GREATER
+            if (System.Runtime.Intrinsics.X86.Avx2.IsSupported != bool.Parse(Environment.GetEnvironmentVariable(EnvVarKey)))
+                throw new Exception("Unexpected Instruction Set");
+#endif
         }
     }
 }


### PR DESCRIPTION
Changes:

- allow the users to specify `IlcOptimizationPreference`, use `Speed` as default
- allow the users to specify `IlcInstructionSet`, use host process settings as default

Sample benchmark:

```cs
private string a = new string('a', 1000) + "a";
private string b = new string('a', 1000) + "b";

[Benchmark]
public bool Compare() => a.Equals(b, System.StringComparison.Ordinal);
```

```cmd
dotnet run -c Release -f net6.0 --filter *Compare --job short --keepFiles true --runtimes nativeaot7.0
```

## Before

|  Method |       Runtime |          Toolchain |     Mean |    Error |   StdDev |
|-------- |-------------- |------------------- |---------:|---------:|---------:|
| Compare | NativeAOT 7.0 | ILCompiler 7.0.0-* | 66.88 ns | 2.263 ns | 0.124 ns |

## After

|  Method |       Runtime |          Toolchain |     Mean |    Error |   StdDev |
|-------- |-------------- |------------------- |---------:|---------:|---------:|
| Compare | NativeAOT 7.0 | ILCompiler 7.0.0-* | 35.42 ns | 0.539 ns | 0.030 ns |

Sample settings on my x64 AMD machine:

```xml
<ItemGroup>
    <IlcArg Include="--instructionset:base,sse,sse2,sse3,sse4.1,sse4.2,avx,avx2,aes,bmi,bmi2,fma,lzcnt,pclmul,popcnt" />
</ItemGroup>
```




cc @jkotas @MichalStrehovsky 
