### PR TITLE
ExecuteResult: Surface a Data property so the full output can be acce…

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/Results/ExecuteResult.cs
+++ b/src/BenchmarkDotNet/Toolchains/Results/ExecuteResult.cs
@@ -14,6 +14,7 @@ namespace BenchmarkDotNet.Toolchains.Results
         public int? ExitCode { get; }
         public int? ProcessId { get; }
         public IReadOnlyList<string> Errors => errors;
+        public IReadOnlyList<string> Data => data;
         public IReadOnlyList<Measurement> Measurements => measurements;
         public IReadOnlyList<string> ExtraOutput { get; }
         internal readonly GcStats GcStats;


### PR DESCRIPTION
…ssed.

This would help with exporters that need to access the process output, which might have error details.

cc @adamsitnik