### PR TITLE
Added a command line arg for not inducing any GCs while running Benchmarks

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -209,6 +209,9 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option("wasmDataDir", Required = false, HelpText = "Wasm data directory")]
         public DirectoryInfo WasmDataDirectory { get; set; }
 
+        [Option("noForcedGCs", Required = false, HelpText = "Specifying would not forcefully induce any GCs.")]
+        public bool NoForcedGCs { get; set; }
+
         internal bool UserProvidedFilters => Filters.Any() || AttributeNames.Any() || AllCategories.Any() || AnyCategories.Any();
 
         [Usage(ApplicationAlias = "")]

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -294,6 +294,8 @@ namespace BenchmarkDotNet.ConsoleArguments
                 baseJob = baseJob.RunOncePerIteration();
             if (options.MemoryRandomization)
                 baseJob = baseJob.WithMemoryRandomization();
+            if (options.NoForcedGCs)
+                baseJob = baseJob.WithGcForce(false);
 
             if (options.EnvironmentVariables.Any())
             {

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -569,7 +569,7 @@ namespace BenchmarkDotNet.Tests
 
             foreach (var job in parsedConfiguration.config.GetJobs())
             {
-                Assert.True(job.Environment.Gc.Force == false);
+                Assert.False(job.Environment.Gc.Force);
             }
         }
     }

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -560,5 +560,17 @@ namespace BenchmarkDotNet.Tests
         {
             Assert.False(ConfigParser.Parse(new[] { "--envVars", "INVALID_NO_SEPARATOR" }, new OutputLogger(Output)).isSuccess);
         }
+
+        [Fact]
+        public void UserCanSpecifyNoForceGCs()
+        {
+            var parsedConfiguration = ConfigParser.Parse(new[] { "--noForcedGCs" }, new OutputLogger(Output));
+            Assert.True(parsedConfiguration.isSuccess);
+
+            foreach (var job in parsedConfiguration.config.GetJobs())
+            {
+                Assert.True(job.Environment.Gc.Force == false);
+            }
+        }
     }
 }


### PR DESCRIPTION
Added a new commandline argument: ``--noForcedGCs`` that doesn't invoke any induced GCs. This is an important consideration for GC based microbenchmarks where we want to not force any GCs so that we can compare multiple runs in an equitable way. 

PS: I am not sure where to have added documentation for this. 