### PR TITLE
[NativeAOT] use PublishAot and don't reference ILCompiler in explicit way

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -392,7 +392,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 case RuntimeMoniker.NativeAot60:
                     return CreateAotJob(baseJob, options, runtimeMoniker, "6.0.0-*", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json");
                 case RuntimeMoniker.NativeAot70:
-                    return CreateAotJob(baseJob, options, runtimeMoniker, "7.0.0-*", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json");
+                    return CreateAotJob(baseJob, options, runtimeMoniker, "", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json");
                 case RuntimeMoniker.Wasm:
                     return MakeWasmJob(baseJob, options, RuntimeInformation.IsNetCore ? CoreRuntime.GetCurrentVersion().MsBuildMoniker : "net5.0", runtimeMoniker);
                 case RuntimeMoniker.WasmNet50:

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -132,6 +132,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <UseSharedCompilation>false</UseSharedCompilation>
     <Deterministic>true</Deterministic>
     <RunAnalyzers>false</RunAnalyzers>
+    <PublishAot Condition="" '$(TargetFramework)' != 'net6.0' "">true</PublishAot>
     <IlcOptimizationPreference>{ilcOptimizationPreference}</IlcOptimizationPreference>
     {GetTrimmingSettings()}
     <IlcGenerateCompleteTypeMetadata>{ilcGenerateCompleteTypeMetadata}</IlcGenerateCompleteTypeMetadata>
@@ -146,13 +147,16 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <Compile Include=""{Path.GetFileName(artifactsPaths.ProgramCodePath)}"" Exclude=""bin\**;obj\**;**\*.xproj;packages\**"" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include=""Microsoft.DotNet.ILCompiler"" Version=""{ilCompilerVersion}"" />
+    {GetILCompilerPackageReference()}
     <ProjectReference Include=""{GetProjectFilePath(buildPartition.RepresentativeBenchmarkCase.Descriptor.Type, logger).FullName}"" />
   </ItemGroup>
   <ItemGroup>
     {string.Join(Environment.NewLine, GetRdXmlFiles(buildPartition.RepresentativeBenchmarkCase.Descriptor.Type, logger).Select(file => $"<RdXmlFile Include=\"{file}\" />"))}
   </ItemGroup>
 </Project>";
+
+        private string GetILCompilerPackageReference()
+            => string.IsNullOrEmpty(ilCompilerVersion) ? "" : $@"<PackageReference Include=""Microsoft.DotNet.ILCompiler"" Version=""{ilCompilerVersion}"" />";
 
         private string GetTrimmingSettings()
             => rootAllApplicationAssemblies

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
@@ -14,10 +14,10 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             .ToToolchain();
 
         /// <summary>
-        /// compiled as net7.0, targets latest (7.0.0-*) NativeAOT build from the .NET 7 feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json
+        /// compiled as net7.0, targets latest NativeAOT build from the .NET 7 feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json
         /// </summary>
         public static readonly IToolchain Net70 = CreateBuilder()
-            .UseNuGet("7.0.0-*", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json")
+            .UseNuGet("", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json")
             .TargetFrameworkMoniker("net7.0")
             .ToToolchain();
 

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
@@ -25,14 +25,16 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         /// creates a NativeAOT toolchain targeting NuGet build of Microsoft.DotNet.ILCompiler
         /// Based on https://github.com/dotnet/runtimelab/blob/d0a37893a67c125f9b0cd8671846ff7d867df241/samples/HelloWorld/README.md#add-corert-to-your-project
         /// </summary>
-        /// <param name="microsoftDotNetILCompilerVersion">the version of Microsoft.DotNet.ILCompiler which should be used. The default is: "7.0.0-*"</param>
+        /// <param name="microsoftDotNetILCompilerVersion">the version of Microsoft.DotNet.ILCompiler which should be used. The default is empty which maps to latest version.</param>
         /// <param name="nuGetFeedUrl">url to NuGet feed, The default is: "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json"</param>
         [PublicAPI]
-        public NativeAotToolchainBuilder UseNuGet(string microsoftDotNetILCompilerVersion = "7.0.0-*", string nuGetFeedUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json")
+        public NativeAotToolchainBuilder UseNuGet(string microsoftDotNetILCompilerVersion = "", string nuGetFeedUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json")
         {
-            ilCompilerVersion = microsoftDotNetILCompilerVersion ?? throw new ArgumentNullException(nameof(microsoftDotNetILCompilerVersion));
+            ilCompilerVersion = microsoftDotNetILCompilerVersion;
 
             Feeds[Generator.NativeAotNuGetFeed] = nuGetFeedUrl ?? throw new ArgumentNullException(nameof(nuGetFeedUrl));
+
+            DisplayName(string.IsNullOrEmpty(ilCompilerVersion) ? "Latest ILCompiler" : $"ILCompiler {ilCompilerVersion}");
 
             isIlCompilerConfigured = true;
 
@@ -54,6 +56,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             ilCompilerVersion = "7.0.0-dev";
             Feeds["dotnet7"] = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json";
             useTempFolderForRestore = true;
+            DisplayName("local ILCompiler build");
 
             isIlCompilerConfigured = true;
 
@@ -148,7 +151,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
                 throw new InvalidOperationException("You need to use UseNuGet or UseLocalBuild methods to tell us which ILCompiler to use.");
 
             return new NativeAotToolchain(
-                displayName: displayName ?? (ilCompilerVersion != null ? $"ILCompiler {ilCompilerVersion}" : "local ILCompiler build"),
+                displayName: displayName,
                 ilCompilerVersion: ilCompilerVersion,
                 runtimeFrameworkVersion: runtimeFrameworkVersion,
                 targetFrameworkMoniker: GetTargetFrameworkMoniker(),


### PR DESCRIPTION
After recent SDK changes the NativeAOT support got broken again. This time the failure was silent: since we were not setting `PublishAot` to true, the published app was regular .NET app, not NativeAOT.

This PR sets  `PublishAot` to `true` and removes the explicit reference to `ILCompiler` if it's specific version was not provided.

I've tested:
- support for the old CoreRT bits (we are going to remove it once .NET 7 is released and BDN repo can move to .NET 7 SDK)
- support for the latests NativeAOT bits
- support for benchmarking specific NativeAOT version

@AndreyAkinshin we might need to release a new BDN version soon (preferably with #2092 merged as well)

cc @MichalStrehovsky 