### PR TITLE
Restrict what's published to AppVeyor NuGet feed (BDN nightly)

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -58,6 +58,7 @@ public class BuildContext : FrostingContext
 
     private IAppVeyorProvider AppVeyor => this.BuildSystem().AppVeyor;
     public bool IsOnAppVeyorAndNotPr => AppVeyor.IsRunningOnAppVeyor && !AppVeyor.Environment.PullRequest.IsPullRequest;
+    public bool IsOnAppVeyorAndBdnNightlyCiCd => IsOnAppVeyorAndNotPr && AppVeyor.Environment.Repository.Branch == "master" && this.IsRunningOnWindows();
     public bool IsLocalBuild => this.BuildSystem().IsLocalBuild;
     public bool IsCiBuild => !this.BuildSystem().IsLocalBuild;
 
@@ -360,6 +361,11 @@ public class AllTestsTask : FrostingTask<BuildContext>
 [IsDependentOn(typeof(BuildTask))]
 public class PackTask : FrostingTask<BuildContext>
 {
+    public override bool ShouldRun(BuildContext context)
+    {
+        return context.IsOnAppVeyorAndBdnNightlyCiCd;
+    }
+
     public override void Run(BuildContext context)
     {
         var settingsSrc = new DotNetCorePackSettings


### PR DESCRIPTION
- Fixes cake build regression introduced by switching from the old cake script
https://github.com/dotnet/BenchmarkDotNet/blob/a936815f2a58d9b728cfc5fe620bba17481c180c/build.cake#L151-L153
- and additionally excludes any builds triggered from commits to non-master branches.

The Cake Pack task is executed only if the build:
- runs on AppVeyor
- is not a PR
- is triggered from 'master' branch
- runs on Windows

Reason:
On AppVeyor, the packages produced by Pack are automatically uploaded as artifacts AND to the AppVeyor NuGet feed.
On GitHub and Azure Pipelines, Pack output is discarded anyway.

Fixes #1937.