### PR TITLE
Update StaThread intro documentation

### DIFF
--- a/docs/articles/samples/IntroStaThread.md
+++ b/docs/articles/samples/IntroStaThread.md
@@ -6,9 +6,9 @@ uid: BenchmarkDotNet.Samples.IntroStaThread
 
 If the code you want to benchmark requires `[System.STAThread]`
   then you need to apply this attribute to the benchmarked method.
-BenchmarkDotNet will generate executable with `[STAThread]` applied to it's `Main` method. 
+BenchmarkDotNet will generate an executable with `[STAThread]` applied to its `Main` method.
 
-Currently it does not work for .NET Core 2.0 due to [this](https://github.com/dotnet/runtime/issues/8834) bug.
+Using this feature on .NET Core requires .NET Core 2.1 or newer. Older versions will not work due to [this](https://github.com/dotnet/runtime/issues/8834) bug.
 
 ### Source code
 


### PR DESCRIPTION
Call out that support for `[STAThread]` was fixed in .NET Core 2.1.

Fix a couple minor grammatical errors.