### PR TITLE
Don't store references in Consumer

### DIFF
--- a/src/BenchmarkDotNet/Engines/Consumer.cs
+++ b/src/BenchmarkDotNet/Engines/Consumer.cs
@@ -139,10 +139,8 @@ namespace BenchmarkDotNet.Engines
                 Volatile.Write(ref longHolder, (long)(object)value);
             else if (typeof(T) == typeof(ulong))
                 Volatile.Write(ref ulongHolder, (ulong)(object)value);
-            else if (default(T) == null && !typeof(T).IsValueType)
-                DeadCodeEliminationHelper.KeepAliveWithoutBoxing(value);
             else
-                DeadCodeEliminationHelper.KeepAliveWithoutBoxingReadonly(value); // non-primitive value types
+                DeadCodeEliminationHelper.KeepAliveWithoutBoxingReadonly(value); // non-primitive and nullable value types
         }
 
         internal static bool IsConsumable(Type type)


### PR DESCRIPTION
Fixes #1942

Also fixes boxing nullable value types (`default(T) == null` also returns true for nullable value types, causing the box to occur).