### PR TITLE
Roslyn Toolchain does not support .NET Core

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/Roslyn/RoslynToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/Roslyn/RoslynToolchain.cs
@@ -1,6 +1,7 @@
 ﻿using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Running;
 using JetBrains.Annotations;
 
@@ -24,6 +25,12 @@ namespace BenchmarkDotNet.Toolchains.Roslyn
         {
             if (!base.IsSupported(benchmarkCase, logger, resolver))
             {
+                return false;
+            }
+
+            if (!RuntimeInformation.IsFullFramework)
+            {
+                logger.WriteLineError("The Roslyn toolchain is only supported on .NET Framework");
                 return false;
             }
 

--- a/tests/BenchmarkDotNet.IntegrationTests/NugetReferenceTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/NugetReferenceTests.cs
@@ -29,7 +29,7 @@ namespace BenchmarkDotNet.IntegrationTests
             CanExecute<WithCallToNewtonsoft>(config);
         }
 
-        [Fact]
+        [FactClassicDotNetOnly("Roslyn toolchain does not support .NET Core")]
         public void RoslynToolchainDoesNotSupportNuGetPackageDependency()
         {
             var toolchain = RoslynToolchain.Instance;


### PR DESCRIPTION
Currently, it writes the error and does not return to console.