### PR TITLE
use AnyCPU for S390x

### DIFF
--- a/src/BenchmarkDotNet/Extensions/ConfigurationExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ConfigurationExtensions.cs
@@ -20,8 +20,6 @@ namespace BenchmarkDotNet.Extensions
                     return "ARM";
                 case Platform.Arm64:
                     return "ARM64";
-                case Platform.S390x:
-                    return "S390x";
                 default:
                     return "AnyCPU";
             }


### PR DESCRIPTION
fixes #1711

context: tools like MSBuild and Rolsyn don't support S390x yet, so we need to use `AnyCPU` as a platform target

cc @stefan-sf-ibm