### PR TITLE
Make a bit of BenchmarkDotNet trimmable

### DIFF
--- a/src/BenchmarkDotNet.Annotations/Attributes/DynamicallyAccessedMembersAttribute.cs
+++ b/src/BenchmarkDotNet.Annotations/Attributes/DynamicallyAccessedMembersAttribute.cs
@@ -23,7 +23,7 @@ namespace System.Diagnostics.CodeAnalysis
     /// </remarks>
     [AttributeUsage(
         AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
-        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method,
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Class,
         Inherited = false)]
     internal sealed class DynamicallyAccessedMembersAttribute : Attribute
     {

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -44,6 +44,10 @@
   <ItemGroup>
     <ProjectReference Include="..\BenchmarkDotNet.Annotations\BenchmarkDotNet.Annotations.csproj" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <Compile Include="..\BenchmarkDotNet.Annotations\Attributes\DynamicallyAccessedMembersAttribute.cs" Link="Properties\DynamicallyAccessedMembersAttribute.cs" />
+    <Compile Include="..\BenchmarkDotNet.Annotations\Attributes\DynamicallyAccessedMemberTypes.cs" Link="Properties\DynamicallyAccessedMemberTypes.cs" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\BenchmarkDotNet.Disassembler.x64\DataContracts.cs" Link="Disassemblers\DataContracts.cs" />
   </ItemGroup>

--- a/src/BenchmarkDotNet/Characteristics/Characteristic.cs
+++ b/src/BenchmarkDotNet/Characteristics/Characteristic.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using static BenchmarkDotNet.Characteristics.CharacteristicHelper;
 
 namespace BenchmarkDotNet.Characteristics
@@ -7,7 +8,7 @@ namespace BenchmarkDotNet.Characteristics
     {
         public static readonly object EmptyValue = new object();
 
-        public static Characteristic<T> Create<TOwner, T>(string memberName)
+        public static Characteristic<T> Create<TOwner, [DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(string memberName)
             where TOwner : CharacteristicObject
             => new Characteristic<T>(
                 memberName,
@@ -15,7 +16,7 @@ namespace BenchmarkDotNet.Characteristics
                 null, default,
                 false);
 
-        public static Characteristic<T> Create<TOwner, T>(string memberName, T fallbackValue)
+        public static Characteristic<T> Create<TOwner, [DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(string memberName, T fallbackValue)
             where TOwner : CharacteristicObject
             => new Characteristic<T>(
                 memberName,
@@ -23,7 +24,7 @@ namespace BenchmarkDotNet.Characteristics
                 null, fallbackValue,
                 false);
 
-        public static Characteristic<T> Create<TOwner, T>(string memberName, Func<CharacteristicObject, T, T> resolver, T fallbackValue, bool ignoreOnApply)
+        public static Characteristic<T> Create<TOwner, [DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(string memberName, Func<CharacteristicObject, T, T> resolver, T fallbackValue, bool ignoreOnApply)
             where TOwner : CharacteristicObject
             => new Characteristic<T>(
                 memberName,
@@ -31,7 +32,7 @@ namespace BenchmarkDotNet.Characteristics
                 resolver, fallbackValue,
                 ignoreOnApply);
 
-        public static Characteristic<T> CreateHidden<TOwner, T>(string memberName)
+        public static Characteristic<T> CreateHidden<TOwner, [DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(string memberName)
             where TOwner : CharacteristicObject
             => new Characteristic<T>(
                 memberName,
@@ -39,7 +40,7 @@ namespace BenchmarkDotNet.Characteristics
                 null, default,
                 false, true);
 
-        public static Characteristic<T> CreateIgnoreOnApply<TOwner, T>(string memberName)
+        public static Characteristic<T> CreateIgnoreOnApply<TOwner, [DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(string memberName)
             where TOwner : CharacteristicObject
             => new Characteristic<T>(
                 memberName,
@@ -49,7 +50,7 @@ namespace BenchmarkDotNet.Characteristics
 
         protected Characteristic(
             string id,
-            Type characteristicType,
+            [DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] Type characteristicType,
             Type declaringType,
             object fallbackValue,
             bool ignoreOnApply,
@@ -78,6 +79,7 @@ namespace BenchmarkDotNet.Characteristics
 
         public bool DontShowInSummary { get; }
 
+        [DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)]
         public Type CharacteristicType { get; }
 
         public Type DeclaringType { get; }

--- a/src/BenchmarkDotNet/Characteristics/CharacteristicHelper.cs
+++ b/src/BenchmarkDotNet/Characteristics/CharacteristicHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -39,14 +40,16 @@ namespace BenchmarkDotNet.Characteristics
         [PublicAPI] public static IReadOnlyList<Characteristic> GetThisTypeCharacteristics(this CharacteristicObject obj) =>
             GetThisTypeCharacteristics(obj.GetType());
 
-        public static IReadOnlyList<Characteristic> GetThisTypeCharacteristics(Type characteristicObjectType)
+        public static IReadOnlyList<Characteristic> GetThisTypeCharacteristics(
+            [DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] Type characteristicObjectType)
         {
             if (!IsCharacteristicObjectSubclass(characteristicObjectType))
                 return EmptyCharacteristics;
             return ThisTypeCharacteristics.GetOrAdd(characteristicObjectType, GetThisTypeCharacteristicsCore);
         }
 
-        private static IReadOnlyList<Characteristic> GetThisTypeCharacteristicsCore(Type characteristicObjectType)
+        private static IReadOnlyList<Characteristic> GetThisTypeCharacteristicsCore(
+            [DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] Type characteristicObjectType)
         {
             var fieldValues = characteristicObjectType.GetTypeInfo()
                 .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy | BindingFlags.Static)
@@ -73,14 +76,16 @@ namespace BenchmarkDotNet.Characteristics
         public static IReadOnlyList<Characteristic> GetAllCharacteristics(this CharacteristicObject obj) =>
             GetAllCharacteristics(obj.GetType());
 
-        public static IReadOnlyList<Characteristic> GetAllCharacteristics(Type characteristicObjectType)
+        public static IReadOnlyList<Characteristic> GetAllCharacteristics(
+            [DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] Type characteristicObjectType)
         {
             if (!IsCharacteristicObjectSubclass(characteristicObjectType))
                 return EmptyCharacteristics;
             return AllTypeCharacteristics.GetOrAdd(characteristicObjectType, GetAllCharacteristicsCore);
         }
 
-        private static IReadOnlyList<Characteristic> GetAllCharacteristicsCore(Type characteristicObjectType)
+        private static IReadOnlyList<Characteristic> GetAllCharacteristicsCore(
+            [DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] Type characteristicObjectType)
         {
             var result = new List<Characteristic>();
 
@@ -90,7 +95,8 @@ namespace BenchmarkDotNet.Characteristics
         }
 
         private static void FillAllCharacteristicsCore(
-            Type characteristicObjectType, List<Characteristic> result, HashSet<Characteristic> visited)
+            [DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] Type characteristicObjectType,
+            List<Characteristic> result, HashSet<Characteristic> visited)
         {
             // DONTTOUCH: DO NOT change the order of characteristic as it may break logic of some operations.
 
@@ -113,7 +119,9 @@ namespace BenchmarkDotNet.Characteristics
             }
         }
 
-        public static IReadOnlyList<Characteristic> GetAllPresentableCharacteristics(Type characteristicObjectType, bool includeIgnoreOnApply = false) =>
+        public static IReadOnlyList<Characteristic> GetAllPresentableCharacteristics(
+            [DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] Type characteristicObjectType,
+            bool includeIgnoreOnApply = false) =>
             GetAllCharacteristics(characteristicObjectType)
                 .Where(c => c.IsPresentableCharacteristic(includeIgnoreOnApply))
                 .ToArray();

--- a/src/BenchmarkDotNet/Characteristics/CharacteristicObject.cs
+++ b/src/BenchmarkDotNet/Characteristics/CharacteristicObject.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 
+using NotNullAttribute = JetBrains.Annotations.NotNullAttribute;
+
 namespace BenchmarkDotNet.Characteristics
 {
     // TODO: better naming.

--- a/src/BenchmarkDotNet/Characteristics/CharacteristicObject.cs
+++ b/src/BenchmarkDotNet/Characteristics/CharacteristicObject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -7,9 +8,14 @@ using JetBrains.Annotations;
 namespace BenchmarkDotNet.Characteristics
 {
     // TODO: better naming.
+    [DynamicallyAccessedMembers(CharacteristicMemberTypes)]
     public abstract class CharacteristicObject
     {
         #region IdCharacteristic
+
+        internal const DynamicallyAccessedMemberTypes CharacteristicMemberTypes =
+            DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties
+            | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields;
 
         protected static string ResolveId(CharacteristicObject obj, string actual)
         {
@@ -134,7 +140,7 @@ namespace BenchmarkDotNet.Characteristics
             return false;
         }
 
-        internal T GetValue<T>(Characteristic<T> characteristic)
+        internal T GetValue<[DynamicallyAccessedMembers(CharacteristicMemberTypes)] T>(Characteristic<T> characteristic)
         {
             return (T)GetValue((Characteristic)characteristic);
         }
@@ -154,12 +160,12 @@ namespace BenchmarkDotNet.Characteristics
         #endregion
 
         #region Resolve
-        public T ResolveValue<T>(Characteristic<T> characteristic, IResolver resolver)
+        public T ResolveValue<[DynamicallyAccessedMembers(CharacteristicMemberTypes)] T>(Characteristic<T> characteristic, IResolver resolver)
         {
             return resolver.Resolve(this, characteristic);
         }
 
-        public T ResolveValue<T>(Characteristic<T> characteristic, IResolver resolver, T defaultValue)
+        public T ResolveValue<[DynamicallyAccessedMembers(CharacteristicMemberTypes)] T>(Characteristic<T> characteristic, IResolver resolver, T defaultValue)
         {
             return resolver.Resolve(this, characteristic, defaultValue);
         }
@@ -174,7 +180,7 @@ namespace BenchmarkDotNet.Characteristics
             return resolver.Resolve(this, characteristic, defaultValue);
         }
 
-        public T ResolveValue<T>(Characteristic<T> characteristic, T defaultValue)
+        public T ResolveValue<[DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(Characteristic<T> characteristic, T defaultValue)
         {
             return HasValue(characteristic) ? GetValue(characteristic) : (T)characteristic.ResolveValueCore(this, defaultValue);
         }
@@ -185,14 +191,14 @@ namespace BenchmarkDotNet.Characteristics
             return HasValue(characteristic) ? GetValue(characteristic) : characteristic.ResolveValueCore(this, defaultValue);
         }
 
-        public T? ResolveValueAsNullable<T>(Characteristic<T> characteristic) where T : struct
+        public T? ResolveValueAsNullable<[DynamicallyAccessedMembers(CharacteristicMemberTypes)] T>(Characteristic<T> characteristic) where T : struct
         {
             return HasValue(characteristic) ? GetValue(characteristic) : (T?)null;
         }
         #endregion
 
         #region Set value
-        internal void SetValue<T>(Characteristic<T> characteristic, T value)
+        internal void SetValue<[DynamicallyAccessedMembers(CharacteristicMemberTypes)] T>(Characteristic<T> characteristic, T value)
         {
             SetValue((Characteristic)characteristic, value);
         }

--- a/src/BenchmarkDotNet/Characteristics/CharacteristicObject`1.cs
+++ b/src/BenchmarkDotNet/Characteristics/CharacteristicObject`1.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Characteristics
 {
@@ -32,10 +33,10 @@ namespace BenchmarkDotNet.Characteristics
 
         public new T UnfreezeCopy() => (T)UnfreezeCopyCore();
 
-        protected static Characteristic<TC> CreateCharacteristic<TC>(string memberName) => Characteristic.Create<T, TC>(memberName);
+        protected static Characteristic<TC> CreateCharacteristic<[DynamicallyAccessedMembers(CharacteristicMemberTypes)] TC>(string memberName) => Characteristic.Create<T, TC>(memberName);
 
-        protected static Characteristic<TC> CreateHiddenCharacteristic<TC>(string memberName) => Characteristic.CreateHidden<T, TC>(memberName);
+        protected static Characteristic<TC> CreateHiddenCharacteristic<[DynamicallyAccessedMembers(CharacteristicMemberTypes)] TC>(string memberName) => Characteristic.CreateHidden<T, TC>(memberName);
 
-        protected static Characteristic<TC> CreateIgnoreOnApplyCharacteristic<TC>(string memberName) => Characteristic.CreateIgnoreOnApply<T, TC>(memberName);
+        protected static Characteristic<TC> CreateIgnoreOnApplyCharacteristic<[DynamicallyAccessedMembers(CharacteristicMemberTypes)] TC>(string memberName) => Characteristic.CreateIgnoreOnApply<T, TC>(memberName);
     }
 }

--- a/src/BenchmarkDotNet/Characteristics/Characteristic`1.cs
+++ b/src/BenchmarkDotNet/Characteristics/Characteristic`1.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace BenchmarkDotNet.Characteristics
 {
-    public class Characteristic<T> : Characteristic
+    public class Characteristic<[DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T> : Characteristic
     {
         internal Characteristic(
             string id,

--- a/src/BenchmarkDotNet/Characteristics/CompositeResolver.cs
+++ b/src/BenchmarkDotNet/Characteristics/CompositeResolver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace BenchmarkDotNet.Characteristics
@@ -25,7 +26,7 @@ namespace BenchmarkDotNet.Characteristics
             throw new InvalidOperationException($"There is no default resolver for {characteristic.FullId}");
         }
 
-        public T Resolve<T>(CharacteristicObject obj, Characteristic<T> characteristic)
+        public T Resolve<[DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(CharacteristicObject obj, Characteristic<T> characteristic)
         {
             if (obj.HasValue(characteristic))
                 return characteristic[obj];
@@ -47,7 +48,7 @@ namespace BenchmarkDotNet.Characteristics
             return defaultValue;
         }
 
-        public T Resolve<T>(CharacteristicObject obj, Characteristic<T> characteristic, T defaultValue)
+        public T Resolve<[DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(CharacteristicObject obj, Characteristic<T> characteristic, T defaultValue)
         {
             if (obj.HasValue(characteristic))
                 return characteristic[obj];

--- a/src/BenchmarkDotNet/Characteristics/IResolver.cs
+++ b/src/BenchmarkDotNet/Characteristics/IResolver.cs
@@ -1,4 +1,6 @@
-﻿namespace BenchmarkDotNet.Characteristics
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace BenchmarkDotNet.Characteristics
 {
     /// <summary>
     /// An entity which can resolve default values of <see cref="Characteristic{T}"/>.
@@ -9,10 +11,10 @@
 
         object Resolve(CharacteristicObject obj, Characteristic characteristic);
 
-        T Resolve<T>(CharacteristicObject obj, Characteristic<T> characteristic);
+        T Resolve<[DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(CharacteristicObject obj, Characteristic<T> characteristic);
 
         object Resolve(CharacteristicObject obj, Characteristic characteristic, object defaultValue);
 
-        T Resolve<T>(CharacteristicObject obj, Characteristic<T> characteristic, T defaultValue);
+        T Resolve<[DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(CharacteristicObject obj, Characteristic<T> characteristic, T defaultValue);
     }
 }

--- a/src/BenchmarkDotNet/Characteristics/Resolver.cs
+++ b/src/BenchmarkDotNet/Characteristics/Resolver.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace BenchmarkDotNet.Characteristics
 {
@@ -7,10 +8,10 @@ namespace BenchmarkDotNet.Characteristics
     {
         private readonly Dictionary<Characteristic, Func<CharacteristicObject, object>> resolvers = new Dictionary<Characteristic, Func<CharacteristicObject, object>>();
 
-        protected void Register<T>(Characteristic<T> characteristic, Func<T> resolver) =>
+        protected void Register<[DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(Characteristic<T> characteristic, Func<T> resolver) =>
             resolvers[characteristic] = obj => resolver();
 
-        protected void Register<T>(Characteristic<T> characteristic, Func<CharacteristicObject, T> resolver) =>
+        protected void Register<[DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(Characteristic<T> characteristic, Func<CharacteristicObject, T> resolver) =>
             resolvers[characteristic] = obj => resolver(obj);
 
         public bool CanResolve(Characteristic characteristic) => resolvers.ContainsKey(characteristic);
@@ -25,7 +26,7 @@ namespace BenchmarkDotNet.Characteristics
             throw new InvalidOperationException($"There is no default resolver for {characteristic.FullId}");
         }
 
-        public T Resolve<T>(CharacteristicObject obj, Characteristic<T> characteristic)
+        public T Resolve<[DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(CharacteristicObject obj, Characteristic<T> characteristic)
         {
             if (obj.HasValue(characteristic))
                 return characteristic[obj];
@@ -46,7 +47,7 @@ namespace BenchmarkDotNet.Characteristics
             return defaultValue;
         }
 
-        public T Resolve<T>(CharacteristicObject obj, Characteristic<T> characteristic, T defaultValue)
+        public T Resolve<[DynamicallyAccessedMembers(CharacteristicObject.CharacteristicMemberTypes)] T>(CharacteristicObject obj, Characteristic<T> characteristic, T defaultValue)
         {
             if (obj.HasValue(characteristic))
                 return characteristic[obj];

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -144,9 +144,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <Compile Include=""{Path.GetFileName(artifactsPaths.ProgramCodePath)}"" Exclude=""bin\**;obj\**;**\*.xproj;packages\**"" />
   </ItemGroup>
   <ItemGroup>
-    <TrimmerRootAssembly Include=""BenchmarkDotNet"" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include=""Microsoft.DotNet.ILCompiler"" Version=""{ilCompilerVersion}"" />
     <ProjectReference Include=""{GetProjectFilePath(buildPartition.RepresentativeBenchmarkCase.Descriptor.Type, logger).FullName}"" />
   </ItemGroup>


### PR DESCRIPTION
Another attempt at fixing the problem I tried to fix in #2020.

In that pull request, I reflection-rooted all of BenchmarkDotNet, but that looks like it increases the size of the closure too much (https://github.com/dotnet/performance/pull/2532). So here I'm rolling that part back and annotating enough of the `Characteristic` APIs to make it so that we shouldn't run into the original problem.

I basically added `<EnableTrimAnalyzer>true</EnableTrimAnalyzer>` to the BechmarkDotNet project, looked at the trimming warning in https://github.com/dotnet/BenchmarkDotNet/blob/63e28c100a42a6492d09a0b93a8a4c141061bb0d/src/BenchmarkDotNet/Characteristics/CharacteristicHelper.cs#L49-L68 where we were getting the crash and kept adding annotations until it stopped generating new warnings.

We now have an annotation in a spot that should make sure the `Job` class has all fields and properties kept (it's used with one of the annotated `Create` methods).

There are more trimming warnings that I didn't try to solve because they're unrelated to the problem at hand.

Cc @adamsitnik 
Cc @dotnet/ilc-contrib FYI