### PR TITLE
Nit: fix broken link

### DIFF
--- a/docs/articles/guides/how-to-run.md
+++ b/docs/articles/guides/how-to-run.md
@@ -28,7 +28,7 @@ static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program
 Also you can use the config command style to specify some config from command line (more [](xref:docs.console-args)):
 
 ```log
-dotnet run -c Release -- --job short --runtimes net472 net6.0 --filter *BenchmarkClass1*
+dotnet run -c Release -- --job short --runtimes net472 net7.0 --filter *BenchmarkClass1*
 ```
 
 The most important thing about `BenchmarkSwitcher` is that you need to pass the `args` from `Main` to the `Run` method. If you don't, it won't parse the arguments.

--- a/docs/articles/guides/how-to-run.md
+++ b/docs/articles/guides/how-to-run.md
@@ -25,10 +25,10 @@ If you have more types and you want to choose which benchmark to run (either by 
 static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 ```
 
-Also you can use the config command style to specify some config from command line (more @docs.console-args):
+Also you can use the config command style to specify some config from command line (more [](xref:docs.console-args)):
 
 ```log
-dotnet run -c Release -- --job short --runtimes net461 netcoreapp21--filter *BenchmarkClass1*
+dotnet run -c Release -- --job short --runtimes net472 net6.0 --filter *BenchmarkClass1*
 ```
 
 The most important thing about `BenchmarkSwitcher` is that you need to pass the `args` from `Main` to the `Run` method. If you don't, it won't parse the arguments.
@@ -53,6 +53,3 @@ var summary = BenchmarkRunner.RunSource(benchmarkSource);
 ```
 
 **Note:** it works only for Full .NET Framework. It's not recommended to use this approach.
-
-
-


### PR DESCRIPTION

[Docs](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html?tabs=tabid-1%2Ctabid-a#:~:text=Do%20not%20use%20the%20%40uid%20link%20in%20brackets%20(like%20this%3A%20(%40uid)).%20DocFX%20cannot%20parse%20this%20link.%20The%20%40uid%20link%20should%20be%20separated%20with%20white%20spaces.%20If%20you%20need%20to%20add%20a%20link%20in%20brackets%2C%20use%20%5B%5D(xref%3Auid).):
> Do not use the @uid link in brackets (like this: (@uid)). DocFX cannot parse this link. The @uid link should be separated with white spaces. If you need to add a link in brackets, use [](xref:uid).

---

Master:
![image](https://user-images.githubusercontent.com/19392641/186922012-e8f90886-b97b-4bf9-8c2a-9dee1a083174.png)

PR:
![image](https://user-images.githubusercontent.com/19392641/186921937-ab544f40-7dfe-44a6-a2c6-b53f77e44876.png)