### PR TITLE
Issue #1024: Calculate baseline by the fastest benchmark

### DIFF
--- a/src/BenchmarkDotNet/Attributes/AutomaticBaselineAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/AutomaticBaselineAttribute.cs
@@ -1,0 +1,13 @@
+﻿using BenchmarkDotNet.Configs;
+using System;
+
+namespace BenchmarkDotNet.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class AutomaticBaselineAttribute : Attribute, IConfigSource
+    {
+        public IConfig Config { get; }
+
+        public AutomaticBaselineAttribute(AutomaticBaselineMode mode) => Config = ManualConfig.CreateEmpty().WithAutomaticBaseline(mode);
+    }
+}

--- a/src/BenchmarkDotNet/Configs/AutomaticBaselineMode.cs
+++ b/src/BenchmarkDotNet/Configs/AutomaticBaselineMode.cs
@@ -1,0 +1,8 @@
+﻿namespace BenchmarkDotNet.Configs
+{
+    public enum AutomaticBaselineMode
+    {
+        None,
+        Fastest
+    }
+}

--- a/src/BenchmarkDotNet/Configs/DebugConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DebugConfig.cs
@@ -87,5 +87,7 @@ namespace BenchmarkDotNet.Configs
         public ConfigOptions Options => ConfigOptions.KeepBenchmarkFiles | ConfigOptions.DisableOptimizationsValidator;
 
         public IReadOnlyList<Conclusion> ConfigAnalysisConclusion => emptyConclusion;
+
+        public AutomaticBaselineMode AutomaticBaselineMode { get; } = AutomaticBaselineMode.None;
     }
 }

--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -106,5 +106,7 @@ namespace BenchmarkDotNet.Configs
         public IEnumerable<IFilter> GetFilters() => Array.Empty<IFilter>();
 
         public IEnumerable<IColumnHidingRule> GetColumnHidingRules() => Array.Empty<IColumnHidingRule>();
+
+        public AutomaticBaselineMode AutomaticBaselineMode { get; } = AutomaticBaselineMode.None;
     }
 }

--- a/src/BenchmarkDotNet/Configs/IConfig.cs
+++ b/src/BenchmarkDotNet/Configs/IConfig.cs
@@ -57,5 +57,7 @@ namespace BenchmarkDotNet.Configs
         /// Collect any errors or warnings when composing the configuration
         /// </summary>
         IReadOnlyList<Conclusion> ConfigAnalysisConclusion { get; }
+
+        AutomaticBaselineMode AutomaticBaselineMode { get; }
     }
 }

--- a/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
@@ -53,7 +53,8 @@ namespace BenchmarkDotNet.Configs
             SummaryStyle summaryStyle,
             ConfigOptions options,
             TimeSpan buildTimeout,
-            IReadOnlyList<Conclusion> configAnalysisConclusion)
+            IReadOnlyList<Conclusion> configAnalysisConclusion,
+            AutomaticBaselineMode automaticBaselineMode)
         {
             columnProviders = uniqueColumnProviders;
             loggers = uniqueLoggers;
@@ -74,6 +75,7 @@ namespace BenchmarkDotNet.Configs
             Options = options;
             BuildTimeout = buildTimeout;
             ConfigAnalysisConclusion = configAnalysisConclusion;
+            AutomaticBaselineMode = automaticBaselineMode;
         }
 
         public ConfigUnionRule UnionRule { get; }
@@ -83,6 +85,7 @@ namespace BenchmarkDotNet.Configs
         [NotNull] public IOrderer Orderer { get; }
         public SummaryStyle SummaryStyle { get; }
         public TimeSpan BuildTimeout { get; }
+        public AutomaticBaselineMode AutomaticBaselineMode { get; }
 
         public IEnumerable<IColumnProvider> GetColumnProviders() => columnProviders;
         public IEnumerable<IExporter> GetExporters() => exporters;

--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -71,7 +71,8 @@ namespace BenchmarkDotNet.Configs
                 source.SummaryStyle ?? SummaryStyle.Default,
                 source.Options,
                 source.BuildTimeout,
-                configAnalyse.AsReadOnly()
+                configAnalyse.AsReadOnly(),
+                source.AutomaticBaselineMode
             );
         }
 

--- a/src/BenchmarkDotNet/Configs/ManualConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ManualConfig.cs
@@ -53,6 +53,7 @@ namespace BenchmarkDotNet.Configs
         [PublicAPI] public IOrderer Orderer { get; set; }
         [PublicAPI] public SummaryStyle SummaryStyle { get; set; }
         [PublicAPI] public TimeSpan BuildTimeout { get; set; } = DefaultConfig.Instance.BuildTimeout;
+        [PublicAPI] public AutomaticBaselineMode AutomaticBaselineMode { get; private set; }
 
         public IReadOnlyList<Conclusion> ConfigAnalysisConclusion => emptyConclusion;
 
@@ -95,6 +96,12 @@ namespace BenchmarkDotNet.Configs
         public ManualConfig WithBuildTimeout(TimeSpan buildTimeout)
         {
             BuildTimeout = buildTimeout;
+            return this;
+        }
+
+        public ManualConfig WithAutomaticBaseline(AutomaticBaselineMode automaticBaselineMode)
+        {
+            AutomaticBaselineMode = automaticBaselineMode;
             return this;
         }
 
@@ -254,6 +261,7 @@ namespace BenchmarkDotNet.Configs
             columnHidingRules.AddRange(config.GetColumnHidingRules());
             Options |= config.Options;
             BuildTimeout = GetBuildTimeout(BuildTimeout, config.BuildTimeout);
+            AutomaticBaselineMode = config.AutomaticBaselineMode;
         }
 
         /// <summary>

--- a/tests/BenchmarkDotNet.IntegrationTests/AutomaticBaselineTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/AutomaticBaselineTests.cs
@@ -1,0 +1,53 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class AutomaticBaselineTests
+    {
+        [Fact]
+        public void AutomaticBaselineSelectionIsCorrect()
+        {
+            var config = CreateConfig();
+
+            var summary = BenchmarkRunner.Run<BaselineSample>();
+
+            var table = summary.GetTable(SummaryStyle.Default);
+            var column = table.Columns.Single(c => c.Header == "Ratio");
+            Assert.Equal(2, column.Content.Length);
+            Assert.Equal(1.0, double.Parse(column.Content[1])); // Ratio of TwoMilliseconds
+            Assert.True(double.Parse(column.Content[0]) > 1.0); // Ratio of TwoHundredMilliseconds
+        }
+
+        [AutomaticBaseline(AutomaticBaselineMode.Fastest)]
+        public class BaselineSample
+        {
+            [Benchmark]
+            public void TwoHundredMilliseconds()
+            {
+                Thread.Sleep(200);
+            }
+
+            [Benchmark]
+            public void TwoMilliseconds()
+            {
+                Thread.Sleep(2);
+            }
+        }
+
+        private IConfig CreateConfig()
+            => ManualConfig.CreateEmpty()
+                .AddJob(Job.ShortRun
+                    .WithEvaluateOverhead(false) // no need to run idle for this test
+                    .WithWarmupCount(0) // don't run warmup to save some time for our CI runs
+                    .WithIterationCount(1)) // single iteration is enough for us
+                .AddColumnProvider(DefaultColumnProviders.Instance);
+    }
+}


### PR DESCRIPTION
Fixes #1024 
The idea is inside `Summary.cs`