### PR TITLE
Make ParamsAllValues validator mandatory

### DIFF
--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -26,7 +26,8 @@ namespace BenchmarkDotNet.Configs
             ConfigValidator.DontFailOnError,
             ShadowCopyValidator.DontFailOnError,
             JitOptimizationsValidator.DontFailOnError,
-            DeferredExecutionValidator.DontFailOnError
+            DeferredExecutionValidator.DontFailOnError,
+            ParamsAllValuesValidator.FailOnError
         };
 
         /// <summary>


### PR DESCRIPTION
The author forgot to add this validator to the list of required validators in #908.

### Example
```C#
[DryJob]
public class MyClass
{
    [ParamsAllValues] public int MyParam;
    [Benchmark] public void MyMethod(){ }
}
```

The first command has `DefaultConfig`.
The second command has `ManualConfig.CreateMinimumViable()`.
![image](https://user-images.githubusercontent.com/19392641/196033637-4710cc32-a957-4fe7-84b4-e83c0d7e25ca.png)
