### PR TITLE
Bugfix SmartParameter source code generation

### DIFF
--- a/src/BenchmarkDotNet/Code/CodeGenerator.cs
+++ b/src/BenchmarkDotNet/Code/CodeGenerator.cs
@@ -189,7 +189,8 @@ namespace BenchmarkDotNet.Code
             return new NonVoidDeclarationsProvider(descriptor);
         }
 
-        private static string GetParamsContent(BenchmarkCase benchmarkCase)
+        // internal for tests
+        internal static string GetParamsContent(BenchmarkCase benchmarkCase)
             => string.Join(
                 string.Empty,
                 benchmarkCase.Parameters.Items

--- a/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
+++ b/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
@@ -14,7 +14,7 @@ namespace BenchmarkDotNet.Parameters
     internal static class SmartParamBuilder
     {
         [SuppressMessage("ReSharper", "CoVariantArrayConversion")]
-        internal static object[] CreateForParams(MemberInfo source, object[] values)
+        internal static object[] CreateForParams(Type parameterType, MemberInfo source, object[] values)
         {
             // IEnumerable<object>
             if (values.IsEmpty() || values.All(SourceCodeHelper.IsCompilationTimeConstant))
@@ -24,7 +24,7 @@ namespace BenchmarkDotNet.Parameters
             if (values.All(value => value is object[] array && array.Length == 1 && SourceCodeHelper.IsCompilationTimeConstant(array[0])))
                 return values.Select(x => ((object[])x)[0]).ToArray();
 
-            return values.Select((value, index) => new SmartParameter(source, value, index)).ToArray();
+            return values.Select((value, index) => new SmartParameter(parameterType, source, value, index)).ToArray();
         }
 
         internal static ParameterInstances CreateForArguments(MethodInfo benchmark, ParameterDefinition[] parameterDefinitions, (MemberInfo source, object[] values) valuesInfo, int sourceIndex, SummaryStyle summaryStyle)
@@ -106,12 +106,14 @@ namespace BenchmarkDotNet.Parameters
 
     internal class SmartParameter : IParam
     {
+        private readonly Type parameterType;
         private readonly MemberInfo source;
         private readonly MethodBase method;
         private readonly int index;
 
-        public SmartParameter(MemberInfo source, object value, int index)
+        public SmartParameter(Type parameterType, MemberInfo source, object value, int index)
         {
+            this.parameterType = parameterType;
             this.source = source;
             method = source is PropertyInfo property ? property.GetMethod : source as MethodInfo;
             Value = value;
@@ -124,7 +126,7 @@ namespace BenchmarkDotNet.Parameters
 
         public string ToSourceCode()
         {
-            string cast = Value == null ? string.Empty : $"({Value.GetType().GetCorrectCSharpTypeName()})";
+            string cast = $"({parameterType.GetCorrectCSharpTypeName()})"; // it's an object so we need to cast it to the right type
 
             string instancePrefix = method.IsStatic ? source.DeclaringType.GetCorrectCSharpTypeName() : "instance";
 

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -191,10 +191,10 @@ namespace BenchmarkDotNet.Running
 
             var paramsDefinitions = GetDefinitions<ParamsAttribute>((attribute, parameterType) => GetValidValues(attribute.Values, parameterType));
 
-            var paramsSourceDefinitions = GetDefinitions<ParamsSourceAttribute>((attribute, _) =>
+            var paramsSourceDefinitions = GetDefinitions<ParamsSourceAttribute>((attribute, parameterType) =>
             {
                 var paramsValues = GetValidValuesForParamsSource(type, attribute.Name);
-                return SmartParamBuilder.CreateForParams(paramsValues.source, paramsValues.values);
+                return SmartParamBuilder.CreateForParams(parameterType, paramsValues.source, paramsValues.values);
             });
 
             var paramsAllValuesDefinitions = GetDefinitions<ParamsAllValuesAttribute>((_, parameterType) => GetAllValidValues(parameterType));

--- a/tests/BenchmarkDotNet.IntegrationTests/ParamSourceTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ParamSourceTests.cs
@@ -1,15 +1,30 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Reflection;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
     public class ParamSourceTests: BenchmarkTestExecutor
     {
+        public ParamSourceTests(ITestOutputHelper output) : base(output) { }
+
+        public static IEnumerable<object[]> GetToolchains()
+            => new[]
+                {
+                    new object[] { Job.Default.GetToolchain() },
+                    new object[] { InProcessEmitToolchain.Instance },
+                };
+
         [Fact]
         public void ParamSourceCanHandleStringWithSurrogates()
         {
@@ -34,6 +49,160 @@ namespace BenchmarkDotNet.IntegrationTests
 
             [Benchmark]
             public void Method() { }
+        }
+
+        private Summary CanExecuteWithExtraInfo(Type type, IToolchain toolchain)
+        {
+            IConfig config = CreateSimpleConfig(job: Job.Dry.WithToolchain(toolchain));
+            // Show the relevant codegen excerpt in test results (the *.notcs is not part of the logs)
+            // This uses the private static CodeGenerator.GetParamsContent() method.
+            // Method changes there must be applied here - or consider making the method internal.
+            // TODO Should we omit the extra info if (toolchain.IsInProcess)? Doesn't use GetParamsContent().
+            Output.WriteLine("// Benchmarks and CodeGenerator.GetParamsContent()");
+            BenchmarkRunInfo runInfo = BenchmarkConverter.TypeToBenchmarks(type, config);
+            MethodInfo getParamsContent = typeof(Code.CodeGenerator).GetMethod("GetParamsContent", BindingFlags.Static | BindingFlags.NonPublic, null, new[] { typeof(BenchmarkCase) }, null);
+            Assert.NotNull(getParamsContent);
+            foreach (BenchmarkCase benchmarkCase in runInfo.BenchmarksCases)
+            {
+                Output.WriteLine("//   " + benchmarkCase.DisplayInfo);
+                Output.WriteLine((string)getParamsContent.Invoke(null, new object[] { benchmarkCase }));
+            }
+            return CanExecute(type, config);
+        }
+
+        public interface ITargetInterface
+        {
+            int Data { get; }
+        }
+
+        private class NonPublicSource : ITargetInterface
+        {
+            public int Data { get; }
+            public NonPublicSource(int data) => Data = data;
+            public override string ToString() => "src " + Data.ToString();
+        }
+
+        public class PrivateClassWithPublicInterface
+        {
+            public static IEnumerable<ITargetInterface> GetSource()
+            {
+                yield return null;
+                yield return new NonPublicSource(1);
+                yield return new NonPublicSource(2);
+            }
+
+            [ParamsSource(nameof(GetSource))]
+            public ITargetInterface ParamsTarget { get; set; }
+
+            [Benchmark]
+            public int Benchmark() => ParamsTarget?.Data ?? 0;
+        }
+
+        [Theory, MemberData(nameof(GetToolchains))]
+        public void PrivateClassWithPublicInterface_Succeeds(IToolchain toolchain) => CanExecuteWithExtraInfo(typeof(PrivateClassWithPublicInterface), toolchain);
+
+        public class PrivateClassWithPublicInterface_Array
+        {
+            public IEnumerable<ITargetInterface[]> GetSource()
+            {
+                yield return null;
+                yield return Array.Empty<NonPublicSource>();
+                yield return new NonPublicSource[] { null };
+                yield return new[] { new NonPublicSource(1), new NonPublicSource(2) };
+            }
+
+            [ParamsSource(nameof(GetSource))]
+            public ITargetInterface[] ParamsTarget { get; set; }
+
+            [Benchmark]
+            public int Benchmark() => ParamsTarget?.Sum(p => p?.Data ?? 0) ?? 0;
+        }
+
+        [Theory, MemberData(nameof(GetToolchains))]
+        public void PrivateClassWithPublicInterface_Array_Succeeds(IToolchain toolchain) => CanExecuteWithExtraInfo(typeof(PrivateClassWithPublicInterface_Array), toolchain);
+
+        public class PrivateClassWithPublicInterface_Enumerable
+        {
+            public IEnumerable<IEnumerable<ITargetInterface>> GetSource()
+            {
+                IEnumerable<ITargetInterface> YieldNull() { yield return null; }
+                yield return null;
+                yield return Enumerable.Empty<NonPublicSource>();
+                yield return YieldNull();
+                yield return PrivateClassWithPublicInterface.GetSource();
+            }
+
+            [ParamsSource(nameof(GetSource))]
+            public IEnumerable<ITargetInterface> ParamsTarget { get; set; }
+
+            [Benchmark]
+            public int Benchmark() => ParamsTarget?.Sum(p => p?.Data ?? 0) ?? 0;
+        }
+
+        [Theory, MemberData(nameof(GetToolchains))]
+        public void PrivateClassWithPublicInterface_Enumerable_Succeeds(IToolchain toolchain) => CanExecuteWithExtraInfo(typeof(PrivateClassWithPublicInterface_Enumerable), toolchain);
+
+        public class PrivateClassWithPublicInterface_AsObject
+        {
+            public static IEnumerable<object> GetSource()
+            {
+                yield return null;
+                yield return new NonPublicSource(1);
+                yield return new NonPublicSource(2);
+            }
+
+            [ParamsSource(nameof(GetSource))]
+            public ITargetInterface ParamsTarget { get; set; }
+
+            [Benchmark]
+            public int Benchmark() => ParamsTarget?.Data ?? 0;
+        }
+
+        [Theory, MemberData(nameof(GetToolchains))]
+        public void PrivateClassWithPublicInterface_AsObject_Succeeds(IToolchain toolchain) => CanExecuteWithExtraInfo(typeof(PrivateClassWithPublicInterface_AsObject), toolchain);
+
+        public class PublicSource
+        {
+            public int Data { get; }
+            public PublicSource(int data) => Data = data;
+            // Notes:
+            // - op_Implicit would be meaningless since codegen wouldn't have to do anything.
+            // - TODO op_Explicit is currently not supported by InProcessEmitToolchain (See TryChangeType() in Toolchains/InProcess.Emit.Implementation/Runnable/RunnableReflectionHelpers.cs)
+            public static explicit operator TargetType(PublicSource @this) => @this != null ? new TargetType(@this.Data) : null;
+            public override string ToString() => "src " + Data.ToString();
+        }
+
+        public class TargetType
+        {
+            public int Data { get; }
+            public TargetType(int data) => Data = data;
+            public override string ToString() => "target " + Data.ToString();
+        }
+
+        public class SourceWithExplicitCastToTarget
+        {
+            public static IEnumerable<PublicSource> GetSource()
+            {
+                yield return null;
+                yield return new PublicSource(1);
+                yield return new PublicSource(2);
+            }
+
+            [ParamsSource(nameof(GetSource))]
+            public TargetType ParamsTarget { get; set; }
+
+            [Benchmark]
+            public int Benchmark() => ParamsTarget?.Data ?? 0;
+        }
+
+        [Fact]
+        public void SourceWithExplicitCastToTarget_DefaultToolchain_Succeeds() => CanExecuteWithExtraInfo(typeof(SourceWithExplicitCastToTarget), Job.Default.GetToolchain());
+
+        [Fact]
+        public void SourceWithExplicitCastToTarget_InProcessToolchain_Throws()
+        {
+            // See notes on op_Explicit above.
+            Assert.ThrowsAny<Exception>(() => CanExecuteWithExtraInfo(typeof(SourceWithExplicitCastToTarget), InProcessEmitToolchain.Instance));
         }
     }
 }


### PR DESCRIPTION
SmartParameter codegen must use the target type for casting, not the type of the source value.
Basically, this is a follow up to PR #1228 (1678a49a7b044b7915c3cbcd64300501cfef9035), which fixed this problem for SmartArgument.
EDIT: ~Fixes #2011. Probably also #1812 and a few similar issues reported in the past.~
Fixes #2011, fixes #1812, fixes #1177.

@adamsitnik 
Not sure yet if the fix is complete or if the shortcuts in `SmartParamBuilder.CreateForParams()` that bypass the creation of `SmartParameter` instances have to be removed. Same for `BenchmarkConverter.GetValidValues()`.
(test failures are unrelated, though)