### PR TITLE
Tell the user about the asterisk

### DIFF
--- a/src/BenchmarkDotNet/Running/UserInteraction.cs
+++ b/src/BenchmarkDotNet/Running/UserInteraction.cs
@@ -39,6 +39,7 @@ namespace BenchmarkDotNet.Running
                 logger.WriteLineHelp($"You should select the target benchmark(s). Please, print a number of a benchmark (e.g. `0`) or a contained benchmark caption (e.g. `{benchmarkCaptionExample}`).");
                 logger.WriteLineHelp("If you want to select few, please separate them with space ` ` (e.g. `1 2 3`).");
                 logger.WriteLineHelp($"You can also provide the class name in console arguments by using --filter. (e.g. `{filterExample}`).");
+                logger.WriteLineHelp($"Enter the asterisk `*` to select all.");
 
                 string userInput = Console.ReadLine();
                 if (userInput == null)


### PR DESCRIPTION
Is this written somewhere? Looks pretty used

https://github.com/dotnet/BenchmarkDotNet/blob/f17453cef3a91ac90540dec1dcdee21725def6f8/src/BenchmarkDotNet/Running/UserInteraction.cs#L97-L103

FYI: 
It's not `string.Contains` but `IEnumerable.Contains`, so the input "a*b" or "**" doesn't work (as excepted).