### PR TITLE
use ClrMd v2 disassembler on Windows whenever possible

### DIFF
--- a/src/BenchmarkDotNet/Disassemblers/LinuxDisassembler.cs
+++ b/src/BenchmarkDotNet/Disassemblers/LinuxDisassembler.cs
@@ -2,11 +2,11 @@ using BenchmarkDotNet.Diagnosers;
 
 namespace BenchmarkDotNet.Disassemblers
 {
-    internal class LinuxDisassembler
+    internal class SameArchitectureDisassembler
     {
         private readonly DisassemblyDiagnoserConfig config;
 
-        internal LinuxDisassembler(DisassemblyDiagnoserConfig config) => this.config = config;
+        internal SameArchitectureDisassembler(DisassemblyDiagnoserConfig config) => this.config = config;
 
         internal DisassemblyResult Disassemble(DiagnoserActionParameters parameters)
             => ClrMdV2Disassembler.AttachAndDisassemble(BuildDisassemblerSettings(parameters));

--- a/src/BenchmarkDotNet/Disassemblers/WindowsDisassembler.cs
+++ b/src/BenchmarkDotNet/Disassemblers/WindowsDisassembler.cs
@@ -61,23 +61,20 @@ namespace BenchmarkDotNet.Disassemblers
             }
         }
 
-        private static string GetDisassemblerPath(Process process, Platform platform)
-        {
-            switch (platform)
+        internal static Platform GetDisassemblerArchitecture(Process process, Platform platform)
+            => platform switch
             {
-                case Platform.AnyCpu:
-                    return GetDisassemblerPath(process,
-                        NativeMethods.Is64Bit(process)
-                            ? Platform.X64
-                            : Platform.X86);
-                case Platform.X86:
-                    return GetDisassemblerPath("x86");
-                case Platform.X64:
-                    return GetDisassemblerPath("x64");
-                default:
-                    throw new NotSupportedException($"Platform {platform} not supported!");
-            }
-        }
+                Platform.AnyCpu => NativeMethods.Is64Bit(process) ? Platform.X64 : Platform.X86, // currently ARM is not supported
+                _ => platform
+            };
+
+        private static string GetDisassemblerPath(Process process, Platform platform)
+            => GetDisassemblerArchitecture(process, platform) switch
+            {
+                Platform.X86 => GetDisassemblerPath("x86"),
+                Platform.X64 => GetDisassemblerPath("x64"),
+                _ => throw new NotSupportedException($"Platform {platform} not supported!")
+            };
 
         private static string GetDisassemblerPath(string architectureName)
         {


### PR DESCRIPTION
I've tried to repro bug reported in #2063 but I've failed (script running for a whole day, everything fine).

I am guessing that the issue was caused by the fact that ClrMd 1.x has failed to attach to the benchmark process. I've seen it in the past over the years.

The best we can do is to use ClrMd v2 diassembler when the host process and benchmark process architectures are the same. It should be just more reliable.

Why we have two diassemblers? Because ClrMd2 comes with a LOT of new `System*` dependencies and in order to make it work we would need to embed at least few dozens of `System.*.dll`:

https://github.com/dotnet/BenchmarkDotNet/blob/0f457d1d476b466751774fa150d1ed08ea652bf1/src/BenchmarkDotNet/BenchmarkDotNet.csproj#L42-L45

Why do we still keep the standalone disassembler?

https://adamsitnik.com/Disassembly-Diagnoser/#desktop-net


