### PR TITLE
Escape Param data for the exporters

### DIFF
--- a/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
@@ -28,6 +28,16 @@ namespace BenchmarkDotNet.Extensions
         }
 
         /// <summary>
+        /// Escapes UNICODE control characters
+        /// </summary>
+        /// <param name="str">string to escape</param>
+        /// <param name="quote">True to put (double) quotes around the string literal</param>
+        internal static string EscapeSpecialCharacters(this string str, bool quote)
+        {
+            return Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(str, quote);
+        }
+
+        /// <summary>
         /// replaces all invalid file name chars with their number representation
         /// </summary>
         internal static string AsValidFileName(this string inputPath)

--- a/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
@@ -16,7 +16,7 @@ namespace BenchmarkDotNet.Extensions
         internal static string ToLowerCase(this bool value) => value ? "true" : "false"; // to avoid .ToString().ToLower() allocation
 
         // source: https://stackoverflow.com/a/12364234/5852046
-        internal static string Escape(this string cliArg)
+        internal static string EscapeCommandLine(this string cliArg)
         {
             if (string.IsNullOrEmpty(cliArg))
                 return cliArg;

--- a/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterInstance.cs
@@ -44,14 +44,14 @@ namespace BenchmarkDotNet.Parameters
                 case null:
                     return NullParameterTextRepresentation;
                 case IParam parameter:
-                    return Trim(parameter.DisplayText, maxParameterColumnWidth);
+                    return Trim(parameter.DisplayText, maxParameterColumnWidth).EscapeSpecialCharacters(false);
                 case IFormattable formattable:
-                    return Trim(formattable.ToString(null, cultureInfo), maxParameterColumnWidth);
+                    return Trim(formattable.ToString(null, cultureInfo), maxParameterColumnWidth).EscapeSpecialCharacters(false);
                 // no trimming for types!
                 case Type type:
                     return type.IsNullable() ? $"{Nullable.GetUnderlyingType(type).GetDisplayName()}?" : type.GetDisplayName();
                 default:
-                    return Trim(value.ToString(), maxParameterColumnWidth);
+                    return Trim(value.ToString(), maxParameterColumnWidth).EscapeSpecialCharacters(false);
             }
         }
 

--- a/src/BenchmarkDotNet/Running/BenchmarkId.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkId.cs
@@ -30,7 +30,7 @@ namespace BenchmarkDotNet.Running
 
         public override int GetHashCode() => Value;
 
-        public string ToArguments() => $"--benchmarkName {FullBenchmarkName.Escape()} --job {JobId.Escape()} --benchmarkId {Value}";
+        public string ToArguments() => $"--benchmarkName {FullBenchmarkName.EscapeCommandLine()} --job {JobId.EscapeCommandLine()} --benchmarkId {Value}";
 
         public string ToArguments(string fromBenchmark, string toBenchmark) => $"{AnonymousPipesHost.AnonymousPipesDescriptors} {fromBenchmark} {toBenchmark} {ToArguments()}";
 

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
@@ -69,7 +69,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             var startInfo = DotNetCliCommandExecutor.BuildStartInfo(
                 CustomDotNetCliPath,
                 artifactsPaths.BinariesDirectoryPath,
-                $"{executableName.Escape()} {benchmarkId.ToArguments(inputFromBenchmark.GetClientHandleAsString(), acknowledgments.GetClientHandleAsString())}",
+                $"{executableName.EscapeCommandLine()} {benchmarkId.ToArguments(inputFromBenchmark.GetClientHandleAsString(), acknowledgments.GetClientHandleAsString())}",
                 redirectStandardOutput: true,
                 redirectStandardInput: false,
                 redirectStandardError: false); // #1629

--- a/src/BenchmarkDotNet/Toolchains/Roslyn/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/Roslyn/Generator.cs
@@ -38,8 +38,8 @@ namespace BenchmarkDotNet.Toolchains.Roslyn
             list.Add("/unsafe");
             list.Add("/deterministic");
             list.Add("/platform:" + buildPartition.Platform.ToConfig());
-            list.Add("/appconfig:" + artifactsPaths.AppConfigPath.Escape());
-            var references = GetAllReferences(buildPartition.RepresentativeBenchmarkCase).Select(assembly => assembly.Location.Escape());
+            list.Add("/appconfig:" + artifactsPaths.AppConfigPath.EscapeCommandLine());
+            var references = GetAllReferences(buildPartition.RepresentativeBenchmarkCase).Select(assembly => assembly.Location.EscapeCommandLine());
             list.Add("/reference:" + string.Join(",", references));
             list.Add(Path.GetFileName(artifactsPaths.ProgramCodePath));
 

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.Escape_ParamsAndArguments.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.Escape_ParamsAndArguments.approved.txt
@@ -1,0 +1,19 @@
+﻿=== Escape_ParamsAndArguments ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+ Method | StringParam | charArg |     Mean |   Error |  StdDev |
+------- |------------ |-------- |---------:|--------:|--------:|
+    Foo |          \t |      \t | 102.0 ns | 6.09 ns | 1.58 ns | ^
+    Foo |          \t |      \n | 202.0 ns | 6.09 ns | 1.58 ns | ^
+    Bar |          \t |       ? | 302.0 ns | 6.09 ns | 1.58 ns | ^
+    Foo |          \n |      \t | 402.0 ns | 6.09 ns | 1.58 ns | ^
+    Foo |          \n |      \n | 502.0 ns | 6.09 ns | 1.58 ns | ^
+    Bar |          \n |       ? | 602.0 ns | 6.09 ns | 1.58 ns | ^
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/MarkdownExporterApprovalTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Exporters/MarkdownExporterApprovalTests.cs
@@ -255,6 +255,17 @@ namespace BenchmarkDotNet.Tests.Exporters
                 [Benchmark] public void Foo() {}
                 [Benchmark] public void Bar() {}
             }
+
+            /* Escape Params */
+
+            public class Escape_ParamsAndArguments
+            {
+                [Params("\t", "\n"), UsedImplicitly] public string StringParam;
+
+                [Arguments('\t')] [Arguments('\n')]
+                [Benchmark] public void Foo(char charArg) {}
+                [Benchmark] public void Bar() {}
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds escaping the `Param` data for the exporters only. 
Currently, you can only pass `\t`, `\n`, other control characters throw an exception in the generated project). 

Try `Param["\0"] string Param` (In the linked PR below I fix it).

---

`Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(str, quote);` 
the naming is 10/10 😄. It escapes the non-displayed characters and emojis.

---

I don't escape the `column.ColumnName`, because that would require calling `.EscapeSpecialCharacter()` after every 'column.ColumName' (~20 times).

Fixes #1867
Fixes #1839