### PR TITLE
Rework ReturnValueValidator and ExecutionValidator

### DIFF
--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -179,6 +179,10 @@ namespace BenchmarkDotNet.Running
                 const BindingFlags reflectionFlags = BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
                 var allMembers = type.GetTypeMembersWithGivenAttribute<TAttribute>(reflectionFlags);
+
+                foreach (var member in allMembers.Where(m => !m.IsPublic))
+                    throw new InvalidOperationException($"Member \"{member.Name}\" must be public if it has the [{typeof(TAttribute).Name}] attribute applied to it");
+
                 return allMembers.Select(member =>
                     new ParameterDefinition(
                         member.Name,

--- a/src/BenchmarkDotNet/Validators/ExecutionValidator.cs
+++ b/src/BenchmarkDotNet/Validators/ExecutionValidator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using BenchmarkDotNet.Running;
 
 namespace BenchmarkDotNet.Validators
 {
@@ -12,20 +11,20 @@ namespace BenchmarkDotNet.Validators
         private ExecutionValidator(bool failOnError)
             : base(failOnError) { }
 
-        protected override void ExecuteBenchmarks(object benchmarkTypeInstance, IEnumerable<BenchmarkCase> benchmarks, List<ValidationError> errors)
+        protected override void ExecuteBenchmarks(IEnumerable<BenchmarkExecutor> executors, List<ValidationError> errors)
         {
-            foreach (var benchmark in benchmarks)
+            foreach (var executor in executors)
             {
                 try
                 {
-                    benchmark.Descriptor.WorkloadMethod.Invoke(benchmarkTypeInstance, null);
+                    executor.Invoke();
                 }
                 catch (Exception ex)
                 {
                     errors.Add(new ValidationError(
                         TreatsWarningsAsErrors,
-                        $"Failed to execute benchmark '{benchmark.DisplayInfo}', exception was: '{GetDisplayExceptionMessage(ex)}'",
-                        benchmark));
+                        $"Failed to execute benchmark '{executor.BenchmarkCase.DisplayInfo}', exception was: '{GetDisplayExceptionMessage(ex)}'",
+                        executor.BenchmarkCase));
                 }
             }
         }

--- a/src/BenchmarkDotNet/Validators/ExecutionValidatorBase.cs
+++ b/src/BenchmarkDotNet/Validators/ExecutionValidatorBase.cs
@@ -121,9 +121,9 @@ namespace BenchmarkDotNet.Validators
             return true;
         }
 
-        private string GetAttributeName(Type type) => type.Name.Replace("Attribute", string.Empty);
+        private static string GetAttributeName(Type type) => type.Name.Replace("Attribute", string.Empty);
 
-        private void TryToGetTaskResult(object result)
+        private static void TryToGetTaskResult(object result)
         {
             if (result == null)
             {

--- a/src/BenchmarkDotNet/Validators/ReturnValueValidator.cs
+++ b/src/BenchmarkDotNet/Validators/ReturnValueValidator.cs
@@ -137,7 +137,7 @@ namespace BenchmarkDotNet.Validators
 
                 return false;
 
-                Array ToStructuralEquatable(object obj)
+                static Array ToStructuralEquatable(object obj)
                 {
                     switch (obj)
                     {

--- a/src/BenchmarkDotNet/Validators/ReturnValueValidator.cs
+++ b/src/BenchmarkDotNet/Validators/ReturnValueValidator.cs
@@ -4,11 +4,9 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
-
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Parameters;
 using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 
 namespace BenchmarkDotNet.Validators
 {
@@ -20,22 +18,21 @@ namespace BenchmarkDotNet.Validators
         private ReturnValueValidator(bool failOnError)
             : base(failOnError) { }
 
-        protected override void ExecuteBenchmarks(object benchmarkTypeInstance, IEnumerable<BenchmarkCase> benchmarks, List<ValidationError> errors)
+        protected override void ExecuteBenchmarks(IEnumerable<BenchmarkExecutor> executors, List<ValidationError> errors)
         {
-            foreach (var parameterGroup in benchmarks.GroupBy(i => i.Parameters, ParameterInstancesEqualityComparer.Instance))
+            foreach (var parameterGroup in executors.GroupBy(i => i.BenchmarkCase.Parameters, ParameterInstancesEqualityComparer.Instance))
             {
                 var results = new List<(BenchmarkCase benchmark, object returnValue)>();
                 bool hasErrorsInGroup = false;
 
-                foreach (var benchmark in parameterGroup.DistinctBy(i => i.Descriptor.WorkloadMethod))
+                foreach (var executor in parameterGroup.DistinctBy(e => e.BenchmarkCase.Descriptor.WorkloadMethod))
                 {
                     try
                     {
-                        InProcessNoEmitRunner.FillMembers(benchmarkTypeInstance, benchmark);
-                        var result = benchmark.Descriptor.WorkloadMethod.Invoke(benchmarkTypeInstance, null);
+                        var result = executor.Invoke();
 
-                        if (benchmark.Descriptor.WorkloadMethod.ReturnType != typeof(void))
-                            results.Add((benchmark, result));
+                        if (executor.BenchmarkCase.Descriptor.WorkloadMethod.ReturnType != typeof(void))
+                            results.Add((executor.BenchmarkCase, result));
                     }
                     catch (Exception ex)
                     {
@@ -43,8 +40,8 @@ namespace BenchmarkDotNet.Validators
 
                         errors.Add(new ValidationError(
                             TreatsWarningsAsErrors,
-                            $"Failed to execute benchmark '{benchmark.DisplayInfo}', exception was: '{GetDisplayExceptionMessage(ex)}'",
-                            benchmark));
+                            $"Failed to execute benchmark '{executor.BenchmarkCase.DisplayInfo}', exception was: '{GetDisplayExceptionMessage(ex)}'",
+                            executor.BenchmarkCase));
                     }
                 }
 
@@ -75,7 +72,11 @@ namespace BenchmarkDotNet.Validators
                 if (x.Count != y.Count)
                     return false;
 
-                return x.Items.OrderBy(i => i.Name).Zip(y.Items.OrderBy(i => i.Name), (a, b) => a.Name == b.Name && Equals(a.Value, b.Value)).All(i => i);
+                return x.Items
+                    .Where(i => !i.IsArgument)
+                    .OrderBy(i => i.Name)
+                    .Zip(y.Items.OrderBy(i => i.Name), (a, b) => a.Name == b.Name && Equals(a.Value, b.Value))
+                    .All(i => i);
             }
 
             public int GetHashCode(ParameterInstances obj)
@@ -84,7 +85,7 @@ namespace BenchmarkDotNet.Validators
                     return 0;
 
                 var hashCode = new HashCode();
-                foreach (var instance in obj.Items.OrderBy(i => i.Name))
+                foreach (var instance in obj.Items.Where(i => !i.IsArgument).OrderBy(i => i.Name))
                 {
                     hashCode.Add(instance.Name);
                     hashCode.Add(instance.Value);

--- a/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
@@ -303,7 +303,7 @@ namespace BenchmarkDotNet.Tests.Validators
                 .ToList();
 
             Assert.NotEmpty(validationErrors);
-            Assert.StartsWith("Fields marked with [Params] must be public", validationErrors.Single().Message);
+            Assert.StartsWith($"Member \"{nameof(NonPublicFieldWithParams.Field)}\" must be public if it has the [Params]", validationErrors.Single().Message);
         }
 
         public class NonPublicFieldWithParams

--- a/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
@@ -298,12 +298,8 @@ namespace BenchmarkDotNet.Tests.Validators
         [Fact]
         public void NonPublicFieldsWithParamsAreDiscovered()
         {
-            var validationErrors = ExecutionValidator.FailOnError
-                .Validate(BenchmarkConverter.TypeToBenchmarks(typeof(NonPublicFieldWithParams)))
-                .ToList();
-
-            Assert.NotEmpty(validationErrors);
-            Assert.StartsWith($"Member \"{nameof(NonPublicFieldWithParams.Field)}\" must be public if it has the [Params]", validationErrors.Single().Message);
+            Assert.Throws<InvalidOperationException>(
+                () => ExecutionValidator.FailOnError.Validate(BenchmarkConverter.TypeToBenchmarks(typeof(NonPublicFieldWithParams))));
         }
 
         public class NonPublicFieldWithParams
@@ -316,6 +312,29 @@ namespace BenchmarkDotNet.Tests.Validators
 
             [Benchmark]
             public void NonThrowing() { }
+        }
+
+        [Fact]
+        public void NonPublicFieldsWithParamsSourceAreDiscovered()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => ExecutionValidator.FailOnError.Validate(BenchmarkConverter.TypeToBenchmarks(typeof(NonPublicFieldWithParamsSource))));
+        }
+
+        public class NonPublicFieldWithParamsSource
+        {
+#pragma warning disable CS0649
+            [ParamsSource(nameof(Get))]
+            internal int Field;
+#pragma warning restore CS0649
+
+            [Benchmark]
+            public void NonThrowing() { }
+
+            public IEnumerable<object> Get()
+            {
+                yield return 0;
+            }
         }
 
         [Fact]

--- a/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace BenchmarkDotNet.Tests.Validators
 {
-    [Collection("Disable parallelism due to a bug: https://github.com/xunit/xunit/issues/2587")]
+    // xUnit bug: https://github.com/xunit/xunit/issues/2587"
+    [Collection("Disable parallelism")]
     public class ExecutionValidatorTests
     {
         [Fact]

--- a/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/ExecutionValidatorTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace BenchmarkDotNet.Tests.Validators
 {
+    [Collection("Disable parallelism due to a bug: https://github.com/xunit/xunit/issues/2587")]
     public class ExecutionValidatorTests
     {
         [Fact]

--- a/tests/BenchmarkDotNet.Tests/Validators/ReturnValueValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/ReturnValueValidatorTests.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Validators;
@@ -251,6 +253,83 @@ namespace BenchmarkDotNet.Tests.Validators
 
             [Benchmark]
             public int Bar() => ++Value;
+        }
+
+        [Fact]
+        public void ArgumentsAreSupported()
+            => AssertConsistent<ArgumentsAreSupportedClass>();
+
+        public class ArgumentsAreSupportedClass
+        {
+            [Arguments(1)]
+            [Arguments(2)]
+            [Benchmark]
+            public int Foo(int arg) => arg;
+
+            [Arguments(2)]
+            [Arguments(4)]
+            [Benchmark]
+            public int Bar(int arg) => arg / 2;
+        }
+
+        [Fact]
+        public void ArgumentsSourceAreSupported()
+            => AssertConsistent<ArgumentsSourceAreSupportedClass>();
+
+        public class ArgumentsSourceAreSupportedClass
+        {
+            [ArgumentsSource(nameof(GetArguments))]
+            [Benchmark]
+            public int Foo(int arg) => arg;
+
+            [ArgumentsSource(nameof(GetArguments))]
+            [Benchmark]
+            public int Bar(int arg) => arg;
+
+            public IEnumerable<object> GetArguments()
+            {
+                yield return 1;
+                yield return 2;
+            }
+        }
+
+        [Fact]
+        public void ArgumentsWithArgumentsSourceAreSupported()
+            => AssertConsistent<ArgumentsWithArgumentsSourceAreSupportedClass>();
+
+        public class ArgumentsWithArgumentsSourceAreSupportedClass
+        {
+            [ArgumentsSource(nameof(GetArguments))]
+            [Benchmark]
+            public int Foo(int arg) => arg;
+
+            [Benchmark]
+            [Arguments(1)]
+            [Arguments(2)]
+            public int Bar(int arg) => arg;
+
+            public IEnumerable<object> GetArguments()
+            {
+                yield return 1;
+                yield return 2;
+            }
+        }
+
+        [Fact]
+        public void AsyncSetupIsSupported()
+            => AssertConsistent<AsyncSetupIsSupportedClass>();
+
+        public class AsyncSetupIsSupportedClass
+        {
+            [Benchmark]
+            public async Task<int> Foo()
+            {
+                await Task.Delay(1);
+                return 1;
+            }
+
+            [Benchmark]
+            public int Bar() => 1;
         }
 
         private static void AssertConsistent<TBenchmark>()

--- a/tests/BenchmarkDotNet.Tests/Validators/ReturnValueValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/ReturnValueValidatorTests.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 namespace BenchmarkDotNet.Tests.Validators
 {
-    [Collection("Disable parallelism due to a bug: https://github.com/xunit/xunit/issues/2587")]
+    // xUnit bug: https://github.com/xunit/xunit/issues/2587"
+    [Collection("Disable parallelism")]
     public class ReturnValueValidatorTests
     {
         private const string ErrorMessagePrefix = "Inconsistent benchmark return values";

--- a/tests/BenchmarkDotNet.Tests/Validators/ReturnValueValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/ReturnValueValidatorTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace BenchmarkDotNet.Tests.Validators
 {
+    [Collection("Disable parallelism due to a bug: https://github.com/xunit/xunit/issues/2587")]
     public class ReturnValueValidatorTests
     {
         private const string ErrorMessagePrefix = "Inconsistent benchmark return values";


### PR DESCRIPTION
- Add `ParamsSource` support
- Add `Arguments`/`ArgumentsSource` support
- Fill `Params`/`ParamsSource` before `GlobalSetup` (fixes #2083 fixes #848)
- Await async benchmarks (previously, only `GlobalSetup`/`GlobalCleanup` were awaited)
- Call `IterationSetup`/`IterationCleanup`
- Show error for the async iteration methods

Each benchmark is run on the new instance.

**ReturnValueValidator**:
- Compare `Task` value instead task objects itself