### PR TITLE
Add ByType logical rule

### DIFF
--- a/src/BenchmarkDotNet/Configs/BenchmarkLogicalGroupRule.cs
+++ b/src/BenchmarkDotNet/Configs/BenchmarkLogicalGroupRule.cs
@@ -2,6 +2,6 @@
 {
     public enum BenchmarkLogicalGroupRule
     {
-        ByMethod, ByJob, ByParams, ByCategory
+        ByMethod, ByJob, ByParams, ByCategory, ByType
     }
 }

--- a/src/BenchmarkDotNet/Order/DefaultOrderer.cs
+++ b/src/BenchmarkDotNet/Order/DefaultOrderer.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Parameters;
 using BenchmarkDotNet.Reports;
@@ -20,7 +21,8 @@ namespace BenchmarkDotNet.Order
         private readonly IComparer<string[]> categoryComparer = CategoryComparer.Instance;
         private readonly IComparer<ParameterInstances> paramsComparer = ParameterComparer.Instance;
         private readonly IComparer<Job> jobComparer = JobComparer.Instance;
-        private readonly IComparer<Descriptor> targetComparer;
+        private readonly IComparer<Descriptor> typeComparer = TypeComparer.Instance;
+        private readonly IComparer<Descriptor> methodComparer;
 
         public SummaryOrderPolicy SummaryOrderPolicy { get; }
         public MethodOrderPolicy MethodOrderPolicy { get; }
@@ -31,7 +33,7 @@ namespace BenchmarkDotNet.Order
         {
             SummaryOrderPolicy = summaryOrderPolicy;
             MethodOrderPolicy = methodOrderPolicy;
-            targetComparer = new DescriptorComparer(methodOrderPolicy);
+            methodComparer = new MethodComparer(methodOrderPolicy);
         }
 
         [PublicAPI]
@@ -39,7 +41,7 @@ namespace BenchmarkDotNet.Order
             ImmutableArray<BenchmarkCase> benchmarkCases,
             IEnumerable<BenchmarkLogicalGroupRule> order = null)
         {
-            var benchmarkComparer = new BenchmarkComparer(categoryComparer, paramsComparer, jobComparer, targetComparer, order);
+            var benchmarkComparer = new BenchmarkComparer(categoryComparer, paramsComparer, jobComparer, typeComparer, methodComparer, order);
             var list = benchmarkCases.ToList();
             list.Sort(benchmarkComparer);
             return list;
@@ -87,8 +89,15 @@ namespace BenchmarkDotNet.Order
         {
             var explicitRules = benchmarkCase.Config.GetLogicalGroupRules().ToList();
             var implicitRules = new List<BenchmarkLogicalGroupRule>();
+
+            bool hasMultipleTypes = allBenchmarksCases.DistinctBy(b => b.Descriptor.Type).Count() > 1;
             bool hasJobBaselines = allBenchmarksCases.Any(b => b.Job.Meta.Baseline);
             bool hasDescriptorBaselines = allBenchmarksCases.Any(b => b.Descriptor.Baseline);
+
+            if (hasMultipleTypes)
+            {
+                implicitRules.Add(BenchmarkLogicalGroupRule.ByType);
+            }
             if (hasJobBaselines)
             {
                 implicitRules.Add(BenchmarkLogicalGroupRule.ByParams);
@@ -114,8 +123,11 @@ namespace BenchmarkDotNet.Order
             {
                 switch (rule)
                 {
+                    case BenchmarkLogicalGroupRule.ByType:
+                        keys.Add(benchmarkCase.Descriptor.TypeInfo);
+                        break;
                     case BenchmarkLogicalGroupRule.ByMethod:
-                        keys.Add(benchmarkCase.Descriptor.DisplayInfo);
+                        keys.Add(benchmarkCase.Descriptor.WorkloadMethodDisplayInfo);
                         break;
                     case BenchmarkLogicalGroupRule.ByJob:
                         keys.Add(benchmarkCase.Job.DisplayInfo);
@@ -139,7 +151,7 @@ namespace BenchmarkDotNet.Order
             IEnumerable<IGrouping<string, BenchmarkCase>> logicalGroups,
             IEnumerable<BenchmarkLogicalGroupRule> order = null)
         {
-            var benchmarkComparer = new BenchmarkComparer(categoryComparer, paramsComparer, jobComparer, targetComparer, order);
+            var benchmarkComparer = new BenchmarkComparer(categoryComparer, paramsComparer, jobComparer, typeComparer, methodComparer, order);
             var logicalGroupComparer = new LogicalGroupComparer(benchmarkComparer);
             var list = logicalGroups.ToList();
             list.Sort(logicalGroupComparer);
@@ -153,6 +165,7 @@ namespace BenchmarkDotNet.Order
             private static readonly BenchmarkLogicalGroupRule[] DefaultOrder =
             {
                 BenchmarkLogicalGroupRule.ByCategory,
+                BenchmarkLogicalGroupRule.ByType,
                 BenchmarkLogicalGroupRule.ByParams,
                 BenchmarkLogicalGroupRule.ByJob,
                 BenchmarkLogicalGroupRule.ByMethod
@@ -161,18 +174,21 @@ namespace BenchmarkDotNet.Order
             private readonly IComparer<string[]> categoryComparer;
             private readonly IComparer<ParameterInstances> paramsComparer;
             private readonly IComparer<Job> jobComparer;
-            private readonly IComparer<Descriptor> targetComparer;
+            private readonly IComparer<Descriptor> typeComparer;
+            private readonly IComparer<Descriptor> methodComparer;
             private readonly List<BenchmarkLogicalGroupRule> order;
 
             public BenchmarkComparer(
                 IComparer<string[]> categoryComparer,
                 IComparer<ParameterInstances> paramsComparer,
                 IComparer<Job> jobComparer,
-                IComparer<Descriptor> targetComparer,
+                IComparer<Descriptor> typeComparer,
+                IComparer<Descriptor> methodComparer,
                 IEnumerable<BenchmarkLogicalGroupRule> order)
             {
                 this.categoryComparer = categoryComparer;
-                this.targetComparer = targetComparer;
+                this.typeComparer = typeComparer;
+                this.methodComparer = methodComparer;
                 this.jobComparer = jobComparer;
                 this.paramsComparer = paramsComparer;
 
@@ -192,7 +208,8 @@ namespace BenchmarkDotNet.Order
                 {
                     int compare = rule switch
                     {
-                        BenchmarkLogicalGroupRule.ByMethod => targetComparer?.Compare(x.Descriptor, y.Descriptor) ?? 0,
+                        BenchmarkLogicalGroupRule.ByType => typeComparer?.Compare(x.Descriptor, y.Descriptor) ?? 0,
+                        BenchmarkLogicalGroupRule.ByMethod => methodComparer?.Compare(x.Descriptor, y.Descriptor) ?? 0,
                         BenchmarkLogicalGroupRule.ByJob => jobComparer?.Compare(x.Job, y.Job) ?? 0,
                         BenchmarkLogicalGroupRule.ByParams => paramsComparer?.Compare(x.Parameters, y.Parameters) ?? 0,
                         BenchmarkLogicalGroupRule.ByCategory => categoryComparer?.Compare(x.Descriptor.Categories, y.Descriptor.Categories) ?? 0,

--- a/src/BenchmarkDotNet/Running/DescriptorComparer.cs
+++ b/src/BenchmarkDotNet/Running/DescriptorComparer.cs
@@ -5,14 +5,14 @@ using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Running
 {
-    internal class DescriptorComparer : IComparer<Descriptor>
+    internal class MethodComparer : IComparer<Descriptor>
     {
-        [PublicAPI] public static readonly IComparer<Descriptor> Alphabetical = new DescriptorComparer(MethodOrderPolicy.Alphabetical);
-        [PublicAPI] public static readonly IComparer<Descriptor> Declared = new DescriptorComparer(MethodOrderPolicy.Declared);
+        [PublicAPI] public static readonly IComparer<Descriptor> Alphabetical = new MethodComparer(MethodOrderPolicy.Alphabetical);
+        [PublicAPI] public static readonly IComparer<Descriptor> Declared = new MethodComparer(MethodOrderPolicy.Declared);
 
         private readonly MethodOrderPolicy methodOrderPolicy;
 
-        public DescriptorComparer(MethodOrderPolicy methodOrderPolicy)
+        public MethodComparer(MethodOrderPolicy methodOrderPolicy)
         {
             this.methodOrderPolicy = methodOrderPolicy;
         }
@@ -25,7 +25,7 @@ namespace BenchmarkDotNet.Running
             switch (methodOrderPolicy)
             {
                 case MethodOrderPolicy.Alphabetical:
-                    return string.CompareOrdinal(x.DisplayInfo, y.DisplayInfo);
+                    return string.CompareOrdinal(x.WorkloadMethodDisplayInfo, y.WorkloadMethodDisplayInfo);
                 case MethodOrderPolicy.Declared:
                     return x.MethodIndex - y.MethodIndex;
                 default:

--- a/src/BenchmarkDotNet/Running/TypeComparer.cs
+++ b/src/BenchmarkDotNet/Running/TypeComparer.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace BenchmarkDotNet.Running
+{
+    internal class TypeComparer : IComparer<Descriptor>
+    {
+        public static readonly IComparer<Descriptor> Instance = new TypeComparer();
+
+        public int Compare(Descriptor x, Descriptor y)
+        {
+            if (x == null && y == null) return 0;
+            if (x != null && y == null) return 1;
+            if (x == null) return -1;
+            return string.CompareOrdinal(x.TypeInfo, y.TypeInfo);
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.Invalid_TwoJobBaselines.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.Invalid_TwoJobBaselines.approved.txt
@@ -8,14 +8,14 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   Job2   : extra output line
 
 
- Method |  Job |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank |                LogicalGroup | Baseline |
-------- |----- |---------:|--------:|--------:|------:|--------:|-----:|---------------------------- |--------- |
-    Foo | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Invalid_TwoJobBaselines.Foo |      Yes |
-    Foo | Job2 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    2 | Invalid_TwoJobBaselines.Foo |      Yes |
-        |      |          |         |         |       |         |      |                             |          |
-    Bar | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Invalid_TwoJobBaselines.Bar |      Yes |
-    Bar | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 | Invalid_TwoJobBaselines.Bar |      Yes |
+ Method |  Job |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
+------- |----- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
+    Foo | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |          Foo |      Yes |
+    Foo | Job2 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    2 |          Foo |      Yes |
+        |      |          |         |         |       |         |      |              |          |
+    Bar | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |          Bar |      Yes |
+    Bar | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 |          Bar |      Yes |
 
 Errors: 2
-* Only 1 job in a group can have "Baseline = true" applied to it, group Invalid_TwoJobBaselines.Foo in class Invalid_TwoJobBaselines has 2
-* Only 1 job in a group can have "Baseline = true" applied to it, group Invalid_TwoJobBaselines.Bar in class Invalid_TwoJobBaselines has 2
+* Only 1 job in a group can have "Baseline = true" applied to it, group Foo in class Invalid_TwoJobBaselines has 2
+* Only 1 job in a group can have "Baseline = true" applied to it, group Bar in class Invalid_TwoJobBaselines has 2

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.JobBaseline_MethodsJobs.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.JobBaseline_MethodsJobs.approved.txt
@@ -8,15 +8,15 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   Job2   : extra output line
 
 
- Method |  Job |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank |                 LogicalGroup | Baseline |
-------- |----- |---------:|--------:|--------:|------:|--------:|-----:|----------------------------- |--------- |
-   Base | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | JobBaseline_MethodsJobs.Base |      Yes |
-   Base | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    2 | JobBaseline_MethodsJobs.Base |       No |
-        |      |          |         |         |       |         |      |                              |          |
-    Foo | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  JobBaseline_MethodsJobs.Foo |      Yes |
-    Foo | Job2 | 502.0 ns | 6.09 ns | 1.58 ns |  2.49 |    0.01 |    2 |  JobBaseline_MethodsJobs.Foo |       No |
-        |      |          |         |         |       |         |      |                              |          |
-    Bar | Job1 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  JobBaseline_MethodsJobs.Bar |      Yes |
-    Bar | Job2 | 602.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 |  JobBaseline_MethodsJobs.Bar |       No |
+ Method |  Job |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
+------- |----- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
+   Base | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |         Base |      Yes |
+   Base | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    2 |         Base |       No |
+        |      |          |         |         |       |         |      |              |          |
+    Foo | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |          Foo |      Yes |
+    Foo | Job2 | 502.0 ns | 6.09 ns | 1.58 ns |  2.49 |    0.01 |    2 |          Foo |       No |
+        |      |          |         |         |       |         |      |              |          |
+    Bar | Job1 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |          Bar |      Yes |
+    Bar | Job2 | 602.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 |          Bar |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.JobBaseline_MethodsParamsJobs.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.JobBaseline_MethodsParamsJobs.approved.txt
@@ -8,24 +8,24 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   Job2   : extra output line
 
 
- Method |  Job | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank |                                  LogicalGroup | Baseline |
-------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------------------------------------- |--------- |
-   Base | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  [Param=2]-JobBaseline_MethodsParamsJobs.Base |      Yes | ^
-   Base | Job2 |     2 |   402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    2 |  [Param=2]-JobBaseline_MethodsParamsJobs.Base |       No |
-        |      |       |            |         |         |       |         |      |                                               |          |
-    Foo | Job1 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |   [Param=2]-JobBaseline_MethodsParamsJobs.Foo |      Yes |
-    Foo | Job2 |     2 |   502.0 ns | 6.09 ns | 1.58 ns |  2.49 |    0.01 |    2 |   [Param=2]-JobBaseline_MethodsParamsJobs.Foo |       No |
-        |      |       |            |         |         |       |         |      |                                               |          |
-    Bar | Job1 |     2 |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |   [Param=2]-JobBaseline_MethodsParamsJobs.Bar |      Yes |
-    Bar | Job2 |     2 |   602.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 |   [Param=2]-JobBaseline_MethodsParamsJobs.Bar |       No |
-        |      |       |            |         |         |       |         |      |                                               |          |
-   Base | Job1 |    10 |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-JobBaseline_MethodsParamsJobs.Base |      Yes | ^
-   Base | Job2 |    10 | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.43 |    0.00 |    2 | [Param=10]-JobBaseline_MethodsParamsJobs.Base |       No |
-        |      |       |            |         |         |       |         |      |                                               |          |
-    Foo | Job1 |    10 |   802.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  [Param=10]-JobBaseline_MethodsParamsJobs.Foo |      Yes |
-    Foo | Job2 |    10 | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.37 |    0.00 |    2 |  [Param=10]-JobBaseline_MethodsParamsJobs.Foo |       No |
-        |      |       |            |         |         |       |         |      |                                               |          |
-    Bar | Job1 |    10 |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  [Param=10]-JobBaseline_MethodsParamsJobs.Bar |      Yes |
-    Bar | Job2 |    10 | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |    2 |  [Param=10]-JobBaseline_MethodsParamsJobs.Bar |       No |
+ Method |  Job | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank |    LogicalGroup | Baseline |
+------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------- |--------- |
+   Base | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  [Param=2]-Base |      Yes | ^
+   Base | Job2 |     2 |   402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    2 |  [Param=2]-Base |       No |
+        |      |       |            |         |         |       |         |      |                 |          |
+    Foo | Job1 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |   [Param=2]-Foo |      Yes |
+    Foo | Job2 |     2 |   502.0 ns | 6.09 ns | 1.58 ns |  2.49 |    0.01 |    2 |   [Param=2]-Foo |       No |
+        |      |       |            |         |         |       |         |      |                 |          |
+    Bar | Job1 |     2 |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |   [Param=2]-Bar |      Yes |
+    Bar | Job2 |     2 |   602.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 |   [Param=2]-Bar |       No |
+        |      |       |            |         |         |       |         |      |                 |          |
+   Base | Job1 |    10 |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-Base |      Yes | ^
+   Base | Job2 |    10 | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.43 |    0.00 |    2 | [Param=10]-Base |       No |
+        |      |       |            |         |         |       |         |      |                 |          |
+    Foo | Job1 |    10 |   802.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  [Param=10]-Foo |      Yes |
+    Foo | Job2 |    10 | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.37 |    0.00 |    2 |  [Param=10]-Foo |       No |
+        |      |       |            |         |         |       |         |      |                 |          |
+    Bar | Job1 |    10 |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  [Param=10]-Bar |      Yes |
+    Bar | Job2 |    10 | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |    2 |  [Param=10]-Bar |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.NoBaseline_MethodsParamsJobs_GroupByAll.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.NoBaseline_MethodsParamsJobs_GroupByAll.approved.txt
@@ -8,38 +8,38 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   Job2   : extra output line
 
 
- Method |  Job | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank |                                                    LogicalGroup | Baseline |
-------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------------------------------------------------------- |--------- |
-     A1 | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=2]-CatA |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A1 | Job1 |    10 |   502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=10]-CatA |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A1 | Job2 |     2 |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=2]-CatA |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A1 | Job2 |    10 |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=10]-CatA |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A2 | Job1 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=2]-CatA |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A2 | Job1 |    10 |   602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=10]-CatA |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A2 | Job2 |     2 |   402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=2]-CatA |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A2 | Job2 |    10 |   802.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=10]-CatA |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B1 | Job1 |     2 |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=2]-CatB |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B1 | Job1 |    10 | 1,302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=10]-CatB |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B1 | Job2 |     2 | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=2]-CatB |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B1 | Job2 |    10 | 1,502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=10]-CatB |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B2 | Job1 |     2 | 1,002.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=2]-CatB |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B2 | Job1 |    10 | 1,402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=10]-CatB |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B2 | Job2 |     2 | 1,202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=2]-CatB |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B2 | Job2 |    10 | 1,602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=10]-CatB |       No | ^
+ Method |  Job | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank |            LogicalGroup | Baseline |
+------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|------------------------ |--------- |
+     A1 | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  A1-Job1-[Param=2]-CatA |      Yes | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     A1 | Job1 |    10 |   502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | A1-Job1-[Param=10]-CatA |      Yes | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     A1 | Job2 |     2 |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  A1-Job2-[Param=2]-CatA |      Yes | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     A1 | Job2 |    10 |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | A1-Job2-[Param=10]-CatA |      Yes | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     A2 | Job1 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 |  A2-Job1-[Param=2]-CatA |       No | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     A2 | Job1 |    10 |   602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | A2-Job1-[Param=10]-CatA |       No | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     A2 | Job2 |     2 |   402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 |  A2-Job2-[Param=2]-CatA |       No | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     A2 | Job2 |    10 |   802.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | A2-Job2-[Param=10]-CatA |       No | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     B1 | Job1 |     2 |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  B1-Job1-[Param=2]-CatB |      Yes | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     B1 | Job1 |    10 | 1,302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | B1-Job1-[Param=10]-CatB |      Yes | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     B1 | Job2 |     2 | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  B1-Job2-[Param=2]-CatB |      Yes | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     B1 | Job2 |    10 | 1,502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | B1-Job2-[Param=10]-CatB |      Yes | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     B2 | Job1 |     2 | 1,002.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 |  B2-Job1-[Param=2]-CatB |       No | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     B2 | Job1 |    10 | 1,402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | B2-Job1-[Param=10]-CatB |       No | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     B2 | Job2 |     2 | 1,202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 |  B2-Job2-[Param=2]-CatB |       No | ^
+        |      |       |            |         |         |       |         |      |                         |          |
+     B2 | Job2 |    10 | 1,602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | B2-Job2-[Param=10]-CatB |       No | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.NoBaseline_MethodsParamsJobs_GroupByMethod.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterApprovalTests.GroupExporterTest.NoBaseline_MethodsParamsJobs_GroupByMethod.approved.txt
@@ -8,21 +8,21 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   Job2   : extra output line
 
 
- Method |  Job | Param |       Mean |   Error |  StdDev | Rank |                                    LogicalGroup | Baseline |
-------- |----- |------ |-----------:|--------:|--------:|-----:|------------------------------------------------ |--------- |
-   Base | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |    1 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base |       No | ^
-   Base | Job2 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |    2 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base |       No |
-   Base | Job1 |    10 |   302.0 ns | 6.09 ns | 1.58 ns |    3 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base |       No | ^
-   Base | Job2 |    10 |   402.0 ns | 6.09 ns | 1.58 ns |    4 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base |       No |
-        |      |       |            |         |         |      |                                                 |          |
-    Foo | Job1 |     2 |   502.0 ns | 6.09 ns | 1.58 ns |    1 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Foo |       No | ^
-    Foo | Job2 |     2 |   702.0 ns | 6.09 ns | 1.58 ns |    2 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Foo |       No |
-    Foo | Job1 |    10 |   902.0 ns | 6.09 ns | 1.58 ns |    3 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Foo |       No | ^
-    Foo | Job2 |    10 | 1,102.0 ns | 6.09 ns | 1.58 ns |    4 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Foo |       No |
-        |      |       |            |         |         |      |                                                 |          |
-    Bar | Job1 |     2 |   602.0 ns | 6.09 ns | 1.58 ns |    1 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Bar |       No | ^
-    Bar | Job2 |     2 |   802.0 ns | 6.09 ns | 1.58 ns |    2 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Bar |       No |
-    Bar | Job1 |    10 | 1,002.0 ns | 6.09 ns | 1.58 ns |    3 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Bar |       No | ^
-    Bar | Job2 |    10 | 1,202.0 ns | 6.09 ns | 1.58 ns |    4 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Bar |       No |
+ Method |  Job | Param |       Mean |   Error |  StdDev | Rank | LogicalGroup | Baseline |
+------- |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
+   Base | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |    1 |         Base |       No | ^
+   Base | Job2 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |    2 |         Base |       No |
+   Base | Job1 |    10 |   302.0 ns | 6.09 ns | 1.58 ns |    3 |         Base |       No | ^
+   Base | Job2 |    10 |   402.0 ns | 6.09 ns | 1.58 ns |    4 |         Base |       No |
+        |      |       |            |         |         |      |              |          |
+    Foo | Job1 |     2 |   502.0 ns | 6.09 ns | 1.58 ns |    1 |          Foo |       No | ^
+    Foo | Job2 |     2 |   702.0 ns | 6.09 ns | 1.58 ns |    2 |          Foo |       No |
+    Foo | Job1 |    10 |   902.0 ns | 6.09 ns | 1.58 ns |    3 |          Foo |       No | ^
+    Foo | Job2 |    10 | 1,102.0 ns | 6.09 ns | 1.58 ns |    4 |          Foo |       No |
+        |      |       |            |         |         |      |              |          |
+    Bar | Job1 |     2 |   602.0 ns | 6.09 ns | 1.58 ns |    1 |          Bar |       No | ^
+    Bar | Job2 |     2 |   802.0 ns | 6.09 ns | 1.58 ns |    2 |          Bar |       No |
+    Bar | Job1 |    10 | 1,002.0 ns | 6.09 ns | 1.58 ns |    3 |          Bar |       No | ^
+    Bar | Job2 |    10 | 1,202.0 ns | 6.09 ns | 1.58 ns |    4 |          Bar |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByCategory.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByCategory.approved.txt
@@ -1,0 +1,22 @@
+﻿=== NoBaseline.ByCategory ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |            A |       No | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |            A |       No |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |            A |       No | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |            A |       No |
+        |        |            |       |          |         |         |              |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |            B |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |            B |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |            B |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |            B |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByCategory.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByCategory.approved.txt
@@ -9,14 +9,14 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
 
    Type | Method | Categories | Param |     Mean |   Error |  StdDev | LogicalGroup | Baseline |
 ------- |------- |----------- |------ |---------:|--------:|--------:|------------- |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |            A |       No | ^
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |            A |       No |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |            A |       No | ^
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |            A |       No |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |     A-Bench1 |       No | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     A-Bench1 |       No |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |     A-Bench1 |       No | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     A-Bench1 |       No |
         |        |            |       |          |         |         |              |          |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |            B |       No | ^
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |            B |       No |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |            B |       No | ^
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |            B |       No |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |     B-Bench2 |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     B-Bench2 |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |     B-Bench2 |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     B-Bench2 |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByJob.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByJob.approved.txt
@@ -7,15 +7,16 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   DefaultJob : extra output line
 
 
-   Type | Method | Categories | Param |     Mean |   Error |  StdDev | LogicalGroup | Baseline |
-------- |------- |----------- |------ |---------:|--------:|--------:|------------- |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No | ^
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No | ^
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No | ^
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No | ^
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No |
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev |      LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------------------ |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns | DefaultJob-Bench1 |       No | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns | DefaultJob-Bench1 |       No |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns | DefaultJob-Bench1 |       No | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns | DefaultJob-Bench1 |       No |
+        |        |            |       |          |         |         |                   |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns | DefaultJob-Bench2 |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns | DefaultJob-Bench2 |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns | DefaultJob-Bench2 |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns | DefaultJob-Bench2 |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByJob.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByJob.approved.txt
@@ -1,0 +1,21 @@
+﻿=== NoBaseline.ByJob ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   DefaultJob |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByMethod.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByMethod.approved.txt
@@ -9,16 +9,16 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
 
    Type | Method | Categories | Param |     Mean |   Error |  StdDev | LogicalGroup | Baseline |
 ------- |------- |----------- |------ |---------:|--------:|--------:|------------- |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   Bench1.Foo |       No | ^
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   Bench1.Foo |       No | ^
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   Foo-Bench1 |       No | ^
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   Foo-Bench1 |       No | ^
         |        |            |       |          |         |         |              |          |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   Bench2.Foo |       No | ^
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   Bench2.Foo |       No | ^
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   Foo-Bench2 |       No | ^
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   Foo-Bench2 |       No | ^
         |        |            |       |          |         |         |              |          |
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   Bench1.Bar |       No | ^
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   Bench1.Bar |       No | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   Bar-Bench1 |       No | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   Bar-Bench1 |       No | ^
         |        |            |       |          |         |         |              |          |
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   Bench2.Bar |       No | ^
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   Bench2.Bar |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   Bar-Bench2 |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   Bar-Bench2 |       No | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByMethod.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByMethod.approved.txt
@@ -1,0 +1,24 @@
+﻿=== NoBaseline.ByMethod ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   Bench1.Foo |       No | ^
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   Bench1.Foo |       No | ^
+        |        |            |       |          |         |         |              |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   Bench2.Foo |       No | ^
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   Bench2.Foo |       No | ^
+        |        |            |       |          |         |         |              |          |
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   Bench1.Bar |       No | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   Bench1.Bar |       No | ^
+        |        |            |       |          |         |         |              |          |
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   Bench2.Bar |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   Bench2.Bar |       No | ^
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByParams.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByParams.approved.txt
@@ -7,16 +7,18 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   DefaultJob : extra output line
 
 
-   Type | Method | Categories | Param |     Mean |   Error |  StdDev | LogicalGroup | Baseline |
-------- |------- |----------- |------ |---------:|--------:|--------:|------------- |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   [Param=10] |       No | ^
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   [Param=10] |       No |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   [Param=10] |       No |
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   [Param=10] |       No |
-        |        |            |       |          |         |         |              |          |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   [Param=20] |       No | ^
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   [Param=20] |       No |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   [Param=20] |       No |
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   [Param=20] |       No |
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev |      LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------------------ |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns | [Param=10]-Bench1 |       No | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns | [Param=10]-Bench1 |       No |
+        |        |            |       |          |         |         |                   |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns | [Param=10]-Bench2 |       No |
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns | [Param=10]-Bench2 |       No |
+        |        |            |       |          |         |         |                   |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns | [Param=20]-Bench1 |       No | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns | [Param=20]-Bench1 |       No |
+        |        |            |       |          |         |         |                   |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns | [Param=20]-Bench2 |       No |
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns | [Param=20]-Bench2 |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByParams.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByParams.approved.txt
@@ -1,0 +1,22 @@
+﻿=== NoBaseline.ByParams ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   [Param=10] |       No | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   [Param=10] |       No |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |   [Param=10] |       No |
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |   [Param=10] |       No |
+        |        |            |       |          |         |         |              |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   [Param=20] |       No | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   [Param=20] |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |   [Param=20] |       No |
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |   [Param=20] |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByType.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.ByType.approved.txt
@@ -1,0 +1,22 @@
+﻿=== NoBaseline.ByType ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |       Bench1 |       No | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |       Bench1 |       No |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |       Bench1 |       No | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |       Bench1 |       No |
+        |        |            |       |          |         |         |              |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |       Bench2 |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |       Bench2 |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |       Bench2 |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |       Bench2 |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.Default.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.Default.approved.txt
@@ -9,13 +9,14 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
 
    Type | Method | Categories | Param |     Mean |   Error |  StdDev | LogicalGroup | Baseline |
 ------- |------- |----------- |------ |---------:|--------:|--------:|------------- |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |            * |       No | ^
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |            * |       No |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |            * |       No | ^
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |            * |       No |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |            * |       No | ^
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |            * |       No |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |            * |       No | ^
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |            * |       No |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |       Bench1 |       No | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |       Bench1 |       No |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |       Bench1 |       No | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |       Bench1 |       No |
+        |        |            |       |          |         |         |              |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |       Bench2 |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |       Bench2 |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |       Bench2 |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |       Bench2 |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.Default.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.NoBaseline.Default.approved.txt
@@ -1,0 +1,21 @@
+﻿=== NoBaseline.Default ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |            * |       No | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |            * |       No |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |            * |       No | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |            * |       No |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |            * |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |            * |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |            * |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |            * |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByCategory.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByCategory.approved.txt
@@ -7,18 +7,18 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   DefaultJob : extra output line
 
 
-   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |            LogicalGroup | Baseline |
-------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|------------------------ |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | A-[Param=10]-DefaultJob |      Yes | ^
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | A-[Param=10]-DefaultJob |       No |
-        |        |            |       |          |         |         |       |         |                         |          |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | A-[Param=20]-DefaultJob |      Yes | ^
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | A-[Param=20]-DefaultJob |       No |
-        |        |            |       |          |         |         |       |         |                         |          |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | B-[Param=10]-DefaultJob |       No | ^
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | B-[Param=10]-DefaultJob |       No |
-        |        |            |       |          |         |         |       |         |                         |          |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | B-[Param=20]-DefaultJob |       No | ^
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | B-[Param=20]-DefaultJob |       No |
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                   LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|------------------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | A-Bench1-[Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | A-Bench1-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                                |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | A-Bench1-[Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | A-Bench1-[Param=20]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                                |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | B-Bench2-[Param=10]-DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | B-Bench2-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                                |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | B-Bench2-[Param=20]-DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | B-Bench2-[Param=20]-DefaultJob |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByCategory.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByCategory.approved.txt
@@ -1,0 +1,24 @@
+﻿=== OneBaseline.ByCategory ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |            LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|------------------------ |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | A-[Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | A-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                         |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | A-[Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | A-[Param=20]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                         |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | B-[Param=10]-DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | B-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                         |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | B-[Param=20]-DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | B-[Param=20]-DefaultJob |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByJob.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByJob.approved.txt
@@ -1,0 +1,22 @@
+﻿=== OneBaseline.ByJob ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=10] |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-[Param=10] |       No |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=10] |       No |
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-[Param=10] |       No |
+        |        |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=20] |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-[Param=20] |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=20] |       No |
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-[Param=20] |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByJob.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByJob.approved.txt
@@ -7,16 +7,18 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   DefaultJob : extra output line
 
 
-   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
-------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=10] |      Yes | ^
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-[Param=10] |       No |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=10] |       No |
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-[Param=10] |       No |
-        |        |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=20] |      Yes | ^
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-[Param=20] |       No |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=20] |       No |
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-[Param=20] |       No |
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                 LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|----------------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-Bench1-[Param=10] |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-Bench1-[Param=10] |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-Bench1-[Param=20] |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-Bench1-[Param=20] |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | DefaultJob-Bench2-[Param=10] |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | DefaultJob-Bench2-[Param=10] |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | DefaultJob-Bench2-[Param=20] |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | DefaultJob-Bench2-[Param=20] |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByMethod.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByMethod.approved.txt
@@ -9,20 +9,20 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
 
    Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                     LogicalGroup | Baseline |
 ------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|--------------------------------- |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1.Foo-[Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Foo-Bench1-[Param=10]-DefaultJob |      Yes | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1.Foo-[Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Foo-Bench1-[Param=20]-DefaultJob |      Yes | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Foo-[Param=10]-DefaultJob |       No | ^
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Foo-Bench2-[Param=10]-DefaultJob |       No | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Foo-[Param=20]-DefaultJob |       No | ^
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Foo-Bench2-[Param=20]-DefaultJob |       No | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench1.Bar-[Param=10]-DefaultJob |       No | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bar-Bench1-[Param=10]-DefaultJob |       No | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench1.Bar-[Param=20]-DefaultJob |       No | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bar-Bench1-[Param=20]-DefaultJob |       No | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Bar-[Param=10]-DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bar-Bench2-[Param=10]-DefaultJob |       No | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Bar-[Param=20]-DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bar-Bench2-[Param=20]-DefaultJob |       No | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByMethod.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByMethod.approved.txt
@@ -1,0 +1,28 @@
+﻿=== OneBaseline.ByMethod ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                     LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|--------------------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1.Foo-[Param=10]-DefaultJob |      Yes | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1.Foo-[Param=20]-DefaultJob |      Yes | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Foo-[Param=10]-DefaultJob |       No | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Foo-[Param=20]-DefaultJob |       No | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench1.Bar-[Param=10]-DefaultJob |       No | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench1.Bar-[Param=20]-DefaultJob |       No | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Bar-[Param=10]-DefaultJob |       No | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Bar-[Param=20]-DefaultJob |       No | ^
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByParams.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByParams.approved.txt
@@ -7,16 +7,18 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   DefaultJob : extra output line
 
 
-   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
-------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes | ^
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |       No |
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
-        |        |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes | ^
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |       No |
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                 LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|----------------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-Bench1-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-Bench1-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | [Param=10]-Bench2-DefaultJob |       No |
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | [Param=10]-Bench2-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-Bench1-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-Bench1-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | [Param=20]-Bench2-DefaultJob |       No |
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | [Param=20]-Bench2-DefaultJob |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByParams.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByParams.approved.txt
@@ -1,0 +1,22 @@
+﻿=== OneBaseline.ByParams ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |       No |
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |       No |
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByType.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.ByType.approved.txt
@@ -1,0 +1,24 @@
+﻿=== OneBaseline.ByType ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                 LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|----------------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1-[Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | Bench1-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1-[Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | Bench1-[Param=20]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2-[Param=10]-DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2-[Param=20]-DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2-[Param=20]-DefaultJob |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.Default.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.Default.approved.txt
@@ -1,0 +1,22 @@
+﻿=== OneBaseline.Default ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |       No |
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |       No |
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.Default.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.OneBaseline.Default.approved.txt
@@ -7,16 +7,18 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   DefaultJob : extra output line
 
 
-   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
-------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes | ^
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |       No |
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
-        |        |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes | ^
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |       No |
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                 LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|----------------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1-[Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | Bench1-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1-[Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | Bench1-[Param=20]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2-[Param=10]-DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2-[Param=20]-DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2-[Param=20]-DefaultJob |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByCategory.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByCategory.approved.txt
@@ -1,0 +1,24 @@
+﻿=== TwoBaselines.ByCategory ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |            LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|------------------------ |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | A-[Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | A-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                         |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | A-[Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | A-[Param=20]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                         |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | B-[Param=10]-DefaultJob |      Yes | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | B-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                         |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | B-[Param=20]-DefaultJob |      Yes | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | B-[Param=20]-DefaultJob |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByCategory.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByCategory.approved.txt
@@ -7,18 +7,18 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   DefaultJob : extra output line
 
 
-   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |            LogicalGroup | Baseline |
-------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|------------------------ |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | A-[Param=10]-DefaultJob |      Yes | ^
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | A-[Param=10]-DefaultJob |       No |
-        |        |            |       |          |         |         |       |         |                         |          |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | A-[Param=20]-DefaultJob |      Yes | ^
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | A-[Param=20]-DefaultJob |       No |
-        |        |            |       |          |         |         |       |         |                         |          |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | B-[Param=10]-DefaultJob |      Yes | ^
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | B-[Param=10]-DefaultJob |       No |
-        |        |            |       |          |         |         |       |         |                         |          |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | B-[Param=20]-DefaultJob |      Yes | ^
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | B-[Param=20]-DefaultJob |       No |
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                   LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|------------------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | A-Bench1-[Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | A-Bench1-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                                |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | A-Bench1-[Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | A-Bench1-[Param=20]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                                |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | B-Bench2-[Param=10]-DefaultJob |      Yes | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | B-Bench2-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                                |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | B-Bench2-[Param=20]-DefaultJob |      Yes | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | B-Bench2-[Param=20]-DefaultJob |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByJob.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByJob.approved.txt
@@ -7,18 +7,18 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   DefaultJob : extra output line
 
 
-   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
-------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=10] |      Yes | ^
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-[Param=10] |       No |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=10] |      Yes |
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-[Param=10] |       No |
-        |        |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=20] |      Yes | ^
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-[Param=20] |       No |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=20] |      Yes |
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-[Param=20] |       No |
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                 LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|----------------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-Bench1-[Param=10] |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-Bench1-[Param=10] |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-Bench1-[Param=20] |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-Bench1-[Param=20] |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-Bench2-[Param=10] |      Yes | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-Bench2-[Param=10] |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-Bench2-[Param=20] |      Yes | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-Bench2-[Param=20] |       No |
 
-Errors: 2
-* Only 1 benchmark method in a group can have "Baseline = true" applied to it, group DefaultJob-[Param=10] in class Bench1 has 2
-* Only 1 benchmark method in a group can have "Baseline = true" applied to it, group DefaultJob-[Param=20] in class Bench1 has 2
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByJob.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByJob.approved.txt
@@ -1,0 +1,24 @@
+﻿=== TwoBaselines.ByJob ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=10] |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-[Param=10] |       No |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=10] |      Yes |
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-[Param=10] |       No |
+        |        |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=20] |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-[Param=20] |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=20] |      Yes |
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-[Param=20] |       No |
+
+Errors: 2
+* Only 1 benchmark method in a group can have "Baseline = true" applied to it, group DefaultJob-[Param=10] in class Bench1 has 2
+* Only 1 benchmark method in a group can have "Baseline = true" applied to it, group DefaultJob-[Param=20] in class Bench1 has 2

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByMethod.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByMethod.approved.txt
@@ -1,0 +1,28 @@
+﻿=== TwoBaselines.ByMethod ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                     LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|--------------------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1.Foo-[Param=10]-DefaultJob |      Yes | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1.Foo-[Param=20]-DefaultJob |      Yes | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2.Foo-[Param=10]-DefaultJob |      Yes | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2.Foo-[Param=20]-DefaultJob |      Yes | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench1.Bar-[Param=10]-DefaultJob |       No | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench1.Bar-[Param=20]-DefaultJob |       No | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Bar-[Param=10]-DefaultJob |       No | ^
+        |        |            |       |          |         |         |       |         |                                  |          |
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Bar-[Param=20]-DefaultJob |       No | ^
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByMethod.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByMethod.approved.txt
@@ -9,20 +9,20 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
 
    Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                     LogicalGroup | Baseline |
 ------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|--------------------------------- |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1.Foo-[Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Foo-Bench1-[Param=10]-DefaultJob |      Yes | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1.Foo-[Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Foo-Bench1-[Param=20]-DefaultJob |      Yes | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2.Foo-[Param=10]-DefaultJob |      Yes | ^
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Foo-Bench2-[Param=10]-DefaultJob |      Yes | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2.Foo-[Param=20]-DefaultJob |      Yes | ^
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Foo-Bench2-[Param=20]-DefaultJob |      Yes | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench1.Bar-[Param=10]-DefaultJob |       No | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bar-Bench1-[Param=10]-DefaultJob |       No | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench1.Bar-[Param=20]-DefaultJob |       No | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bar-Bench1-[Param=20]-DefaultJob |       No | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Bar-[Param=10]-DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bar-Bench2-[Param=10]-DefaultJob |       No | ^
         |        |            |       |          |         |         |       |         |                                  |          |
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Bar-[Param=20]-DefaultJob |       No | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bar-Bench2-[Param=20]-DefaultJob |       No | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByParams.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByParams.approved.txt
@@ -1,0 +1,24 @@
+﻿=== TwoBaselines.ByParams ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes |
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes |
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+
+Errors: 2
+* Only 1 benchmark method in a group can have "Baseline = true" applied to it, group [Param=10]-DefaultJob in class Bench1 has 2
+* Only 1 benchmark method in a group can have "Baseline = true" applied to it, group [Param=20]-DefaultJob in class Bench1 has 2

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByParams.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByParams.approved.txt
@@ -7,18 +7,18 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   DefaultJob : extra output line
 
 
-   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
-------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes | ^
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes |
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
-        |        |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes | ^
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes |
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                 LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|----------------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-Bench1-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-Bench1-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-Bench2-DefaultJob |      Yes |
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-Bench2-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-Bench1-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-Bench1-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-Bench2-DefaultJob |      Yes |
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-Bench2-DefaultJob |       No |
 
-Errors: 2
-* Only 1 benchmark method in a group can have "Baseline = true" applied to it, group [Param=10]-DefaultJob in class Bench1 has 2
-* Only 1 benchmark method in a group can have "Baseline = true" applied to it, group [Param=20]-DefaultJob in class Bench1 has 2
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByType.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.ByType.approved.txt
@@ -1,0 +1,24 @@
+﻿=== TwoBaselines.ByType ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                 LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|----------------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1-[Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | Bench1-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1-[Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | Bench1-[Param=20]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2-[Param=10]-DefaultJob |      Yes | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | Bench2-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2-[Param=20]-DefaultJob |      Yes | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | Bench2-[Param=20]-DefaultJob |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.Default.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.Default.approved.txt
@@ -7,18 +7,18 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   DefaultJob : extra output line
 
 
-   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
-------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
- Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes | ^
- Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
- Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes |
- Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
-        |        |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes | ^
- Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
- Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes |
- Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                 LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|----------------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1-[Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | Bench1-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench1-[Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | Bench1-[Param=20]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2-[Param=10]-DefaultJob |      Yes | ^
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | Bench2-[Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2-[Param=20]-DefaultJob |      Yes | ^
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | Bench2-[Param=20]-DefaultJob |       No |
 
-Errors: 2
-* Only 1 benchmark method in a group can have "Baseline = true" applied to it, group [Param=10]-DefaultJob in class Bench1 has 2
-* Only 1 benchmark method in a group can have "Baseline = true" applied to it, group [Param=20]-DefaultJob in class Bench1 has 2
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.Default.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselines.Default.approved.txt
@@ -1,0 +1,24 @@
+﻿=== TwoBaselines.Default ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+
+
+   Type | Method | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
+------- |------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
+ Bench1 |    Foo |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
+ Bench2 |    Foo |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes |
+ Bench2 |    Bar |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
+        |        |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |          A |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes | ^
+ Bench1 |    Bar |          A |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+ Bench2 |    Foo |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes |
+ Bench2 |    Bar |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+
+Errors: 2
+* Only 1 benchmark method in a group can have "Baseline = true" applied to it, group [Param=10]-DefaultJob in class Bench1 has 2
+* Only 1 benchmark method in a group can have "Baseline = true" applied to it, group [Param=20]-DefaultJob in class Bench1 has 2

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByCategory.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByCategory.approved.txt
@@ -1,0 +1,32 @@
+﻿=== TwoBaselinesWithJobs.ByCategory ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  Job1       : extra output line
+  Job2       : extra output line
+  DefaultJob : extra output line
+
+
+   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |            LogicalGroup | Baseline |
+------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|------------------------ |--------- |
+ Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       A-[Param=10]-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |       A-[Param=10]-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                         |          |
+ Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       A-[Param=10]-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |       A-[Param=10]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                         |          |
+ Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       A-[Param=20]-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |       A-[Param=20]-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                         |          |
+ Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       A-[Param=20]-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |       A-[Param=20]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                         |          |
+ Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | B-[Param=10]-DefaultJob |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | B-[Param=10]-DefaultJob |       No |
+        |        |            |            |       |          |         |         |       |         |                         |          |
+ Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | B-[Param=20]-DefaultJob |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | B-[Param=20]-DefaultJob |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByCategory.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByCategory.approved.txt
@@ -9,24 +9,24 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   DefaultJob : extra output line
 
 
-   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |            LogicalGroup | Baseline |
-------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|------------------------ |--------- |
- Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       A-[Param=10]-Job1 |      Yes | ^
- Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |       A-[Param=10]-Job1 |       No |
-        |        |            |            |       |          |         |         |       |         |                         |          |
- Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       A-[Param=10]-Job2 |      Yes |
- Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |       A-[Param=10]-Job2 |       No |
-        |        |            |            |       |          |         |         |       |         |                         |          |
- Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       A-[Param=20]-Job1 |      Yes | ^
- Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |       A-[Param=20]-Job1 |       No |
-        |        |            |            |       |          |         |         |       |         |                         |          |
- Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       A-[Param=20]-Job2 |      Yes |
- Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |       A-[Param=20]-Job2 |       No |
-        |        |            |            |       |          |         |         |       |         |                         |          |
- Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | B-[Param=10]-DefaultJob |      Yes | ^
- Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | B-[Param=10]-DefaultJob |       No |
-        |        |            |            |       |          |         |         |       |         |                         |          |
- Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | B-[Param=20]-DefaultJob |      Yes | ^
- Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | B-[Param=20]-DefaultJob |       No |
+   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                   LogicalGroup | Baseline |
+------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|------------------------------- |--------- |
+ Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       A-Bench1-[Param=10]-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |       A-Bench1-[Param=10]-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                                |          |
+ Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       A-Bench1-[Param=10]-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |       A-Bench1-[Param=10]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                                |          |
+ Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       A-Bench1-[Param=20]-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |       A-Bench1-[Param=20]-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                                |          |
+ Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       A-Bench1-[Param=20]-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |       A-Bench1-[Param=20]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                                |          |
+ Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | B-Bench2-[Param=10]-DefaultJob |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | B-Bench2-[Param=10]-DefaultJob |       No |
+        |        |            |            |       |          |         |         |       |         |                                |          |
+ Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | B-Bench2-[Param=20]-DefaultJob |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | B-Bench2-[Param=20]-DefaultJob |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByJob.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByJob.approved.txt
@@ -9,24 +9,24 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   Job2       : extra output line
 
 
-   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
-------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
- Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=10] |      Yes | ^
- Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-[Param=10] |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=20] |      Yes | ^
- Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-[Param=20] |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Job1-[Param=10] |      Yes | ^
- Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |       Job1-[Param=10] |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Job1-[Param=20] |      Yes | ^
- Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |       Job1-[Param=20] |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Job2-[Param=10] |      Yes | ^
- Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |       Job2-[Param=10] |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Job2-[Param=20] |      Yes | ^
- Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |       Job2-[Param=20] |       No |
+   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                 LogicalGroup | Baseline |
+------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|----------------------------- |--------- |
+ Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-Bench2-[Param=10] |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-Bench2-[Param=10] |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-Bench2-[Param=20] |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-Bench2-[Param=20] |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Job1-Bench1-[Param=10] |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |       Job1-Bench1-[Param=10] |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Job1-Bench1-[Param=20] |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |       Job1-Bench1-[Param=20] |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Job2-Bench1-[Param=10] |      Yes | ^
+ Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |       Job2-Bench1-[Param=10] |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Job2-Bench1-[Param=20] |      Yes | ^
+ Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |       Job2-Bench1-[Param=20] |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByJob.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByJob.approved.txt
@@ -1,0 +1,32 @@
+﻿=== TwoBaselinesWithJobs.ByJob ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  DefaultJob : extra output line
+  Job1       : extra output line
+  Job2       : extra output line
+
+
+   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
+------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
+ Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=10] |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | DefaultJob-[Param=10] |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | DefaultJob-[Param=20] |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | DefaultJob-[Param=20] |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Job1-[Param=10] |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |       Job1-[Param=10] |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Job1-[Param=20] |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |       Job1-[Param=20] |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Job2-[Param=10] |      Yes | ^
+ Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |       Job2-[Param=10] |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Job2-[Param=20] |      Yes | ^
+ Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |       Job2-[Param=20] |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByMethod.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByMethod.approved.txt
@@ -11,28 +11,28 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
 
    Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                     LogicalGroup | Baseline |
 ------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|--------------------------------- |--------- |
- Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1.Foo-[Param=10]-Job1 |      Yes | ^
+ Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Foo-Bench1-[Param=10]-Job1 |      Yes | ^
         |        |            |            |       |          |         |         |       |         |                                  |          |
- Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1.Foo-[Param=10]-Job2 |      Yes |
+ Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Foo-Bench1-[Param=10]-Job2 |      Yes |
         |        |            |            |       |          |         |         |       |         |                                  |          |
- Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1.Foo-[Param=20]-Job1 |      Yes | ^
+ Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Foo-Bench1-[Param=20]-Job1 |      Yes | ^
         |        |            |            |       |          |         |         |       |         |                                  |          |
- Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1.Foo-[Param=20]-Job2 |      Yes |
+ Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Foo-Bench1-[Param=20]-Job2 |      Yes |
         |        |            |            |       |          |         |         |       |         |                                  |          |
- Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2.Foo-[Param=10]-DefaultJob |      Yes | ^
+ Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Foo-Bench2-[Param=10]-DefaultJob |      Yes | ^
         |        |            |            |       |          |         |         |       |         |                                  |          |
- Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2.Foo-[Param=20]-DefaultJob |      Yes | ^
+ Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Foo-Bench2-[Param=20]-DefaultJob |      Yes | ^
         |        |            |            |       |          |         |         |       |         |                                  |          |
- Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bench1.Bar-[Param=10]-Job1 |       No | ^
+ Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bar-Bench1-[Param=10]-Job1 |       No | ^
         |        |            |            |       |          |         |         |       |         |                                  |          |
- Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bench1.Bar-[Param=10]-Job2 |       No |
+ Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bar-Bench1-[Param=10]-Job2 |       No |
         |        |            |            |       |          |         |         |       |         |                                  |          |
- Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bench1.Bar-[Param=20]-Job1 |       No | ^
+ Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bar-Bench1-[Param=20]-Job1 |       No | ^
         |        |            |            |       |          |         |         |       |         |                                  |          |
- Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bench1.Bar-[Param=20]-Job2 |       No |
+ Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bar-Bench1-[Param=20]-Job2 |       No |
         |        |            |            |       |          |         |         |       |         |                                  |          |
- Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Bar-[Param=10]-DefaultJob |       No | ^
+ Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bar-Bench2-[Param=10]-DefaultJob |       No | ^
         |        |            |            |       |          |         |         |       |         |                                  |          |
- Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Bar-[Param=20]-DefaultJob |       No | ^
+ Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bar-Bench2-[Param=20]-DefaultJob |       No | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByMethod.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByMethod.approved.txt
@@ -1,0 +1,38 @@
+﻿=== TwoBaselinesWithJobs.ByMethod ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  Job1       : extra output line
+  Job2       : extra output line
+  DefaultJob : extra output line
+
+
+   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                     LogicalGroup | Baseline |
+------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|--------------------------------- |--------- |
+ Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1.Foo-[Param=10]-Job1 |      Yes | ^
+        |        |            |            |       |          |         |         |       |         |                                  |          |
+ Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1.Foo-[Param=10]-Job2 |      Yes |
+        |        |            |            |       |          |         |         |       |         |                                  |          |
+ Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1.Foo-[Param=20]-Job1 |      Yes | ^
+        |        |            |            |       |          |         |         |       |         |                                  |          |
+ Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1.Foo-[Param=20]-Job2 |      Yes |
+        |        |            |            |       |          |         |         |       |         |                                  |          |
+ Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2.Foo-[Param=10]-DefaultJob |      Yes | ^
+        |        |            |            |       |          |         |         |       |         |                                  |          |
+ Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2.Foo-[Param=20]-DefaultJob |      Yes | ^
+        |        |            |            |       |          |         |         |       |         |                                  |          |
+ Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bench1.Bar-[Param=10]-Job1 |       No | ^
+        |        |            |            |       |          |         |         |       |         |                                  |          |
+ Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bench1.Bar-[Param=10]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                                  |          |
+ Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bench1.Bar-[Param=20]-Job1 |       No | ^
+        |        |            |            |       |          |         |         |       |         |                                  |          |
+ Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bench1.Bar-[Param=20]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                                  |          |
+ Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Bar-[Param=10]-DefaultJob |       No | ^
+        |        |            |            |       |          |         |         |       |         |                                  |          |
+ Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bench2.Bar-[Param=20]-DefaultJob |       No | ^
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByParams.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByParams.approved.txt
@@ -9,24 +9,24 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   DefaultJob : extra output line
 
 
-   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
-------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
- Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=10]-Job1 |      Yes | ^
- Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |       [Param=10]-Job1 |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=10]-Job2 |      Yes |
- Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |       [Param=10]-Job2 |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes |
- Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=20]-Job1 |      Yes | ^
- Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |       [Param=20]-Job1 |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=20]-Job2 |      Yes |
- Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |       [Param=20]-Job2 |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes |
- Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                 LogicalGroup | Baseline |
+------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|----------------------------- |--------- |
+ Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=10]-Bench1-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |       [Param=10]-Bench1-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=10]-Bench1-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |       [Param=10]-Bench1-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-Bench2-DefaultJob |      Yes |
+ Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-Bench2-DefaultJob |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=20]-Bench1-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |       [Param=20]-Bench1-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=20]-Bench1-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |       [Param=20]-Bench1-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-Bench2-DefaultJob |      Yes |
+ Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-Bench2-DefaultJob |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByParams.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByParams.approved.txt
@@ -1,0 +1,32 @@
+﻿=== TwoBaselinesWithJobs.ByParams ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  Job1       : extra output line
+  Job2       : extra output line
+  DefaultJob : extra output line
+
+
+   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
+------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
+ Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=10]-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |       [Param=10]-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=10]-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |       [Param=10]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes |
+ Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=20]-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |       [Param=20]-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=20]-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |       [Param=20]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes |
+ Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByType.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.ByType.approved.txt
@@ -1,0 +1,32 @@
+﻿=== TwoBaselinesWithJobs.ByType ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  Job1       : extra output line
+  Job2       : extra output line
+  DefaultJob : extra output line
+
+
+   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                 LogicalGroup | Baseline |
+------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|----------------------------- |--------- |
+ Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1-[Param=10]-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |       Bench1-[Param=10]-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1-[Param=10]-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |       Bench1-[Param=10]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1-[Param=20]-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |       Bench1-[Param=20]-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1-[Param=20]-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |       Bench1-[Param=20]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2-[Param=10]-DefaultJob |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | Bench2-[Param=10]-DefaultJob |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2-[Param=20]-DefaultJob |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | Bench2-[Param=20]-DefaultJob |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.Default.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.Default.approved.txt
@@ -1,0 +1,32 @@
+﻿=== TwoBaselinesWithJobs.Default ===
+
+BenchmarkDotNet=v0.10.x-mock, OS=Microsoft Windows NT 10.0.x.mock, VM=Hyper-V
+MockIntel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz), 1 CPU, 8 logical and 4 physical cores
+Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
+  [Host]     : Clr 4.0.x.mock, 64mock RyuJIT-v4.6.x.mock CONFIGURATION
+  Job1       : extra output line
+  Job2       : extra output line
+  DefaultJob : extra output line
+
+
+   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
+------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
+ Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=10]-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |       [Param=10]-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=10]-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |       [Param=10]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=20]-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |       [Param=20]-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=20]-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |       [Param=20]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
+        |        |            |            |       |          |         |         |       |         |                       |          |
+ Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+
+Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.Default.approved.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/ApprovedFiles/MarkdownExporterMultipleClassApprovalTests.LogicalRuleTest.TwoBaselinesWithJobs.Default.approved.txt
@@ -9,24 +9,24 @@ Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
   DefaultJob : extra output line
 
 
-   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |          LogicalGroup | Baseline |
-------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|---------------------- |--------- |
- Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=10]-Job1 |      Yes | ^
- Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |       [Param=10]-Job1 |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=10]-Job2 |      Yes |
- Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |       [Param=10]-Job2 |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=20]-Job1 |      Yes | ^
- Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |       [Param=20]-Job1 |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       [Param=20]-Job2 |      Yes |
- Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |       [Param=20]-Job2 |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=10]-DefaultJob |      Yes | ^
- Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | [Param=10]-DefaultJob |       No |
-        |        |            |            |       |          |         |         |       |         |                       |          |
- Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | [Param=20]-DefaultJob |      Yes | ^
- Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | [Param=20]-DefaultJob |       No |
+   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                 LogicalGroup | Baseline |
+------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|----------------------------- |--------- |
+ Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1-[Param=10]-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |       Bench1-[Param=10]-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1-[Param=10]-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |       Bench1-[Param=10]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1-[Param=20]-Job1 |      Yes | ^
+ Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |       Bench1-[Param=20]-Job1 |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Bench1-[Param=20]-Job2 |      Yes |
+ Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |       Bench1-[Param=20]-Job2 |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2-[Param=10]-DefaultJob |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 | Bench2-[Param=10]-DefaultJob |       No |
+        |        |            |            |       |          |         |         |       |         |                              |          |
+ Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Bench2-[Param=20]-DefaultJob |      Yes | ^
+ Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 | Bench2-[Param=20]-DefaultJob |       No |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/MarkdownExporterMultipleClassApprovalTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Exporters/MarkdownExporterMultipleClassApprovalTests.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using ApprovalTests;
+using ApprovalTests.Namers;
+using ApprovalTests.Reporters;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Tests.Mocks;
+using BenchmarkDotNet.Validators;
+using JetBrains.Annotations;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.Exporters
+{
+    [UseReporter(typeof(XUnit2Reporter))]
+    [UseApprovalSubdirectory("ApprovedFiles")]
+    [Collection("ApprovalTests")]
+    public class MarkdownExporterMultipleClassApprovalTests : IDisposable
+    {
+        private readonly CultureInfo initCulture;
+
+        public MarkdownExporterMultipleClassApprovalTests() => initCulture = Thread.CurrentThread.CurrentCulture;
+
+        [UsedImplicitly]
+        public static TheoryData<Type, BenchmarkLogicalGroupRule?> GetLogicalGroupRules()
+        {
+            var data = new TheoryData<Type, BenchmarkLogicalGroupRule?>();
+
+            foreach (var type in typeof(LogicalGroupBenchmarks).GetNestedTypes())
+            {
+                data.Add(type, null); // no logical rule
+
+                foreach (var rule in Enum.GetValues(typeof(BenchmarkLogicalGroupRule)))
+                    data.Add(type, (BenchmarkLogicalGroupRule?)rule);
+            }
+
+            return data;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetLogicalGroupRules))]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void LogicalRuleTest(Type benchmarkType, BenchmarkLogicalGroupRule? rule)
+        {
+            var config = DefaultConfig.Instance;
+            if (rule is { } logicalRule)
+                config = config.AddLogicalGroupRules(logicalRule);
+
+            var fileName = rule == null
+                ? $"{benchmarkType.Name}.Default"
+                : $"{benchmarkType.Name}.{rule}";
+
+            NamerFactory.AdditionalInformation = fileName;
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+
+            var logger = new AccumulationLogger();
+            logger.WriteLine($"=== " + fileName + " ===");
+
+            var exporter = MarkdownExporter.Mock;
+            var summary = MockFactory.CreateSummary(config, benchmarkType.GetNestedTypes());
+            exporter.ExportToLog(summary, logger);
+
+            var validator = BaselineValidator.FailOnError;
+            var errors = validator.Validate(new ValidationParameters(summary.BenchmarksCases, summary.BenchmarksCases.First().Config)).ToList();
+            logger.WriteLine();
+            logger.WriteLine("Errors: " + errors.Count);
+            foreach (var error in errors)
+                logger.WriteLineError("* " + error.Message);
+
+            Approvals.Verify(logger.GetLog());
+        }
+
+        public void Dispose() => Thread.CurrentThread.CurrentCulture = initCulture;
+
+        public static class LogicalGroupBenchmarks
+        {
+            public static class NoBaseline
+            {
+                [LogicalGroupColumn, CategoriesColumn, BaselineColumn]
+                [BenchmarkCategory("A")]
+                public class Bench1
+                {
+                    [Params(10, 20)] public int Param;
+                    [Benchmark] public void Foo() { }
+                    [Benchmark] public void Bar() { }
+                }
+
+                [BenchmarkCategory("B")]
+                public class Bench2
+                {
+                    [Params(10, 20)] public int Param;
+                    [Benchmark] public void Foo() { }
+                    [Benchmark] public void Bar() { }
+                }
+            }
+
+            public static class OneBaseline
+            {
+                [LogicalGroupColumn, CategoriesColumn, BaselineColumn]
+                [BenchmarkCategory("A")]
+                public class Bench1
+                {
+                    [Params(10, 20)] public int Param;
+                    [Benchmark(Baseline = true)] public void Foo() { }
+                    [Benchmark] public void Bar() { }
+                }
+
+                [BenchmarkCategory("B")]
+                public class Bench2
+                {
+                    [Params(10, 20)] public int Param;
+                    [Benchmark] public void Foo() { }
+                    [Benchmark] public void Bar() { }
+                }
+            }
+
+            public static class TwoBaselines
+            {
+                [LogicalGroupColumn, CategoriesColumn, BaselineColumn]
+                [BenchmarkCategory("A")]
+                public class Bench1
+                {
+                    [Params(10, 20)] public int Param;
+                    [Benchmark(Baseline = true)] public void Foo() { }
+                    [Benchmark] public void Bar() { }
+                }
+
+                [BenchmarkCategory("B")]
+                public class Bench2
+                {
+                    [Params(10, 20)] public int Param;
+                    [Benchmark(Baseline = true)] public void Foo() { }
+                    [Benchmark] public void Bar() { }
+                }
+            }
+
+            public static class TwoBaselinesWithJobs
+            {
+                [LogicalGroupColumn, CategoriesColumn, BaselineColumn]
+                [BenchmarkCategory("A")]
+                [SimpleJob(id: "Job1"), SimpleJob(id: "Job2")]
+                public class Bench1
+                {
+                    [Params(10, 20)] public int Param;
+                    [Benchmark(Baseline = true)] public void Foo() { }
+                    [Benchmark] public void Bar() { }
+                }
+
+                [BenchmarkCategory("B")]
+                public class Bench2
+                {
+                    [Params(10, 20)] public int Param;
+                    [Benchmark(Baseline = true)] public void Foo() { }
+                    [Benchmark] public void Bar() { }
+                }
+            }
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
+++ b/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
@@ -32,6 +32,21 @@ namespace BenchmarkDotNet.Tests.Mocks
                 ImmutableArray<IColumnHidingRule>.Empty);
         }
 
+        public static Summary CreateSummary(IConfig config, params Type[] benchmarkTypes)
+        {
+            var runInfos = benchmarkTypes.Select(type => BenchmarkConverter.TypeToBenchmarks(type, config));
+            return new Summary(
+                "MockSummary",
+                runInfos.SelectMany(i => i.BenchmarksCases.Select((benchmark, index) => CreateReport(benchmark, 5, (index + 1) * 100))).ToImmutableArray(),
+                new HostEnvironmentInfoBuilder().WithoutDotNetSdkVersion().Build(),
+                string.Empty,
+                string.Empty,
+                TimeSpan.FromMinutes(1),
+                TestCultureInfo.Instance,
+                ImmutableArray<ValidationError>.Empty,
+                ImmutableArray<IColumnHidingRule>.Empty);
+        }
+
         public static Summary CreateSummary(IConfig config) => new Summary(
                 "MockSummary",
                 CreateReports(config),


### PR DESCRIPTION
Fixes #1164
Fixes #2022

Look at "Update existing tests" and "Update new tests" to see what has changed.

# Fixes:

## https://github.com/dotnet/BenchmarkDotNet/issues/1164#issue-448217544
<details>

Master:
```
|       Type | Method |     Mean |    Error |   StdDev | Ratio |
|----------- |------- |---------:|---------:|---------:|------:|
| Formatting |    Old | 15.52 ms | 0.306 ms | 0.017 ms |  1.00 |
|    Parsing |    Old | 15.54 ms | 1.847 ms | 0.101 ms |  1.00 |
| Formatting |    New | 15.48 ms | 2.415 ms | 0.132 ms |  1.00 |
|    Parsing |    New | 15.49 ms | 1.244 ms | 0.068 ms |  1.00 |

```
PR:
```
|       Type | Method |     Mean |    Error |   StdDev | Ratio |
|----------- |------- |---------:|---------:|---------:|------:|
| Formatting |    Old | 15.46 ms | 0.039 ms | 0.035 ms |  1.00 |
| Formatting |    New | 15.62 ms | 0.081 ms | 0.075 ms |  1.01 |
|            |        |          |          |          |       |
|    Parsing |    Old | 15.59 ms | 0.039 ms | 0.036 ms |  1.00 |
|    Parsing |    New | 15.54 ms | 0.076 ms | 0.071 ms |  1.00 |
```
</details>

## https://github.com/dotnet/BenchmarkDotNet/issues/2022#issue-1279202717

<details>

Master:
```
         Type |       Method | Pending |     Mean |   Error |  StdDev | LogicalGroup |
------------- |------------- |-------- |---------:|--------:|--------:|------------- |
   AsyncAwait |     Callback |   False | 102.0 ns | 6.09 ns | 1.58 ns |            * |
 ContinueWith |     Callback |   False | 102.0 ns | 6.09 ns | 1.58 ns |            * |
   AsyncAwait | ProtoPromise |   False | 202.0 ns | 6.09 ns | 1.58 ns |            * |
 ContinueWith | ProtoPromise |   False | 202.0 ns | 6.09 ns | 1.58 ns |            * |
   AsyncAwait |   RsgPromise |   False | 302.0 ns | 6.09 ns | 1.58 ns |            * |
 ContinueWith |   RsgPromise |   False | 302.0 ns | 6.09 ns | 1.58 ns |            * |
   AsyncAwait |         Task |   False | 402.0 ns | 6.09 ns | 1.58 ns |            * |
 ContinueWith |         Task |   False | 402.0 ns | 6.09 ns | 1.58 ns |            * |
   AsyncAwait |      UniTask |   False | 502.0 ns | 6.09 ns | 1.58 ns |            * |
 ContinueWith |      UniTask |   False | 502.0 ns | 6.09 ns | 1.58 ns |            * |
   AsyncAwait |    ValueTask |   False | 602.0 ns | 6.09 ns | 1.58 ns |            * |
 ContinueWith |    ValueTask |   False | 602.0 ns | 6.09 ns | 1.58 ns |            * |
```

PR
```
         Type |       Method | Pending |     Mean |   Error |  StdDev | LogicalGroup |
------------- |------------- |-------- |---------:|--------:|--------:|------------- |
   AsyncAwait |     Callback |   False | 102.0 ns | 6.09 ns | 1.58 ns |   AsyncAwait |
   AsyncAwait | ProtoPromise |   False | 202.0 ns | 6.09 ns | 1.58 ns |   AsyncAwait |
   AsyncAwait |   RsgPromise |   False | 302.0 ns | 6.09 ns | 1.58 ns |   AsyncAwait |
   AsyncAwait |         Task |   False | 402.0 ns | 6.09 ns | 1.58 ns |   AsyncAwait |
   AsyncAwait |      UniTask |   False | 502.0 ns | 6.09 ns | 1.58 ns |   AsyncAwait |
   AsyncAwait |    ValueTask |   False | 602.0 ns | 6.09 ns | 1.58 ns |   AsyncAwait |
              |              |         |          |         |         |              |
 ContinueWith |     Callback |   False | 102.0 ns | 6.09 ns | 1.58 ns | ContinueWith |
 ContinueWith | ProtoPromise |   False | 202.0 ns | 6.09 ns | 1.58 ns | ContinueWith |
 ContinueWith |   RsgPromise |   False | 302.0 ns | 6.09 ns | 1.58 ns | ContinueWith |
 ContinueWith |         Task |   False | 402.0 ns | 6.09 ns | 1.58 ns | ContinueWith |
 ContinueWith |      UniTask |   False | 502.0 ns | 6.09 ns | 1.58 ns | ContinueWith |
 ContinueWith |    ValueTask |   False | 602.0 ns | 6.09 ns | 1.58 ns | ContinueWith |

```
</details>

## https://github.com/dotnet/BenchmarkDotNet/issues/1864#issuecomment-1001346715
<details>

Master
```
                  Type |          Method |   N |     Mean |   Error |  StdDev | LogicalGroup |
---------------------- |---------------- |---- |---------:|--------:|--------:|------------- |
          AsyncPending | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns |            * |
         AsyncResolved | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns |            * |
          AwaitPending | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns |            * |
         AwaitResolved | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns |            * |
 ContinueWithFromValue | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns |            * |
   ContinueWithPending | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns |            * |
  ContinueWithResolved | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns |            * |
          AsyncPending | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns |            * |
         AsyncResolved | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns |            * |
          AwaitPending | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns |            * |
         AwaitResolved | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns |            * |
 ContinueWithFromValue | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns |            * |
   ContinueWithPending | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns |            * |
  ContinueWithResolved | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns |            * |

```
PR
```
                  Type |          Method |   N |     Mean |   Error |  StdDev |          LogicalGroup |
---------------------- |---------------- |---- |---------:|--------:|--------:|---------------------- |
          AsyncPending | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns |          AsyncPending |
          AsyncPending | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns |          AsyncPending |
                       |                 |     |          |         |         |                       |
         AsyncResolved | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns |         AsyncResolved |
         AsyncResolved | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns |         AsyncResolved |
                       |                 |     |          |         |         |                       |
          AwaitPending | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns |          AwaitPending |
          AwaitPending | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns |          AwaitPending |
                       |                 |     |          |         |         |                       |
         AwaitResolved | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns |         AwaitResolved |
         AwaitResolved | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns |         AwaitResolved |
                       |                 |     |          |         |         |                       |
 ContinueWithFromValue | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns | ContinueWithFromValue |
 ContinueWithFromValue | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns | ContinueWithFromValue |
                       |                 |     |          |         |         |                       |
   ContinueWithPending | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns |   ContinueWithPending |
   ContinueWithPending | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns |   ContinueWithPending |
                       |                 |     |          |         |         |                       |
  ContinueWithResolved | ProtoPromise_V1 | 100 | 102.0 ns | 6.09 ns | 1.58 ns |  ContinueWithResolved |
  ContinueWithResolved | ProtoPromise_V2 | 100 | 202.0 ns | 6.09 ns | 1.58 ns |  ContinueWithResolved |
```
</details>

## https://github.com/dotnet/BenchmarkDotNet/issues/1864#issuecomment-1031364986
<details>

Master
```
                 Type |           Method |     Mean |   Error |  StdDev | LogicalGroup |
--------------------- |----------------- |---------:|--------:|--------:|------------- |
      ArrayBenchmarks |            Empty | 102.0 ns | 6.09 ns | 1.58 ns |            * |
      EmptyBenchmarks |  EnumerableEmpty | 102.0 ns | 6.09 ns | 1.58 ns |            * |
 EnumerableBenchmarks |            Empty | 102.0 ns | 6.09 ns | 1.58 ns |            * |
     StringBenchmarks | ConstructorArray | 102.0 ns | 6.09 ns | 1.58 ns |            * |
      EmptyBenchmarks |       ArrayEmpty | 202.0 ns | 6.09 ns | 1.58 ns |            * |
     StringBenchmarks |  ConstructorSpan | 202.0 ns | 6.09 ns | 1.58 ns |            * |

```
PR
```
                 Type |           Method |     Mean |   Error |  StdDev |         LogicalGroup |
--------------------- |----------------- |---------:|--------:|--------:|--------------------- |
      ArrayBenchmarks |            Empty | 102.0 ns | 6.09 ns | 1.58 ns |      ArrayBenchmarks |
                      |                  |          |         |         |                      |
      EmptyBenchmarks |  EnumerableEmpty | 102.0 ns | 6.09 ns | 1.58 ns |      EmptyBenchmarks |
      EmptyBenchmarks |       ArrayEmpty | 202.0 ns | 6.09 ns | 1.58 ns |      EmptyBenchmarks |
                      |                  |          |         |         |                      |
 EnumerableBenchmarks |            Empty | 102.0 ns | 6.09 ns | 1.58 ns | EnumerableBenchmarks |
                      |                  |          |         |         |                      |
     StringBenchmarks | ConstructorArray | 102.0 ns | 6.09 ns | 1.58 ns |     StringBenchmarks |
     StringBenchmarks |  ConstructorSpan | 202.0 ns | 6.09 ns | 1.58 ns |     StringBenchmarks |
```
</details>


# Tests
Yes, that's a lot of tests, but now it's easy to change the ordering logic as there are a lot of cases covered.

For example, this change produces a better output, but it breaks output for `OneBaseline` in some test (it starts display baseline numbers instead a question mark):
```diff
- if (hasMultipleTypes)
+ if (hasMultipleTypes && explicitRules.IsEmpty())
```

# Question
What is the correct table for this?

<details>

```C#
[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByMethod)]
[LogicalGroupColumn, CategoriesColumn, BaselineColumn]
[BenchmarkCategory("A")]
[SimpleJob(id: "Job1"), SimpleJob(id: "Job2")]
public class Bench1
{
    [Params(10, 20)] public int Param;
    [Benchmark(Baseline = true)] public void Foo() { }
    [Benchmark] public void Bar() { }
}

[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByMethod)]
[LogicalGroupColumn, CategoriesColumn, BaselineColumn]
[BenchmarkCategory("B")]
public class Bench2
{
    [Params(10, 20)] public int Param;
    [Benchmark(Baseline = true)] public void Foo() { }
    [Benchmark] public void Bar() { }
}
```

Master/PR output is:
```
   Type | Method |        Job | Categories | Param |     Mean |   Error |  StdDev | Ratio | RatioSD |                     LogicalGroup | Baseline |
------- |------- |----------- |----------- |------ |---------:|--------:|--------:|------:|--------:|--------------------------------- |--------- |
 Bench1 |    Foo |       Job1 |          A |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Foo-Bench1-[Param=10]-Job1 |      Yes | ^
        |        |            |            |       |          |         |         |       |         |                                  |          |
 Bench1 |    Foo |       Job2 |          A |    10 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Foo-Bench1-[Param=10]-Job2 |      Yes |
        |        |            |            |       |          |         |         |       |         |                                  |          |
 Bench1 |    Foo |       Job1 |          A |    20 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Foo-Bench1-[Param=20]-Job1 |      Yes | ^
        |        |            |            |       |          |         |         |       |         |                                  |          |
 Bench1 |    Foo |       Job2 |          A |    20 | 702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |       Foo-Bench1-[Param=20]-Job2 |      Yes |
        |        |            |            |       |          |         |         |       |         |                                  |          |
 Bench2 |    Foo | DefaultJob |          B |    10 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Foo-Bench2-[Param=10]-DefaultJob |      Yes | ^
        |        |            |            |       |          |         |         |       |         |                                  |          |
 Bench2 |    Foo | DefaultJob |          B |    20 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 | Foo-Bench2-[Param=20]-DefaultJob |      Yes | ^
        |        |            |            |       |          |         |         |       |         |                                  |          |
 Bench1 |    Bar |       Job1 |          A |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bar-Bench1-[Param=10]-Job1 |       No | ^
        |        |            |            |       |          |         |         |       |         |                                  |          |
 Bench1 |    Bar |       Job2 |          A |    10 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bar-Bench1-[Param=10]-Job2 |       No |
        |        |            |            |       |          |         |         |       |         |                                  |          |
 Bench1 |    Bar |       Job1 |          A |    20 | 602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bar-Bench1-[Param=20]-Job1 |       No | ^
        |        |            |            |       |          |         |         |       |         |                                  |          |
 Bench1 |    Bar |       Job2 |          A |    20 | 802.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |       Bar-Bench1-[Param=20]-Job2 |       No |
        |        |            |            |       |          |         |         |       |         |                                  |          |
 Bench2 |    Bar | DefaultJob |          B |    10 | 202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bar-Bench2-[Param=10]-DefaultJob |       No | ^
        |        |            |            |       |          |         |         |       |         |                                  |          |
 Bench2 |    Bar | DefaultJob |          B |    20 | 402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? | Bar-Bench2-[Param=20]-DefaultJob |       No | ^

```
</details>