### PR TITLE
when Host process is not .NET Core, CoreRunToolchain should use latest available TFM

### DIFF
--- a/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
+++ b/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
@@ -139,6 +139,5 @@ namespace BenchmarkDotNet.Jobs
         /// Mono with the Ahead of Time LLVM Compiler backend and .net7.0
         /// </summary>
         MonoAOTLLVMNet70
-
     }
 }

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -163,12 +163,6 @@ namespace BenchmarkDotNet.ConsoleArguments
                 return false;
             }
 
-            if (!options.CoreRunPaths.IsNullOrEmpty() && !RuntimeInformation.IsNetCore)
-            {
-                logger.WriteLineError("CoreRun path can be used only for .NET Core host processes.");
-                return false;
-            }
-
             if (options.HardwareCounters.Count() > 3)
             {
                 logger.WriteLineError("You can't use more than 3 HardwareCounters at the same time.");
@@ -505,7 +499,10 @@ namespace BenchmarkDotNet.ConsoleArguments
                 .WithToolchain(new CoreRunToolchain(
                     coreRunPath,
                     createCopy: true,
-                    targetFrameworkMoniker: RuntimeInformation.GetCurrentRuntime().MsBuildMoniker,
+                    targetFrameworkMoniker:
+                        RuntimeInformation.IsNetCore
+                            ? RuntimeInformation.GetCurrentRuntime().MsBuildMoniker
+                            : CoreRuntime.Latest.MsBuildMoniker, // use most recent tfm, as the toolchain is being used only by dotnet/runtime contributors
                     customDotNetCliPath: options.CliPath,
                     restorePath: options.RestorePath,
                     displayName: GetCoreRunToolchainDisplayName(options.CoreRunPaths, coreRunPath)));

--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
@@ -20,6 +20,8 @@ namespace BenchmarkDotNet.Environments
         public static readonly CoreRuntime Core60 = new CoreRuntime(RuntimeMoniker.Net60, "net6.0", ".NET 6.0");
         public static readonly CoreRuntime Core70 = new CoreRuntime(RuntimeMoniker.Net70, "net7.0", ".NET 7.0");
 
+        public static CoreRuntime Latest => Core70; // when dotnet/runtime branches for 8.0, this will need to get updated
+
         private CoreRuntime(RuntimeMoniker runtimeMoniker, string msBuildMoniker, string displayName)
             : base(runtimeMoniker, msBuildMoniker, displayName)
         {

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -151,10 +151,16 @@ namespace BenchmarkDotNet.Tests
         }
 
         [FactClassicDotNetOnly("It's impossible to determine TFM for CoreRunToolchain if host process is not .NET (Core) process")]
-        public void SpecifyingCoreRunWithFullFrameworkHostGivesError()
+        public void SpecifyingCoreRunWithFullFrameworkTargetsMostRecentTfm()
         {
             var fakePath = typeof(object).Assembly.Location;
-            Assert.False(ConfigParser.Parse(new[] { "--corerun", fakePath }, new OutputLogger(Output)).isSuccess);
+            var config = ConfigParser.Parse(new[] { "--corerun", fakePath }, new OutputLogger(Output)).config;
+
+            Job coreRunJob = config.GetJobs().Single();
+
+            CoreRunToolchain coreRunToolchain = (CoreRunToolchain)coreRunJob.GetToolchain();
+            DotNetCliGenerator generator = (DotNetCliGenerator)coreRunToolchain.Generator;
+            Assert.Equal("net7.0", generator.TargetFrameworkMoniker);
         }
 
         [FactDotNetCoreOnly("It's impossible to determine TFM for CoreRunToolchain if host process is not .NET (Core) process")]


### PR DESCRIPTION
as it's used only by dotnet/runtime contributors

Sample usage:

```cmd
dotnet run -c Release -f net48 --filter ** --runtimes net48 netcoreapp3.1 net5.0 --corerun d:\coreclrtest\main\corerun.exe
```

Translates to: take all benchmarks that can be build for net4.8, build and run the generated project for:
* net48
* netcoreapp3.1
* net5.0
* build as net7.0, run using provided corerun

cc @stephentoub