### PR TITLE
Handle addresses larger than 2GB for 32-bit benchmarks #1469

### DIFF
--- a/docs/articles/configs/jobs.md
+++ b/docs/articles/configs/jobs.md
@@ -33,9 +33,9 @@ It's a single string characteristic. It allows to name your job. This name will 
   * `CpuGroups`:  Specifies whether garbage collection supports multiple CPU groups
   * `Force`: Specifies whether the BenchmarkDotNet's benchmark runner forces full garbage collection after each benchmark invocation
   * `AllowVeryLargeObjects`:  On 64-bit platforms, enables arrays that are greater than 2 gigabytes (GB) in total size
-* `LargeAddressAware`: Specifies that BenchmarkDotNet's benchmark runner can handle addresses larger than 2 gigabytes. See also: @BenchmarkDotNet.Samples.IntroLargeAddressAware
-  * `false`: Benchmark runner uses the default (64-bit: enabled; 32-bit:disabled).
-  * `true`: Explicitly specify that BenchmarkDotNet's benchmark runner can handle addresses larger than 2 gigabytes.
+* `LargeAddressAware`: Specifies that benchmark can handle addresses larger than 2 gigabytes. See also: @BenchmarkDotNet.Samples.IntroLargeAddressAware and [LARGEADDRESSAWARE](https://learn.microsoft.com/cpp/build/reference/largeaddressaware-handle-large-addresses)
+  * `false`: Benchmark uses the defaults (64-bit: enabled; 32-bit: disabled).
+  * `true`: Explicitly specify that benchmark can handle addresses larger than 2 gigabytes.
 * `EnvironmentVariables`: customized environment variables for target benchmark. See also: @BenchmarkDotNet.Samples.IntroEnvVars
 
 BenchmarkDotNet will use host process environment characteristics for non specified values.

--- a/docs/articles/configs/jobs.md
+++ b/docs/articles/configs/jobs.md
@@ -33,6 +33,9 @@ It's a single string characteristic. It allows to name your job. This name will 
   * `CpuGroups`:  Specifies whether garbage collection supports multiple CPU groups
   * `Force`: Specifies whether the BenchmarkDotNet's benchmark runner forces full garbage collection after each benchmark invocation
   * `AllowVeryLargeObjects`:  On 64-bit platforms, enables arrays that are greater than 2 gigabytes (GB) in total size
+* `LargeAddressAware`: Specifies that BenchmarkDotNet's benchmark runner can handle addresses larger than 2 gigabytes. See also: @BenchmarkDotNet.Samples.IntroLargeAddressAware
+  * `false`: Benchmark runner uses the default (64-bit: enabled; 32-bit:disabled).
+  * `true`: Explicitly specify that BenchmarkDotNet's benchmark runner can handle addresses larger than 2 gigabytes.
 * `EnvironmentVariables`: customized environment variables for target benchmark. See also: @BenchmarkDotNet.Samples.IntroEnvVars
 
 BenchmarkDotNet will use host process environment characteristics for non specified values.

--- a/docs/articles/samples/IntroLargeAddressAware.md
+++ b/docs/articles/samples/IntroLargeAddressAware.md
@@ -1,0 +1,16 @@
+---
+uid: BenchmarkDotNet.Samples.IntroLargeAddressAware
+title: "Sample: IntroLargeAddressAware"
+---
+
+## Sample: IntroLargeAddressAware
+
+### Source code
+
+[!code-csharp[IntroLargeAddressAware.cs](../../../samples/BenchmarkDotNet.Samples/IntroLargeAddressAware.cs)]
+
+### Links
+
+* The permanent link to this sample: @BenchmarkDotNet.Samples.IntroLargeAddressAware
+
+---

--- a/docs/articles/samples/toc.yml
+++ b/docs/articles/samples/toc.yml
@@ -64,6 +64,8 @@
   href: IntroJobBaseline.md
 - name: IntroJoin
   href: IntroJoin.md
+- name: IntroLargeAddressAware
+  href: IntroLargeAddressAware.md
 - name: IntroMonitoring
   href: IntroMonitoring.md
 - name: IntroMultimodal

--- a/samples/BenchmarkDotNet.Samples/IntroLargeAddressAware.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroLargeAddressAware.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+
+namespace BenchmarkDotNet.Samples
+{
+    [MemoryDiagnoser]
+    [Config(typeof(Config))]
+    public class IntroLargeAddressAware
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddJob(Job.Default
+                    .WithRuntime(ClrRuntime.Net462)
+                    .WithPlatform(Platform.X86)
+                    .WithLargeAddressAware()
+                    .WithId("Framework"));
+            }
+        }
+
+        [Benchmark]
+        public void AllocateMoreThan2GB()
+        {
+            const int oneGB = 1024 * 1024 * 1024;
+            const int halfGB = oneGB / 2;
+            byte[] bytes1 = new byte[oneGB];
+            byte[] bytes2 = new byte[oneGB];
+            byte[] bytes3 = new byte[halfGB];
+            GC.KeepAlive(bytes1);
+            GC.KeepAlive(bytes2);
+            GC.KeepAlive(bytes3);
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Jobs/EnvironmentMode.cs
+++ b/src/BenchmarkDotNet/Jobs/EnvironmentMode.cs
@@ -16,6 +16,7 @@ namespace BenchmarkDotNet.Jobs
         public static readonly Characteristic<GcMode> GcCharacteristic = CreateCharacteristic<GcMode>(nameof(Gc));
         public static readonly Characteristic<IReadOnlyList<EnvironmentVariable>> EnvironmentVariablesCharacteristic = CreateCharacteristic<IReadOnlyList<EnvironmentVariable>>(nameof(EnvironmentVariables));
         public static readonly Characteristic<Guid?> PowerPlanModeCharacteristic = CreateCharacteristic<Guid?>(nameof(PowerPlanMode));
+        public static readonly Characteristic<bool> LargeAddressAwareCharacteristic = CreateCharacteristic<bool>(nameof(LargeAddressAware));
 
         public static readonly EnvironmentMode LegacyJitX86 = new EnvironmentMode(nameof(LegacyJitX86), Jit.LegacyJit, Platform.X86).Freeze();
         public static readonly EnvironmentMode LegacyJitX64 = new EnvironmentMode(nameof(LegacyJitX64), Jit.LegacyJit, Platform.X64).Freeze();
@@ -94,6 +95,17 @@ namespace BenchmarkDotNet.Jobs
         {
             get => PowerPlanModeCharacteristic[this];
             set => PowerPlanModeCharacteristic[this] = value;
+        }
+
+        /// <summary>
+        /// Specifies that BenchmarkDotNet's benchmark runner can handle addresses larger than 2 gigabytes.
+        /// <value>false: Benchmark runner uses the default (64-bit: enabled; 32-bit:disabled). This is the default.</value>
+        /// <value>true: Explicitly specify that BenchmarkDotNet's benchmark runner can handle addresses larger than 2 gigabytes.</value>
+        /// </summary>
+        public bool LargeAddressAware
+        {
+            get => LargeAddressAwareCharacteristic[this];
+            set => LargeAddressAwareCharacteristic[this] = value;
         }
 
         /// <summary>

--- a/src/BenchmarkDotNet/Jobs/EnvironmentMode.cs
+++ b/src/BenchmarkDotNet/Jobs/EnvironmentMode.cs
@@ -105,7 +105,15 @@ namespace BenchmarkDotNet.Jobs
         public bool LargeAddressAware
         {
             get => LargeAddressAwareCharacteristic[this];
-            set => LargeAddressAwareCharacteristic[this] = value;
+            set
+            {
+                if (!RuntimeInformation.IsWindows())
+                {
+                    throw new NotSupportedException("LargeAddressAware is a Windows-specific concept.");
+                }
+
+                LargeAddressAwareCharacteristic[this] = value;
+            }
         }
 
         /// <summary>

--- a/src/BenchmarkDotNet/Jobs/EnvironmentMode.cs
+++ b/src/BenchmarkDotNet/Jobs/EnvironmentMode.cs
@@ -98,9 +98,9 @@ namespace BenchmarkDotNet.Jobs
         }
 
         /// <summary>
-        /// Specifies that BenchmarkDotNet's benchmark runner can handle addresses larger than 2 gigabytes.
-        /// <value>false: Benchmark runner uses the default (64-bit: enabled; 32-bit:disabled). This is the default.</value>
-        /// <value>true: Explicitly specify that BenchmarkDotNet's benchmark runner can handle addresses larger than 2 gigabytes.</value>
+        /// Specifies that benchmark can handle addresses larger than 2 gigabytes.
+        /// <value>false: Benchmark uses the default (64-bit: enabled; 32-bit:disabled). This is the default.</value>
+        /// <value>true: Explicitly specify that benchmark can handle addresses larger than 2 gigabytes.</value>
         /// </summary>
         public bool LargeAddressAware
         {

--- a/src/BenchmarkDotNet/Jobs/JobExtensions.cs
+++ b/src/BenchmarkDotNet/Jobs/JobExtensions.cs
@@ -79,7 +79,7 @@ namespace BenchmarkDotNet.Jobs
         /// <summary>
         /// Specifies that BenchmarkDotNet's benchmark runner can handle addresses larger than 2 gigabytes.
         /// </summary>
-        public static Job WithLargeAddressAware(this Job job) => job.WithCore(j => j.Environment.LargeAddressAware = true);
+        public static Job WithLargeAddressAware(this Job job, bool value = true) => job.WithCore(j => j.Environment.LargeAddressAware = value);
 
         /// <summary>
         /// Put segments that should be deleted on a standby list for future use instead of releasing them back to the OS

--- a/src/BenchmarkDotNet/Jobs/JobExtensions.cs
+++ b/src/BenchmarkDotNet/Jobs/JobExtensions.cs
@@ -77,6 +77,11 @@ namespace BenchmarkDotNet.Jobs
         public static Job WithGcAllowVeryLargeObjects(this Job job, bool value) => job.WithCore(j => j.Environment.Gc.AllowVeryLargeObjects = value);
 
         /// <summary>
+        /// Specifies that BenchmarkDotNet's benchmark runner can handle addresses larger than 2 gigabytes.
+        /// </summary>
+        public static Job WithLargeAddressAware(this Job job) => job.WithCore(j => j.Environment.LargeAddressAware = true);
+
+        /// <summary>
         /// Put segments that should be deleted on a standby list for future use instead of releasing them back to the OS
         /// <remarks>The default is false</remarks>
         /// </summary>

--- a/src/BenchmarkDotNet/Jobs/JobExtensions.cs
+++ b/src/BenchmarkDotNet/Jobs/JobExtensions.cs
@@ -77,7 +77,7 @@ namespace BenchmarkDotNet.Jobs
         public static Job WithGcAllowVeryLargeObjects(this Job job, bool value) => job.WithCore(j => j.Environment.Gc.AllowVeryLargeObjects = value);
 
         /// <summary>
-        /// Specifies that BenchmarkDotNet's benchmark runner can handle addresses larger than 2 gigabytes.
+        /// Specifies that benchmark can handle addresses larger than 2 gigabytes.
         /// </summary>
         public static Job WithLargeAddressAware(this Job job, bool value = true) => job.WithCore(j => j.Environment.LargeAddressAware = value);
 

--- a/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
@@ -41,6 +41,8 @@ namespace BenchmarkDotNet.Running
                     return false;
                 if (jobX.Environment.Platform != jobY.Environment.Platform) // platform is set in .csproj
                     return false;
+                if (jobX.Environment.LargeAddressAware != jobY.Environment.LargeAddressAware)
+                    return false;
                 if (AreDifferent(jobX.Infrastructure.BuildConfiguration, jobY.Infrastructure.BuildConfiguration)) // Debug vs Release
                     return false;
                 if (AreDifferent(jobX.Infrastructure.Arguments, jobY.Infrastructure.Arguments)) // arguments can be anything (Mono runtime settings or MsBuild parameters)
@@ -74,6 +76,7 @@ namespace BenchmarkDotNet.Running
                 hashCode ^= obj.Descriptor.Type.Assembly.Location.GetHashCode();
                 hashCode ^= (int)job.Environment.Jit;
                 hashCode ^= (int)job.Environment.Platform;
+                hashCode ^= job.Environment.LargeAddressAware.GetHashCode();
                 hashCode ^= job.Environment.Gc.GetHashCode();
 
                 if (job.Infrastructure.BuildConfiguration != null)

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
@@ -26,7 +26,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         }
 
         public BuildResult Build(GenerateResult generateResult, BuildPartition buildPartition, ILogger logger)
-            => new DotNetCliCommand(
+        {
+            BuildResult buildResult = new DotNetCliCommand(
                     CustomDotNetCliPath,
                     string.Empty,
                     generateResult,
@@ -37,5 +38,13 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                     logOutput: LogOutput,
                     retryFailedBuildWithNoDeps: RetryFailedBuildWithNoDeps)
                 .RestoreThenBuild();
+            if (
+                buildResult.IsBuildSuccess &&
+                buildPartition.RepresentativeBenchmarkCase.Job.Environment.LargeAddressAware)
+            {
+                LargeAddressAware.SetLargeAddressAware(generateResult.ArtifactsPaths.ExecutablePath);
+            }
+            return buildResult;
+        }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
@@ -38,8 +38,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                     logOutput: LogOutput,
                     retryFailedBuildWithNoDeps: RetryFailedBuildWithNoDeps)
                 .RestoreThenBuild();
-            if (
-                buildResult.IsBuildSuccess &&
+            if (buildResult.IsBuildSuccess &&
                 buildPartition.RepresentativeBenchmarkCase.Job.Environment.LargeAddressAware)
             {
                 LargeAddressAware.SetLargeAddressAware(generateResult.ArtifactsPaths.ExecutablePath);

--- a/src/BenchmarkDotNet/Toolchains/LargeAddressAware.cs
+++ b/src/BenchmarkDotNet/Toolchains/LargeAddressAware.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.IO;
+
+namespace BenchmarkDotNet.Toolchains
+{
+    // From https://github.com/KirillOsenkov/LargeAddressAware/blob/95e5fc6024438f94325df4bac6ef73c77bf90e71/SetLargeAddressAware/LargeAddressAware.cs
+    public class LargeAddressAware
+    {
+        public static bool IsLargeAddressAware(string filePath)
+        {
+            bool isLargeAddressAware = false;
+            PrepareStream(filePath, (stream, binaryReader) => isLargeAddressAware = (binaryReader.ReadInt16() & 0x20) != 0);
+            return isLargeAddressAware;
+        }
+
+        public static void SetLargeAddressAware(string filePath)
+        {
+            PrepareStream(filePath, (stream, binaryReader) =>
+            {
+                var value = binaryReader.ReadInt16();
+                if ((value & 0x20) == 0)
+                {
+                    value = (short)(value | 0x20);
+                    stream.Position -= 2;
+                    var binaryWriter = new BinaryWriter(stream);
+                    binaryWriter.Write(value);
+                    binaryWriter.Flush();
+                }
+            });
+        }
+
+        private static void PrepareStream(string filePath, Action<Stream, BinaryReader> action)
+        {
+            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
+            {
+                if (stream.Length < 0x3C)
+                {
+                    return;
+                }
+
+                var binaryReader = new BinaryReader(stream);
+
+                // MZ header
+                if (binaryReader.ReadInt16() != 0x5A4D)
+                {
+                    return;
+                }
+
+                stream.Position = 0x3C;
+                var peHeaderLocation = binaryReader.ReadInt32();
+
+                stream.Position = peHeaderLocation;
+
+                // PE header
+                if (binaryReader.ReadInt32() != 0x4550)
+                {
+                    return;
+                }
+
+                stream.Position += 0x12;
+
+                action(stream, binaryReader);
+            }
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Toolchains/LargeAddressAware.cs
+++ b/src/BenchmarkDotNet/Toolchains/LargeAddressAware.cs
@@ -4,14 +4,8 @@ using System.IO;
 namespace BenchmarkDotNet.Toolchains
 {
     // From https://github.com/KirillOsenkov/LargeAddressAware/blob/95e5fc6024438f94325df4bac6ef73c77bf90e71/SetLargeAddressAware/LargeAddressAware.cs
-    public class LargeAddressAware
+    internal class LargeAddressAware
     {
-        public static bool IsLargeAddressAware(string filePath)
-        {
-            bool isLargeAddressAware = false;
-            PrepareStream(filePath, (stream, binaryReader) => isLargeAddressAware = (binaryReader.ReadInt16() & 0x20) != 0);
-            return isLargeAddressAware;
-        }
 
         public static void SetLargeAddressAware(string filePath)
         {

--- a/tests/BenchmarkDotNet.IntegrationTests/LargeAddressAwareTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/LargeAddressAwareTest.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Tests.Loggers;
+using BenchmarkDotNet.Tests.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class LargeAddressAwareTest
+    {
+        private readonly ITestOutputHelper output;
+
+        public LargeAddressAwareTest(ITestOutputHelper outputHelper) => output = outputHelper;
+
+        [FactWindowsOnly("CLR is a valid job only on Windows")]
+        public void BenchmarkCanAllocateMoreThan2Gb()
+        {
+            var summary = BenchmarkRunner
+                .Run<NeedsMoreThan2GB>(
+                    ManualConfig.CreateEmpty()
+                        .AddJob(Job.Dry.WithRuntime(CoreRuntime.Core60).WithPlatform(Platform.X64).WithId("Core"))
+                        .AddJob(Job.Dry.WithRuntime(ClrRuntime.Net462).WithPlatform(Platform.X86).WithLargeAddressAware().WithId("Framework"))
+                        .AddColumnProvider(DefaultColumnProviders.Instance)
+                        .AddLogger(new OutputLogger(output)));
+
+            Assert.True(summary.Reports
+                .All(report => report.ExecuteResults
+                .All(executeResult => executeResult.FoundExecutable)));
+
+            Assert.True(summary.Reports.All(report => report.AllMeasurements.Any()));
+
+            Assert.True(summary.Reports
+                .Single(report => report.BenchmarkCase.Job.Environment.Runtime is ClrRuntime)
+                .ExecuteResults
+                .Any());
+
+            Assert.True(summary.Reports
+                .Single(report => report.BenchmarkCase.Job.Environment.Runtime is CoreRuntime)
+                .ExecuteResults
+                .Any());
+
+            Assert.Contains(".NET Framework", summary.AllRuntimes);
+            Assert.Contains(".NET 6.0", summary.AllRuntimes);
+        }
+    }
+
+    public class NeedsMoreThan2GB
+    {
+        [Benchmark]
+        public void AllocateMoreThan2GB()
+        {
+            Console.WriteLine($"Is64BitProcess = {Environment.Is64BitProcess}");
+
+            const int oneGB = 1024 * 1024 * 1024;
+            const int halfGB = oneGB / 2;
+            byte[] bytes1 = new byte[oneGB];
+            byte[] bytes2 = new byte[oneGB];
+            byte[] bytes3 = new byte[halfGB];
+            GC.KeepAlive(bytes1);
+            GC.KeepAlive(bytes2);
+            GC.KeepAlive(bytes3);
+        }
+    }
+}


### PR DESCRIPTION
Fix #1469

It seems that BenchmarkDotNet does not support `Job.Dry.WithRuntime(CoreRuntime.Core60).WithPlatform(Platform.X86)`, so the feature becomes .Net Framework only. See also [ProcessorArchitectureTest](https://github.com/dotnet/BenchmarkDotNet/blob/master/tests/BenchmarkDotNet.IntegrationTests/ProcessorArchitectureTest.cs#L22) which skips this too.