### PR TITLE
adding validation errors when the benchmarks are unsupported

### DIFF
--- a/samples/BenchmarkDotNet.Samples/IntroWasm.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroWasm.cs
@@ -39,7 +39,7 @@ namespace BenchmarkDotNet.Samples
             NetCoreAppSettings netCoreAppSettings = new NetCoreAppSettings(
                 targetFrameworkMoniker: "net5.0", runtimeFrameworkVersion: null, name: "Wasm",
                 customDotNetCliPath: cliPath);
-            IToolchain toolChain = WasmToolChain.From(netCoreAppSettings);
+            IToolchain toolChain = WasmToolchain.From(netCoreAppSettings);
 
             BenchmarkRunner.Run<IntroCustomMonoFluentConfig>(DefaultConfig.Instance
                 .AddJob(Job.ShortRun.WithRuntime(runtime).WithToolchain(toolChain)));

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -17,13 +17,13 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Reports;
-using BenchmarkDotNet.Toolchains.NativeAot;
 using BenchmarkDotNet.Toolchains.CoreRun;
 using BenchmarkDotNet.Toolchains.CsProj;
 using BenchmarkDotNet.Toolchains.DotNetCli;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
-using BenchmarkDotNet.Toolchains.MonoWasm;
 using BenchmarkDotNet.Toolchains.MonoAotLLVM;
+using BenchmarkDotNet.Toolchains.MonoWasm;
+using BenchmarkDotNet.Toolchains.NativeAot;
 using CommandLine;
 using Perfolizer.Horology;
 using Perfolizer.Mathematics.OutlierDetection;
@@ -113,7 +113,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 }
                 else if (runtimeMoniker == RuntimeMoniker.MonoAOTLLVM && (options.AOTCompilerPath == null || options.AOTCompilerPath.IsNotNullButDoesNotExist()))
                 {
-                     logger.WriteLineError($"The provided {nameof(options.AOTCompilerPath)} \"{ options.AOTCompilerPath }\" does NOT exist. It MUST be provided.");
+                    logger.WriteLineError($"The provided {nameof(options.AOTCompilerPath)} \"{options.AOTCompilerPath}\" does NOT exist. It MUST be provided.");
                 }
             }
 
@@ -265,7 +265,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 baseJob = baseJob.WithOutlierMode(options.Outliers);
 
             if (options.Affinity.HasValue)
-                baseJob = baseJob.WithAffinity((IntPtr) options.Affinity.Value);
+                baseJob = baseJob.WithAffinity((IntPtr)options.Affinity.Value);
 
             if (options.LaunchCount.HasValue)
                 baseJob = baseJob.WithLaunchCount(options.LaunchCount.Value);
@@ -376,6 +376,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                     return baseJob
                         .WithRuntime(runtimeMoniker.GetRuntime())
                         .WithToolchain(CsProjClassicNetToolchain.From(runtimeId, options.RestorePath?.FullName));
+
                 case RuntimeMoniker.NetCoreApp20:
                 case RuntimeMoniker.NetCoreApp21:
                 case RuntimeMoniker.NetCoreApp22:
@@ -390,26 +391,37 @@ namespace BenchmarkDotNet.ConsoleArguments
                     return baseJob
                         .WithRuntime(runtimeMoniker.GetRuntime())
                         .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings(runtimeId, null, runtimeId, options.CliPath?.FullName, options.RestorePath?.FullName)));
+
                 case RuntimeMoniker.Mono:
                     return baseJob.WithRuntime(new MonoRuntime("Mono", options.MonoPath?.FullName));
+
                 case RuntimeMoniker.NativeAot60:
                     return CreateAotJob(baseJob, options, runtimeMoniker, "6.0.0-*", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json");
+
                 case RuntimeMoniker.NativeAot70:
                     return CreateAotJob(baseJob, options, runtimeMoniker, "", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json");
+
                 case RuntimeMoniker.Wasm:
                     return MakeWasmJob(baseJob, options, RuntimeInformation.IsNetCore ? CoreRuntime.GetCurrentVersion().MsBuildMoniker : "net5.0", runtimeMoniker);
+
                 case RuntimeMoniker.WasmNet50:
                     return MakeWasmJob(baseJob, options, "net5.0", runtimeMoniker);
+
                 case RuntimeMoniker.WasmNet60:
                     return MakeWasmJob(baseJob, options, "net6.0", runtimeMoniker);
+
                 case RuntimeMoniker.WasmNet70:
                     return MakeWasmJob(baseJob, options, "net7.0", runtimeMoniker);
+
                 case RuntimeMoniker.MonoAOTLLVM:
                     return MakeMonoAOTLLVMJob(baseJob, options, RuntimeInformation.IsNetCore ? CoreRuntime.GetCurrentVersion().MsBuildMoniker : "net6.0");
+
                 case RuntimeMoniker.MonoAOTLLVMNet60:
                     return MakeMonoAOTLLVMJob(baseJob, options, "net6.0");
+
                 case RuntimeMoniker.MonoAOTLLVMNet70:
                     return MakeMonoAOTLLVMJob(baseJob, options, "net7.0");
+
                 default:
                     throw new NotSupportedException($"Runtime {runtimeId} is not supported");
             }
@@ -467,7 +479,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 wasmDataDir: options.WasmDataDirectory?.FullName,
                 moniker: moniker);
 
-            var toolChain = WasmToolChain.From(new NetCoreAppSettings(
+            var toolChain = WasmToolchain.From(new NetCoreAppSettings(
                 targetFrameworkMoniker: wasmRuntime.MsBuildMoniker,
                 runtimeFrameworkVersion: null,
                 name: wasmRuntime.Name,
@@ -554,7 +566,6 @@ namespace BenchmarkDotNet.ConsoleArguments
                         break;
                     }
             }
-
 
             if (commonLongestPrefixIndex <= 1)
                 return coreRunPath.FullName;

--- a/src/BenchmarkDotNet/Loggers/LoggerExtensions.cs
+++ b/src/BenchmarkDotNet/Loggers/LoggerExtensions.cs
@@ -20,7 +20,7 @@ namespace BenchmarkDotNet.Loggers
 
         public static void WriteLineHint(this ILogger logger, string text) => logger.WriteLine(LogKind.Hint, text);
 
-        public static void Write(this ILogger logger, string text) =>  logger.Write(LogKind.Default, text);
+        public static void Write(this ILogger logger, string text) => logger.Write(LogKind.Default, text);
 
         [PublicAPI]
         public static void WriteHelp(this ILogger logger, string text) => logger.Write(LogKind.Help, text);

--- a/src/BenchmarkDotNet/Reports/Summary.cs
+++ b/src/BenchmarkDotNet/Reports/Summary.cs
@@ -83,11 +83,8 @@ namespace BenchmarkDotNet.Reports
         public bool IsMultipleRuntimes
             => isMultipleRuntimes ??= BenchmarksCases.Length > 1 ? BenchmarksCases.Select(benchmark => benchmark.GetRuntime()).Distinct().Count() > 1 : false;
 
-        internal static Summary NothingToRun(string title, string resultsDirectoryPath, string logFilePath)
-            => new Summary(title, ImmutableArray<BenchmarkReport>.Empty, HostEnvironmentInfo.GetCurrent(), resultsDirectoryPath, logFilePath, TimeSpan.Zero, DefaultCultureInfo.Instance, ImmutableArray<ValidationError>.Empty, ImmutableArray<IColumnHidingRule>.Empty);
-
-        internal static Summary ValidationFailed(string title, string resultsDirectoryPath, string logFilePath, ImmutableArray<ValidationError> validationErrors)
-            => new Summary(title, ImmutableArray<BenchmarkReport>.Empty, HostEnvironmentInfo.GetCurrent(), resultsDirectoryPath, logFilePath, TimeSpan.Zero, DefaultCultureInfo.Instance, validationErrors, ImmutableArray<IColumnHidingRule>.Empty);
+        internal static Summary ValidationFailed(string title, string resultsDirectoryPath, string logFilePath, ImmutableArray<ValidationError>? validationErrors = null)
+            => new Summary(title, ImmutableArray<BenchmarkReport>.Empty, HostEnvironmentInfo.GetCurrent(), resultsDirectoryPath, logFilePath, TimeSpan.Zero, DefaultCultureInfo.Instance, validationErrors ?? ImmutableArray<ValidationError>.Empty, ImmutableArray<IColumnHidingRule>.Empty);
 
         internal static Summary Join(List<Summary> summaries, ClockSpan clockSpan)
             => new Summary(

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -47,13 +47,19 @@ namespace BenchmarkDotNet.Running
             {
                 var compositeLogger = CreateCompositeLogger(benchmarkRunInfos, streamLogger);
 
-                var supportedBenchmarks = GetSupportedBenchmarks(benchmarkRunInfos, compositeLogger, resolver);
-                if (!supportedBenchmarks.Any(benchmarks => benchmarks.BenchmarksCases.Any()))
-                    return new[] { Summary.NothingToRun(title, resultsFolderPath, logFilePath) };
+                compositeLogger.WriteLineInfo("// Validating benchmarks:");
 
-                var validationErrors = Validate(supportedBenchmarks, compositeLogger);
+                var (supportedBenchmarks, validationErrors) = GetSupportedBenchmarks(benchmarkRunInfos, compositeLogger, resolver);
+
+                validationErrors.AddRange(Validate(supportedBenchmarks));
+
+                PrintValidationErrors(compositeLogger, validationErrors);
+
                 if (validationErrors.Any(validationError => validationError.IsCritical))
-                    return new[] { Summary.ValidationFailed(title, resultsFolderPath, logFilePath, validationErrors) };
+                    return new[] { Summary.ValidationFailed(title, resultsFolderPath, logFilePath, validationErrors.ToImmutableArray()) };
+
+                if (!supportedBenchmarks.Any(benchmarks => benchmarks.BenchmarksCases.Any()))
+                    return new[] { Summary.ValidationFailed(title, resultsFolderPath, logFilePath) };
 
                 int totalBenchmarkCount = supportedBenchmarks.Sum(benchmarkInfo => benchmarkInfo.BenchmarksCases.Length);
                 int benchmarksToRunCount = totalBenchmarkCount;
@@ -145,7 +151,7 @@ namespace BenchmarkDotNet.Running
             var cultureInfo = config.CultureInfo ?? DefaultCultureInfo.Instance;
             var reports = new List<BenchmarkReport>();
             string title = GetTitle(new[] { benchmarkRunInfo });
-            var consoleTitle =  RuntimeInformation.IsWindows() ?  Console.Title : string.Empty;
+            var consoleTitle = RuntimeInformation.IsWindows() ? Console.Title : string.Empty;
 
             logger.WriteLineInfo($"// Found {benchmarks.Length} benchmarks:");
             foreach (var benchmark in benchmarks)
@@ -236,7 +242,7 @@ namespace BenchmarkDotNet.Running
                 logFilePath,
                 runEnd.GetTimeSpan() - runStart.GetTimeSpan(),
                 cultureInfo,
-                Validate(new[] { benchmarkRunInfo }, NullLogger.Instance), // validate them once again, but don't print the output
+                Validate(benchmarkRunInfo), // validate them once again, but don't print the output
                 config.GetColumnHidingRules().ToImmutableArray());
         }
 
@@ -306,10 +312,8 @@ namespace BenchmarkDotNet.Running
             logger.WriteLineHeader("// ***** BenchmarkRunner: End *****");
         }
 
-        private static ImmutableArray<ValidationError> Validate(BenchmarkRunInfo[] benchmarks, ILogger logger)
+        private static ImmutableArray<ValidationError> Validate(params BenchmarkRunInfo[] benchmarks)
         {
-            logger.WriteLineInfo("// Validating benchmarks:");
-
             var validationErrors = new List<ValidationError>();
 
             if (benchmarks.Any(b => b.Config.Options.IsSet(ConfigOptions.JoinSummary)))
@@ -325,9 +329,6 @@ namespace BenchmarkDotNet.Running
 
             foreach (var benchmarkRunInfo in benchmarks)
                 validationErrors.AddRange(benchmarkRunInfo.Config.GetCompositeValidator().Validate(new ValidationParameters(benchmarkRunInfo.BenchmarksCases, benchmarkRunInfo.Config)));
-
-            foreach (var validationError in validationErrors.Distinct())
-                logger.WriteLineError(validationError.Message);
 
             return validationErrors.ToImmutableArray();
         }
@@ -531,13 +532,26 @@ namespace BenchmarkDotNet.Running
         private static void LogTotalTime(ILogger logger, TimeSpan time, int executedBenchmarksCount, string message = "Total time")
             => logger.WriteLineStatistic($"{message}: {time.ToFormattedTotalTime(DefaultCultureInfo.Instance)}, executed benchmarks: {executedBenchmarksCount}");
 
-        private static BenchmarkRunInfo[] GetSupportedBenchmarks(BenchmarkRunInfo[] benchmarkRunInfos, ILogger logger, IResolver resolver)
-            => benchmarkRunInfos.Select(info => new BenchmarkRunInfo(
-                    info.BenchmarksCases.Where(benchmark => benchmark.GetToolchain().IsSupported(benchmark, logger, resolver)).ToArray(),
+        private static (BenchmarkRunInfo[], List<ValidationError>) GetSupportedBenchmarks(BenchmarkRunInfo[] benchmarkRunInfos, ILogger logger, IResolver resolver)
+        {
+            List<ValidationError> validationErrors = new ();
+
+            var benchmarksRunInfo = benchmarkRunInfos.Select(info => new BenchmarkRunInfo(
+                    info.BenchmarksCases.Where(benchmark =>
+                    {
+                        var benchmarkValidationErrors = benchmark.GetToolchain().Validate(benchmark, resolver);
+
+                        validationErrors.AddRange(benchmarkValidationErrors);
+
+                        return !benchmarkValidationErrors.Any();
+                    }).ToArray(),
                     info.Type,
                     info.Config))
                 .Where(infos => infos.BenchmarksCases.Any())
                 .ToArray();
+
+            return (benchmarkRunInfos, validationErrors);
+        }
 
         private static string GetRootArtifactsFolderPath(BenchmarkRunInfo[] benchmarkRunInfos)
         {
@@ -651,6 +665,20 @@ namespace BenchmarkDotNet.Running
             double avgSecondsPerBenchmark = executedBenchmarkCount > 0 ? runsChronometer.GetElapsed().GetTimeSpan().TotalSeconds / executedBenchmarkCount : 0;
             TimeSpan fromNow = TimeSpan.FromSeconds(avgSecondsPerBenchmark * benchmarksToRunCount);
             return fromNow;
+        }
+
+        private static void PrintValidationErrors(ILogger logger, IEnumerable<ValidationError> validationErrors)
+        {
+            foreach (var validationError in validationErrors.Distinct())
+            {
+                if (validationError.BenchmarkCase != null)
+                {
+                    logger.WriteLineInfo($"// Benchmark {validationError.BenchmarkCase.DisplayInfo}");
+                }
+
+                logger.WriteLineError($"//    * {validationError.Message}");
+                logger.WriteLine();
+            }
         }
     }
 }

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -539,11 +539,9 @@ namespace BenchmarkDotNet.Running
             var benchmarksRunInfo = benchmarkRunInfos.Select(info => new BenchmarkRunInfo(
                     info.BenchmarksCases.Where(benchmark =>
                     {
-                        var benchmarkValidationErrors = benchmark.GetToolchain().Validate(benchmark, resolver);
-
-                        validationErrors.AddRange(benchmarkValidationErrors);
-
-                        return !benchmarkValidationErrors.Any();
+                        var errors = benchmark.GetToolchain().Validate(benchmark, resolver).ToArray();
+                        validationErrors.AddRange(errors);
+                        return !errors.Any();
                     }).ToArray(),
                     info.Type,
                     info.Config))

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs
@@ -136,7 +136,7 @@ namespace BenchmarkDotNet.Running
             catch (InvalidBenchmarkDeclarationException e)
             {
                 ConsoleLogger.Default.WriteLineError(e.Message);
-                return Summary.NothingToRun(e.Message, string.Empty, string.Empty);
+                return Summary.ValidationFailed(e.Message, string.Empty, string.Empty);
             }
         }
 
@@ -149,7 +149,7 @@ namespace BenchmarkDotNet.Running
             catch (InvalidBenchmarkDeclarationException e)
             {
                 ConsoleLogger.Default.WriteLineError(e.Message);
-                return new[] { Summary.NothingToRun(e.Message, string.Empty, string.Empty) };
+                return new[] { Summary.ValidationFailed(e.Message, string.Empty, string.Empty) };
             }
         }
     }

--- a/src/BenchmarkDotNet/Running/BuildPartition.cs
+++ b/src/BenchmarkDotNet/Running/BuildPartition.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Portability;
-using BenchmarkDotNet.Toolchains.NativeAot;
 using BenchmarkDotNet.Toolchains.CsProj;
 using BenchmarkDotNet.Toolchains.MonoWasm;
 using BenchmarkDotNet.Toolchains.Roslyn;
@@ -51,7 +48,7 @@ namespace BenchmarkDotNet.Running
         public bool IsNativeAot => RepresentativeBenchmarkCase.Job.IsNativeAOT();
 
         public bool IsWasm => Runtime is WasmRuntime // given job can have Wasm toolchain set, but Runtime == default ;)
-            || (RepresentativeBenchmarkCase.Job.Infrastructure.TryGetToolchain(out var toolchain) && toolchain is WasmToolChain);
+            || (RepresentativeBenchmarkCase.Job.Infrastructure.TryGetToolchain(out var toolchain) && toolchain is WasmToolchain);
 
         public bool IsNetFramework => Runtime is ClrRuntime
             || (RepresentativeBenchmarkCase.Job.Infrastructure.TryGetToolchain(out var toolchain) && (toolchain is RoslynToolchain || toolchain is CsProjClassicNetToolchain));

--- a/src/BenchmarkDotNet/Toolchains/CoreRun/CoreRunToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRun/CoreRunToolchain.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using BenchmarkDotNet.Characteristics;
-using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.DotNetCli;
+using BenchmarkDotNet.Validators;
 
 namespace BenchmarkDotNet.Toolchains.CoreRun
 {
@@ -57,18 +58,17 @@ namespace BenchmarkDotNet.Toolchains.CoreRun
 
         public override string ToString() => Name;
 
-        public bool IsSupported(BenchmarkCase benchmark, ILogger logger, IResolver resolver)
+        public IEnumerable<ValidationError> Validate(BenchmarkCase benchmark, IResolver resolver)
         {
             if (!SourceCoreRun.Exists)
             {
-                logger.WriteLineError($"Provided CoreRun path does not exist, benchmark '{benchmark.DisplayInfo}' will not be executed. Please remember that BDN expects path to CoreRun.exe (corerun on Unix), not to Core_Root folder.");
-                return false;
+                yield return
+                    new ValidationError(true, $"Provided CoreRun path does not exist, benchmark '{benchmark.DisplayInfo}' will not be executed. Please remember that BDN expects path to CoreRun.exe (corerun on Unix), not to Core_Root folder.", benchmark);
             }
-
-            if (Toolchain.InvalidCliPath(CustomDotNetCliPath?.FullName, benchmark, logger))
-                return false;
-
-            return true;
+            else if (Toolchain.IsCliPathInvalid(CustomDotNetCliPath?.FullName, benchmark, out var invalidCliError))
+            {
+                yield return invalidCliError;
+            }
         }
 
         private static FileInfo GetShadowCopyPath(FileInfo coreRunPath)

--- a/src/BenchmarkDotNet/Toolchains/CoreRun/CoreRunToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRun/CoreRunToolchain.cs
@@ -62,8 +62,9 @@ namespace BenchmarkDotNet.Toolchains.CoreRun
         {
             if (!SourceCoreRun.Exists)
             {
-                yield return
-                    new ValidationError(true, $"Provided CoreRun path does not exist, benchmark '{benchmark.DisplayInfo}' will not be executed. Please remember that BDN expects path to CoreRun.exe (corerun on Unix), not to Core_Root folder.", benchmark);
+                yield return new ValidationError(true,
+                    $"Provided CoreRun path does not exist, benchmark '{benchmark.DisplayInfo}' will not be executed. Please remember that BDN expects path to CoreRun.exe (corerun on Unix), not to Core_Root folder.",
+                    benchmark);
             }
             else if (Toolchain.IsCliPathInvalid(CustomDotNetCliPath?.FullName, benchmark, out var invalidCliError))
             {

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
@@ -43,8 +43,9 @@ namespace BenchmarkDotNet.Toolchains.CsProj
 
             if (!RuntimeInformation.IsWindows())
             {
-                yield return
-                    new ValidationError(true, $"Classic .NET toolchain is supported only for Windows, benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
+                yield return new ValidationError(true,
+                    $"Classic .NET toolchain is supported only for Windows, benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
+                    benchmarkCase);
             }
             else if (IsCliPathInvalid(customDotNetCliPath: null, benchmarkCase, out var invalidCliError))
             {

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
@@ -1,8 +1,9 @@
-﻿using BenchmarkDotNet.Characteristics;
-using BenchmarkDotNet.Loggers;
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.DotNetCli;
+using BenchmarkDotNet.Validators;
 using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Toolchains.CsProj
@@ -33,21 +34,22 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         public static IToolchain From(string targetFrameworkMoniker, string packagesPath = null)
             => new CsProjClassicNetToolchain(targetFrameworkMoniker, targetFrameworkMoniker, packagesPath);
 
-        public override bool IsSupported(BenchmarkCase benchmarkCase, ILogger logger, IResolver resolver)
+        public override IEnumerable<ValidationError> Validate(BenchmarkCase benchmarkCase, IResolver resolver)
         {
-            if (!base.IsSupported(benchmarkCase, logger, resolver))
-                return false;
+            foreach (var validationError in base.Validate(benchmarkCase, resolver))
+            {
+                yield return validationError;
+            }
 
             if (!RuntimeInformation.IsWindows())
             {
-                logger.WriteLineError($"Classic .NET toolchain is supported only for Windows, benchmark '{benchmarkCase.DisplayInfo}' will not be executed");
-                return false;
+                yield return
+                    new ValidationError(true, $"Classic .NET toolchain is supported only for Windows, benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
             }
-
-            if (InvalidCliPath(customDotNetCliPath: null, benchmarkCase, logger))
-                return false;
-
-            return true;
+            else if (IsCliPathInvalid(customDotNetCliPath: null, benchmarkCase, out var invalidCliError))
+            {
+                yield return invalidCliError;
+            }
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
@@ -54,25 +54,29 @@ namespace BenchmarkDotNet.Toolchains.CsProj
 
             if (benchmarkCase.Job.HasValue(EnvironmentMode.JitCharacteristic) && benchmarkCase.Job.ResolveValue(EnvironmentMode.JitCharacteristic, resolver) == Jit.LegacyJit)
             {
-                yield return
-                    new ValidationError(true, $"Currently dotnet cli toolchain supports only RyuJit, benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
+                yield return new ValidationError(true,
+                    $"Currently dotnet cli toolchain supports only RyuJit, benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
+                    benchmarkCase);
             }
             if (benchmarkCase.Job.ResolveValue(GcMode.CpuGroupsCharacteristic, resolver))
             {
-                yield return
-                    new ValidationError(true, $"Currently project.json does not support CpuGroups (app.config does), benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
+                yield return new ValidationError(true,
+                    $"Currently project.json does not support CpuGroups (app.config does), benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
+                    benchmarkCase);
             }
             if (benchmarkCase.Job.ResolveValue(GcMode.AllowVeryLargeObjectsCharacteristic, resolver))
             {
-                yield return
-                    new ValidationError(true, $"Currently project.json does not support gcAllowVeryLargeObjects (app.config does), benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
+                yield return new ValidationError(true,
+                    $"Currently project.json does not support gcAllowVeryLargeObjects (app.config does), benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
+                    benchmarkCase);
             }
 
             var benchmarkAssembly = benchmarkCase.Descriptor.Type.Assembly;
             if (benchmarkAssembly.IsLinqPad())
             {
-                yield return
-                    new ValidationError(true, $"Currently CsProjCoreToolchain does not support LINQPad 6+. Please use {nameof(InProcessEmitToolchain)} instead.", benchmarkCase);
+                yield return new ValidationError(true,
+                    $"Currently CsProjCoreToolchain does not support LINQPad 6+. Please use {nameof(InProcessEmitToolchain)} instead.",
+                    benchmarkCase);
             }
         }
 

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
@@ -1,13 +1,14 @@
-﻿using BenchmarkDotNet.Characteristics;
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.DotNetCli;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
+using BenchmarkDotNet.Validators;
 using JetBrains.Annotations;
-using System;
 
 namespace BenchmarkDotNet.Toolchains.CsProj
 {
@@ -39,38 +40,40 @@ namespace BenchmarkDotNet.Toolchains.CsProj
                 new DotNetCliExecutor(settings.CustomDotNetCliPath),
                 settings.CustomDotNetCliPath);
 
-        public override bool IsSupported(BenchmarkCase benchmarkCase, ILogger logger, IResolver resolver)
+        public override IEnumerable<ValidationError> Validate(BenchmarkCase benchmarkCase, IResolver resolver)
         {
-            if (!base.IsSupported(benchmarkCase, logger, resolver))
-                return false;
+            foreach (var validationError in base.Validate(benchmarkCase, resolver))
+            {
+                yield return validationError;
+            }
 
-            if (InvalidCliPath(CustomDotNetCliPath, benchmarkCase, logger))
-                return false;
+            if (IsCliPathInvalid(CustomDotNetCliPath, benchmarkCase, out var invalidCliError))
+            {
+                yield return invalidCliError;
+            }
 
             if (benchmarkCase.Job.HasValue(EnvironmentMode.JitCharacteristic) && benchmarkCase.Job.ResolveValue(EnvironmentMode.JitCharacteristic, resolver) == Jit.LegacyJit)
             {
-                logger.WriteLineError($"Currently dotnet cli toolchain supports only RyuJit, benchmark '{benchmarkCase.DisplayInfo}' will not be executed");
-                return false;
+                yield return
+                    new ValidationError(true, $"Currently dotnet cli toolchain supports only RyuJit, benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
             }
             if (benchmarkCase.Job.ResolveValue(GcMode.CpuGroupsCharacteristic, resolver))
             {
-                logger.WriteLineError($"Currently project.json does not support CpuGroups (app.config does), benchmark '{benchmarkCase.DisplayInfo}' will not be executed");
-                return false;
+                yield return
+                    new ValidationError(true, $"Currently project.json does not support CpuGroups (app.config does), benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
             }
             if (benchmarkCase.Job.ResolveValue(GcMode.AllowVeryLargeObjectsCharacteristic, resolver))
             {
-                logger.WriteLineError($"Currently project.json does not support gcAllowVeryLargeObjects (app.config does), benchmark '{benchmarkCase.DisplayInfo}' will not be executed");
-                return false;
+                yield return
+                    new ValidationError(true, $"Currently project.json does not support gcAllowVeryLargeObjects (app.config does), benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
             }
 
             var benchmarkAssembly = benchmarkCase.Descriptor.Type.Assembly;
             if (benchmarkAssembly.IsLinqPad())
             {
-                logger.WriteLineError($"Currently CsProjCoreToolchain does not support LINQPad 6+. Please use {nameof(InProcessEmitToolchain)} instead. Benchmark '{benchmarkCase.DisplayInfo}' will not be executed");
-                return false;
+                yield return
+                    new ValidationError(true, $"Currently CsProjCoreToolchain does not support LINQPad 6+. Please use {nameof(InProcessEmitToolchain)} instead.", benchmarkCase);
             }
-
-            return true;
         }
 
         public override bool Equals(object obj) => obj is CsProjCoreToolchain typed && Equals(typed);

--- a/src/BenchmarkDotNet/Toolchains/IToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/IToolchain.cs
@@ -1,6 +1,7 @@
-﻿using BenchmarkDotNet.Characteristics;
-using BenchmarkDotNet.Loggers;
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
 using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Toolchains
@@ -13,6 +14,6 @@ namespace BenchmarkDotNet.Toolchains
         IExecutor Executor { get; }
         bool IsInProcess { get; }
 
-        bool IsSupported(BenchmarkCase benchmarkCase, ILogger logger, IResolver resolver);
+        IEnumerable<ValidationError> Validate(BenchmarkCase benchmarkCase, IResolver resolver);
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitToolchain.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-
+using System.Collections.Generic;
 using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
-
+using BenchmarkDotNet.Validators;
 using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
@@ -39,13 +39,8 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
             Executor = new InProcessNoEmitExecutor(timeout, logOutput);
         }
 
-        /// <summary>Determines whether the specified benchmark is supported.</summary>
-        /// <param name="benchmarkCase">The benchmark.</param>
-        /// <param name="logger">The logger.</param>
-        /// <param name="resolver">The resolver.</param>
-        /// <returns><c>true</c> if the benchmark can be run with the toolchain.</returns>
-        public bool IsSupported(BenchmarkCase benchmarkCase, ILogger logger, IResolver resolver) =>
-            InProcessValidator.IsSupported(benchmarkCase, logger);
+        public IEnumerable<ValidationError> Validate(BenchmarkCase benchmarkCase, IResolver resolver) =>
+            InProcessValidator.Validate(benchmarkCase);
 
         /// <summary>Name of the toolchain.</summary>
         /// <value>The name of the toolchain.</value>

--- a/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess.NoEmit/InProcessNoEmitToolchain.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using BenchmarkDotNet.Characteristics;
-using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Validators;
 using JetBrains.Annotations;

--- a/src/BenchmarkDotNet/Toolchains/InProcess/InProcessToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/InProcessToolchain.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-
+using System.Collections.Generic;
 using BenchmarkDotNet.Characteristics;
-using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
 
 namespace BenchmarkDotNet.Toolchains.InProcess
 {
@@ -39,13 +39,12 @@ namespace BenchmarkDotNet.Toolchains.InProcess
             Executor = new InProcessExecutor(timeout, codegenMode, logOutput);
         }
 
-        /// <summary>Determines whether the specified benchmark is supported.</summary>
+        /// <summary>Validates the specified benchmark.</summary>
         /// <param name="benchmarkCase">The benchmark.</param>
-        /// <param name="logger">The logger.</param>
         /// <param name="resolver">The resolver.</param>
-        /// <returns><c>true</c> if the benchmark can be run with the toolchain.</returns>
-        public bool IsSupported(BenchmarkCase benchmarkCase, ILogger logger, IResolver resolver) =>
-            InProcessValidator.IsSupported(benchmarkCase, logger);
+        /// <returns>Collection of validation errors, when not empty means that toolchain does not support provided benchmark.</returns>
+        public IEnumerable<ValidationError> Validate(BenchmarkCase benchmarkCase, IResolver resolver)
+            => InProcessValidator.Validate(benchmarkCase);
 
         /// <summary>Name of the toolchain.</summary>
         /// <value>The name of the toolchain.</value>

--- a/src/BenchmarkDotNet/Toolchains/InProcess/InProcessToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/InProcessToolchain.cs
@@ -43,8 +43,8 @@ namespace BenchmarkDotNet.Toolchains.InProcess
         /// <param name="benchmarkCase">The benchmark.</param>
         /// <param name="resolver">The resolver.</param>
         /// <returns>Collection of validation errors, when not empty means that toolchain does not support provided benchmark.</returns>
-        public IEnumerable<ValidationError> Validate(BenchmarkCase benchmarkCase, IResolver resolver)
-            => InProcessValidator.Validate(benchmarkCase);
+        public IEnumerable<ValidationError> Validate(BenchmarkCase benchmarkCase, IResolver resolver) =>
+            InProcessValidator.Validate(benchmarkCase);
 
         /// <summary>Name of the toolchain.</summary>
         /// <value>The name of the toolchain.</value>

--- a/src/BenchmarkDotNet/Toolchains/Mono/MonoAotToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/Mono/MonoAotToolchain.cs
@@ -26,28 +26,33 @@ namespace BenchmarkDotNet.Toolchains.Mono
                 yield return validationError;
             }
 
-            if (!benchmarkCase.Job.Environment.HasValue(EnvironmentMode.RuntimeCharacteristic) || !(benchmarkCase.Job.Environment.Runtime is MonoRuntime))
+            if (!benchmarkCase.Job.Environment.HasValue(EnvironmentMode.RuntimeCharacteristic) || benchmarkCase.Job.Environment.Runtime is not MonoRuntime)
             {
-                yield return
-                    new ValidationError(true, "The MonoAOT toolchain requires the Runtime property to be configured explicitly to an instance of MonoRuntime class", benchmarkCase);
+                yield return new ValidationError(true,
+                    "The MonoAOT toolchain requires the Runtime property to be configured explicitly to an instance of MonoRuntime class",
+                    benchmarkCase);
             }
 
             if ((benchmarkCase.Job.Environment.Runtime is MonoRuntime monoRuntime) && !string.IsNullOrEmpty(monoRuntime.MonoBclPath) && !Directory.Exists(monoRuntime.MonoBclPath))
             {
-                yield return
-                    new ValidationError(true, $"The MonoBclPath provided for MonoAOT toolchain: {monoRuntime.MonoBclPath} does NOT exist.", benchmarkCase);
+                yield return new ValidationError(true,
+                    $"The MonoBclPath provided for MonoAOT toolchain: {monoRuntime.MonoBclPath} does NOT exist.",
+                    benchmarkCase);
             }
 
             if (benchmarkCase.Job.HasValue(InfrastructureMode.BuildConfigurationCharacteristic)
                 && benchmarkCase.Job.ResolveValue(InfrastructureMode.BuildConfigurationCharacteristic, resolver) != InfrastructureMode.ReleaseConfigurationName)
             {
-                yield return
-                    new ValidationError(true, "The MonoAOT toolchain does not allow to rebuild source project, so defining custom build configuration makes no sense", benchmarkCase);
+                yield return new ValidationError(true,
+                    "The MonoAOT toolchain does not allow to rebuild source project, so defining custom build configuration makes no sense",
+                    benchmarkCase);
             }
 
             if (benchmarkCase.Job.HasValue(InfrastructureMode.NuGetReferencesCharacteristic))
             {
-                yield return new ValidationError(true, "The MonoAOT toolchain does not allow specifying NuGet package dependencies", benchmarkCase);
+                yield return new ValidationError(true,
+                    "The MonoAOT toolchain does not allow specifying NuGet package dependencies",
+                    benchmarkCase);
             }
         }
     }

--- a/src/BenchmarkDotNet/Toolchains/Mono/MonoAotToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/Mono/MonoAotToolchain.cs
@@ -1,11 +1,12 @@
-﻿using BenchmarkDotNet.Characteristics;
+﻿using System.Collections.Generic;
+using System.IO;
+using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.Roslyn;
+using BenchmarkDotNet.Validators;
 using JetBrains.Annotations;
-using System.IO;
 
 namespace BenchmarkDotNet.Toolchains.Mono
 {
@@ -18,39 +19,36 @@ namespace BenchmarkDotNet.Toolchains.Mono
         {
         }
 
-        public override bool IsSupported(BenchmarkCase benchmarkCase, ILogger logger, IResolver resolver)
+        public override IEnumerable<ValidationError> Validate(BenchmarkCase benchmarkCase, IResolver resolver)
         {
-            if (!base.IsSupported(benchmarkCase, logger, resolver))
+            foreach (var validationError in base.Validate(benchmarkCase, resolver))
             {
-                return false;
+                yield return validationError;
             }
 
             if (!benchmarkCase.Job.Environment.HasValue(EnvironmentMode.RuntimeCharacteristic) || !(benchmarkCase.Job.Environment.Runtime is MonoRuntime))
             {
-                logger.WriteLineError("The MonoAOT toolchain requires the Runtime property to be configured explicitly to an instance of MonoRuntime class");
-                return false;
+                yield return
+                    new ValidationError(true, "The MonoAOT toolchain requires the Runtime property to be configured explicitly to an instance of MonoRuntime class", benchmarkCase);
             }
 
             if ((benchmarkCase.Job.Environment.Runtime is MonoRuntime monoRuntime) && !string.IsNullOrEmpty(monoRuntime.MonoBclPath) && !Directory.Exists(monoRuntime.MonoBclPath))
             {
-                logger.WriteLineError($"The MonoBclPath provided for MonoAOT toolchain: {monoRuntime.MonoBclPath} does NOT exist.");
-                return false;
+                yield return
+                    new ValidationError(true, $"The MonoBclPath provided for MonoAOT toolchain: {monoRuntime.MonoBclPath} does NOT exist.", benchmarkCase);
             }
 
             if (benchmarkCase.Job.HasValue(InfrastructureMode.BuildConfigurationCharacteristic)
                 && benchmarkCase.Job.ResolveValue(InfrastructureMode.BuildConfigurationCharacteristic, resolver) != InfrastructureMode.ReleaseConfigurationName)
             {
-                logger.WriteLineError("The MonoAOT toolchain does not allow to rebuild source project, so defining custom build configuration makes no sense");
-                return false;
+                yield return
+                    new ValidationError(true, "The MonoAOT toolchain does not allow to rebuild source project, so defining custom build configuration makes no sense", benchmarkCase);
             }
 
             if (benchmarkCase.Job.HasValue(InfrastructureMode.NuGetReferencesCharacteristic))
             {
-                logger.WriteLineError("The MonoAOT toolchain does not allow specifying NuGet package dependencies");
-                return false;
+                yield return new ValidationError(true, "The MonoAOT toolchain does not allow specifying NuGet package dependencies", benchmarkCase);
             }
-
-            return true;
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmToolchain.cs
@@ -1,40 +1,46 @@
-﻿using BenchmarkDotNet.Toolchains.DotNetCli;
-using JetBrains.Annotations;
+﻿using System.Collections.Generic;
 using BenchmarkDotNet.Characteristics;
-using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Portability;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.DotNetCli;
+using BenchmarkDotNet.Validators;
+using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Toolchains.MonoWasm
 {
     [PublicAPI]
-    public class WasmToolChain : Toolchain
+    public class WasmToolchain : Toolchain
     {
         private string CustomDotNetCliPath { get; }
 
-        private WasmToolChain(string name, IGenerator generator, IBuilder builder, IExecutor executor, string customDotNetCliPath)
+        private WasmToolchain(string name, IGenerator generator, IBuilder builder, IExecutor executor, string customDotNetCliPath)
             : base(name, generator, builder, executor)
         {
             CustomDotNetCliPath = customDotNetCliPath;
         }
 
-        public override bool IsSupported(BenchmarkCase benchmarkCase, ILogger logger, IResolver resolver)
+        public override IEnumerable<ValidationError> Validate(BenchmarkCase benchmarkCase, IResolver resolver)
         {
-            if (!base.IsSupported(benchmarkCase, logger, resolver))
-                return false;
-
-            if (InvalidCliPath(CustomDotNetCliPath, benchmarkCase, logger))
-                return false;
+            foreach (var validationError in base.Validate(benchmarkCase, resolver))
+            {
+                yield return validationError;
+            }
 
             if (RuntimeInformation.IsWindows())
-                logger.WriteLineInfo($"{nameof(WasmToolChain)} is supported only on Unix, benchmark '{benchmarkCase.DisplayInfo}' might not work correctly");
+            {
+                yield return
+                    new ValidationError(true, $"{nameof(WasmToolchain)} is supported only on Unix, benchmark '{benchmarkCase.DisplayInfo}' might not work correctly", benchmarkCase);
+            } else if (IsCliPathInvalid(CustomDotNetCliPath, benchmarkCase, out var invalidCliError))
+            {
+                yield return invalidCliError;
+            }
 
-            return true;
+
         }
 
         [PublicAPI]
         public static IToolchain From(NetCoreAppSettings netCoreAppSettings)
-            => new WasmToolChain(netCoreAppSettings.Name,
+            => new WasmToolchain(netCoreAppSettings.Name,
                     new WasmGenerator(netCoreAppSettings.TargetFrameworkMoniker,
                         netCoreAppSettings.CustomDotNetCliPath,
                         netCoreAppSettings.PackagesPath,

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmToolchain.cs
@@ -28,14 +28,14 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
 
             if (RuntimeInformation.IsWindows())
             {
-                yield return
-                    new ValidationError(true, $"{nameof(WasmToolchain)} is supported only on Unix, benchmark '{benchmarkCase.DisplayInfo}' might not work correctly", benchmarkCase);
-            } else if (IsCliPathInvalid(CustomDotNetCliPath, benchmarkCase, out var invalidCliError))
+                yield return new ValidationError(true,
+                    $"{nameof(WasmToolchain)} is supported only on Unix, benchmark '{benchmarkCase.DisplayInfo}' might not work correctly",
+                    benchmarkCase);
+            }
+            else if (IsCliPathInvalid(CustomDotNetCliPath, benchmarkCase, out var invalidCliError))
             {
                 yield return invalidCliError;
             }
-
-
         }
 
         [PublicAPI]

--- a/src/BenchmarkDotNet/Toolchains/Roslyn/RoslynToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/Roslyn/RoslynToolchain.cs
@@ -31,27 +31,31 @@ namespace BenchmarkDotNet.Toolchains.Roslyn
 
             if (!RuntimeInformation.IsFullFramework)
             {
-                yield return
-                    new ValidationError(true, "The Roslyn toolchain is only supported on .NET Framework", benchmarkCase);
+                yield return new ValidationError(true,
+                    "The Roslyn toolchain is only supported on .NET Framework",
+                    benchmarkCase);
             }
 
             if (benchmarkCase.Job.ResolveValue(GcMode.RetainVmCharacteristic, resolver))
             {
-                yield return
-                    new ValidationError(true, $"Currently App.config does not support RetainVM option, benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
+                yield return new ValidationError(true,
+                    $"Currently App.config does not support RetainVM option, benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
+                    benchmarkCase);
             }
 
             if (benchmarkCase.Job.HasValue(InfrastructureMode.BuildConfigurationCharacteristic)
                 && benchmarkCase.Job.ResolveValue(InfrastructureMode.BuildConfigurationCharacteristic, resolver) != InfrastructureMode.ReleaseConfigurationName)
             {
-                yield return
-                    new ValidationError(true, "The Roslyn toolchain does not allow to rebuild source project, so defining custom build configuration makes no sense", benchmarkCase);
+                yield return new ValidationError(true,
+                    "The Roslyn toolchain does not allow to rebuild source project, so defining custom build configuration makes no sense",
+                    benchmarkCase);
             }
 
             if (benchmarkCase.Job.HasValue(InfrastructureMode.NuGetReferencesCharacteristic))
             {
-                yield return
-                    new ValidationError(true, "The Roslyn toolchain does not allow specifying NuGet package dependencies", benchmarkCase);
+                yield return new ValidationError(true,
+                    "The Roslyn toolchain does not allow specifying NuGet package dependencies",
+                    benchmarkCase);
             }
         }
     }

--- a/src/BenchmarkDotNet/Toolchains/Roslyn/RoslynToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/Roslyn/RoslynToolchain.cs
@@ -1,8 +1,9 @@
-﻿using BenchmarkDotNet.Characteristics;
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
 using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Toolchains.Roslyn
@@ -21,39 +22,37 @@ namespace BenchmarkDotNet.Toolchains.Roslyn
         }
 
         [PublicAPI]
-        public override bool IsSupported(BenchmarkCase benchmarkCase, ILogger logger, IResolver resolver)
+        public override IEnumerable<ValidationError> Validate(BenchmarkCase benchmarkCase, IResolver resolver)
         {
-            if (!base.IsSupported(benchmarkCase, logger, resolver))
+            foreach (var validationError in base.Validate(benchmarkCase, resolver))
             {
-                return false;
+                yield return validationError;
             }
 
             if (!RuntimeInformation.IsFullFramework)
             {
-                logger.WriteLineError("The Roslyn toolchain is only supported on .NET Framework");
-                return false;
+                yield return
+                    new ValidationError(true, "The Roslyn toolchain is only supported on .NET Framework", benchmarkCase);
             }
 
             if (benchmarkCase.Job.ResolveValue(GcMode.RetainVmCharacteristic, resolver))
             {
-                logger.WriteLineError($"Currently App.config does not support RetainVM option, benchmark '{benchmarkCase.DisplayInfo}' will not be executed");
-                return false;
+                yield return
+                    new ValidationError(true, $"Currently App.config does not support RetainVM option, benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
             }
 
             if (benchmarkCase.Job.HasValue(InfrastructureMode.BuildConfigurationCharacteristic)
                 && benchmarkCase.Job.ResolveValue(InfrastructureMode.BuildConfigurationCharacteristic, resolver) != InfrastructureMode.ReleaseConfigurationName)
             {
-                logger.WriteLineError("The Roslyn toolchain does not allow to rebuild source project, so defining custom build configuration makes no sense");
-                return false;
+                yield return
+                    new ValidationError(true, "The Roslyn toolchain does not allow to rebuild source project, so defining custom build configuration makes no sense", benchmarkCase);
             }
 
             if (benchmarkCase.Job.HasValue(InfrastructureMode.NuGetReferencesCharacteristic))
             {
-                logger.WriteLineError("The Roslyn toolchain does not allow specifying NuGet package dependencies");
-                return false;
+                yield return
+                    new ValidationError(true, "The Roslyn toolchain does not allow specifying NuGet package dependencies", benchmarkCase);
             }
-
-            return true;
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/Toolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/Toolchain.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
@@ -35,25 +34,27 @@ namespace BenchmarkDotNet.Toolchains
             var jit = benchmarkCase.Job.ResolveValue(EnvironmentMode.JitCharacteristic, resolver);
             if (!(runtime is MonoRuntime) && jit == Jit.Llvm)
             {
-                yield return
-                    new ValidationError(true, $"Llvm is supported only for Mono, benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
+                yield return new ValidationError(true,
+                    $"Llvm is supported only for Mono, benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
+                    benchmarkCase);
             }
 
             if (runtime is MonoRuntime mono && !benchmarkCase.GetToolchain().IsInProcess)
             {
                 if (string.IsNullOrEmpty(mono.CustomPath) && !HostEnvironmentInfo.GetCurrent().IsMonoInstalled.Value)
                 {
-                    yield return
-                        new ValidationError(true, $"Mono is not installed or added to PATH, benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
+                    yield return new ValidationError(true,
+                        $"Mono is not installed or added to PATH, benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
+                        benchmarkCase);
                 }
 
                 if (!string.IsNullOrEmpty(mono.CustomPath) && !File.Exists(mono.CustomPath))
                 {
-                    yield return
-                        new ValidationError(true, $"We could not find Mono in provided path ({mono.CustomPath}), benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
+                    yield return new ValidationError(true,
+                        $"We could not find Mono in provided path ({mono.CustomPath}), benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
+                        benchmarkCase);
                 }
             }
-
         }
 
         internal static bool IsCliPathInvalid(string customDotNetCliPath, BenchmarkCase benchmarkCase, out ValidationError validationError)
@@ -62,13 +63,19 @@ namespace BenchmarkDotNet.Toolchains
 
             if (string.IsNullOrEmpty(customDotNetCliPath) && !HostEnvironmentInfo.GetCurrent().IsDotNetCliInstalled())
             {
-                validationError = new ValidationError(true, $"BenchmarkDotNet requires dotnet cli to be installed or path to local dotnet cli provided in explicit way using `--cli` argument, benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
+                validationError = new ValidationError(true,
+                    $"BenchmarkDotNet requires dotnet cli to be installed or path to local dotnet cli provided in explicit way using `--cli` argument, benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
+                    benchmarkCase);
+
                 return true;
             }
 
             if (!string.IsNullOrEmpty(customDotNetCliPath) && !File.Exists(customDotNetCliPath))
             {
-                validationError = new ValidationError(true, $"Provided custom dotnet cli path does not exist, benchmark '{benchmarkCase.DisplayInfo}' will not be executed", benchmarkCase);
+                validationError = new ValidationError(true,
+                    $"Provided custom dotnet cli path does not exist, benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
+                    benchmarkCase);
+
                 return true;
             }
 

--- a/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
@@ -4,15 +4,14 @@ using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Toolchains.NativeAot;
 using BenchmarkDotNet.Toolchains.CsProj;
 using BenchmarkDotNet.Toolchains.DotNetCli;
-using BenchmarkDotNet.Toolchains.InProcess;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 using BenchmarkDotNet.Toolchains.Mono;
-using BenchmarkDotNet.Toolchains.Roslyn;
 using BenchmarkDotNet.Toolchains.MonoWasm;
+using BenchmarkDotNet.Toolchains.NativeAot;
+using BenchmarkDotNet.Toolchains.Roslyn;
 
 namespace BenchmarkDotNet.Toolchains
 {
@@ -66,7 +65,7 @@ namespace BenchmarkDotNet.Toolchains
                             : NativeAotToolchain.CreateBuilder().UseNuGet().TargetFrameworkMoniker(nativeAotRuntime.MsBuildMoniker).ToToolchain();
 
                 case WasmRuntime wasmRuntime:
-                    return WasmToolChain.From(new NetCoreAppSettings(targetFrameworkMoniker: wasmRuntime.MsBuildMoniker, name: wasmRuntime.Name, runtimeFrameworkVersion: null));
+                    return WasmToolchain.From(new NetCoreAppSettings(targetFrameworkMoniker: wasmRuntime.MsBuildMoniker, name: wasmRuntime.Name, runtimeFrameworkVersion: null));
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(runtime), runtime, "Runtime not supported");
@@ -79,26 +78,37 @@ namespace BenchmarkDotNet.Toolchains
             {
                 case RuntimeMoniker.Net461:
                     return CsProjClassicNetToolchain.Net461;
+
                 case RuntimeMoniker.Net462:
                     return CsProjClassicNetToolchain.Net462;
+
                 case RuntimeMoniker.Net47:
                     return CsProjClassicNetToolchain.Net47;
+
                 case RuntimeMoniker.Net471:
                     return CsProjClassicNetToolchain.Net471;
+
                 case RuntimeMoniker.Net472:
                     return CsProjClassicNetToolchain.Net472;
+
                 case RuntimeMoniker.Net48:
                     return CsProjClassicNetToolchain.Net48;
+
                 case RuntimeMoniker.Net481:
                     return CsProjClassicNetToolchain.Net481;
+
                 case RuntimeMoniker.NetCoreApp20:
                     return CsProjCoreToolchain.NetCoreApp20;
+
                 case RuntimeMoniker.NetCoreApp21:
                     return CsProjCoreToolchain.NetCoreApp21;
+
                 case RuntimeMoniker.NetCoreApp22:
                     return CsProjCoreToolchain.NetCoreApp22;
+
                 case RuntimeMoniker.NetCoreApp30:
                     return CsProjCoreToolchain.NetCoreApp30;
+
                 case RuntimeMoniker.NetCoreApp31:
                     return CsProjCoreToolchain.NetCoreApp31;
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -106,14 +116,19 @@ namespace BenchmarkDotNet.Toolchains
 #pragma warning restore CS0618 // Type or member is obsolete
                 case RuntimeMoniker.Net50:
                     return CsProjCoreToolchain.NetCoreApp50;
+
                 case RuntimeMoniker.Net60:
                     return CsProjCoreToolchain.NetCoreApp60;
+
                 case RuntimeMoniker.Net70:
                     return CsProjCoreToolchain.NetCoreApp70;
+
                 case RuntimeMoniker.NativeAot60:
                     return NativeAotToolchain.Net60;
+
                 case RuntimeMoniker.NativeAot70:
                     return NativeAotToolchain.Net70;
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(runtimeMoniker), runtimeMoniker, "RuntimeMoniker not supported");
             }

--- a/src/BenchmarkDotNet/Validators/ValidationError.cs
+++ b/src/BenchmarkDotNet/Validators/ValidationError.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using BenchmarkDotNet.Running;
 using JetBrains.Annotations;
 
@@ -36,7 +37,7 @@ namespace BenchmarkDotNet.Validators
                 return true;
             if (obj.GetType() != this.GetType())
                 return false;
-            return Equals((ValidationError) obj);
+            return Equals((ValidationError)obj);
         }
 
         public override int GetHashCode()
@@ -49,6 +50,7 @@ namespace BenchmarkDotNet.Validators
                 return hashCode;
             }
         }
+
 
         public static bool operator ==(ValidationError left, ValidationError right) => Equals(left, right);
 

--- a/tests/BenchmarkDotNet.IntegrationTests/InProcessTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/InProcessTest.cs
@@ -8,6 +8,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
@@ -56,10 +57,28 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void BenchmarkActionValueTaskOfTSupported() => TestInvoke(x => x.InvokeOnceValueTaskOfT(), UnrollFactor, DecimalResult);
 
+        [Fact]
+        public void BenchmarkDifferentPlatformReturnsValidationError()
+        {
+            var otherPlatform = IntPtr.Size == 8
+                ? Platform.X86
+                : Platform.X64;
+
+            var otherPlatformConfig = new ManualConfig()
+                .With(Job.Dry.With(InProcessToolchain.Instance).With(otherPlatform))
+                .With(new OutputLogger(Output))
+                .With(DefaultColumnProviders.Instance);
+
+            var runInfo = BenchmarkConverter.TypeToBenchmarks(typeof(BenchmarkAllCases), otherPlatformConfig);
+            var summary = BenchmarkRunner.Run(runInfo);
+
+            Assert.NotEmpty(summary.ValidationErrors);
+        }
+
         [AssertionMethod]
         private void TestInvoke(Expression<Action<BenchmarkAllCases>> methodCall, int unrollFactor)
         {
-            var targetMethod = ((MethodCallExpression) methodCall.Body).Method;
+            var targetMethod = ((MethodCallExpression)methodCall.Body).Method;
             var descriptor = new Descriptor(typeof(BenchmarkAllCases), targetMethod, targetMethod, targetMethod);
 
             // Run mode
@@ -97,7 +116,7 @@ namespace BenchmarkDotNet.IntegrationTests
         [AssertionMethod]
         private void TestInvoke<T>(Expression<Func<BenchmarkAllCases, T>> methodCall, int unrollFactor, object expectedResult)
         {
-            var targetMethod = ((MethodCallExpression) methodCall.Body).Method;
+            var targetMethod = ((MethodCallExpression)methodCall.Body).Method;
             var descriptor = new Descriptor(typeof(BenchmarkAllCases), targetMethod);
 
             // Run mode

--- a/tests/BenchmarkDotNet.IntegrationTests/NugetReferenceTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/NugetReferenceTests.cs
@@ -1,22 +1,22 @@
-﻿using BenchmarkDotNet.Jobs;
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Portability;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Tests.XUnit;
+using BenchmarkDotNet.Toolchains;
+using BenchmarkDotNet.Toolchains.Roslyn;
+using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
-using BenchmarkDotNet.Portability;
-using BenchmarkDotNet.Toolchains;
-using BenchmarkDotNet.Attributes;
-using Newtonsoft.Json;
-using System;
-using BenchmarkDotNet.Toolchains.Roslyn;
-using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Loggers;
-using System.Collections.Immutable;
-using BenchmarkDotNet.Tests.XUnit;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
     public class NuGetReferenceTests : BenchmarkTestExecutor
     {
-        public NuGetReferenceTests(ITestOutputHelper output) : base(output) { }
+        public NuGetReferenceTests(ITestOutputHelper output) : base(output)
+        {
+        }
 
         [FactNotLinux("For some reason this test is unstable on Ubuntu for both AzureDevOps and Travis CI")]
         public void UserCanSpecifyCustomNuGetPackageDependency()
@@ -37,19 +37,18 @@ namespace BenchmarkDotNet.IntegrationTests
             var unsupportedJob = Job.Dry.WithToolchain(toolchain).WithNuGet("Newtonsoft.Json", "11.0.2");
             var unsupportedJobConfig = CreateSimpleConfig(job: unsupportedJob);
             var unsupportedJobBenchmark = BenchmarkConverter.TypeToBenchmarks(typeof(WithCallToNewtonsoft), unsupportedJobConfig);
-            var unsupportedJobLogger = new CompositeLogger(unsupportedJobConfig.GetLoggers().ToImmutableHashSet());
+
             foreach (var benchmarkCase in unsupportedJobBenchmark.BenchmarksCases)
             {
-                Assert.False(toolchain.IsSupported(benchmarkCase, unsupportedJobLogger, BenchmarkRunnerClean.DefaultResolver));
+                Assert.NotEmpty(toolchain.Validate(benchmarkCase, BenchmarkRunnerClean.DefaultResolver));
             }
 
             var supportedJob = Job.Dry.WithToolchain(toolchain);
             var supportedConfig = CreateSimpleConfig(job: supportedJob);
             var supportedBenchmark = BenchmarkConverter.TypeToBenchmarks(typeof(WithCallToNewtonsoft), supportedConfig);
-            var supportedLogger = new CompositeLogger(supportedConfig.GetLoggers().ToImmutableHashSet());
             foreach (var benchmarkCase in supportedBenchmark.BenchmarksCases)
             {
-                Assert.True(toolchain.IsSupported(benchmarkCase, supportedLogger, BenchmarkRunnerClean.DefaultResolver));
+                Assert.Empty(toolchain.Validate(benchmarkCase, BenchmarkRunnerClean.DefaultResolver));
             }
         }
 


### PR DESCRIPTION
Aims to fix #989, added a similar test to the one that is described in the issue.
After this PR, the summary will include validation errors and the output will look like this:
```
  Standard Output: 
// Benchmark BenchmarkAllCases.InvokeOnceVoid: Dry(Platform=X86, Toolchain=InProcessToolchain, InvocationCount=16, IterationCount=1, LaunchCount=1, RunStrategy=ColdStart, UnrollFactor=16, WarmupCount=1)
// cannot be run in-process. Validation errors:
//    * Job Dry, EnvironmentMode.Platform was run as X64 (X86 expected). Fix your test runner options.

// Benchmark BenchmarkAllCases.InvokeOnceTaskAsync: Dry(Platform=X86, Toolchain=InProcessToolchain, InvocationCount=16, IterationCount=1, LaunchCount=1, RunStrategy=ColdStart, UnrollFactor=16, WarmupCount=1)
// cannot be run in-process. Validation errors:
//    * Job Dry, EnvironmentMode.Platform was run as X64 (X86 expected). Fix your test runner options.

// Benchmark BenchmarkAllCases.InvokeOnceRefType: Dry(Platform=X86, Toolchain=InProcessToolchain, InvocationCount=16, IterationCount=1, LaunchCount=1, RunStrategy=ColdStart, UnrollFactor=16, WarmupCount=1)
// cannot be run in-process. Validation errors:
//    * Job Dry, EnvironmentMode.Platform was run as X64 (X86 expected). Fix your test runner options.

// Benchmark BenchmarkAllCases.InvokeOnceValueType: Dry(Platform=X86, Toolchain=InProcessToolchain, InvocationCount=16, IterationCount=1, LaunchCount=1, RunStrategy=ColdStart, UnrollFactor=16, WarmupCount=1)
// cannot be run in-process. Validation errors:
//    * Job Dry, EnvironmentMode.Platform was run as X64 (X86 expected). Fix your test runner options.

// Benchmark BenchmarkAllCases.InvokeOnceTaskOfTAsync: Dry(Platform=X86, Toolchain=InProcessToolchain, InvocationCount=16, IterationCount=1, LaunchCount=1, RunStrategy=ColdStart, UnrollFactor=16, WarmupCount=1)
// cannot be run in-process. Validation errors:
//    * Job Dry, EnvironmentMode.Platform was run as X64 (X86 expected). Fix your test runner options.

// Benchmark BenchmarkAllCases.InvokeOnceValueTaskOfT: Dry(Platform=X86, Toolchain=InProcessToolchain, InvocationCount=16, IterationCount=1, LaunchCount=1, RunStrategy=ColdStart, UnrollFactor=16, WarmupCount=1)
// cannot be run in-process. Validation errors:
//    * Job Dry, EnvironmentMode.Platform was run as X64 (X86 expected). Fix your test runner options.

No suitable benchmarks were found
```
Although I believe it fits the purpose of what is described in the original issue, the error is not that specific, if we want to have something more specific we will have to introduce a new method in the IToolChain interface as the existing one returns only a bool https://github.com/dotnet/BenchmarkDotNet/blob/master/src/BenchmarkDotNet/Toolchains/IToolchain.cs#L16 