### PR TITLE
Opt out of metadata trimming

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -133,7 +133,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <RunAnalyzers>false</RunAnalyzers>
     <IlcOptimizationPreference>{ilcOptimizationPreference}</IlcOptimizationPreference>
     {GetTrimmingSettings()}
-    <IlcTrimMetadata>false</IlcTrimMetadata>
     <IlcGenerateCompleteTypeMetadata>{ilcGenerateCompleteTypeMetadata}</IlcGenerateCompleteTypeMetadata>
     <IlcGenerateStackTraceData>{ilcGenerateStackTraceData}</IlcGenerateStackTraceData>
     <EnsureNETCoreAppRuntime>false</EnsureNETCoreAppRuntime> <!-- workaround for 'This runtime may not be supported by.NET Core.' error -->
@@ -142,6 +141,9 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
   {GetRuntimeSettings(buildPartition.RepresentativeBenchmarkCase.Job.Environment.Gc, buildPartition.Resolver)}
   <ItemGroup>
     <Compile Include=""{Path.GetFileName(artifactsPaths.ProgramCodePath)}"" Exclude=""bin\**;obj\**;**\*.xproj;packages\**"" />
+  </ItemGroup>
+  <ItemGroup>
+    <TrimmerRootAssembly Include="BenchmarkDotNet" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include=""Microsoft.DotNet.ILCompiler"" Version=""{ilCompilerVersion}"" />

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -133,6 +133,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <RunAnalyzers>false</RunAnalyzers>
     <IlcOptimizationPreference>{ilcOptimizationPreference}</IlcOptimizationPreference>
     {GetTrimmingSettings()}
+    <IlcTrimMetadata>false</IlcTrimMetadata>
     <IlcGenerateCompleteTypeMetadata>{ilcGenerateCompleteTypeMetadata}</IlcGenerateCompleteTypeMetadata>
     <IlcGenerateStackTraceData>{ilcGenerateStackTraceData}</IlcGenerateStackTraceData>
     <EnsureNETCoreAppRuntime>false</EnsureNETCoreAppRuntime> <!-- workaround for 'This runtime may not be supported by.NET Core.' error -->

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -143,7 +143,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <Compile Include=""{Path.GetFileName(artifactsPaths.ProgramCodePath)}"" Exclude=""bin\**;obj\**;**\*.xproj;packages\**"" />
   </ItemGroup>
   <ItemGroup>
-    <TrimmerRootAssembly Include="BenchmarkDotNet" />
+    <TrimmerRootAssembly Include=""BenchmarkDotNet"" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include=""Microsoft.DotNet.ILCompiler"" Version=""{ilCompilerVersion}"" />


### PR DESCRIPTION
Benchmark.NET opts itself into trimming, but it's trim compatible only by accident ~~(it's reflecting on things that are statically referenced and therefore would be kept by IL-based trimming solutions). NativeAOT is able to trim metadata more aggressively - e.g. an accessed field might still have its name and metadata removed and the only thing that is kept is a location in memory that can be read and written.~~

~~I'm now seeing Benchmark.NET failing with latest ILCompiler packages after https://github.com/dotnet/runtime/pull/70201 that enabled more aggressive trimming.~~

It's reflecting on a field that is not used in any other way than by unanalyzable reflection. We would previously keep all fields, irrespective of whether they're used on reflected on https://github.com/dotnet/runtime/pull/70546.

Benchmark.NET should ideally `<EnableTrimAnalyzer>true</EnableTrimAnalyzer>` in the BenchmarkDotNet.csproj project and fix all the warnings and the problem will go away. But enabling compat mode should help too.