### PR TITLE
Fix disassembler

### DIFF
--- a/src/BenchmarkDotNet/Disassemblers/ClrMdV2Disassembler.cs
+++ b/src/BenchmarkDotNet/Disassemblers/ClrMdV2Disassembler.cs
@@ -190,13 +190,13 @@ namespace BenchmarkDotNet.Disassemblers
 
         private static IEnumerable<Asm> GetValidInstructions(List<Asm> disassembled)
         {
-            // We are now going to search for the last valid instruction (ret or int).
-            // It's important to loop from the end, as return can be followed by interrupt.
+            // We are now going to search for the last valid instruction (ret).
+            // In theory we could also search for interrupts, but that would produce a lot of garbage in the output.
 
             int lastValidInstructionIndex = 0;
-            for (int i = disassembled.Count - 1; i >= 0; i--)
+            for (int i = 0; i < disassembled.Count - 1; i++)
             {
-                if (disassembled[i].Instruction.FlowControl is FlowControl.Interrupt or FlowControl.Return)
+                if (disassembled[i].Instruction.FlowControl is FlowControl.Return)
                 {
                     lastValidInstructionIndex = i;
                     break;

--- a/src/BenchmarkDotNet/Disassemblers/ClrMdV2Disassembler.cs
+++ b/src/BenchmarkDotNet/Disassemblers/ClrMdV2Disassembler.cs
@@ -298,7 +298,7 @@ namespace BenchmarkDotNet.Disassemblers
         // HotSize can be missing or be invalid, we are not using it https://github.com/microsoft/clrmd/issues/1036
         private static ILToNativeMap[] GetCompleteNativeMap(ClrMethod method)
             => method.ILOffsetMap
-                .Where(map => method.NativeCode <= map.StartAddress && map.StartAddress < map.EndAddress) // some maps have 0 length?
+                .Where(map => map.StartAddress < map.EndAddress) // some maps have 0 length?
                 .OrderBy(map => map.StartAddress) // we need to print in the machine code order, not IL! #536
                 .ToArray();
 


### PR DESCRIPTION
Fixes #2074

Sample C# code:

```cs
public class Repro
{
    [Benchmark]
    public void Simple()
    {
        Empty();
        Call();
        WithThrow(false);
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    private void Empty() { }

    [Benchmark]
    public void Call() => Console.WriteLine();

    private void WithThrow(bool doThrow)
    {
        if (doThrow) throw new NotImplementedException();
    }
}
```

Output for ClrMD v1:

<details>

ClrMd V1

## .NET 6.0.8 (6.0.822.36306), X64 RyuJIT AVX2
```assembly
; BenchmarkDotNet.Samples.Repro.Simple()
       push      rbp
       sub       rsp,20
       lea       rbp,[rsp+20]
       mov       [rbp+10],rcx
       mov       rcx,[rbp+10]
       call      0000000000001D90
       mov       rcx,[rbp+10]
       call      0000000000001D98
       mov       rcx,[rbp+10]
       xor       edx,edx
       call      0000000000001DA0
       nop
       add       rsp,20
       pop       rbp
       ret
; Total bytes of code 50
```
```assembly
; BenchmarkDotNet.Samples.Repro.Empty()
       push      rbp
       mov       rbp,rsp
       mov       [rbp+10],rcx
       pop       rbp
       ret
; Total bytes of code 10
```
```assembly
; BenchmarkDotNet.Samples.Repro.Call()
       push      rbp
       sub       rsp,20
       lea       rbp,[rsp+20]
       mov       [rbp+10],rcx
       call      0000000000002BA8
       nop
       add       rsp,20
       pop       rbp
       ret
; Total bytes of code 26
```
```assembly
; BenchmarkDotNet.Samples.Repro.WithThrow(Boolean)
       push      rbp
       sub       rsp,30
       lea       rbp,[rsp+30]
       xor       eax,eax
       mov       [rbp+0FFF8],rax
       mov       [rbp+10],rcx
       mov       [rbp+18],edx
       mov       ecx,[rbp+18]
       movzx     ecx,cl
       test      ecx,ecx
       je        short 00000000000092F6
       mov       rcx,offset MT_System.NotImplementedException
       call      000000000000B2D0
       mov       [rbp+0FFF8],rax
       mov       rcx,[rbp+0FFF8]
       call      0000000000006DF8
       mov       rcx,[rbp+0FFF8]
       call      00000000000055B0
       nop
       add       rsp,30
       pop       rbp
       ret
; Total bytes of code 77
```
```assembly
; System.Console.WriteLine()
       sub       rsp,28
       call      qword ptr [38D8]
       mov       rcx,rax
       lea       r11,[3278]
       cmp       [rcx],ecx
       call      qword ptr [3278]
       nop
       add       rsp,28
       ret
; Total bytes of code 34
```
**Method was not JITted yet.**
System.NotImplementedException..ctor()


</details>

Output for ClrMD v2 before bug fix:

<details>

## .NET 6.0.8 (6.0.822.36306), X64 RyuJIT AVX2
```assembly
; BenchmarkDotNet.Samples.Repro.Simple()
       push      rbp
       sub       rsp,20
       lea       rbp,[rsp+20]
       mov       [rbp+10],rcx
       mov       rcx,[rbp+10]
       call      BenchmarkDotNet.Samples.Repro.Empty()
       mov       rcx,[rbp+10]
       call      BenchmarkDotNet.Samples.Repro.Call()
       mov       rcx,[rbp+10]
       xor       edx,edx
       call      BenchmarkDotNet.Samples.Repro.WithThrow(Boolean)
       nop
       add       rsp,20
       pop       rbp
       ret
       add       [rax],al
       sbb       [7FFD4CB0924C],eax
       add       [rax],edx
       add       [rax],al
       add       [rax],al
       add       [rax],al
       add       [rax],al
       add       [rax],al
       (bad)
; Total bytes of code 75
```
```assembly
; BenchmarkDotNet.Samples.Repro.Empty()
       push      rbp
       mov       rbp,rsp
       mov       [rbp+10],rcx
       pop       rbp
       ret
       add       [rax],al
       sbb       [rcx],eax
       add       [rax],eax
       add       [rax],edx
       add       [rax],al
       add       [rax],al
       add       al,dh
       mov       bpl,1A
       std
       jg        short M01_L00
M01_L00:
       add       [rbp+48],dl
       sub       esp,20
       (bad)
; Total bytes of code 40
```
```assembly
; BenchmarkDotNet.Samples.Repro.Call()
       push      rbp
       sub       rsp,20
       lea       rbp,[rsp+20]
       mov       [rbp+10],rcx
       call      System.Console.WriteLine()
       nop
       add       rsp,20
       pop       rbp
       ret
       add       [rax],al
       sbb       [7FFD4CB092A4],eax
       add       [rax],edx
       add       [rax],al
       add       [rax+45],dh
       mov       ch,1A
       std
       jg        short M02_L00
M02_L00:
       add       [rbp+48],dl
       (bad)
; Total bytes of code 51
```
```assembly
; BenchmarkDotNet.Samples.Repro.WithThrow(Boolean)
       push      rbp
       sub       rsp,30
       lea       rbp,[rsp+30]
       xor       eax,eax
       mov       [rbp-8],rax
       mov       [rbp+10],rcx
       mov       [rbp+18],edx
       mov       ecx,[rbp+18]
       movzx     ecx,cl
       test      ecx,ecx
       je        short M03_L00
       mov       rcx,offset MT_System.NotImplementedException
       call      CORINFO_HELP_NEWSFAST
       mov       [rbp-8],rax
       mov       rcx,[rbp-8]
       call      System.NotImplementedException..ctor()
       mov       rcx,[rbp-8]
       call      CORINFO_HELP_THROW
M03_L00:
       nop
       add       rsp,30
       pop       rbp
       ret
       add       [rax],al
       add       [rcx],bl
       add       eax,52050002
       add       [rax],edx
       add       [rax],al
       add       [rax],al
       add       [rax],al
       add       [rax],al
       add       [rax],al
       add       [rax],al
       (bad)
; Total bytes of code 102
```
```assembly
; System.Console.WriteLine()
       sub       rsp,28
       call      qword ptr [System.IO.ConsoleStream.ValidateRead(Byte[], Int32, Int32)]
       mov       rcx,rax
       lea       r11,[System.IO.ConsoleStream.ValidateRead(Byte[], Int32, Int32)]
       cmp       [rcx],ecx
       call      qword ptr [System.IO.ConsoleStream.ValidateRead(Byte[], Int32, Int32)]
       nop
       add       rsp,28
       ret
       int       3
       int       3
       int       3
       int       3
       int       3
       int       3
       int       3
       int       3
       int       3
       int       3
       int       3
       int       3
       int       3
       int       3
       push      rsi
       sub       rsp,20
       mov       esi,ecx
       (bad)
; Total bytes of code 60
```
**Method was not JITted yet.**
System.NotImplementedException..ctor()

</details>

Output for ClrMD v2 after bug fix:

<details>

## .NET 6.0.8 (6.0.822.36306), X64 RyuJIT AVX2
```assembly
; BenchmarkDotNet.Samples.Repro.Simple()
       push      rbp
       sub       rsp,20
       lea       rbp,[rsp+20]
       mov       [rbp+10],rcx
       mov       rcx,[rbp+10]
       call      BenchmarkDotNet.Samples.Repro.Empty()
       mov       rcx,[rbp+10]
       call      BenchmarkDotNet.Samples.Repro.Call()
       mov       rcx,[rbp+10]
       xor       edx,edx
       call      BenchmarkDotNet.Samples.Repro.WithThrow(Boolean)
       nop
       add       rsp,20
       pop       rbp
       ret
; Total bytes of code 50
```
```assembly
; BenchmarkDotNet.Samples.Repro.Empty()
       push      rbp
       mov       rbp,rsp
       mov       [rbp+10],rcx
       pop       rbp
       ret
; Total bytes of code 10
```
```assembly
; BenchmarkDotNet.Samples.Repro.Call()
       push      rbp
       sub       rsp,20
       lea       rbp,[rsp+20]
       mov       [rbp+10],rcx
       call      System.Console.WriteLine()
       nop
       add       rsp,20
       pop       rbp
       ret
; Total bytes of code 26
```
```assembly
; BenchmarkDotNet.Samples.Repro.WithThrow(Boolean)
       push      rbp
       sub       rsp,30
       lea       rbp,[rsp+30]
       xor       eax,eax
       mov       [rbp-8],rax
       mov       [rbp+10],rcx
       mov       [rbp+18],edx
       mov       ecx,[rbp+18]
       movzx     ecx,cl
       test      ecx,ecx
       je        short M03_L00
       mov       rcx,offset MT_System.NotImplementedException
       call      CORINFO_HELP_NEWSFAST
       mov       [rbp-8],rax
       mov       rcx,[rbp-8]
       call      System.NotImplementedException..ctor()
       mov       rcx,[rbp-8]
       call      CORINFO_HELP_THROW
M03_L00:
       nop
       add       rsp,30
       pop       rbp
       ret
; Total bytes of code 77
```
```assembly
; System.Console.WriteLine()
       sub       rsp,28
       call      qword ptr [System.IO.ConsoleStream.ValidateRead(Byte[], Int32, Int32)]
       mov       rcx,rax
       lea       r11,[System.IO.ConsoleStream.ValidateRead(Byte[], Int32, Int32)]
       cmp       [rcx],ecx
       call      qword ptr [System.IO.ConsoleStream.ValidateRead(Byte[], Int32, Int32)]
       nop
       add       rsp,28
       ret
; Total bytes of code 34
```
**Method was not JITted yet.**
System.NotImplementedException..ctor()

</details>
