### PR TITLE
Add glob filters support to disassembler to allow disassembling specific methods

### DIFF
--- a/src/BenchmarkDotNet.Disassembler.x64/ClrMdV1Disassembler.cs
+++ b/src/BenchmarkDotNet.Disassembler.x64/ClrMdV1Disassembler.cs
@@ -4,6 +4,7 @@ using Microsoft.Diagnostics.Runtime.Interop;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace BenchmarkDotNet.Disassemblers
 {
@@ -26,13 +27,20 @@ namespace BenchmarkDotNet.Disassemblers
 
                 var state = new State(runtime);
 
-                var typeWithBenchmark = state.Runtime.Heap.GetTypeByName(settings.TypeName);
+                if (settings.Filters.Length > 0)
+                {
+                    FilterAndEnqueue(state, settings);
+                }
+                else
+                {
+                    var typeWithBenchmark = state.Runtime.Heap.GetTypeByName(settings.TypeName);
 
-                state.Todo.Enqueue(
-                    new MethodInfo(
-                        // the Disassembler Entry Method is always parameterless, so check by name is enough
-                        typeWithBenchmark.Methods.Single(method => method.IsPublic && method.Name == settings.MethodName),
-                        0));
+                    state.Todo.Enqueue(
+                        new MethodInfo(
+                            // the Disassembler Entry Method is always parameterless, so check by name is enough
+                            typeWithBenchmark.Methods.Single(method => method.IsPublic && method.Name == settings.MethodName),
+                            0));
+                }
 
                 var disassembledMethods = Disassemble(settings, state);
 
@@ -59,6 +67,28 @@ namespace BenchmarkDotNet.Disassemblers
             control?.Execute(DEBUG_OUTCTL.NOT_LOGGED, ".reload", DEBUG_EXECUTE.NOT_LOGGED);
         }
 
+        private static void FilterAndEnqueue(State state, Settings settings)
+        {
+            Regex[] filters = settings.Filters
+                .Select(pattern => new Regex(WildcardToRegex(pattern), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)).ToArray();
+
+            foreach (ClrModule module in state.Runtime.Modules)
+                foreach (ClrType type in module.EnumerateTypes())
+                    foreach (ClrMethod method in type.Methods.Where(method => CanBeDisassembled(method) && method.GetFullSignature() != null))
+                        foreach (Regex filter in filters)
+                        {
+                            if (filter.IsMatch(method.GetFullSignature()))
+                            {
+                                state.Todo.Enqueue(new MethodInfo(method,
+                                    depth: settings.MaxDepth)); // don't allow for recursive disassembling
+                                break;
+                            }
+                        }
+        }
+
+        // copied from GlobFilter type (this type must not reference BDN)
+        private static string WildcardToRegex(string pattern) => $"^{Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".")}$";
+
         private static DisassembledMethod[] Disassemble(Settings settings, State state)
         {
             var result = new List<DisassembledMethod>();
@@ -77,11 +107,14 @@ namespace BenchmarkDotNet.Disassemblers
             return result.ToArray();
         }
 
+        private static bool CanBeDisassembled(ClrMethod method)
+            => !((method.ILOffsetMap is null || method.ILOffsetMap.Length == 0) && (method.HotColdInfo is null || method.HotColdInfo.HotStart == 0 || method.HotColdInfo.HotSize == 0));
+
         private static DisassembledMethod DisassembleMethod(MethodInfo methodInfo, State state, Settings settings)
         {
             var method = methodInfo.Method;
 
-            if ((method.ILOffsetMap is null || method.ILOffsetMap.Length == 0) && (method.HotColdInfo is null || method.HotColdInfo.HotStart == 0 || method.HotColdInfo.HotSize == 0))
+            if (!CanBeDisassembled(method))
             {
                 if (method.IsPInvoke)
                     return CreateEmpty(method, "PInvoke method");

--- a/src/BenchmarkDotNet.Disassembler.x64/DataContracts.cs
+++ b/src/BenchmarkDotNet.Disassembler.x64/DataContracts.cs
@@ -101,7 +101,7 @@ namespace BenchmarkDotNet.Disassemblers
 
     internal class Settings
     {
-        internal Settings(int processId, string typeName, string methodName, bool printSource, int maxDepth, string resultsPath)
+        internal Settings(int processId, string typeName, string methodName, bool printSource, int maxDepth, string resultsPath, string[] filters)
         {
             ProcessId = processId;
             TypeName = typeName;
@@ -109,6 +109,7 @@ namespace BenchmarkDotNet.Disassemblers
             PrintSource = printSource;
             MaxDepth = methodName == DisassemblerConstants.DisassemblerEntryMethodName && maxDepth != int.MaxValue ? maxDepth + 1 : maxDepth;
             ResultsPath = resultsPath;
+            Filters = filters;
         }
 
         internal int ProcessId { get; }
@@ -116,6 +117,7 @@ namespace BenchmarkDotNet.Disassemblers
         internal string MethodName { get; }
         internal bool PrintSource { get; }
         internal int MaxDepth { get; }
+        internal string[] Filters;
         internal string ResultsPath { get; }
 
         internal static Settings FromArgs(string[] args)
@@ -125,7 +127,8 @@ namespace BenchmarkDotNet.Disassemblers
                 methodName: args[2],
                 printSource: bool.Parse(args[3]),
                 maxDepth: int.Parse(args[4]),
-                resultsPath: args[5]
+                resultsPath: args[5],
+                filters: args.Skip(6).ToArray()
             );
     }
 

--- a/src/BenchmarkDotNet/Attributes/DisassemblyDiagnoserAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/DisassemblyDiagnoserAttribute.cs
@@ -14,6 +14,7 @@ namespace BenchmarkDotNet.Attributes
         /// <param name="exportHtml">Exports to HTML with clickable links. False by default.</param>
         /// <param name="exportCombinedDisassemblyReport">Exports all benchmarks to a single HTML report. Makes it easy to compare different runtimes or methods (each becomes a column in HTML table).</param>
         /// <param name="exportDiff">Exports a diff of the assembly code to the Github markdown format. False by default.</param>
+        /// <param name="filters">Glob patterns applied to full method signatures by the the disassembler.</param>
         public DisassemblyDiagnoserAttribute(
             int maxDepth = 1,
             bool printSource = false,
@@ -21,18 +22,28 @@ namespace BenchmarkDotNet.Attributes
             bool exportGithubMarkdown = true,
             bool exportHtml = false,
             bool exportCombinedDisassemblyReport = false,
-            bool exportDiff = false)
+            bool exportDiff = false,
+            params string[] filters)
         {
             Config = ManualConfig.CreateEmpty().AddDiagnoser(
                 new DisassemblyDiagnoser(
                     new DisassemblyDiagnoserConfig(
                         maxDepth: maxDepth,
+                        filters: filters,
                         printSource: printSource,
                         printInstructionAddresses: printInstructionAddresses,
                         exportGithubMarkdown: exportGithubMarkdown,
                         exportHtml: exportHtml,
                         exportCombinedDisassemblyReport: exportCombinedDisassemblyReport,
                         exportDiff: exportDiff)));
+        }
+
+        // CLS-Compliant Code requires a constructor without an array in the argument list
+        protected DisassemblyDiagnoserAttribute()
+        {
+            Config = ManualConfig.CreateEmpty().AddDiagnoser(
+                new DisassemblyDiagnoser(
+                    new DisassemblyDiagnoserConfig()));
         }
 
         public IConfig Config { get; }

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -148,6 +148,9 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option("disasmDepth", Required = false, Default = 1, HelpText = "Sets the recursive depth for the disassembler.")]
         public int DisassemblerRecursiveDepth { get; set; }
 
+        [Option("disasmFilter", Required = false, HelpText = "Glob patterns applied to full method signatures by the the disassembler.")]
+        public IEnumerable<string> DisassemblerFilters { get; set; }
+
         [Option("disasmDiff", Required = false, Default = false, HelpText = "Generates diff reports for the disassembler.")]
         public bool DisassemblerDiff { get; set; }
 

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -214,7 +214,10 @@ namespace BenchmarkDotNet.ConsoleArguments
             if (options.UseThreadingDiagnoser)
                 config.AddDiagnoser(ThreadingDiagnoser.Default);
             if (options.UseDisassemblyDiagnoser)
-                config.AddDiagnoser(new DisassemblyDiagnoser(new DisassemblyDiagnoserConfig(maxDepth: options.DisassemblerRecursiveDepth, exportDiff: options.DisassemblerDiff)));
+                config.AddDiagnoser(new DisassemblyDiagnoser(new DisassemblyDiagnoserConfig(
+                    maxDepth: options.DisassemblerRecursiveDepth,
+                    filters: options.DisassemblerFilters.ToArray(),
+                    exportDiff: options.DisassemblerDiff)));
             if (!string.IsNullOrEmpty(options.Profiler))
                 config.AddDiagnoser(DiagnosersLoader.GetImplementation<IProfiler>(profiler => profiler.ShortName.EqualsWithIgnoreCase(options.Profiler)));
 

--- a/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoserConfig.cs
+++ b/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoserConfig.cs
@@ -1,6 +1,7 @@
 ﻿using BenchmarkDotNet.Disassemblers.Exporters;
 using Iced.Intel;
 using JetBrains.Annotations;
+using System;
 using System.Collections.Generic;
 
 namespace BenchmarkDotNet.Diagnosers
@@ -8,6 +9,7 @@ namespace BenchmarkDotNet.Diagnosers
     public class DisassemblyDiagnoserConfig
     {
         /// <param name="maxDepth">Includes called methods to given level. 1 by default, indexed from 1. To print just the benchmark set it to 0.</param>
+        /// <param name="filters">Glob patterns applied to full method signatures by the the disassembler.</param>
         /// <param name="formatter">Assembly code formatter. If not provided, MasmFormatter with the recommended settings will be used.</param>
         /// <param name="printSource">C#|F#|VB source code will be printed. False by default.</param>
         /// <param name="printInstructionAddresses">Print instruction addresses. False by default</param>
@@ -18,6 +20,7 @@ namespace BenchmarkDotNet.Diagnosers
         [PublicAPI]
         public DisassemblyDiagnoserConfig(
             int maxDepth = 1,
+            string[] filters = null,
             Formatter formatter = null,
             bool printSource = false,
             bool printInstructionAddresses = false,
@@ -27,6 +30,7 @@ namespace BenchmarkDotNet.Diagnosers
             bool exportDiff = false)
         {
             MaxDepth = maxDepth;
+            Filters = filters ?? Array.Empty<string>();
             Formatter = formatter ?? CreateDefaultFormatter();
             PrintSource = printSource;
             PrintInstructionAddresses = printInstructionAddresses;
@@ -39,6 +43,7 @@ namespace BenchmarkDotNet.Diagnosers
         public bool PrintSource { get; }
         public bool PrintInstructionAddresses { get; }
         public int MaxDepth { get; }
+        public string[] Filters { get; }
         public bool ExportGithubMarkdown { get; }
         public bool ExportHtml { get; }
         public bool ExportCombinedDisassemblyReport { get; }

--- a/src/BenchmarkDotNet/Disassemblers/SameArchitectureDisassembler.cs
+++ b/src/BenchmarkDotNet/Disassemblers/SameArchitectureDisassembler.cs
@@ -18,6 +18,7 @@ namespace BenchmarkDotNet.Disassemblers
                 methodName: DisassemblerConstants.DisassemblerEntryMethodName,
                 printSource: config.PrintSource,
                 maxDepth: config.MaxDepth,
+                filters: config.Filters,
                 resultsPath: default
             );
     }

--- a/src/BenchmarkDotNet/Disassemblers/WindowsDisassembler.cs
+++ b/src/BenchmarkDotNet/Disassemblers/WindowsDisassembler.cs
@@ -141,8 +141,12 @@ namespace BenchmarkDotNet.Disassemblers
                 .Append(DisassemblerConstants.DisassemblerEntryMethodName).Append(' ')
                 .Append(config.PrintSource).Append(' ')
                 .Append(config.MaxDepth).Append(' ')
-                .Append($"\"{resultsPath}\"")
+                .Append(Escape(resultsPath))
+                .Append(' ')
+                .Append(string.Join(" ", config.Filters.Select(Escape)))
                 .ToString();
+
+        private static string Escape(string value) => $"\"{value}\"";
 
         // code copied from https://stackoverflow.com/a/33206186/5852046
         private static class NativeMethods

--- a/src/BenchmarkDotNet/Filters/GlobFilter.cs
+++ b/src/BenchmarkDotNet/Filters/GlobFilter.cs
@@ -9,18 +9,20 @@ namespace BenchmarkDotNet.Filters
     /// </summary>
     public class GlobFilter : IFilter
     {
-        private readonly (string userValue, Regex regex)[] patterns;
+        private readonly Regex[] patterns;
 
-        public GlobFilter(string[] patterns)
-            => this.patterns = patterns.Select(pattern => (pattern, new Regex(WildcardToRegex(pattern), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))).ToArray();
+        public GlobFilter(string[] patterns) => this.patterns = ToRegex(patterns);
 
         public bool Predicate(BenchmarkCase benchmarkCase)
         {
             var benchmark = benchmarkCase.Descriptor.WorkloadMethod;
             string fullBenchmarkName = benchmarkCase.Descriptor.GetFilterName();
 
-            return patterns.Any(pattern => pattern.regex.IsMatch(fullBenchmarkName));
+            return patterns.Any(pattern => pattern.IsMatch(fullBenchmarkName));
         }
+
+        internal static Regex[] ToRegex(string[] patterns)
+            => patterns.Select(pattern => new Regex(WildcardToRegex(pattern), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)).ToArray();
 
         // https://stackoverflow.com/a/6907849/5852046 not perfect but should work for all we need
         private static string WildcardToRegex(string pattern) => $"^{Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".")}$";

--- a/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
@@ -88,6 +88,23 @@ namespace BenchmarkDotNet.IntegrationTests
             AssertDisassembled(disassemblyDiagnoser, $"{nameof(WithCalls.Recursive)}()");
         }
 
+        [TheoryWindowsOnly(WindowsOnly)]
+        [MemberData(nameof(GetAllJits))]
+        [Trait(Constants.Category, Constants.BackwardCompatibilityCategory)]
+        public void CanDisassembleAllMethodCallsUsingFilters(Jit jit, Platform platform, Runtime runtime)
+        {
+            var disassemblyDiagnoser = new DisassemblyDiagnoser(
+                new DisassemblyDiagnoserConfig(printSource: true, maxDepth: 1, filters: new[] { "*WithCalls*" }));
+
+            CanExecute<WithCalls>(CreateConfig(jit, platform, runtime, disassemblyDiagnoser, RunStrategy.ColdStart));
+
+            AssertDisassembled(disassemblyDiagnoser, $"{nameof(WithCalls.Benchmark)}(Int32)");
+            AssertDisassembled(disassemblyDiagnoser, $"{nameof(WithCalls.Benchmark)}(Boolean)");
+            AssertDisassembled(disassemblyDiagnoser, $"{nameof(WithCalls.Static)}()");
+            AssertDisassembled(disassemblyDiagnoser, $"{nameof(WithCalls.Instance)}()");
+            AssertDisassembled(disassemblyDiagnoser, $"{nameof(WithCalls.Recursive)}()");
+        }
+
         public class Generic<T> where T : new()
         {
             [Benchmark]


### PR DESCRIPTION
So far, the disassembler was always loading the type that was generated by BDN, searching for the benchmark method, disassembling it and when encountered direct method calls, disassembling the called methods as well (if their depth was <= configured depth).

This was working fine, but only for direct method calls. For indirect, the disassembly was incomplete.

When I was working on https://github.com/dotnet/runtime/pull/73064 it was really a PITA to me, and I tried to come up with a workaround for it. So here it is: a possibility to specify a glob pattern(s) for methods that we want to be disassembled.

How it works:
- ClrMD is used to enumerate over all modules
- for each module, all types are enumerated
- for each type, every method that can be disassembled and its full signature matches one of the provided filters is getting disassembled
- recursive disassembling is disabled for filtered methods (if A is filtered and it calls B, but B does not satisfy the filters, B is not decompiled). I could change that easily, I just need a good use case example.


Sample results for the [Perf_Encoding.GetBytes](https://github.com/dotnet/performance/blob/d7dac8a7ca12a28d099192f8a901cf8e30361384/src/benchmarks/micro/libraries/System.Text.Encoding/Perf.Encoding.cs) benchmark:

Before:

```assembly
; System.Text.Tests.Perf_Encoding.GetBytes()
       mov       [rsp+8],rcx
       mov       rax,[rcx+10]
       mov       rcx,rax
       mov       rdx,[rsp+8]
       mov       rdx,[rdx+18]
       mov       rax,[rax]
       mov       rax,[rax+58]
       jmp       qword ptr [rax+10]
; Total bytes of code 32
```

After:

```cmd
dotnet run -c Release -f net7.0 --filter "*Perf_Encoding.GetBytes" --disasm --disasmFilter *ASCIIUtility.NarrowUtf16ToAscii_Intrinsified*
```

```assembly
; System.Text.ASCIIUtility.NarrowUtf16ToAscii_Intrinsified(Char*, Byte*, UIntPtr)
       sub       rsp,48
       movdqu    xmm0,[rcx]
       movups    xmm1,[System.Reflection.CustomAttributeExtensions.GetCustomAttribute[[System.__Canon, System.Private.CoreLib]](System.Reflection.Assembly)]
       ptest     xmm0,xmm1
       jne       near ptr M00_L04
       mov       r9,rdx
       movaps    xmm2,xmm0
       packuswb  xmm2,xmm0
       movaps    [rsp+20],xmm2
       mov       rax,[rsp+20]
       mov       [rsp+40],rax
       mov       rax,[rsp+40]
       mov       [r9],rax
       mov       eax,8
       test      dl,8
       jne       short M00_L00
       movdqu    xmm0,[rcx+10]
       ptest     xmm0,xmm1
       jne       short M00_L02
       movaps    xmm2,xmm0
       packuswb  xmm2,xmm0
       movaps    [rsp+10],xmm2
       mov       rax,[rsp+10]
       mov       [rsp+30],rax
       mov       rax,[rsp+30]
       lea       r10,[r9+8]
       mov       [r10],rax
M00_L00:
       and       rdx,0F
       mov       eax,10
       sub       rax,rdx
       sub       r8,10
M00_L01:
       movdqu    xmm0,[rcx+rax*2]
       movdqu    xmm2,[rcx+rax*2+10]
       movaps    xmm3,xmm0
       por       xmm3,xmm2
       ptest     xmm3,xmm1
       jne       short M00_L03
       packuswb  xmm0,xmm2
       movaps    xmm2,xmm0
       movdqu    [r9+rax],xmm2
       add       rax,10
       cmp       rax,r8
       jbe       short M00_L01
M00_L02:
       add       rsp,48
       ret
M00_L03:
       ptest     xmm0,xmm1
       jne       short M00_L02
       movaps    xmm2,xmm0
       packuswb  xmm2,xmm0
       movaps    [rsp],xmm2
       mov       rdx,[rsp]
       mov       [rsp+38],rdx
       mov       rdx,[rsp+38]
       add       r9,rax
       mov       [r9],rdx
       add       rax,8
       jmp       short M00_L02
M00_L04:
       xor       eax,eax
       add       rsp,48
       ret
       int       3
       int       3
       int       3
       int       3
       int       3
       int       3
       movdqu    xmm0,[rcx]
       pmovmskb  eax,xmm0
       test      eax,eax
       jne       short 00007FFAFCDBE1E4
       xorps     xmm1,xmm1
       punpcklbw xmm0,xmm1
       (bad)
; Total bytes of code 261
```

cc @kunalspathak @AndyAyersMS @egorbo @janvorli @stephentoub