### PR TITLE
Added the kernel stacks keyword as a parameter to the ETWConfig so that call stacks for specific kernel keywords can be collected. 

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.Windows/EtwProfilerConfig.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/EtwProfilerConfig.cs
@@ -18,6 +18,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
         public float CpuSampleIntervalInMilliseconds { get; }
 
         public KernelTraceEventParser.Keywords KernelKeywords { get; }
+        public KernelTraceEventParser.Keywords KernelStackKeywords { get; }
 
         public IReadOnlyDictionary<HardwareCounter, Func<ProfileSourceInfo, int>> IntervalSelectors { get; }
 
@@ -37,12 +38,14 @@ namespace BenchmarkDotNet.Diagnostics.Windows
             int bufferSizeInMb = 256,
             float cpuSampleIntervalInMilliseconds = 1.0f,
             KernelTraceEventParser.Keywords kernelKeywords = KernelTraceEventParser.Keywords.ImageLoad | KernelTraceEventParser.Keywords.Profile,
+            KernelTraceEventParser.Keywords kernelStackKeywords = KernelTraceEventParser.Keywords.Profile,
             IReadOnlyDictionary<HardwareCounter, Func<ProfileSourceInfo, int>> intervalSelectors = null,
             IReadOnlyCollection<(Guid providerGuid, TraceEventLevel providerLevel, ulong keywords, TraceEventProviderOptions options)> providers = null,
             bool createHeapSession = false)
         {
             CreateHeapSession = createHeapSession;
             KernelKeywords = kernelKeywords;
+            KernelStackKeywords = kernelStackKeywords;
             PerformExtraBenchmarksRun = performExtraBenchmarksRun;
             BufferSizeInMb = bufferSizeInMb;
             CpuSampleIntervalInMilliseconds = cpuSampleIntervalInMilliseconds;

--- a/src/BenchmarkDotNet.Diagnostics.Windows/Sessions.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/Sessions.cs
@@ -76,7 +76,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
 
             try
             {
-                TraceEventSession.EnableKernelProvider(keywords, KernelTraceEventParser.Keywords.Profile);
+                TraceEventSession.EnableKernelProvider(keywords, Config.KernelStackKeywords);
             }
             catch (Win32Exception)
             {


### PR DESCRIPTION
Use case, there are times where the trace file needs to contain specialized keywords for stacks. Right now, the value is hardcoded to ``Profile`` and this is useful in many cases but to get the flexibility of analyzing cases such as Page Faults via the ``ReferenceSet`` keyword additional stacks need to be made available for more wholistic analysis.   