### PR TITLE
remove last warning

### DIFF
--- a/templates/BenchmarkDotNet.Templates.csproj
+++ b/templates/BenchmarkDotNet.Templates.csproj
@@ -14,6 +14,9 @@
 
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
+
+    <!-- this package does not have any dependencies, avoid getting a NU5128 warning -->
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
that happens during pack command for master branch build on AppVeyor

I've tested that it works locally. Due to the fact that we publish packages only when the PR gets merged to the master branch, I am going to merge it right away.