### PR TITLE
Fix DocFx configuration and build

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -453,8 +453,11 @@ public class DocfxChangelogGenerateTask : FrostingTask<BuildContext>
     }
 }
 
+// In order to work around xref issues in DocFx, BenchmarkDotNet and BenchmarkDotNet.Annotations must be build
+// before running the DocFX_Build target. However, including a dependency on BuildTask here may have unwanted
+// side effects (CleanTask).
+// TODO: Define dependencies when a CI workflow scenario for using the "DocFX_Build" target exists.
 [TaskName("DocFX_Build")]
-[IsDependentOn(typeof(BuildTask))] // Required to fix dofx xref issues
 [IsDependentOn(typeof(DocfxInstallTask))]
 [IsDependentOn(typeof(DocfxChangelogGenerateTask))]
 public class DocfxChangelogBuildTask : FrostingTask<BuildContext>

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -202,7 +202,7 @@ public class BuildContext : FrostingContext
 
 public static class DocumentationHelper
 {
-    public const string DocFxVersion = "2.57.2";
+    public const string DocFxVersion = "2.59.3";
 
     public static readonly string[] BdnAllVersions =
     {
@@ -454,6 +454,7 @@ public class DocfxChangelogGenerateTask : FrostingTask<BuildContext>
 }
 
 [TaskName("DocFX_Build")]
+[IsDependentOn(typeof(BuildTask))] // Required to fix dofx xref issues
 [IsDependentOn(typeof(DocfxInstallTask))]
 [IsDependentOn(typeof(DocfxChangelogGenerateTask))]
 public class DocfxChangelogBuildTask : FrostingTask<BuildContext>

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -15,6 +15,7 @@
         }
       ],
       "dest": "api",
+      "filter": "filter.yml",
       "properties": {
         "TargetFramework": "netstandard2.0"
       },
@@ -54,6 +55,9 @@
     "template": [
       "default",
       "template"
+    ],
+    "xrefService": [
+      "https://xref.docs.microsoft.com/query?uid={uid}"
     ],
     "postProcessors": ["ExtractSearchIndex"],
     "markdownEngineName": "markdig",

--- a/docs/filter.yml
+++ b/docs/filter.yml
@@ -1,0 +1,4 @@
+apiRules:
+- exclude:
+    uidRegex: ^System\.Object
+    type: member # Avoid list of inherited Object members for each type.

--- a/src/BenchmarkDotNet.Annotations/BenchmarkDotNet.Annotations.csproj
+++ b/src/BenchmarkDotNet.Annotations/BenchmarkDotNet.Annotations.csproj
@@ -7,6 +7,8 @@
     <AssemblyName>BenchmarkDotNet.Annotations</AssemblyName>
     <PackageId>BenchmarkDotNet.Annotations</PackageId>
     <RootNamespace>BenchmarkDotNet</RootNamespace>
+    <!-- needed for docfx xref resolver -->
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\BenchmarkDotNet\Helpers\CodeAnnotations.cs" Link="Attributes\CodeAnnotations.cs" />

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -8,6 +8,8 @@
     <AssemblyName>BenchmarkDotNet</AssemblyName>
     <PackageId>BenchmarkDotNet</PackageId>
     <RootNamespace>BenchmarkDotNet</RootNamespace>
+    <!-- needed for docfx xref resolver -->
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Templates\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />


### PR DESCRIPTION
- Bump DocFx version to 2.59.3 (fixes #1992)
- ~Build BDN before building docs (fixes xref issues)~ (see notes on 3c18c4fbba8f6fd6aefbbbd3711692614ae40a92)
- Add \<ProduceReferenceAssembly\> to BDN and BDN.Annotations projects (fixes xref issues)
- Add filter.yml to avoid listing inherited members of System.Object for each type.
- Add xrefService for resolving references to .NET SDK types.