### PR TITLE
Fix ParamColumn null representation

### DIFF
--- a/src/BenchmarkDotNet/Columns/ParamColumn.cs
+++ b/src/BenchmarkDotNet/Columns/ParamColumn.cs
@@ -17,9 +17,15 @@ namespace BenchmarkDotNet.Columns
         }
 
         public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
-        public string GetValue(Summary summary, BenchmarkCase benchmarkCase) =>
-            benchmarkCase.Parameters.Items.FirstOrDefault(item => item.Name == ColumnName)?.ToDisplayText(summary.Style) ??
-            ParameterInstance.NullParameterTextRepresentation;
+        public string GetValue(Summary summary, BenchmarkCase benchmarkCase)
+        {
+            var parameter = benchmarkCase.Parameters.Items.FirstOrDefault(item => item.Name == ColumnName);
+
+            if (parameter is null)
+                return ParameterInstance.UnknownParameterTextRepresentation;
+
+            return parameter.ToDisplayText(summary.Style) ?? ParameterInstance.NullParameterTextRepresentation;
+        }
 
         public bool IsAvailable(Summary summary) => true;
         public bool AlwaysShow => true;

--- a/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
@@ -10,7 +10,8 @@ namespace BenchmarkDotNet.Parameters
 {
     public class ParameterInstance : IDisposable
     {
-        public const string NullParameterTextRepresentation = "?";
+        public const string NullParameterTextRepresentation = "Null";
+        public const string UnknownParameterTextRepresentation = "?";
 
         [PublicAPI] public ParameterDefinition Definition { get; }
 

--- a/tests/BenchmarkDotNet.Tests/Attributes/ApprovedFiles/ParamsAllValuesApprovalTests.BenchmarkShouldProduceSummary.WithAllValuesOfNullableBool.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/ApprovedFiles/ParamsAllValuesApprovalTests.BenchmarkShouldProduceSummary.WithAllValuesOfNullableBool.approved.txt
@@ -9,7 +9,7 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
 
     Method | ParamProperty |     Mean |   Error |  StdDev |
 ---------- |-------------- |---------:|--------:|--------:|
- Benchmark |             ? | 102.0 ns | 6.09 ns | 1.58 ns | ^
+ Benchmark |          Null | 102.0 ns | 6.09 ns | 1.58 ns | ^
  Benchmark |         False | 202.0 ns | 6.09 ns | 1.58 ns | ^
  Benchmark |          True | 302.0 ns | 6.09 ns | 1.58 ns | ^
 

--- a/tests/BenchmarkDotNet.Tests/Attributes/ApprovedFiles/ParamsAllValuesApprovalTests.BenchmarkShouldProduceSummary.WithAllValuesOfNullableEnum.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/ApprovedFiles/ParamsAllValuesApprovalTests.BenchmarkShouldProduceSummary.WithAllValuesOfNullableEnum.approved.txt
@@ -9,7 +9,7 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
 
     Method | ParamProperty |     Mean |   Error |  StdDev |
 ---------- |-------------- |---------:|--------:|--------:|
- Benchmark |             ? | 102.0 ns | 6.09 ns | 1.58 ns | ^
+ Benchmark |          Null | 102.0 ns | 6.09 ns | 1.58 ns | ^
  Benchmark |             A | 202.0 ns | 6.09 ns | 1.58 ns | ^
  Benchmark |             B | 302.0 ns | 6.09 ns | 1.58 ns | ^
  Benchmark |             C | 402.0 ns | 6.09 ns | 1.58 ns | ^

--- a/tests/BenchmarkDotNet.Tests/Attributes/ApprovedFiles/ParamsAllValuesApprovalTests.BenchmarkShouldProduceSummary.WithNotAllowedNullableTypeError.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/ApprovedFiles/ParamsAllValuesApprovalTests.BenchmarkShouldProduceSummary.WithNotAllowedNullableTypeError.approved.txt
@@ -9,7 +9,7 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
 
     Method | ParamProperty |     Mean |   Error |  StdDev |
 ---------- |-------------- |---------:|--------:|--------:|
- Benchmark |             ? | 102.0 ns | 6.09 ns | 1.58 ns | ^
+ Benchmark |          Null | 102.0 ns | 6.09 ns | 1.58 ns | ^
  Benchmark |             0 | 202.0 ns | 6.09 ns | 1.58 ns | ^
 
 Errors: 1

--- a/tests/BenchmarkDotNet.Tests/Columns/ParamColumnTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Columns/ParamColumnTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Parameters;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.Columns
+{
+    public class ParamColumnTests
+    {
+        [Theory]
+        [InlineData("Field", "Field", "str", "str")]
+        [InlineData("Field", "Field", true, "True")]
+        [InlineData("Field", "Field", null, ParameterInstance.NullParameterTextRepresentation)]
+        [InlineData("Field", "F", "str", ParameterInstance.UnknownParameterTextRepresentation)]
+        public void GetValueTest(string columnName, string parameterName, object parameterValue, string expected)
+        {
+            var instance = CreateParameterInstance(parameterName, parameterValue);
+            var summary = CreateMockSummary(instance);
+
+            var column = new ParamColumn(columnName);
+            var actual = column.GetValue(summary, summary.BenchmarksCases.First(), summary.Style);
+            Assert.Equal(expected, actual);
+        }
+
+        private static ParameterInstance CreateParameterInstance(string name, object value)
+        {
+            var summaryStyle = new SummaryStyle(TestCultureInfo.Instance, false, null, null);
+
+            var parameterType = value?.GetType() ?? typeof(object);
+            var definition = new ParameterDefinition(name, false, new[] { value }, false, parameterType, 0);
+            return new ParameterInstance(definition, definition.Values.First(), summaryStyle);
+        }
+
+        private static Summary CreateMockSummary(ParameterInstance instance)
+        {
+            var benchmarkCase = new BenchmarkCase(
+                new Descriptor(null, null),
+                Job.Dry,
+                new ParameterInstances(new ParameterInstance[] { instance }),
+                ImmutableConfigBuilder.Create(new ManualConfig()));
+
+            var benchmarkReport = new BenchmarkReport(true, benchmarkCase, null, null, null, null);
+            return new Summary("", new[] { benchmarkReport }.ToImmutableArray(), HostEnvironmentInfo.GetCurrent(),
+                "", "", TimeSpan.Zero, CultureInfo.InvariantCulture, ImmutableArray<ValidationError>.Empty, ImmutableArray<IColumnHidingRule>.Empty);
+        }
+    }
+}


### PR DESCRIPTION
Null value is ok, but it is shown as unknown.

It's impossible to get Unknown value, but I decided to add handling for this situation.