### PR TITLE
add .NET 4.8.1 support

### DIFF
--- a/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
+++ b/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
@@ -50,6 +50,11 @@ namespace BenchmarkDotNet.Jobs
         Net48,
 
         /// <summary>
+        /// .NET 4.8.1
+        /// </summary>
+        Net481,
+
+        /// <summary>
         /// .NET Core 2.0
         /// </summary>
         NetCoreApp20,

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -364,6 +364,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 case RuntimeMoniker.Net471:
                 case RuntimeMoniker.Net472:
                 case RuntimeMoniker.Net48:
+                case RuntimeMoniker.Net481:
                     return baseJob
                         .WithRuntime(runtimeMoniker.GetRuntime())
                         .WithToolchain(CsProjClassicNetToolchain.From(runtimeId, options.RestorePath?.FullName));

--- a/src/BenchmarkDotNet/Environments/Runtimes/ClrRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/ClrRuntime.cs
@@ -13,6 +13,7 @@ namespace BenchmarkDotNet.Environments
         public static readonly ClrRuntime Net471 = new ClrRuntime(RuntimeMoniker.Net471, "net471", ".NET Framework 4.7.1");
         public static readonly ClrRuntime Net472 = new ClrRuntime(RuntimeMoniker.Net472, "net472", ".NET Framework 4.7.2");
         public static readonly ClrRuntime Net48 = new ClrRuntime(RuntimeMoniker.Net48, "net48", ".NET Framework 4.8");
+        public static readonly ClrRuntime Net481 = new ClrRuntime(RuntimeMoniker.Net481, "net481", ".NET Framework 4.8.1");
 
         public string Version { get; }
 
@@ -62,6 +63,7 @@ namespace BenchmarkDotNet.Environments
                 case "4.7.1": return Net471;
                 case "4.7.2": return Net472;
                 case "4.8":   return Net48;
+                case "4.8.1": return Net481;
                 default: // unlikely to happen but theoretically possible
                     return new ClrRuntime(RuntimeMoniker.NotRecognized, $"net{version.Replace(".", null)}", $".NET Framework {version}");
             }

--- a/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
@@ -22,6 +22,8 @@ namespace BenchmarkDotNet.Extensions
                     return ClrRuntime.Net472;
                 case RuntimeMoniker.Net48:
                     return ClrRuntime.Net48;
+                case RuntimeMoniker.Net481:
+                    return ClrRuntime.Net481;
                 case RuntimeMoniker.NetCoreApp20:
                     return CoreRuntime.Core20;
                 case RuntimeMoniker.NetCoreApp21:

--- a/src/BenchmarkDotNet/Helpers/FrameworkVersionHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/FrameworkVersionHelper.cs
@@ -48,9 +48,10 @@ namespace BenchmarkDotNet.Helpers
                 return "4.7.1";
             if (string.Compare(servicingVersion, "4.8") < 0)
                 return "4.7.2";
+            if (string.Compare(servicingVersion, "4.8.1") < 0)
+                return "4.8";
 
-            // TODO Add support for .NET Framework 4.8.1
-            return "4.8"; // most probably the last major release of Full .NET Framework
+            return "4.8.1"; // most probably the last major release of Full .NET Framework
         }
 
 

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
@@ -20,6 +20,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         [PublicAPI] public static readonly IToolchain Net471 = new CsProjClassicNetToolchain("net471", ".NET Framework 4.7.1");
         [PublicAPI] public static readonly IToolchain Net472 = new CsProjClassicNetToolchain("net472", ".NET Framework 4.7.2");
         [PublicAPI] public static readonly IToolchain Net48 = new CsProjClassicNetToolchain("net48", ".NET Framework 4.8");
+        [PublicAPI] public static readonly IToolchain Net481 = new CsProjClassicNetToolchain("net481", ".NET Framework 4.8.1");
 
         private CsProjClassicNetToolchain(string targetFrameworkMoniker, string name, string packagesPath = null)
             : base(name,

--- a/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
@@ -89,6 +89,8 @@ namespace BenchmarkDotNet.Toolchains
                     return CsProjClassicNetToolchain.Net472;
                 case RuntimeMoniker.Net48:
                     return CsProjClassicNetToolchain.Net48;
+                case RuntimeMoniker.Net481:
+                    return CsProjClassicNetToolchain.Net481;
                 case RuntimeMoniker.NetCoreApp20:
                     return CsProjCoreToolchain.NetCoreApp20;
                 case RuntimeMoniker.NetCoreApp21:

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -357,6 +357,8 @@ namespace BenchmarkDotNet.Tests
         [InlineData("net47")]
         [InlineData("net471")]
         [InlineData("net472")]
+        [InlineData("net48")]
+        [InlineData("net481")]
         public void NetFrameworkMonikerParsedCorrectly(string tfm)
         {
             var config = ConfigParser.Parse(new[] { "-r", tfm }, new OutputLogger(Output)).config;


### PR DESCRIPTION
.NET 4.8.1 has not been released yet, but we are releasing a new BDN version soon and I am not sure if we are going to release another one before 4.8.1 is officially released, so I am adding the support now. So when 4.8.1 is released everything should just work, assuming the users are using latest BDN.

fixes #2039