### PR TITLE
Cleanup dependencies and add net6.0 TFM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ artifacts/*
 BDN.Generated
 BenchmarkDotNet.Samples/Properties/launchSettings.json
 src/BenchmarkDotNet/Disassemblers/net461/*
+src/BenchmarkDotNet/Disassemblers/BenchmarkDotNet.Disassembler.*.nupkg
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet</AssemblyTitle>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);1701;1702;1705;1591;3005;NU1702;CS3001;CS3003</NoWarn>
     <AssemblyName>BenchmarkDotNet</AssemblyName>

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.61" PrivateAssets="contentfiles;analyzers" />
   </ItemGroup>

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -17,17 +17,18 @@
     <PackageReference Include="CommandLineParser" Version="2.4.3" />
     <PackageReference Include="Iced" Version="1.8.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.126102" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Perfolizer" Version="0.2.1" />
-    <PackageReference Include="System.Management" Version="5.0.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
+    <PackageReference Include="System.Management" Version="6.0.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.61" PrivateAssets="contentfiles;analyzers" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <ProjectReference Include="..\BenchmarkDotNet.Disassembler.x64\BenchmarkDotNet.Disassembler.x64.csproj">

--- a/src/BenchmarkDotNet/Engines/IEngine.cs
+++ b/src/BenchmarkDotNet/Engines/IEngine.cs
@@ -4,6 +4,7 @@ using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Reports;
 using JetBrains.Annotations;
+using NotNullAttribute = JetBrains.Annotations.NotNullAttribute;
 
 namespace BenchmarkDotNet.Engines
 {

--- a/src/BenchmarkDotNet/Environments/OsBrandStringHelper.cs
+++ b/src/BenchmarkDotNet/Environments/OsBrandStringHelper.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
 using BenchmarkDotNet.Extensions;
+using NotNullAttribute = JetBrains.Annotations.NotNullAttribute;
 
 namespace BenchmarkDotNet.Environments
 {

--- a/src/BenchmarkDotNet/Environments/ProcessorBrandStringHelper.cs
+++ b/src/BenchmarkDotNet/Environments/ProcessorBrandStringHelper.cs
@@ -7,6 +7,7 @@ using BenchmarkDotNet.Helpers;
 using BenchmarkDotNet.Portability.Cpu;
 using JetBrains.Annotations;
 using Perfolizer.Horology;
+using NotNullAttribute = JetBrains.Annotations.NotNullAttribute;
 
 namespace BenchmarkDotNet.Environments
 {

--- a/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
@@ -42,12 +42,15 @@ namespace BenchmarkDotNet.Extensions
                 hashSet.Add(item);
         }
 
+#if NETSTANDARD
         public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
             => dictionary.TryGetValue(key, out var value) ? value : default;
+#endif
 
         public static double Sqr(this double x) => x * x;
         public static double Pow(this double x, double k) => Math.Pow(x, k);
 
+#if NETSTANDARD
         internal static IEnumerable<TItem> DistinctBy<TItem, TValue>(this IEnumerable<TItem> items, Func<TItem, TValue> selector)
             => DistinctBy(items, selector, EqualityComparer<TValue>.Default);
 
@@ -60,6 +63,7 @@ namespace BenchmarkDotNet.Extensions
                 if (seen.Add(selector(item)))
                     yield return item;
         }
+#endif
 
         internal static void ForEach<T>(this IList<T> source, Action<T> command)
         {

--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -85,6 +85,9 @@ namespace BenchmarkDotNet.Extensions
             if (logger == null)
                 throw new ArgumentNullException(nameof(logger));
 
+            if (!RuntimeInformation.IsWindows() && !RuntimeInformation.IsLinux())
+                return false;
+
             try
             {
                 process.ProcessorAffinity = FixAffinity(processorAffinity);
@@ -103,6 +106,9 @@ namespace BenchmarkDotNet.Extensions
         {
             if (process == null)
                 throw new ArgumentNullException(nameof(process));
+
+            if (!RuntimeInformation.IsWindows() && !RuntimeInformation.IsLinux())
+                return null;
 
             try
             {

--- a/src/BenchmarkDotNet/Helpers/FrameworkVersionHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/FrameworkVersionHelper.cs
@@ -53,6 +53,9 @@ namespace BenchmarkDotNet.Helpers
         }
 
 
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         private static int? GetReleaseNumberFromWindowsRegistry()
         {
             using (var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
@@ -64,6 +67,9 @@ namespace BenchmarkDotNet.Helpers
             }
         }
 
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         internal static string GetLatestNetDeveloperPackVersion()
         {
             if (!(GetReleaseNumberFromWindowsRegistry() is int releaseNumber))

--- a/src/BenchmarkDotNet/Helpers/FrameworkVersionHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/FrameworkVersionHelper.cs
@@ -49,6 +49,7 @@ namespace BenchmarkDotNet.Helpers
             if (string.Compare(servicingVersion, "4.8") < 0)
                 return "4.7.2";
 
+            // TODO Add support for .NET Framework 4.8.1
             return "4.8"; // most probably the last major release of Full .NET Framework
         }
 

--- a/src/BenchmarkDotNet/Portability/Cpu/MosCpuInfoProvider.cs
+++ b/src/BenchmarkDotNet/Portability/Cpu/MosCpuInfoProvider.cs
@@ -9,9 +9,15 @@ namespace BenchmarkDotNet.Portability.Cpu
 {
     internal static class MosCpuInfoProvider
     {
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         internal static readonly Lazy<CpuInfo> MosCpuInfo = new Lazy<CpuInfo>(Load);
 
         [NotNull]
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         private static CpuInfo Load()
         {
             var processorModelNames = new HashSet<string>();

--- a/src/BenchmarkDotNet/Portability/Cpu/SysctlCpuInfoParser.cs
+++ b/src/BenchmarkDotNet/Portability/Cpu/SysctlCpuInfoParser.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using BenchmarkDotNet.Helpers;
 using JetBrains.Annotations;
 using BenchmarkDotNet.Extensions;
+using NotNullAttribute = JetBrains.Annotations.NotNullAttribute;
 
 namespace BenchmarkDotNet.Portability.Cpu
 {

--- a/src/BenchmarkDotNet/Portability/PlatformApis.cs
+++ b/src/BenchmarkDotNet/Portability/PlatformApis.cs
@@ -1,0 +1,311 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace BenchmarkDotNet.Portability
+{
+    // Adapted from https://github.com/dotnet/runtime/tree/v5.0.0-preview.5.20278.1/src/installer/managed/Microsoft.DotNet.PlatformAbstractions/Native
+
+    internal static class PlatformApis
+    {
+        private class DistroInfo
+        {
+            public string Id;
+            public string VersionId;
+        }
+
+        private enum Platform
+        {
+            Unknown = 0,
+            Windows = 1,
+            Linux = 2,
+            Darwin = 3,
+            FreeBSD = 4
+        }
+
+        private static readonly Lazy<Platform> _platform = new Lazy<Platform>(DetermineOSPlatform);
+        private static readonly Lazy<DistroInfo> _distroInfo = new Lazy<DistroInfo>(LoadDistroInfo);
+
+        public static string GetOSName()
+        {
+            switch (GetOSPlatform())
+            {
+                case Platform.Windows:
+                    return "Windows";
+                case Platform.Linux:
+                    return GetDistroId() ?? "Linux";
+                case Platform.Darwin:
+                    return "Mac OS X";
+                case Platform.FreeBSD:
+                    return "FreeBSD";
+                default:
+                    return "Unknown";
+            }
+        }
+
+        public static string GetOSVersion()
+        {
+            switch (GetOSPlatform())
+            {
+                case Platform.Windows:
+                    return NativeMethods.Windows.RtlGetVersion() ?? string.Empty;
+                case Platform.Linux:
+                    return GetDistroVersionId() ?? string.Empty;
+                case Platform.Darwin:
+                    return GetDarwinVersion() ?? string.Empty;
+                case Platform.FreeBSD:
+                    return GetFreeBSDVersion() ?? string.Empty;
+                default:
+                    return string.Empty;
+            }
+        }
+
+        private static string GetDarwinVersion()
+        {
+            Version version;
+            var kernelRelease = NativeMethods.Darwin.GetKernelRelease();
+            if (!Version.TryParse(kernelRelease, out version) || version.Major < 5)
+            {
+                // 10.0 covers all versions prior to Darwin 5
+                // Similarly, if the version is not a valid version number, but we have still detected that it is Darwin, we just assume
+                // it is OS X 10.0
+                return "10.0";
+            }
+            else
+            {
+                // Mac OS X 10.1 mapped to Darwin 5.x, and the mapping continues that way
+                // So just subtract 4 from the Darwin version.
+                // https://en.wikipedia.org/wiki/Darwin_%28operating_system%29
+                return $"10.{version.Major - 4}";
+            }
+        }
+
+        private static string GetFreeBSDVersion()
+        {
+            // This is same as sysctl kern.version
+            // FreeBSD 11.0-RELEASE-p1 FreeBSD 11.0-RELEASE-p1 #0 r306420: Thu Sep 29 01:43:23 UTC 2016     root@releng2.nyi.freebsd.org:/usr/obj/usr/src/sys/GENERIC
+            // What we want is major release as minor releases should be compatible.
+            try
+            {
+                // second token up to first dot
+                return System.Runtime.InteropServices.RuntimeInformation.OSDescription.Split()[1].Split('.')[0];
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static Platform GetOSPlatform()
+        {
+            return _platform.Value;
+        }
+
+        private static string GetDistroId()
+        {
+            return _distroInfo.Value?.Id;
+        }
+
+        private static string GetDistroVersionId()
+        {
+            return _distroInfo.Value?.VersionId;
+        }
+
+        private static DistroInfo LoadDistroInfo()
+        {
+            DistroInfo result = null;
+
+            // Sample os-release file:
+            //   NAME="Ubuntu"
+            //   VERSION = "14.04.3 LTS, Trusty Tahr"
+            //   ID = ubuntu
+            //   ID_LIKE = debian
+            //   PRETTY_NAME = "Ubuntu 14.04.3 LTS"
+            //   VERSION_ID = "14.04"
+            //   HOME_URL = "http://www.ubuntu.com/"
+            //   SUPPORT_URL = "http://help.ubuntu.com/"
+            //   BUG_REPORT_URL = "http://bugs.launchpad.net/ubuntu/"
+            // We use ID and VERSION_ID
+
+            if (File.Exists("/etc/os-release"))
+            {
+                var lines = File.ReadAllLines("/etc/os-release");
+                result = new DistroInfo();
+                foreach (var line in lines)
+                {
+                    if (line.StartsWith("ID=", StringComparison.Ordinal))
+                    {
+                        result.Id = line.Substring(3).Trim('"', '\'');
+                    }
+                    else if (line.StartsWith("VERSION_ID=", StringComparison.Ordinal))
+                    {
+                        result.VersionId = line.Substring(11).Trim('"', '\'');
+                    }
+                }
+            }
+
+            if (result != null)
+            {
+                result = NormalizeDistroInfo(result);
+            }
+
+            return result;
+        }
+
+        // For some distros, we don't want to use the full version from VERSION_ID. One example is
+        // Red Hat Enterprise Linux, which includes a minor version in their VERSION_ID but minor
+        // versions are backwards compatable.
+        //
+        // In this case, we'll normalized RIDs like 'rhel.7.2' and 'rhel.7.3' to a generic
+        // 'rhel.7'. This brings RHEL in line with other distros like CentOS or Debian which
+        // don't put minor version numbers in their VERSION_ID fields because all minor versions
+        // are backwards compatible.
+        private static DistroInfo NormalizeDistroInfo(DistroInfo distroInfo)
+        {
+            // Handle if VersionId is null by just setting the index to -1.
+            int lastVersionNumberSeparatorIndex = distroInfo.VersionId?.IndexOf('.') ?? -1;
+
+            if (lastVersionNumberSeparatorIndex != -1 && distroInfo.Id == "alpine")
+            {
+                // For Alpine, the version reported has three components, so we need to find the second version separator
+                lastVersionNumberSeparatorIndex = distroInfo.VersionId.IndexOf('.', lastVersionNumberSeparatorIndex + 1);
+            }
+
+            if (lastVersionNumberSeparatorIndex != -1 && (distroInfo.Id == "rhel" || distroInfo.Id == "alpine"))
+            {
+                distroInfo.VersionId = distroInfo.VersionId.Substring(0, lastVersionNumberSeparatorIndex);
+            }
+
+            return distroInfo;
+        }
+
+        private static Platform DetermineOSPlatform()
+        {
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                return Platform.Windows;
+            }
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
+            {
+                return Platform.Linux;
+            }
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
+            {
+                return Platform.Darwin;
+            }
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Create("FREEBSD")))
+            {
+                return Platform.FreeBSD;
+            }
+
+            return Platform.Unknown;
+        }
+
+        private static partial class NativeMethods
+        {
+            public static class Darwin
+            {
+                private const int CTL_KERN = 1;
+                private const int KERN_OSRELEASE = 2;
+
+                public unsafe static string GetKernelRelease()
+                {
+                    const uint BUFFER_LENGTH = 32;
+
+                    var name = stackalloc int[2];
+                    name[0] = CTL_KERN;
+                    name[1] = KERN_OSRELEASE;
+
+                    var buf = stackalloc byte[(int)BUFFER_LENGTH];
+                    var len = stackalloc uint[1];
+                    *len = BUFFER_LENGTH;
+
+                    try
+                    {
+                        // If the buffer isn't big enough, it seems sysctl still returns 0 and just sets len to the
+                        // necessary buffer size. This appears to be contrary to the man page, but it's easy to detect
+                        // by simply checking len against the buffer length.
+                        if (sysctl(name, 2, buf, len, IntPtr.Zero, 0) == 0 && *len < BUFFER_LENGTH)
+                        {
+                            return Marshal.PtrToStringAnsi((IntPtr)buf, (int)*len);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new PlatformNotSupportedException("Error reading Darwin Kernel Version", ex);
+                    }
+                    throw new PlatformNotSupportedException("Unknown error reading Darwin Kernel Version");
+                }
+
+                [DllImport("libc")]
+                private unsafe static extern int sysctl(
+                    int* name,
+                    uint namelen,
+                    byte* oldp,
+                    uint* oldlenp,
+                    IntPtr newp,
+                    uint newlen);
+            }
+
+            public static class Unix
+            {
+                public unsafe static string GetUname()
+                {
+                    // Utsname shouldn't be larger than 2K
+                    var buf = stackalloc byte[2048];
+
+                    try
+                    {
+                        if (uname((IntPtr)buf) == 0)
+                        {
+                            return Marshal.PtrToStringAnsi((IntPtr)buf);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new PlatformNotSupportedException("Error reading Unix name", ex);
+                    }
+                    throw new PlatformNotSupportedException("Unknown error reading Unix name");
+                }
+
+                [DllImport("libc")]
+                private static extern int uname(IntPtr utsname);
+            }
+
+            public static class Windows
+            {
+                [StructLayout(LayoutKind.Sequential)]
+                internal struct RTL_OSVERSIONINFOEX
+                {
+                    internal uint dwOSVersionInfoSize;
+                    internal uint dwMajorVersion;
+                    internal uint dwMinorVersion;
+                    internal uint dwBuildNumber;
+                    internal uint dwPlatformId;
+                    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+                    internal string szCSDVersion;
+                }
+
+                // This call avoids the shimming Windows does to report old versions
+                [DllImport("ntdll")]
+                private static extern int RtlGetVersion(out RTL_OSVERSIONINFOEX lpVersionInformation);
+
+                internal static string RtlGetVersion()
+                {
+                    RTL_OSVERSIONINFOEX osvi = new RTL_OSVERSIONINFOEX();
+                    osvi.dwOSVersionInfoSize = (uint)Marshal.SizeOf(osvi);
+                    if (RtlGetVersion(out osvi) == 0)
+                    {
+                        return $"{osvi.dwMajorVersion}.{osvi.dwMinorVersion}.{osvi.dwBuildNumber}";
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -110,8 +110,8 @@ namespace BenchmarkDotNet.Portability
             operatingSystem = RuntimeEnvironment.OperatingSystem;
             operatingSystemVersion = RuntimeEnvironment.OperatingSystemVersion;
 #else
-            operatingSystem = OSDescription;
-            operatingSystemVersion = Environment.OSVersion.VersionString;
+            operatingSystem = PlatformApis.GetOSName();
+            operatingSystemVersion = PlatformApis.GetOSVersion();
 #endif
 
             return OsBrandStringHelper.Prettify(

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -14,7 +14,9 @@ using BenchmarkDotNet.Portability.Cpu;
 using JetBrains.Annotations;
 using Microsoft.Win32;
 using static System.Runtime.InteropServices.RuntimeInformation;
+#if NETSTANDARD
 using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
+#endif
 
 namespace BenchmarkDotNet.Portability
 {
@@ -26,6 +28,9 @@ namespace BenchmarkDotNet.Portability
 
         public static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null; // it allocates a lot of memory, we need to check it once in order to keep Engine non-allocating!
 
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatformGuard("windows")]
+#endif
         public static bool IsFullFramework => FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 
         [PublicAPI]
@@ -67,10 +72,19 @@ namespace BenchmarkDotNet.Portability
 
         internal static string GetArchitecture() => GetCurrentPlatform().ToString();
 
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatformGuard("windows")]
+#endif
         internal static bool IsWindows() => IsOSPlatform(OSPlatform.Windows);
 
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatformGuard("linux")]
+#endif
         internal static bool IsLinux() => IsOSPlatform(OSPlatform.Linux);
 
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatformGuard("osx")]
+#endif
         internal static bool IsMacOSX() => IsOSPlatform(OSPlatform.OSX);
 
         internal static bool IsAndroid() => Type.GetType("Java.Lang.Object, Mono.Android") != null;
@@ -87,9 +101,20 @@ namespace BenchmarkDotNet.Portability
                     return OsBrandStringHelper.PrettifyMacOSX(systemVersion, kernelVersion);
             }
 
+            string operatingSystem;
+            string operatingSystemVersion;
+
+#if NETSTANDARD
+            operatingSystem = RuntimeEnvironment.OperatingSystem;
+            operatingSystemVersion = RuntimeEnvironment.OperatingSystemVersion;
+#else
+            operatingSystem = OSDescription;
+            operatingSystemVersion = Environment.OSVersion.VersionString;
+#endif
+
             return OsBrandStringHelper.Prettify(
-                RuntimeEnvironment.OperatingSystem,
-                RuntimeEnvironment.OperatingSystemVersion,
+                operatingSystem,
+                operatingSystemVersion,
                 GetWindowsUbr());
         }
 

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -329,6 +329,8 @@ namespace BenchmarkDotNet.Portability
         // See http://aakinshin.net/en/blog/dotnet/jit-version-determining-in-runtime/
         private class JitHelper
         {
+            [SuppressMessage("IDE0052", "IDE0052")]
+            [SuppressMessage("IDE0079", "IDE0079")]
             [SuppressMessage("ReSharper", "NotAccessedField.Local")]
             private int bar;
 

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -28,10 +28,12 @@ namespace BenchmarkDotNet.Portability
 
         public static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null; // it allocates a lot of memory, we need to check it once in order to keep Engine non-allocating!
 
+        public static bool IsFullFramework =>
 #if NET6_0_OR_GREATER
-        [System.Runtime.Versioning.SupportedOSPlatformGuard("windows")]
+            false;
+#else
+            FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 #endif
-        public static bool IsFullFramework => FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 
         [PublicAPI]
         public static bool IsNetNative => FrameworkDescription.StartsWith(".NET Native", StringComparison.OrdinalIgnoreCase);

--- a/src/BenchmarkDotNet/Running/ClassicBenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/ClassicBenchmarkConverter.cs
@@ -3,7 +3,11 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+#if NET6_0_OR_GREATER
+using System.Net.Http;
+#else
 using System.Net;
+#endif
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Loggers;
@@ -13,6 +17,10 @@ namespace BenchmarkDotNet.Running
 {
     public static partial class BenchmarkConverter
     {
+#if NET6_0_OR_GREATER
+        private static readonly HttpClient Client = new HttpClient();
+#endif
+
         public static BenchmarkRunInfo[] UrlToBenchmarks(string url, IConfig config = null)
         {
             var logger = HostEnvironmentInfo.FallbackLogger;
@@ -21,9 +29,15 @@ namespace BenchmarkDotNet.Running
             string benchmarkContent;
             try
             {
+#if NET6_0_OR_GREATER
+                using (var request = new HttpRequestMessage(HttpMethod.Get, url))
+                using (var response = Client.Send(request))
+                using (var content = response.Content.ReadAsStream())
+#else
                 var webRequest = WebRequest.Create(url);
                 using (var response = webRequest.GetResponse())
                 using (var content = response.GetResponseStream())
+#endif
                 {
                     if (content == null)
                     {

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/CustomDotNetCliToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/CustomDotNetCliToolchainBuilder.cs
@@ -5,7 +5,9 @@ using System.IO;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Portability;
 using JetBrains.Annotations;
+#if NETSTANDARD
 using Microsoft.DotNet.PlatformAbstractions;
+#endif
 
 namespace BenchmarkDotNet.Toolchains.DotNetCli
 {
@@ -127,7 +129,14 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             // the values taken from https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#macos-rids
             string osPart = RuntimeInformation.IsWindows() ? "win" : (RuntimeInformation.IsMacOSX() ? "osx" : "linux");
 
-            return $"{osPart}-{RuntimeEnvironment.RuntimeArchitecture}";
+            string architecture =
+#if NETSTANDARD
+                RuntimeEnvironment.RuntimeArchitecture;
+#else
+                System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+#endif
+
+            return $"{osPart}-{architecture}";
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/InProcess.Emit/InProcessEmitExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.Emit/InProcessEmitExecutor.cs
@@ -56,7 +56,8 @@ namespace BenchmarkDotNet.Toolchains.InProcess.Emit
 
             if (executeParameters.BenchmarkCase.Descriptor.WorkloadMethod
                 .GetCustomAttributes<STAThreadAttribute>(false)
-                .Any())
+                .Any() &&
+                Portability.RuntimeInformation.IsWindows())
             {
                 runThread.SetApartmentState(ApartmentState.STA);
             }

--- a/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitExecutor.cs
@@ -58,7 +58,8 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
             int exitCode = -1;
             var runThread = new Thread(() => exitCode = ExecuteCore(host, executeParameters));
 
-            if (executeParameters.BenchmarkCase.Descriptor.WorkloadMethod.GetCustomAttributes<STAThreadAttribute>(false).Any())
+            if (executeParameters.BenchmarkCase.Descriptor.WorkloadMethod.GetCustomAttributes<STAThreadAttribute>(false).Any() &&
+                Portability.RuntimeInformation.IsWindows())
             {
                 runThread.SetApartmentState(ApartmentState.STA);
             }

--- a/src/BenchmarkDotNet/Toolchains/InProcess/InProcessExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/InProcessExecutor.cs
@@ -62,7 +62,8 @@ namespace BenchmarkDotNet.Toolchains.InProcess
             int exitCode = -1;
             var runThread = new Thread(() => exitCode = ExecuteCore(host, executeParameters));
 
-            if (executeParameters.BenchmarkCase.Descriptor.WorkloadMethod.GetCustomAttributes<STAThreadAttribute>(false).Any())
+            if (executeParameters.BenchmarkCase.Descriptor.WorkloadMethod.GetCustomAttributes<STAThreadAttribute>(false).Any() &&
+                Portability.RuntimeInformation.IsWindows())
             {
                 runThread.SetApartmentState(ApartmentState.STA);
             }

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Mono.Cecil" Version="0.11.1" />


### PR DESCRIPTION
- Clean up the package dependencies as described in #2009.
- Add a `net6.0` TFM.
- Resolve supported platform and obsolete warnings for .NET 6.
- Add a TODO to correctly return the version for .NET Framework 4.8.1.

Resolves #2009.
