### PR TITLE
Added the ability to not run with Evaluation Overhead

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -218,6 +218,9 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option("noForcedGCs", Required = false, HelpText = "Specifying would not forcefully induce any GCs.")]
         public bool NoForcedGCs { get; set; }
 
+        [Option("noEvaluationOverhead", Required = false, HelpText = "Specifying would not run the evaluation overhead iterations.")]
+        public bool NoEvaluationOverhead { get; set; }
+
         [Option("resume", Required = false, Default = false, HelpText = "Continue the execution if the last run was stopped.")]
         public bool Resume { get; set; }
 

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -218,7 +218,7 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option("noForcedGCs", Required = false, HelpText = "Specifying would not forcefully induce any GCs.")]
         public bool NoForcedGCs { get; set; }
 
-        [Option("noEvaluationOverhead", Required = false, HelpText = "Specifying would not run the evaluation overhead iterations.")]
+        [Option("noOverheadEvaluation", Required = false, HelpText = "Specifying would not run the evaluation overhead iterations.")]
         public bool NoEvaluationOverhead { get; set; }
 
         [Option("resume", Required = false, Default = false, HelpText = "Continue the execution if the last run was stopped.")]

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -301,6 +301,8 @@ namespace BenchmarkDotNet.ConsoleArguments
                 baseJob = baseJob.WithMemoryRandomization();
             if (options.NoForcedGCs)
                 baseJob = baseJob.WithGcForce(false);
+            if (options.NoEvaluationOverhead)
+                baseJob = baseJob.WithEvaluateOverhead(false);
 
             if (options.EnvironmentVariables.Any())
             {

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -576,7 +576,7 @@ namespace BenchmarkDotNet.Tests
         [Fact]
         public void UsersCanSpecifyWithoutOverheadEvalution()
         {
-            var parsedConfiguration = ConfigParser.Parse(new[] { "--noEvaluationOverhead" }, new OutputLogger(Output));
+            var parsedConfiguration = ConfigParser.Parse(new[] { "--noOverheadEvaluation" }, new OutputLogger(Output));
             Assert.True(parsedConfiguration.isSuccess);
 
             foreach (var job in parsedConfiguration.config.GetJobs())

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -572,5 +572,17 @@ namespace BenchmarkDotNet.Tests
                 Assert.False(job.Environment.Gc.Force);
             }
         }
+
+        [Fact]
+        public void UsersCanSpecifyWithoutOverheadEvalution()
+        {
+            var parsedConfiguration = ConfigParser.Parse(new[] { "--noEvaluationOverhead" }, new OutputLogger(Output));
+            Assert.True(parsedConfiguration.isSuccess);
+
+            foreach (var job in parsedConfiguration.config.GetJobs())
+            {
+                Assert.False(job.Accuracy.EvaluateOverhead);
+            }
+        }
     }
 }


### PR DESCRIPTION
For the GC team, doing an equitable comparison without evaluation overhead is important as we do want an equal number of GCs amongst comparands and the baseline we use to run our microbenchmarks with. 

This PR allows us to specify the flag to not run with evaluation overhead, a feature previously only available with the fluent API. 