### PR TITLE
remove dependency to Mono.Posix.NETStandard to unblock WASM benchmarks runs

### DIFF
--- a/samples/BenchmarkDotNet.Samples/IntroLargeAddressAware.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroLargeAddressAware.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
@@ -17,7 +18,7 @@ namespace BenchmarkDotNet.Samples
                 AddJob(Job.Default
                     .WithRuntime(ClrRuntime.Net462)
                     .WithPlatform(Platform.X86)
-                    .WithLargeAddressAware()
+                    .WithLargeAddressAware(value: RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     .WithId("Framework"));
             }
         }

--- a/src/BenchmarkDotNet/Attributes/PerfCollectProfilerAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/PerfCollectProfilerAttribute.cs
@@ -8,8 +8,8 @@ namespace BenchmarkDotNet.Attributes
     public class PerfCollectProfilerAttribute : Attribute, IConfigSource
     {
         /// <param name="performExtraBenchmarksRun">When set to true, benchmarks will be executed one more time with the profiler attached. If set to false, there will be no extra run but the results will contain overhead. False by default.</param>
-        /// <param name="timeoutInSeconds">How long should we wait for the perfcollect script to finish processing the trace. 120s by default.</param>
-        public PerfCollectProfilerAttribute(bool performExtraBenchmarksRun = false, int timeoutInSeconds = 120)
+        /// <param name="timeoutInSeconds">How long should we wait for the perfcollect script to finish processing the trace. 300s by default.</param>
+        public PerfCollectProfilerAttribute(bool performExtraBenchmarksRun = false, int timeoutInSeconds = 300)
         {
             Config = ManualConfig.CreateEmpty().AddDiagnoser(new PerfCollectProfiler(new PerfCollectProfilerConfig(performExtraBenchmarksRun, timeoutInSeconds)));
         }

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Iced" Version="1.17.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.2.332302" />
     <PackageReference Include="Perfolizer" Version="0.2.1" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="System.Management" Version="6.0.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />

--- a/src/BenchmarkDotNet/Diagnosers/PerfCollectProfilerConfig.cs
+++ b/src/BenchmarkDotNet/Diagnosers/PerfCollectProfilerConfig.cs
@@ -5,8 +5,8 @@ namespace BenchmarkDotNet.Diagnosers
     public class PerfCollectProfilerConfig
     {
         /// <param name="performExtraBenchmarksRun">When set to true, benchmarks will be executed one more time with the profiler attached. If set to false, there will be no extra run but the results will contain overhead. False by default.</param>
-        /// <param name="timeoutInSeconds">How long should we wait for the perfcollect script to finish processing the trace. 120s by default.</param>
-        public PerfCollectProfilerConfig(bool performExtraBenchmarksRun = false, int timeoutInSeconds = 120)
+        /// <param name="timeoutInSeconds">How long should we wait for the perfcollect script to finish processing the trace. 300s by default.</param>
+        public PerfCollectProfilerConfig(bool performExtraBenchmarksRun = false, int timeoutInSeconds = 300)
         {
             RunMode = performExtraBenchmarksRun ? RunMode.ExtraRun : RunMode.NoOverhead;
             Timeout = TimeSpan.FromSeconds(timeoutInSeconds);

--- a/src/BenchmarkDotNet/Jobs/EnvironmentMode.cs
+++ b/src/BenchmarkDotNet/Jobs/EnvironmentMode.cs
@@ -107,7 +107,7 @@ namespace BenchmarkDotNet.Jobs
             get => LargeAddressAwareCharacteristic[this];
             set
             {
-                if (!RuntimeInformation.IsWindows())
+                if (value && !RuntimeInformation.IsWindows())
                 {
                     throw new NotSupportedException("LargeAddressAware is a Windows-specific concept.");
                 }

--- a/src/BenchmarkDotNet/Portability/Libc.cs
+++ b/src/BenchmarkDotNet/Portability/Libc.cs
@@ -1,0 +1,29 @@
+﻿using System.Runtime.InteropServices;
+
+namespace BenchmarkDotNet.Portability
+{
+    internal static class libc
+    {
+        [DllImport(nameof(libc))]
+        internal static extern int getppid();
+
+        [DllImport(nameof(libc))]
+        internal static extern uint getuid();
+
+        [DllImport(nameof(libc), SetLastError = true)]
+        internal static extern int kill(int pid, int sig);
+
+        [DllImport(nameof(libc), SetLastError = true)]
+        internal static extern int chmod(string path, uint mode);
+
+        internal static class Signals
+        {
+            internal const int SIGINT = 2;
+        }
+
+        internal static class FilePermissions
+        {
+            internal const uint S_IXUSR = 0x40u;
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Helpers;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Portability;
 using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Toolchains.DotNetCli
@@ -140,7 +140,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             if (!Portability.RuntimeInformation.IsLinux())
                 return "dotnet";
 
-            using (var parentProcess = Process.GetProcessById(getppid()))
+            using (var parentProcess = Process.GetProcessById(libc.getppid()))
             {
                 string parentPath = parentProcess.MainModule?.FileName ?? string.Empty;
                 // sth like /snap/dotnet-sdk/112/dotnet and we should use the exact path instead of just "dotnet"
@@ -153,9 +153,6 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                 return "dotnet";
             }
         }
-
-        [DllImport("libc")]
-        private static extern int getppid();
 
         internal static string GetSdkPath(string cliPath)
         {


### PR DESCRIPTION
fixes #2146

reported by @radical and @lewing in https://github.com/dotnet/performance/pull/2639#issuecomment-1279537243