### PR TITLE
Bugfix MetricColumn: Respect unit when formatting values.

### DIFF
--- a/src/BenchmarkDotNet/Columns/MetricColumn.cs
+++ b/src/BenchmarkDotNet/Columns/MetricColumn.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
+using Perfolizer.Common;
 using Perfolizer.Horology;
 
 namespace BenchmarkDotNet.Columns
@@ -33,12 +34,15 @@ namespace BenchmarkDotNet.Columns
 
             var cultureInfo = summary.GetCultureInfo();
 
-            if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.CodeSize)
-                return SizeValue.FromBytes((long)metric.Value).ToString(style.CodeSizeUnit, cultureInfo, descriptor.NumberFormat);
-            if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Size)
-                return SizeValue.FromBytes((long)metric.Value).ToString(style.SizeUnit, cultureInfo, descriptor.NumberFormat);
-            if (style.PrintUnitsInContent && descriptor.UnitType == UnitType.Time)
-                return TimeInterval.FromNanoseconds(metric.Value).ToString(style.TimeUnit, cultureInfo);
+            bool printUnits = style.PrintUnitsInContent || style.PrintUnitsInHeader;
+            UnitPresentation unitPresentation = UnitPresentation.FromVisibility(style.PrintUnitsInContent);
+
+            if (printUnits && descriptor.UnitType == UnitType.CodeSize)
+                return SizeValue.FromBytes((long)metric.Value).ToString(style.CodeSizeUnit, cultureInfo, descriptor.NumberFormat, unitPresentation);
+            if (printUnits && descriptor.UnitType == UnitType.Size)
+                return SizeValue.FromBytes((long)metric.Value).ToString(style.SizeUnit, cultureInfo, descriptor.NumberFormat, unitPresentation);
+            if (printUnits && descriptor.UnitType == UnitType.Time)
+                return TimeInterval.FromNanoseconds(metric.Value).ToString(style.TimeUnit, cultureInfo, descriptor.NumberFormat, unitPresentation);
 
             return metric.Value.ToString(descriptor.NumberFormat, cultureInfo);
         }

--- a/tests/BenchmarkDotNet.Tests/Columns/MetricColumnTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Columns/MetricColumnTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Parameters;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
+using Perfolizer.Horology;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.Columns
+{
+    public class MetricColumnTests
+    {
+        [Theory]
+        [InlineData(false, false, 42_000.0, "42000")]
+        [InlineData(true, false, 42_000.0, "42.0000 μs")]
+        [InlineData(false, true, 42_000.0, "42.0000")]
+        [InlineData(true, true, 42_000.0, "42.0000 μs")]
+        public void GetValueTest(bool printUnitsInContent, bool printUnitsInHeader, double metricValue, string expected)
+        {
+            var column = new MetricColumn(LocalMetricDescriptor.TimeInstance);
+            var summary = CreateMockSummary(printUnitsInContent, printUnitsInHeader, TimeUnit.Microsecond, metricValue);
+            string actual = column.GetValue(summary, summary.BenchmarksCases.First(), summary.Style);
+            Assert.Equal(expected, actual);
+        }
+
+        private static Summary CreateMockSummary(bool printUnitsInContent, bool printUnitsInHeader, TimeUnit timeUnit, double metricValue)
+        {
+            var summaryStyle = new SummaryStyle(TestCultureInfo.Instance, printUnitsInHeader, null, timeUnit, printUnitsInContent);
+            var config = new ManualConfig().WithSummaryStyle(summaryStyle);
+            var benchmarkCase = new BenchmarkCase(
+                new Descriptor(null, null),
+                Job.Dry,
+                new ParameterInstances(ImmutableArray<ParameterInstance>.Empty),
+                ImmutableConfigBuilder.Create(config));
+            var metric = new Metric(LocalMetricDescriptor.TimeInstance, metricValue);
+            var benchmarkReport = new BenchmarkReport(true, benchmarkCase, null, null, null, new List<Metric>()
+            {
+                metric
+            });
+            return new Summary("", new[] { benchmarkReport }.ToImmutableArray(), HostEnvironmentInfo.GetCurrent(),
+                "", "", TimeSpan.Zero, CultureInfo.InvariantCulture, ImmutableArray<ValidationError>.Empty);
+        }
+
+        [SuppressMessage("ReSharper", "UnassignedGetOnlyAutoProperty")]
+        private sealed class LocalMetricDescriptor : IMetricDescriptor
+        {
+            public static readonly IMetricDescriptor TimeInstance = new LocalMetricDescriptor(UnitType.Time);
+
+            private LocalMetricDescriptor(UnitType unitType)
+            {
+                UnitType = unitType;
+            }
+
+            public string Id { get; } = nameof(LocalMetricDescriptor);
+            public string DisplayName => Id;
+            public string Legend { get; }
+            public string NumberFormat { get; }
+            public UnitType UnitType { get; }
+            public string Unit { get; }
+            public bool TheGreaterTheBetter { get; }
+            public int PriorityInCategory => 0;
+        }
+    }
+}


### PR DESCRIPTION
The previous implementation would only use the given unit if SummaryStyle.PrintUnitsInContent was true, otherwise it would fallback to the default unit, regardless whether SummaryStyle.PrintUnitsInHeader was true or not. This fix takes both SummaryStyle.PrintUnitsIn* into account.

It should be noted that other columns than the MetricColumn do **not** take the visibility of units into account and always use the given unit, be it explicitly selected by the user, or calculated via GetBest*Unit().