### PR TITLE
Fix user input matching

### DIFF
--- a/src/BenchmarkDotNet/Running/UserInteraction.cs
+++ b/src/BenchmarkDotNet/Running/UserInteraction.cs
@@ -90,18 +90,23 @@ namespace BenchmarkDotNet.Running
             if (userInput.IsEmpty())
                 yield break;
 
+            var integerInput = userInput.Where(arg => IsInteger(arg)).ToArray();
+            var stringInput = userInput.Where(arg => !IsInteger(arg)).ToArray();
+
             for (int i = 0; i < allTypes.Count; i++)
             {
                 var type = allTypes[i];
 
-                if (userInput.Any(arg => type.GetDisplayName().ContainsWithIgnoreCase(arg))
-                    || userInput.Contains($"#{i}")
-                    || userInput.Contains(i.ToString())
-                    || userInput.Contains("*"))
+                if (stringInput.Any(arg => type.GetDisplayName().ContainsWithIgnoreCase(arg))
+                    || stringInput.Contains($"#{i}")
+                    || integerInput.Contains($"{i}")
+                    || stringInput.Contains("*"))
                 {
                     yield return type;
                 }
             }
+
+            static bool IsInteger(string str) => int.TryParse(str, out _);
         }
 
         private static void PrintAvailable([NotNull] IReadOnlyList<Type> allTypes, ILogger logger)


### PR DESCRIPTION
Fixes #1709


### Problem
```
Available Benchmarks:
  #0 Test01
  #1 Test02
```
if you write `0` it matches:
* Test01 (by benchmark class index)
* Test01 (class name contains `0`)
* Test02 (class name contains `0`)

### Note

This only applies to interactive mode, the `--filter` cmd option does not work with benchmark class index (`--filter 0` or `--filter #0`)