### PR TITLE
fix the CI

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -137,6 +137,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <IlcGenerateCompleteTypeMetadata>{ilcGenerateCompleteTypeMetadata}</IlcGenerateCompleteTypeMetadata>
     <IlcGenerateStackTraceData>{ilcGenerateStackTraceData}</IlcGenerateStackTraceData>
     <EnsureNETCoreAppRuntime>false</EnsureNETCoreAppRuntime> <!-- workaround for 'This runtime may not be supported by.NET Core.' error -->
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles> <!-- workaround for 'Found multiple publish output files with the same relative path.' error -->
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     {GetInstructionSetSettings(buildPartition)}
   </PropertyGroup>

--- a/tests/BenchmarkDotNet.IntegrationTests/NativeAotTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/NativeAotTests.cs
@@ -23,6 +23,8 @@ namespace BenchmarkDotNet.IntegrationTests
                 return;
             if (ContinuousIntegration.IsAppVeyorOnWindows()) // too time consuming for AppVeyor (1h limit)
                 return;
+            if (NativeAotRuntime.GetCurrentVersion().RuntimeMoniker < RuntimeMoniker.NativeAot70) // we can't target net6.0 and use .NET 7 ILCompiler anymore (#2080)
+                return;
 
             var toolchain = NativeAotToolchain.CreateBuilder().UseNuGet().IlcInstructionSet(IsAvx2Supported() ? "avx2" : "").ToToolchain();
 


### PR DESCRIPTION
The builds has recently started to fail with:

```log
 C:\Program Files\dotnet\sdk\7.0.100-rc.1.22423.16\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ConflictResolution.targets(112,5): error NETSDK1152: Found multiple publish output files with the same relative path: D:\projects\BenchmarkDotNet\tests\BenchmarkDotNet.IntegrationTests\xunit.runner.json, D:\projects\BenchmarkDotNet\tests\BenchmarkDotNet.Tests\xunit.runner.json. [D:\projects\BenchmarkDotNet\tests\BenchmarkDotNet.IntegrationTests\bin\Release\net6.0\7fafdcdc-4f53-49fa-afb4-3e835b41b979\BenchmarkDotNet.Autogenerated.csproj]
```

Since it's just a complain about test project file settings, we can ignore it.

Update: and #2080