### PR TITLE
[Mono] Disable LLVM JIT

### DIFF
--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -149,15 +149,16 @@ namespace BenchmarkDotNet.Extensions
             // disable ReSharper's Dynamic Program Analysis (see https://github.com/dotnet/BenchmarkDotNet/issues/1871 for details)
             start.EnvironmentVariables["JETBRAINS_DPA_AGENT_ENABLE"] = "0";
 
-            if (benchmarkCase.Job.Infrastructure.Toolchain is MonoAotLLVMToolChain)
-            {
-                MonoAotLLVMRuntime aotruntime = (MonoAotLLVMRuntime)benchmarkCase.GetRuntime();
+            // Disable LLVM JIT until LLVM JIT is fixed re: https://github.com/dotnet/runtime/issues/75757
+            // if (benchmarkCase.Job.Infrastructure.Toolchain is MonoAotLLVMToolChain)
+            // {
+            //     MonoAotLLVMRuntime aotruntime = (MonoAotLLVMRuntime)benchmarkCase.GetRuntime();
 
-                if (aotruntime.AOTCompilerMode == MonoAotCompilerMode.llvm)
-                {
-                    start.EnvironmentVariables["MONO_ENV_OPTIONS"] = "--llvm";
-                }
-            }
+            //     if (aotruntime.AOTCompilerMode == MonoAotCompilerMode.llvm)
+            //     {
+            //         start.EnvironmentVariables["MONO_ENV_OPTIONS"] = "--llvm";
+            //     }
+            // }
 
             if (!benchmarkCase.Job.HasValue(EnvironmentMode.EnvironmentVariablesCharacteristic))
                 return;


### PR DESCRIPTION
Fix https://github.com/dotnet/performance/issues/2625

Since the merge of https://github.com/dotnet/runtime/pull/75055/files, Mono llvm-jit has been disabled. This PR is to react to that. This is a temporary change until Mono llvm-jit is fixed.