### PR TITLE
Rename TargetCount to IterationCount in SimpleJob attribute

### DIFF
--- a/docs/articles/configs/jobs.md
+++ b/docs/articles/configs/jobs.md
@@ -61,11 +61,11 @@ In this category, you can specify how to benchmark each method.
 * `MinWarmupIterationCount`: Minimum count of warmup iterations that should be performed, the default value is 6
 * `MaxWarmupIterationCount`: Maximum count of warmup iterations that should be performed, the default value is 50
 
-Usually, you shouldn't specify such characteristics like `LaunchCount`, `WarmupCount`, `TargetCount`, or `IterationTime` because BenchmarkDotNet has a smart algorithm to choose these values automatically based on received measurements. You can specify it for testing purposes or when you are damn sure that you know the right characteristics for your benchmark (when you set `TargetCount` = `20` you should understand why `20` is a good value for your case).
+Usually, you shouldn't specify such characteristics like `LaunchCount`, `WarmupCount`, `IterationCount`, or `IterationTime` because BenchmarkDotNet has a smart algorithm to choose these values automatically based on received measurements. You can specify it for testing purposes or when you are damn sure that you know the right characteristics for your benchmark (when you set `IterationCount` = `20` you should understand why `20` is a good value for your case).
 
 ### Accuracy
 
-If you want to change the accuracy level, you should use the following characteristics instead of manually adjusting values of `WarmupCount`, `TargetCount`, and so on.
+If you want to change the accuracy level, you should use the following characteristics instead of manually adjusting values of `WarmupCount`, `IterationCount`, and so on.
 
 * `MaxRelativeError`, `MaxAbsoluteError`: Maximum acceptable error for a benchmark (by default, BenchmarkDotNet continue iterations until the actual error is less than the specified error). *In these two characteristics*, the error means half of 99.9% confidence interval. `MaxAbsoluteError` is an absolute `TimeInterval`; doesn't have a default value. `MaxRelativeError` defines max acceptable (`(<half of CI 99.9%>) / Mean`).
 * `MinIterationTime`: Minimum time of a single iteration. Unlike `Run.IterationTime`, this characteristic specifies only the lower limit. In case of need, BenchmarkDotNet can increase this value.
@@ -154,7 +154,7 @@ You can also add new jobs via attributes. Examples:
 [DryJob]
 [ClrJob, CoreJob, MonoJob]
 [LegacyJitX86Job, LegacyJitX64Job, RyuJitX64Job]
-[SimpleJob(RunStrategy.ColdStart, launchCount: 1, warmupCount: 5, targetCount: 5, id: "FastAndDirtyJob")]
+[SimpleJob(RunStrategy.ColdStart, launchCount: 1, warmupCount: 5, IterationCount: 5, id: "FastAndDirtyJob")]
 public class MyBenchmarkClass
 ```
 

--- a/docs/articles/configs/jobs.md
+++ b/docs/articles/configs/jobs.md
@@ -154,7 +154,7 @@ You can also add new jobs via attributes. Examples:
 [DryJob]
 [ClrJob, CoreJob, MonoJob]
 [LegacyJitX86Job, LegacyJitX64Job, RyuJitX64Job]
-[SimpleJob(RunStrategy.ColdStart, launchCount: 1, warmupCount: 5, IterationCount: 5, id: "FastAndDirtyJob")]
+[SimpleJob(RunStrategy.ColdStart, launchCount: 1, warmupCount: 5, iterationCount: 5, id: "FastAndDirtyJob")]
 public class MyBenchmarkClass
 ```
 

--- a/docs/articles/faq.md
+++ b/docs/articles/faq.md
@@ -45,7 +45,7 @@ If you don't need such level of precision and just want to have a quick way to g
 For example, you can use the `SimpleJob` or `ShortRunJob` attributes:
 
     ```cs
-    [SimpleJob(launchCount: 1, warmupCount: 3, targetCount: 5, invocationCount:100, id: "QuickJob")]
+    [SimpleJob(launchCount: 1, warmupCount: 3, iterationCount: 5, invocationCount:100, id: "QuickJob")]
     [ShortRunJob]
     ```
 

--- a/docs/articles/guides/choosing-run-strategy.md
+++ b/docs/articles/guides/choosing-run-strategy.md
@@ -21,7 +21,7 @@ A benchmark method should have a steady state.
 Of course, you can manually set all the characteristics. An example:
 
 ```cs
-[SimpleJob(launchCount: 3, warmupCount: 10, targetCount: 30)]
+[SimpleJob(launchCount: 3, warmupCount: 10, iterationCount: 30)]
 public class MyBenchmarkClass
 ```
 

--- a/docs/articles/overview.md
+++ b/docs/articles/overview.md
@@ -134,7 +134,7 @@ public class Md5VsSha256
             Add(new Job(EnvMode.LegacyJitX86, EnvMode.Clr, RunMode.Dry)
                 {
                     Env = { Runtime = Runtime.Clr },
-                    Run = { LaunchCount = 3, WarmupCount = 5, TargetCount = 10 },
+                    Run = { LaunchCount = 3, WarmupCount = 5, IterationCount = 10 },
                     Accuracy = { MaxStdErrRelative = 0.01 }
                 }));
         }

--- a/docs/articles/samples/IntroExportJson.md
+++ b/docs/articles/samples/IntroExportJson.md
@@ -56,7 +56,7 @@ Example of `IntroJsonExport-report-brief.json`:
             "Runtime":"Host",
             "GcMode":"Host",
             "WarmupCount":"Auto",
-            "TargetCount":"Auto",
+            "IterationCount":"Auto",
             "LaunchCount":"Auto",
             "IterationTime":"Auto",
             "Affinity":"Auto"
@@ -114,7 +114,7 @@ Example of `IntroJsonExport-report-brief.json`:
             "Runtime":"Host",
             "GcMode":"Host",
             "WarmupCount":"Auto",
-            "TargetCount":"Auto",
+            "IterationCount":"Auto",
             "LaunchCount":"Auto",
             "IterationTime":"Auto",
             "Affinity":"Auto"

--- a/docs/articles/samples/IntroMonitoring.md
+++ b/docs/articles/samples/IntroMonitoring.md
@@ -16,7 +16,7 @@ It's a perfect mode for benchmarks which doesn't have a steady state and the per
 ### Usage
 
 ```cs
-[SimpleJob(RunStrategy.Monitoring, launchCount: 10, warmupCount: 0, targetCount: 100)]
+[SimpleJob(RunStrategy.Monitoring, launchCount: 10, warmupCount: 0, iterationCount: 100)]
 public class MyBenchmarkClass
 ```
 

--- a/docs/articles/samples/IntroPercentiles.md
+++ b/docs/articles/samples/IntroPercentiles.md
@@ -13,7 +13,7 @@ However, real-world scenarios often have so-called long tail distribution
 The percentiles allow to include the tail of distribution into the comparison.
 However, it requires some preparations steps.
 At first, you should have enough runs to count percentiles from.
-The `TargetCount` in the config should be set to 10-20 runs at least.  
+The `IterationCount` in the config should be set to 10-20 runs at least.  
 
 Second, the count of iterations for each run should not be very high, or the peak timings will be averaged.
 The `IterationTime = 25` works fine for most cases;
@@ -47,7 +47,7 @@ Also, it's very easy to screw the results with incorrect setup. For example, the
 ```cs
 new Job
 {
-	TargetCount = 5,
+	IterationCount = 5,
 	IterationTime = 500
 }
 ```

--- a/samples/BenchmarkDotNet.Samples/IntroColdStart.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroColdStart.cs
@@ -5,7 +5,7 @@ using BenchmarkDotNet.Engines;
 
 namespace BenchmarkDotNet.Samples
 {
-    [SimpleJob(RunStrategy.ColdStart, targetCount: 5)]
+    [SimpleJob(RunStrategy.ColdStart, iterationCount: 5)]
     [MinColumn, MaxColumn, MeanColumn, MedianColumn]
     public class IntroColdStart
     {

--- a/samples/BenchmarkDotNet.Samples/IntroMonitoring.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroMonitoring.cs
@@ -5,7 +5,7 @@ using BenchmarkDotNet.Engines;
 
 namespace BenchmarkDotNet.Samples
 {
-    [SimpleJob(RunStrategy.Monitoring, targetCount: 10, id: "MonitoringJob")]
+    [SimpleJob(RunStrategy.Monitoring, iterationCount: 10, id: "MonitoringJob")]
     [MinColumn, Q1Column, Q3Column, MaxColumn]
     public class IntroMonitoring
     {

--- a/samples/BenchmarkDotNet.Samples/IntroPercentiles.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroPercentiles.cs
@@ -10,7 +10,7 @@ namespace BenchmarkDotNet.Samples
     // Using percentiles for adequate timings representation
     [Config(typeof(Config))]
     [SimpleJob(RunStrategy.ColdStart, launchCount: 4,
-        warmupCount: 3, targetCount: 20, id: "MyJob")]
+        warmupCount: 3, iterationCount: 20, id: "MyJob")]
     public class IntroPercentiles
     {
         // To share between runs.

--- a/samples/BenchmarkDotNet.Samples/IntroRatioSD.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroRatioSD.cs
@@ -8,7 +8,7 @@ namespace BenchmarkDotNet.Samples
     // Don't remove outliers
     [Outliers(OutlierMode.DontRemove)]
     // Skip jitting, pilot, warmup; measure 10 iterations
-    [SimpleJob(RunStrategy.Monitoring, targetCount: 10, invocationCount: 1)]
+    [SimpleJob(RunStrategy.Monitoring, iterationCount: 10, invocationCount: 1)]
     public class IntroRatioSD
     {
         private int counter;

--- a/samples/BenchmarkDotNet.Samples/IntroSetupCleanupIteration.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroSetupCleanupIteration.cs
@@ -5,7 +5,7 @@ using BenchmarkDotNet.Engines;
 namespace BenchmarkDotNet.Samples
 {
     [SimpleJob(RunStrategy.Monitoring, launchCount: 1,
-        warmupCount: 2, targetCount: 3)]
+        warmupCount: 2, iterationCount: 3)]
     public class IntroSetupCleanupIteration
     {
         private int setupCounter;

--- a/samples/BenchmarkDotNet.Samples/IntroSetupCleanupTarget.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroSetupCleanupTarget.cs
@@ -5,7 +5,7 @@ using BenchmarkDotNet.Engines;
 namespace BenchmarkDotNet.Samples
 {
     [SimpleJob(RunStrategy.Monitoring, launchCount: 0,
-        warmupCount: 0, targetCount: 1)]
+        warmupCount: 0, iterationCount: 1)]
     public class IntroSetupCleanupTarget
     {
         [GlobalSetup(Target = nameof(BenchmarkA))]

--- a/samples/BenchmarkDotNet.Samples/IntroStatisticalTesting.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroStatisticalTesting.cs
@@ -9,7 +9,7 @@ namespace BenchmarkDotNet.Samples
     [StatisticalTestColumn(StatisticalTestKind.MannWhitney, ThresholdUnit.Microseconds, 1, true)]
     [StatisticalTestColumn(StatisticalTestKind.Welch, ThresholdUnit.Ratio, 0.03, true)]
     [StatisticalTestColumn(StatisticalTestKind.MannWhitney, ThresholdUnit.Ratio, 0.03, true)]
-    [SimpleJob(warmupCount: 0, targetCount: 5)]
+    [SimpleJob(warmupCount: 0, iterationCount: 5)]
     public class IntroStatisticalTesting
     {
         [Benchmark] public void Sleep50() => Thread.Sleep(50);

--- a/src/BenchmarkDotNet/Attributes/Jobs/SimpleJobAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/Jobs/SimpleJobAttribute.cs
@@ -16,33 +16,33 @@ namespace BenchmarkDotNet.Attributes
         public SimpleJobAttribute(
             int launchCount = DefaultValue,
             int warmupCount = DefaultValue,
-            int targetCount = DefaultValue,
+            int iterationCount = DefaultValue,
             int invocationCount = DefaultValue,
             string id = null,
             bool baseline = false
-        ) : base(CreateJob(id, launchCount, warmupCount, targetCount, invocationCount, null, baseline)) { }
+        ) : base(CreateJob(id, launchCount, warmupCount, iterationCount, invocationCount, null, baseline)) { }
 
         [PublicAPI]
         public SimpleJobAttribute(
             RunStrategy runStrategy,
             int launchCount = DefaultValue,
             int warmupCount = DefaultValue,
-            int targetCount = DefaultValue,
+            int iterationCount = DefaultValue,
             int invocationCount = DefaultValue,
             string id = null,
             bool baseline = false
-        ) : base(CreateJob(id, launchCount, warmupCount, targetCount, invocationCount, runStrategy, baseline)) { }
+        ) : base(CreateJob(id, launchCount, warmupCount, iterationCount, invocationCount, runStrategy, baseline)) { }
 
         [PublicAPI]
         public SimpleJobAttribute(
             RuntimeMoniker runtimeMoniker,
             int launchCount = DefaultValue,
             int warmupCount = DefaultValue,
-            int targetCount = DefaultValue,
+            int iterationCount = DefaultValue,
             int invocationCount = DefaultValue,
             string id = null,
             bool baseline = false
-        ) : base(CreateJob(id, launchCount, warmupCount, targetCount, invocationCount, null, baseline, runtimeMoniker)) { }
+        ) : base(CreateJob(id, launchCount, warmupCount, iterationCount, invocationCount, null, baseline, runtimeMoniker)) { }
 
         [PublicAPI]
         public SimpleJobAttribute(
@@ -50,13 +50,13 @@ namespace BenchmarkDotNet.Attributes
             RuntimeMoniker runtimeMoniker,
             int launchCount = DefaultValue,
             int warmupCount = DefaultValue,
-            int targetCount = DefaultValue,
+            int iterationCount = DefaultValue,
             int invocationCount = DefaultValue,
             string id = null,
             bool baseline = false
-        ) : base(CreateJob(id, launchCount, warmupCount, targetCount, invocationCount, runStrategy, baseline, runtimeMoniker)) { }
+        ) : base(CreateJob(id, launchCount, warmupCount, iterationCount, invocationCount, runStrategy, baseline, runtimeMoniker)) { }
 
-        private static Job CreateJob(string id, int launchCount, int warmupCount, int targetCount, int invocationCount, RunStrategy? runStrategy,
+        private static Job CreateJob(string id, int launchCount, int warmupCount, int iterationCount, int invocationCount, RunStrategy? runStrategy,
             bool baseline, RuntimeMoniker runtimeMoniker = RuntimeMoniker.HostProcess)
         {
             var job = new Job(id);
@@ -74,9 +74,9 @@ namespace BenchmarkDotNet.Attributes
                 manualValuesCount++;
             }
 
-            if (targetCount != DefaultValue)
+            if (iterationCount != DefaultValue)
             {
-                job.Run.IterationCount = targetCount;
+                job.Run.IterationCount = iterationCount;
                 manualValuesCount++;
             }
             if (invocationCount != DefaultValue)

--- a/src/BenchmarkDotNet/Engines/EngineGeneralStage.cs
+++ b/src/BenchmarkDotNet/Engines/EngineGeneralStage.cs
@@ -14,7 +14,7 @@ namespace BenchmarkDotNet.Engines
         private const double MaxOverheadRelativeError = 0.05;
         private const int DefaultWorkloadCount = 10;
 
-        private readonly int? targetCount;
+        private readonly int? iterationCount;
         private readonly double maxRelativeError;
         private readonly TimeInterval? maxAbsoluteError;
         private readonly OutlierMode outlierMode;
@@ -23,7 +23,7 @@ namespace BenchmarkDotNet.Engines
 
         public EngineActualStage(IEngine engine) : base(engine)
         {
-            targetCount = engine.TargetJob.ResolveValueAsNullable(RunMode.IterationCountCharacteristic);
+            iterationCount = engine.TargetJob.ResolveValueAsNullable(RunMode.IterationCountCharacteristic);
             maxRelativeError = engine.TargetJob.ResolveValue(AccuracyMode.MaxRelativeErrorCharacteristic, engine.Resolver);
             maxAbsoluteError = engine.TargetJob.ResolveValueAsNullable(AccuracyMode.MaxAbsoluteErrorCharacteristic);
             outlierMode = engine.TargetJob.ResolveValue(AccuracyMode.OutlierModeCharacteristic, engine.Resolver);
@@ -38,9 +38,9 @@ namespace BenchmarkDotNet.Engines
             => Run(invokeCount, IterationMode.Workload, false, unrollFactor, forceSpecific);
 
         internal IReadOnlyList<Measurement> Run(long invokeCount, IterationMode iterationMode, bool runAuto, int unrollFactor, bool forceSpecific = false)
-            => (runAuto || targetCount == null) && !forceSpecific
+            => (runAuto || iterationCount == null) && !forceSpecific
                 ? RunAuto(invokeCount, iterationMode, unrollFactor)
-                : RunSpecific(invokeCount, iterationMode, targetCount ?? DefaultWorkloadCount, unrollFactor);
+                : RunSpecific(invokeCount, iterationMode, iterationCount ?? DefaultWorkloadCount, unrollFactor);
 
         private List<Measurement> RunAuto(long invokeCount, IterationMode iterationMode, int unrollFactor)
         {


### PR DESCRIPTION
Commit (https://github.com/dotnet/BenchmarkDotNet/commit/5e6e331b9fe1bbb5ef77c9bb025978e0dcf80aa4) did not change the name of TargetCount in the SimpleJob attribute. After the followup (https://github.com/dotnet/BenchmarkDotNet/commit/6d649b06aaa3bb7a818a1770fddc9dd4bcbe82d6) documentation was removed. This fix completes the rename.