### PR TITLE
Print Vector width in summary on older runtimes

### DIFF
--- a/src/BenchmarkDotNet/Portability/Cpu/HardwareIntrinsics.cs
+++ b/src/BenchmarkDotNet/Portability/Cpu/HardwareIntrinsics.cs
@@ -39,7 +39,7 @@ namespace BenchmarkDotNet.Portability.Cpu
             else if (IsArmBaseSupported)
                 return "ArmBase";
             else
-                return string.Empty; // Runtimes prior to .NET Core 3.0 (APIs did not exist)
+                return GetVectorSize(); // Runtimes prior to .NET Core 3.0 (APIs did not exist so we print non-exact Vector info)
         }
 
         internal static string GetFullInfo(Platform platform)


### PR DESCRIPTION
This might help with noticing that legacy Mono does only 128bit SIMD even on AVX2 hardware.