### PR TITLE
Rework "Not unique exporter for exporter type" PR

### DIFF
--- a/src/BenchmarkDotNet/Configs/DebugConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DebugConfig.cs
@@ -52,7 +52,6 @@ namespace BenchmarkDotNet.Configs
 
     public abstract class DebugConfig : IConfig
     {
-        private readonly static Conclusion[] emptyConclusion = Array.Empty<Conclusion>();
         public abstract IEnumerable<Job> GetJobs();
 
         public IEnumerable<IValidator> GetValidators() => Array.Empty<IValidator>();
@@ -85,7 +84,5 @@ namespace BenchmarkDotNet.Configs
         public IEnumerable<BenchmarkLogicalGroupRule> GetLogicalGroupRules() => Array.Empty<BenchmarkLogicalGroupRule>();
 
         public ConfigOptions Options => ConfigOptions.KeepBenchmarkFiles | ConfigOptions.DisableOptimizationsValidator;
-
-        public IReadOnlyList<Conclusion> ConfigAnalysisConclusion => emptyConclusion;
     }
 }

--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -67,6 +67,7 @@ namespace BenchmarkDotNet.Configs
             yield return GenericBenchmarksValidator.DontFailOnError;
             yield return DeferredExecutionValidator.FailOnError;
             yield return ParamsAllValuesValidator.FailOnError;
+            yield return RPlotExporterValidator.FailOnError;
         }
 
         public IOrderer Orderer => null;

--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -20,7 +20,6 @@ namespace BenchmarkDotNet.Configs
     public class DefaultConfig : IConfig
     {
         public static readonly IConfig Instance = new DefaultConfig();
-        private readonly static Conclusion[] emptyConclusion = Array.Empty<Conclusion>();
 
         private DefaultConfig()
         {
@@ -92,8 +91,6 @@ namespace BenchmarkDotNet.Configs
                 return Path.Combine(root, "BenchmarkDotNet.Artifacts");
             }
         }
-
-        public IReadOnlyList<Conclusion> ConfigAnalysisConclusion => emptyConclusion;
 
         public IEnumerable<Job> GetJobs() => Array.Empty<Job>();
 

--- a/src/BenchmarkDotNet/Configs/IConfig.cs
+++ b/src/BenchmarkDotNet/Configs/IConfig.cs
@@ -52,10 +52,5 @@ namespace BenchmarkDotNet.Configs
         /// the auto-generated project build timeout
         /// </summary>
         TimeSpan BuildTimeout { get; }
-
-        /// <summary>
-        /// Collect any errors or warnings when composing the configuration
-        /// </summary>
-        IReadOnlyList<Conclusion> ConfigAnalysisConclusion { get; }
     }
 }

--- a/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
@@ -52,8 +52,7 @@ namespace BenchmarkDotNet.Configs
             IOrderer orderer,
             SummaryStyle summaryStyle,
             ConfigOptions options,
-            TimeSpan buildTimeout,
-            IReadOnlyList<Conclusion> configAnalysisConclusion)
+            TimeSpan buildTimeout)
         {
             columnProviders = uniqueColumnProviders;
             loggers = uniqueLoggers;
@@ -73,7 +72,6 @@ namespace BenchmarkDotNet.Configs
             SummaryStyle = summaryStyle;
             Options = options;
             BuildTimeout = buildTimeout;
-            ConfigAnalysisConclusion = configAnalysisConclusion;
         }
 
         public ConfigUnionRule UnionRule { get; }
@@ -116,7 +114,5 @@ namespace BenchmarkDotNet.Configs
 
             return diagnosersForGivenMode.Any() ? new CompositeDiagnoser(diagnosersForGivenMode) : null;
         }
-
-        public IReadOnlyList<Conclusion> ConfigAnalysisConclusion { get; private set; }
     }
 }

--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -115,8 +115,6 @@ namespace BenchmarkDotNet.Configs
                     foreach (var dependency in exporterDependencies.Dependencies)
                         result.Insert(i, dependency); // All the exporter dependencies should be added before the exporter
 
-            result.Sort((left, right) => (left is IExporterDependencies).CompareTo(right is IExporterDependencies)); // the case when they were defined by user in wrong order ;)
-
             var uniqueExporters = new List<IExporter>();
 
             foreach (var exporter in result)

--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -204,7 +204,7 @@ namespace BenchmarkDotNet.Configs
         {
             public static readonly ExporterComparer Instance = new ExporterComparer();
 
-            public bool Equals(IExporter x, IExporter y) => x.GetType() == y.GetType() && x.Name == y.Name;
+            public bool Equals(IExporter x, IExporter y) => x.GetType() == y.GetType() && x.Id == y.Id;
 
             public int GetHashCode(IExporter obj) => obj.GetType().GetHashCode();
         }

--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -94,30 +94,30 @@ namespace BenchmarkDotNet.Configs
 
         private static ImmutableArray<IExporter> GetExporters(IEnumerable<IExporter> exporters, ImmutableHashSet<IDiagnoser> uniqueDiagnosers)
         {
-            var result = new List<IExporter>();
+            var allExporters = new List<IExporter>();
 
             foreach (var exporter in exporters)
-                result.Add(exporter);
+                allExporters.Add(exporter);
 
             foreach (var diagnoser in uniqueDiagnosers)
             foreach (var exporter in diagnoser.Exporters)
-                result.Add(exporter);
+                allExporters.Add(exporter);
 
             var hardwareCounterDiagnoser = uniqueDiagnosers.OfType<IHardwareCountersDiagnoser>().SingleOrDefault();
             var disassemblyDiagnoser = uniqueDiagnosers.OfType<DisassemblyDiagnoser>().SingleOrDefault();
 
             // we can use InstructionPointerExporter only when we have both IHardwareCountersDiagnoser and DisassemblyDiagnoser
             if (hardwareCounterDiagnoser != default(IHardwareCountersDiagnoser) && disassemblyDiagnoser != default(DisassemblyDiagnoser))
-                result.Add(new InstructionPointerExporter(hardwareCounterDiagnoser, disassemblyDiagnoser));
+                allExporters.Add(new InstructionPointerExporter(hardwareCounterDiagnoser, disassemblyDiagnoser));
 
-            for (int i = result.Count - 1; i >= 0; i--)
-                if (result[i] is IExporterDependencies exporterDependencies)
+            for (int i = allExporters.Count - 1; i >= 0; i--)
+                if (allExporters[i] is IExporterDependencies exporterDependencies)
                     foreach (var dependency in exporterDependencies.Dependencies)
-                        result.Insert(i, dependency); // All the exporter dependencies should be added before the exporter
+                        allExporters.Insert(i, dependency); // All the exporter dependencies should be added before the exporter
 
             var uniqueExporters = new List<IExporter>();
 
-            foreach (var exporter in result)
+            foreach (var exporter in allExporters)
                 if (!uniqueExporters.Contains(exporter, ExporterComparer.Instance))
                     uniqueExporters.Add(exporter);
 

--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -107,7 +107,7 @@ namespace BenchmarkDotNet.Configs
             var disassemblyDiagnoser = uniqueDiagnosers.OfType<DisassemblyDiagnoser>().SingleOrDefault();
 
             // we can use InstructionPointerExporter only when we have both IHardwareCountersDiagnoser and DisassemblyDiagnoser
-            if (hardwareCounterDiagnoser != default(IHardwareCountersDiagnoser) && disassemblyDiagnoser != default(DisassemblyDiagnoser))
+            if (hardwareCounterDiagnoser != null && disassemblyDiagnoser != null)
                 allExporters.Add(new InstructionPointerExporter(hardwareCounterDiagnoser, disassemblyDiagnoser));
 
             for (int i = allExporters.Count - 1; i >= 0; i--)

--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -26,7 +26,8 @@ namespace BenchmarkDotNet.Configs
             ConfigValidator.DontFailOnError,
             ShadowCopyValidator.DontFailOnError,
             JitOptimizationsValidator.DontFailOnError,
-            DeferredExecutionValidator.DontFailOnError
+            DeferredExecutionValidator.DontFailOnError,
+            RPlotExporterValidator.FailOnError
         };
 
         /// <summary>

--- a/src/BenchmarkDotNet/Configs/ManualConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ManualConfig.cs
@@ -20,8 +20,6 @@ namespace BenchmarkDotNet.Configs
 {
     public class ManualConfig : IConfig
     {
-        private readonly static Conclusion[] emptyConclusion = Array.Empty<Conclusion>();
-
         private readonly List<IColumnProvider> columnProviders = new List<IColumnProvider>();
         private readonly List<IExporter> exporters = new List<IExporter>();
         private readonly List<ILogger> loggers = new List<ILogger>();
@@ -53,8 +51,6 @@ namespace BenchmarkDotNet.Configs
         [PublicAPI] public IOrderer Orderer { get; set; }
         [PublicAPI] public SummaryStyle SummaryStyle { get; set; }
         [PublicAPI] public TimeSpan BuildTimeout { get; set; } = DefaultConfig.Instance.BuildTimeout;
-
-        public IReadOnlyList<Conclusion> ConfigAnalysisConclusion => emptyConclusion;
 
         public ManualConfig WithOption(ConfigOptions option, bool value)
         {

--- a/src/BenchmarkDotNet/Exporters/AsciiDocExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/AsciiDocExporter.cs
@@ -6,9 +6,9 @@ namespace BenchmarkDotNet.Exporters
 {
     public class AsciiDocExporter : ExporterBase
     {
-        protected override string FileExtension => "asciidoc";
-
         public static readonly IExporter Default = new AsciiDocExporter();
+
+        protected override string FileExtension => "asciidoc";
 
         private AsciiDocExporter()
         {

--- a/src/BenchmarkDotNet/Exporters/CompositeExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/CompositeExporter.cs
@@ -14,7 +14,7 @@ namespace BenchmarkDotNet.Exporters
 
         public CompositeExporter(ImmutableArray<IExporter> exporters) => this.exporters = exporters;
 
-        public string Name => nameof(CompositeExporter);
+        public string Id => nameof(CompositeExporter);
 
         public void ExportToLog(Summary summary, ILogger logger)
         {

--- a/src/BenchmarkDotNet/Exporters/Csv/CsvExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/Csv/CsvExporter.cs
@@ -6,11 +6,11 @@ namespace BenchmarkDotNet.Exporters.Csv
 {
     public class CsvExporter : ExporterBase
     {
+        public static readonly IExporter Default = new CsvExporter(CsvSeparator.CurrentCulture, SummaryStyle.Default.WithZeroMetricValuesInContent());
+
         private readonly SummaryStyle style;
         private readonly CsvSeparator separator;
         protected override string FileExtension => "csv";
-
-        public static readonly IExporter Default = new CsvExporter(CsvSeparator.CurrentCulture, SummaryStyle.Default.WithZeroMetricValuesInContent());
 
         public CsvExporter(CsvSeparator separator) : this (separator, SummaryStyle.Default.WithZeroMetricValuesInContent())
         {

--- a/src/BenchmarkDotNet/Exporters/ExporterBase.cs
+++ b/src/BenchmarkDotNet/Exporters/ExporterBase.cs
@@ -10,7 +10,7 @@ namespace BenchmarkDotNet.Exporters
 {
     public abstract class ExporterBase : IExporter
     {
-        public string Name => $"{GetType().Name}{FileNameSuffix}";
+        public string Id => $"{GetType().Name}{FileNameSuffix}";
 
         protected virtual string FileExtension => "txt";
         protected virtual string FileNameSuffix => string.Empty;

--- a/src/BenchmarkDotNet/Exporters/IExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/IExporter.cs
@@ -6,7 +6,7 @@ namespace BenchmarkDotNet.Exporters
 {
     public interface IExporter
     {
-        string Name { get; }
+        string Id { get; }
 
         void ExportToLog(Summary summary, ILogger logger);
         IEnumerable<string> ExportToFiles(Summary summary, ILogger consoleLogger);

--- a/src/BenchmarkDotNet/Exporters/InstructionPointerExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/InstructionPointerExporter.cs
@@ -31,7 +31,7 @@ namespace BenchmarkDotNet.Exporters
             this.disassemblyDiagnoser = disassemblyDiagnoser;
         }
 
-        public string Name => nameof(InstructionPointerExporter);
+        public string Id => nameof(InstructionPointerExporter);
 
         public void ExportToLog(Summary summary, ILogger logger) { }
 

--- a/src/BenchmarkDotNet/Exporters/RPlotExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/RPlotExporter.cs
@@ -14,7 +14,7 @@ namespace BenchmarkDotNet.Exporters
     public class RPlotExporter : IExporter, IExporterDependencies
     {
         public static readonly IExporter Default = new RPlotExporter();
-        public string Name => nameof(RPlotExporter);
+        public string Id => nameof(RPlotExporter);
 
         private const string ImageExtension = ".png";
         private static readonly object BuildScriptLock = new object();

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -89,7 +89,7 @@ namespace BenchmarkDotNet.Running
             var typeAttributes = type.GetCustomAttributes(true).OfType<IConfigSource>();
             var assemblyAttributes = type.Assembly.GetCustomAttributes().OfType<IConfigSource>();
 
-            foreach (var configFromAttribute in assemblyAttributes.Concat(typeAttributes))
+            foreach (var configFromAttribute in typeAttributes.Concat(assemblyAttributes))
                 config = ManualConfig.Union(config, configFromAttribute.Config);
 
             return ImmutableConfigBuilder.Create(config);

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -266,12 +266,6 @@ namespace BenchmarkDotNet.Running
             // TODO: make exporter
             ConclusionHelper.Print(logger, config.GetCompositeAnalyser().Analyse(summary).Distinct().ToList());
 
-            if (config.ConfigAnalysisConclusion.Any())
-            {
-                logger.WriteLineHeader("// * Config Issues *");
-                ConclusionHelper.Print(logger, config.ConfigAnalysisConclusion);
-            }
-
             // TODO: move to conclusions
             var columnWithLegends = summary.Table.Columns.Where(c => c.NeedToShow && !string.IsNullOrEmpty(c.OriginalColumn.Legend)).Select(c => c.OriginalColumn).ToArray();
 

--- a/src/BenchmarkDotNet/Validators/RPlotExporterValidator.cs
+++ b/src/BenchmarkDotNet/Validators/RPlotExporterValidator.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Exporters.Csv;
+
+namespace BenchmarkDotNet.Validators
+{
+    public class RPlotExporterValidator : IValidator
+    {
+        public static readonly RPlotExporterValidator FailOnError = new RPlotExporterValidator();
+
+        public bool TreatsWarningsAsErrors => true;
+
+        public IEnumerable<ValidationError> Validate(ValidationParameters validationParameters)
+        {
+            var exporters = validationParameters.Config.GetExporters();
+            if (!ContainRPlotExporter(exporters))
+                yield break;
+
+            if (!ValidateCsvExporter(exporters))
+                yield return new ValidationError(TreatsWarningsAsErrors, "RPlotExporter requires CsvMeasurementsExporter.Default. Do not override CsvMeasurementsExporter");
+        }
+
+        private static bool ContainRPlotExporter(IEnumerable<IExporter> exporters)
+        {
+            return exporters.Any(exporter => exporter.GetType() == typeof(RPlotExporter));
+        }
+
+        private static bool ValidateCsvExporter(IEnumerable<IExporter> exporters)
+        {
+            var exporter = exporters.Cast<CsvMeasurementsExporter>().FirstOrDefault();
+            if (exporter == null)
+                return false;
+
+            return exporter.Separator == CsvMeasurementsExporter.Default.Separator;
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.IntegrationTests/BaselineRatioColumnTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/BaselineRatioColumnTest.cs
@@ -90,7 +90,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
             public string Description => "For Testing Only!";
 
-            public string Name => "TestBenchmarkExporter";
+            public string Id => "TestBenchmarkExporter";
 
             public void ExportToLog(Summary summary, BenchmarkDotNet.Loggers.ILogger logger) => ExportCalled = true;
 

--- a/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
@@ -8,6 +8,7 @@ using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Exporters.Csv;
+using BenchmarkDotNet.Exporters.Xml;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Order;
@@ -350,7 +351,7 @@ namespace BenchmarkDotNet.Tests.Configs
             var leftAddedToTheRight = ManualConfig.Create(right);
             leftAddedToTheRight.Add(left);
 
-            return new[]{ rightAddedToLeft.CreateImmutableConfig(), leftAddedToTheRight.CreateImmutableConfig() };
+            return new[] { rightAddedToLeft.CreateImmutableConfig(), leftAddedToTheRight.CreateImmutableConfig() };
         }
 
         public class TestExporter : IExporter, IExporterDependencies
@@ -390,6 +391,38 @@ namespace BenchmarkDotNet.Tests.Configs
 
             Assert.Single(csvExporters);
             Assert.True(csvExporters.First() == CsvMeasurementsExporter.Default);
+        }
+
+        [Fact]
+        public void DifferentMarkdownExportersAreNotRemoved()
+        {
+            var config = ManualConfig.CreateEmpty();
+            config.AddExporter(MarkdownExporter.Default);
+            config.AddExporter(MarkdownExporter.GitHub);
+
+            var immutableConfig = config.CreateImmutableConfig();
+            var csvExporters = immutableConfig.GetExporters().Cast<MarkdownExporter>().Where(e => e != null).ToArray();
+
+            Assert.Equal(2, csvExporters.Length);
+            Assert.True(csvExporters[0] == MarkdownExporter.Default);
+            Assert.True(csvExporters[1] == MarkdownExporter.GitHub);
+        }
+
+        [Fact]
+        public void DifferentXmlExportersAreNotRemoved()
+        {
+            var config = ManualConfig.CreateEmpty();
+            config.AddExporter(XmlExporter.Default);
+            config.AddExporter(XmlExporter.Full);
+            config.AddExporter(XmlExporter.FullCompressed);
+
+            var immutableConfig = config.CreateImmutableConfig();
+            var csvExporters = immutableConfig.GetExporters().Cast<XmlExporter>().Where(e => e != null).ToArray();
+
+            Assert.Equal(3, csvExporters.Length);
+            Assert.True(csvExporters[0] == XmlExporter.Default);
+            Assert.True(csvExporters[1] == XmlExporter.Full);
+            Assert.True(csvExporters[2] == XmlExporter.FullCompressed);
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
@@ -363,7 +363,7 @@ namespace BenchmarkDotNet.Tests.Configs
 
             public IEnumerable<string> ExportToFiles(Summary summary, ILogger consoleLogger) => Enumerable.Empty<string>();
 
-            public string Name => nameof(TestExporter);
+            public string Id => nameof(TestExporter);
             public void ExportToLog(Summary summary, ILogger logger) { }
         }
 
@@ -373,7 +373,7 @@ namespace BenchmarkDotNet.Tests.Configs
 
             public IEnumerable<string> ExportToFiles(Summary summary, ILogger consoleLogger) => Enumerable.Empty<string>();
 
-            public string Name => nameof(TestExporterDependency);
+            public string Id => nameof(TestExporterDependency);
             public void ExportToLog(Summary summary, ILogger logger) { }
         }
 

--- a/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
@@ -387,10 +387,10 @@ namespace BenchmarkDotNet.Tests.Configs
             config.AddExporter(new CsvMeasurementsExporter(CsvSeparator.Comma));
 
             var immutableConfig = config.CreateImmutableConfig();
-            var csvExporters = immutableConfig.GetExporters().Cast<CsvMeasurementsExporter>().Where(e => e != null).ToArray();
+            var exporters = immutableConfig.GetExporters().Cast<CsvMeasurementsExporter>().Where(e => e != null).ToArray();
 
-            Assert.Single(csvExporters);
-            Assert.True(csvExporters.First() == CsvMeasurementsExporter.Default);
+            Assert.Single(exporters);
+            Assert.True(exporters.First() == CsvMeasurementsExporter.Default);
         }
 
         [Fact]
@@ -401,11 +401,11 @@ namespace BenchmarkDotNet.Tests.Configs
             config.AddExporter(MarkdownExporter.GitHub);
 
             var immutableConfig = config.CreateImmutableConfig();
-            var csvExporters = immutableConfig.GetExporters().Cast<MarkdownExporter>().Where(e => e != null).ToArray();
+            var exporters = immutableConfig.GetExporters().Cast<MarkdownExporter>().Where(e => e != null).ToArray();
 
-            Assert.Equal(2, csvExporters.Length);
-            Assert.True(csvExporters[0] == MarkdownExporter.Default);
-            Assert.True(csvExporters[1] == MarkdownExporter.GitHub);
+            Assert.Equal(2, exporters.Length);
+            Assert.True(exporters[0] == MarkdownExporter.Default);
+            Assert.True(exporters[1] == MarkdownExporter.GitHub);
         }
 
         [Fact]
@@ -417,12 +417,12 @@ namespace BenchmarkDotNet.Tests.Configs
             config.AddExporter(XmlExporter.FullCompressed);
 
             var immutableConfig = config.CreateImmutableConfig();
-            var csvExporters = immutableConfig.GetExporters().Cast<XmlExporter>().Where(e => e != null).ToArray();
+            var exporters = immutableConfig.GetExporters().Cast<XmlExporter>().Where(e => e != null).ToArray();
 
-            Assert.Equal(3, csvExporters.Length);
-            Assert.True(csvExporters[0] == XmlExporter.Default);
-            Assert.True(csvExporters[1] == XmlExporter.Full);
-            Assert.True(csvExporters[2] == XmlExporter.FullCompressed);
+            Assert.Equal(3, exporters.Length);
+            Assert.True(exporters[0] == XmlExporter.Default);
+            Assert.True(exporters[1] == XmlExporter.Full);
+            Assert.True(exporters[2] == XmlExporter.FullCompressed);
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/Exporters/CommonExporterApprovalTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Exporters/CommonExporterApprovalTests.cs
@@ -66,7 +66,7 @@ namespace BenchmarkDotNet.Tests.Exporters
         private static void PrintTitle(AccumulationLogger logger, IExporter exporter)
         {
             logger.WriteLine("############################################");
-            logger.WriteLine($"{exporter.Name}");
+            logger.WriteLine($"{exporter.Id}");
             logger.WriteLine("############################################");
         }
 

--- a/tests/BenchmarkDotNet.Tests/Validators/RPlotValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/RPlotValidatorTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Exporters.Csv;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.Validators
+{
+    public class RPlotValidatorTests
+    {
+        [Fact]
+        public void RPlotExporterRequiresDefaultCsvExporter()
+        {
+            var actualSeparator = Thread.CurrentThread.CurrentCulture.GetActualListSeparator();
+
+            var alternativeSeparator = actualSeparator == CsvSeparator.Comma.ToRealSeparator()
+                ? CsvSeparator.Semicolon
+                : CsvSeparator.Comma;
+
+            var config = ManualConfig.CreateEmpty();
+            config.AddExporter(new CsvMeasurementsExporter(alternativeSeparator));
+            config.AddExporter(RPlotExporter.Default);
+
+            var validationParameters = new ValidationParameters(ImmutableArray<BenchmarkCase>.Empty, config.CreateImmutableConfig());
+            var validationErrors = RPlotExporterValidator.FailOnError.Validate(validationParameters).ToArray();
+
+            Assert.Single(validationErrors);
+            Assert.Equal("RPlotExporter requires CsvMeasurementsExporter.Default. Do not override CsvMeasurementsExporter", validationErrors.First().Message);
+        }
+    }
+}


### PR DESCRIPTION
### Problem
Starting with #1796 PR (#1700 issue), only one exporter per type can be.

#### This means that the following cases stopped working in 0.13.2:
```C#
// DefaultConfig has MarkdownExporterAttribute.Default already
// It prints a warning and Atlassian file is not created.
[MarkdownExporterAttribute.Atlassian] 
public class Klass
{
    [Benchmark] public void M() { }
}
```
Also, it means that it will never works:
```C#
// not working for ManualConfig too
[XmlExporterAttribute.Full] // it uses XmlExporter.Full under the hood
[XmlExporterAttribute.Brief] // it uses XmlExporter.Brief under the hood
```

### Solution
1) revert #1796
2) compare by `IExporter.Name`
3) rename `IExporter.Name` -> `IExporter.Id` because `Name` is misleading, the other entities in BDN uses `Id` for it:
```
Characteristic.Id
IAnalyser.Id
ILogger.Id
IDiagnoser.Ids
```
4) Add `RPlotValidator` to check that user do not override `csv` separator (Currently, all version of csv generates file with same name)