### PR TITLE
Simplify GetHashCode()

### DIFF
--- a/src/BenchmarkDotNet/Analysers/Conclusion.cs
+++ b/src/BenchmarkDotNet/Analysers/Conclusion.cs
@@ -66,7 +66,7 @@ namespace BenchmarkDotNet.Analysers
         {
             return Mergeable
                 ? HashCode.Combine(AnalyserId, Kind, Message)
-                : HashCode.Combine(AnalyserId, Kind, Report?.ToString() ?? string.Empty);
+                : HashCode.Combine(AnalyserId, Kind, Report?.ToString());
         }
     }
 }

--- a/src/BenchmarkDotNet/Analysers/Conclusion.cs
+++ b/src/BenchmarkDotNet/Analysers/Conclusion.cs
@@ -64,9 +64,15 @@ namespace BenchmarkDotNet.Analysers
 
         public override int GetHashCode()
         {
-            return Mergeable
-                ? HashCode.Combine(AnalyserId, Kind, Message)
-                : HashCode.Combine(AnalyserId, Kind, Report?.ToString());
+            unchecked
+            {
+                int hashCode = AnalyserId.GetHashCode();
+                hashCode = (hashCode * 397) ^ (int) Kind;
+                hashCode = Mergeable
+                           ? (hashCode * 397) ^ Message.GetHashCode()
+                           : (hashCode * 397) ^ Report?.ToString().GetHashCode() ?? string.Empty.GetHashCode();
+                return hashCode;
+            }
         }
     }
 }

--- a/src/BenchmarkDotNet/Analysers/Conclusion.cs
+++ b/src/BenchmarkDotNet/Analysers/Conclusion.cs
@@ -64,15 +64,9 @@ namespace BenchmarkDotNet.Analysers
 
         public override int GetHashCode()
         {
-            unchecked
-            {
-                int hashCode = AnalyserId.GetHashCode();
-                hashCode = (hashCode * 397) ^ (int) Kind;
-                hashCode = Mergeable
-                           ? (hashCode * 397) ^ Message.GetHashCode()
-                           : (hashCode * 397) ^ Report?.ToString().GetHashCode() ?? string.Empty.GetHashCode();
-                return hashCode;
-            }
+            return Mergeable
+                ? HashCode.Combine(AnalyserId, Kind, Message)
+                : HashCode.Combine(AnalyserId, Kind, Report?.ToString());
         }
     }
 }

--- a/src/BenchmarkDotNet/Analysers/Conclusion.cs
+++ b/src/BenchmarkDotNet/Analysers/Conclusion.cs
@@ -64,15 +64,9 @@ namespace BenchmarkDotNet.Analysers
 
         public override int GetHashCode()
         {
-            unchecked
-            {
-                int hashCode = AnalyserId.GetHashCode();
-                hashCode = (hashCode * 397) ^ (int) Kind;
-                hashCode = Mergeable
-                           ? (hashCode * 397) ^ Message.GetHashCode()
-                           : (hashCode * 397) ^ Report?.ToString().GetHashCode() ?? string.Empty.GetHashCode();
-                return hashCode;
-            }
+            return Mergeable
+                ? HashCode.Combine(AnalyserId, Kind, Message)
+                : HashCode.Combine(AnalyserId, Kind, Report?.ToString() ?? string.Empty);
         }
     }
 }

--- a/src/BenchmarkDotNet/Analysers/HideColumnsAnalyser.cs
+++ b/src/BenchmarkDotNet/Analysers/HideColumnsAnalyser.cs
@@ -21,7 +21,7 @@ namespace BenchmarkDotNet.Analysers
             var columnNames = string.Join(", ", hiddenColumns.Select(c => c.OriginalColumn.ColumnName));
 
             var message = $"Hidden columns: {columnNames}";
-            yield return Conclusion.CreateHint(Id, message);
+            yield return CreateHint(message);
         }
     }
 }

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -32,9 +32,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <ProjectReference Include="..\BenchmarkDotNet.Disassembler.x64\BenchmarkDotNet.Disassembler.x64.csproj">

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -32,6 +32,9 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <ProjectReference Include="..\BenchmarkDotNet.Disassembler.x64\BenchmarkDotNet.Disassembler.x64.csproj">

--- a/src/BenchmarkDotNet/Columns/SizeUnit.cs
+++ b/src/BenchmarkDotNet/Columns/SizeUnit.cs
@@ -66,16 +66,7 @@ namespace BenchmarkDotNet.Columns
             return Equals((SizeUnit) obj);
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = (Name != null ? Name.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (Description != null ? Description.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ ByteAmount.GetHashCode();
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(Name, Description, ByteAmount);
 
         public static bool operator ==(SizeUnit left, SizeUnit right) => Equals(left, right);
 

--- a/src/BenchmarkDotNet/Columns/SizeUnit.cs
+++ b/src/BenchmarkDotNet/Columns/SizeUnit.cs
@@ -66,7 +66,16 @@ namespace BenchmarkDotNet.Columns
             return Equals((SizeUnit) obj);
         }
 
-        public override int GetHashCode() => HashCode.Combine(Name, Description, ByteAmount);
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = (Name != null ? Name.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Description != null ? Description.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ ByteAmount.GetHashCode();
+                return hashCode;
+            }
+        }
 
         public static bool operator ==(SizeUnit left, SizeUnit right) => Equals(left, right);
 

--- a/src/BenchmarkDotNet/Disassemblers/ClrMdV2Disassembler.cs
+++ b/src/BenchmarkDotNet/Disassemblers/ClrMdV2Disassembler.cs
@@ -327,7 +327,7 @@ namespace BenchmarkDotNet.Disassemblers
                 return x.FilePath == y.FilePath && x.LineNumber == y.LineNumber;
             }
 
-            public int GetHashCode(Sharp obj) => obj.FilePath.GetHashCode() ^ obj.LineNumber;
+            public int GetHashCode(Sharp obj) => HashCode.Combine(obj.FilePath, obj.LineNumber);
         }
     }
 }

--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -223,6 +223,17 @@ namespace BenchmarkDotNet.Engines
 
         public override bool Equals(object obj) => obj is GcStats other && Equals(other);
 
-        public override int GetHashCode() => HashCode.Combine(Gen0Collections, Gen1Collections, Gen2Collections, AllocatedBytes, TotalOperations);
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = Gen0Collections;
+                hashCode = (hashCode * 397) ^ Gen1Collections;
+                hashCode = (hashCode * 397) ^ Gen2Collections;
+                hashCode = (hashCode * 397) ^ AllocatedBytes.GetHashCode();
+                hashCode = (hashCode * 397) ^ TotalOperations.GetHashCode();
+                return hashCode;
+            }
+        }
     }
 }

--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -223,17 +223,6 @@ namespace BenchmarkDotNet.Engines
 
         public override bool Equals(object obj) => obj is GcStats other && Equals(other);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = Gen0Collections;
-                hashCode = (hashCode * 397) ^ Gen1Collections;
-                hashCode = (hashCode * 397) ^ Gen2Collections;
-                hashCode = (hashCode * 397) ^ AllocatedBytes.GetHashCode();
-                hashCode = (hashCode * 397) ^ TotalOperations.GetHashCode();
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(Gen0Collections, Gen1Collections, Gen2Collections, AllocatedBytes, TotalOperations);
     }
 }

--- a/src/BenchmarkDotNet/Engines/ThreadingStats.cs
+++ b/src/BenchmarkDotNet/Engines/ThreadingStats.cs
@@ -86,15 +86,6 @@ namespace BenchmarkDotNet.Engines
 
         public override bool Equals(object obj) => obj is ThreadingStats other && Equals(other);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = CompletedWorkItemCount.GetHashCode();
-                hashCode = (hashCode * 397) ^ LockContentionCount.GetHashCode();
-                hashCode = (hashCode * 397) ^ TotalOperations.GetHashCode();
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(CompletedWorkItemCount, LockContentionCount, TotalOperations);
     }
 }

--- a/src/BenchmarkDotNet/Engines/ThreadingStats.cs
+++ b/src/BenchmarkDotNet/Engines/ThreadingStats.cs
@@ -86,6 +86,15 @@ namespace BenchmarkDotNet.Engines
 
         public override bool Equals(object obj) => obj is ThreadingStats other && Equals(other);
 
-        public override int GetHashCode() => HashCode.Combine(CompletedWorkItemCount, LockContentionCount, TotalOperations);
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = CompletedWorkItemCount.GetHashCode();
+                hashCode = (hashCode * 397) ^ LockContentionCount.GetHashCode();
+                hashCode = (hashCode * 397) ^ TotalOperations.GetHashCode();
+                return hashCode;
+            }
+        }
     }
 }

--- a/src/BenchmarkDotNet/Environments/BenchmarkEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet/Environments/BenchmarkEnvironmentInfo.cs
@@ -70,7 +70,6 @@ namespace BenchmarkDotNet.Environments
             return $"{RuntimeVersion}, {Architecture} {jitInfo}";
         }
 
-        [SuppressMessage("ReSharper", "UnusedMember.Global")] // TODO: should be used or removed
         public static IEnumerable<ValidationError> Validate(Job job)
         {
             if (job.Environment.Jit == Jit.RyuJit && !RuntimeInformation.HasRyuJit())

--- a/src/BenchmarkDotNet/Environments/Runtimes/ClrRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/ClrRuntime.cs
@@ -40,7 +40,7 @@ namespace BenchmarkDotNet.Environments
 
         public bool Equals(ClrRuntime other) => other != null && base.Equals(other) && Version == other.Version;
 
-        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Version);
+        public override int GetHashCode() => base.GetHashCode() ^ (Version?.GetHashCode() ?? 0);
 
         internal static ClrRuntime GetCurrentVersion()
         {

--- a/src/BenchmarkDotNet/Environments/Runtimes/ClrRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/ClrRuntime.cs
@@ -40,7 +40,7 @@ namespace BenchmarkDotNet.Environments
 
         public bool Equals(ClrRuntime other) => other != null && base.Equals(other) && Version == other.Version;
 
-        public override int GetHashCode() => base.GetHashCode() ^ (Version?.GetHashCode() ?? 0);
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Version);
 
         internal static ClrRuntime GetCurrentVersion()
         {

--- a/src/BenchmarkDotNet/Environments/Runtimes/MonoAotLLVMRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/MonoAotLLVMRuntime.cs
@@ -44,6 +44,6 @@ namespace BenchmarkDotNet.Environments
             => other != null && base.Equals(other) && other.AOTCompilerPath == AOTCompilerPath;
 
         public override int GetHashCode()
-            => base.GetHashCode() ^ AOTCompilerPath.GetHashCode();
+            => HashCode.Combine(base.GetHashCode(), AOTCompilerPath);
     }
 }

--- a/src/BenchmarkDotNet/Environments/Runtimes/MonoAotLLVMRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/MonoAotLLVMRuntime.cs
@@ -44,6 +44,6 @@ namespace BenchmarkDotNet.Environments
             => other != null && base.Equals(other) && other.AOTCompilerPath == AOTCompilerPath;
 
         public override int GetHashCode()
-            => HashCode.Combine(base.GetHashCode(), AOTCompilerPath);
+            => base.GetHashCode() ^ AOTCompilerPath.GetHashCode();
     }
 }

--- a/src/BenchmarkDotNet/Environments/Runtimes/MonoRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/MonoRuntime.cs
@@ -32,6 +32,6 @@ namespace BenchmarkDotNet.Environments
             => base.Equals(other) && Name == other?.Name && CustomPath == other?.CustomPath && AotArgs == other?.AotArgs && MonoBclPath == other?.MonoBclPath;
 
         public override int GetHashCode()
-            => HashCode.Combine(base.GetHashCode(), Name, CustomPath, AotArgs, MonoBclPath);
+            => base.GetHashCode() ^ Name.GetHashCode() ^ (CustomPath?.GetHashCode() ?? 0) ^ (AotArgs?.GetHashCode() ?? 0) ^ (MonoBclPath?.GetHashCode() ?? 0);
     }
 }

--- a/src/BenchmarkDotNet/Environments/Runtimes/MonoRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/MonoRuntime.cs
@@ -32,6 +32,6 @@ namespace BenchmarkDotNet.Environments
             => base.Equals(other) && Name == other?.Name && CustomPath == other?.CustomPath && AotArgs == other?.AotArgs && MonoBclPath == other?.MonoBclPath;
 
         public override int GetHashCode()
-            => base.GetHashCode() ^ Name.GetHashCode() ^ (CustomPath?.GetHashCode() ?? 0) ^ (AotArgs?.GetHashCode() ?? 0) ^ (MonoBclPath?.GetHashCode() ?? 0);
+            => HashCode.Combine(base.GetHashCode(), Name, CustomPath, AotArgs, MonoBclPath);
     }
 }

--- a/src/BenchmarkDotNet/Environments/Runtimes/Runtime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/Runtime.cs
@@ -41,6 +41,6 @@ namespace BenchmarkDotNet.Environments
 
         public override bool Equals(object obj) => obj is Runtime other && Equals(other);
 
-        public override int GetHashCode() => HashCode.Combine(Name, RuntimeMoniker, MsBuildMoniker);
+        public override int GetHashCode() => Name.GetHashCode() ^ (int)RuntimeMoniker ^ MsBuildMoniker.GetHashCode();
     }
 }

--- a/src/BenchmarkDotNet/Environments/Runtimes/Runtime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/Runtime.cs
@@ -41,6 +41,6 @@ namespace BenchmarkDotNet.Environments
 
         public override bool Equals(object obj) => obj is Runtime other && Equals(other);
 
-        public override int GetHashCode() => Name.GetHashCode() ^ (int)RuntimeMoniker ^ MsBuildMoniker.GetHashCode();
+        public override int GetHashCode() => HashCode.Combine(Name, RuntimeMoniker, MsBuildMoniker);
     }
 }

--- a/src/BenchmarkDotNet/Environments/Runtimes/Runtime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/Runtime.cs
@@ -41,6 +41,6 @@ namespace BenchmarkDotNet.Environments
 
         public override bool Equals(object obj) => obj is Runtime other && Equals(other);
 
-        public override int GetHashCode() => HashCode.Combine(Name, RuntimeMoniker, MsBuildMoniker);
+        public override int GetHashCode() => HashCode.Combine(Name, MsBuildMoniker, RuntimeMoniker);
     }
 }

--- a/src/BenchmarkDotNet/Environments/Runtimes/WasmRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/WasmRuntime.cs
@@ -46,6 +46,6 @@ namespace BenchmarkDotNet.Environments
             => other != null && base.Equals(other) && other.JavaScriptEngine == JavaScriptEngine && other.JavaScriptEngineArguments == JavaScriptEngineArguments && other.Aot == Aot;
 
         public override int GetHashCode()
-            => base.GetHashCode() ^ (JavaScriptEngine?.GetHashCode() ?? 0) ^ (JavaScriptEngineArguments?.GetHashCode() ?? 0 ^ Aot.GetHashCode());
+            => HashCode.Combine(base.GetHashCode(), JavaScriptEngine, JavaScriptEngineArguments, Aot);
     }
 }

--- a/src/BenchmarkDotNet/Environments/Runtimes/WasmRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/WasmRuntime.cs
@@ -46,6 +46,6 @@ namespace BenchmarkDotNet.Environments
             => other != null && base.Equals(other) && other.JavaScriptEngine == JavaScriptEngine && other.JavaScriptEngineArguments == JavaScriptEngineArguments && other.Aot == Aot;
 
         public override int GetHashCode()
-            => HashCode.Combine(base.GetHashCode(), JavaScriptEngine, JavaScriptEngineArguments, Aot);
+            => base.GetHashCode() ^ (JavaScriptEngine?.GetHashCode() ?? 0) ^ (JavaScriptEngineArguments?.GetHashCode() ?? 0 ^ Aot.GetHashCode());
     }
 }

--- a/src/BenchmarkDotNet/Helpers/HashCode.cs
+++ b/src/BenchmarkDotNet/Helpers/HashCode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
@@ -13,6 +14,11 @@ namespace BenchmarkDotNet
         public void Add<T>(T value)
         {
             hashCode = Hash(hashCode, value);
+        }
+
+        public void Add<T>(T value, IEqualityComparer<T> comparer)
+        {
+            hashCode = Hash(hashCode, value, comparer);
         }
 
         public readonly int ToHashCode() => hashCode;
@@ -107,6 +113,15 @@ namespace BenchmarkDotNet
             unchecked
             {
                 return (hashCode * 397) ^ (value?.GetHashCode() ?? 0);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int Hash<T>(int hashCode, T value, IEqualityComparer<T> comparer)
+        {
+            unchecked
+            {
+                return (hashCode * 397) ^ (value is null ? 0 : (comparer?.GetHashCode(value) ?? value.GetHashCode()));
             }
         }
 

--- a/src/BenchmarkDotNet/Helpers/HashCode.cs
+++ b/src/BenchmarkDotNet/Helpers/HashCode.cs
@@ -5,6 +5,8 @@ using System.Runtime.CompilerServices;
 
 // Mimics System.HashCode, which is missing in NetStandard2.0.
 // Placed in root namespace to avoid ambiguous reference with System.HashCode
+
+// ReSharper disable once CheckNamespace
 namespace BenchmarkDotNet
 {
     internal struct HashCode

--- a/src/BenchmarkDotNet/Helpers/HashCode.cs
+++ b/src/BenchmarkDotNet/Helpers/HashCode.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+// Mimics System.HashCode, which is missing in NetStandard2.0.
+// Placed in root namespace to avoid ambiguous reference with System.HashCode
+namespace BenchmarkDotNet
+{
+    internal struct HashCode
+    {
+        private int hashCode;
+
+        public void Add<T>(T value)
+        {
+            hashCode = Hash(hashCode, value);
+        }
+
+        public readonly int ToHashCode() => hashCode;
+
+        public static int Combine<T1>(T1 value1)
+        {
+            int hashCode = 0;
+            hashCode = Hash(hashCode, value1);
+            return hashCode;
+        }
+
+        public static int Combine<T1, T2>(T1 value1, T2 value2)
+        {
+            int hashCode = 0;
+            hashCode = Hash(hashCode, value1);
+            hashCode = Hash(hashCode, value2);
+            return hashCode;
+        }
+
+        public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
+        {
+            int hashCode = 0;
+            hashCode = Hash(hashCode, value1);
+            hashCode = Hash(hashCode, value2);
+            hashCode = Hash(hashCode, value3);
+            return hashCode;
+        }
+
+        public static int Combine<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4)
+        {
+            int hashCode = 0;
+            hashCode = Hash(hashCode, value1);
+            hashCode = Hash(hashCode, value2);
+            hashCode = Hash(hashCode, value3);
+            hashCode = Hash(hashCode, value4);
+            return hashCode;
+        }
+
+        public static int Combine<T1, T2, T3, T4, T5>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)
+        {
+            int hashCode = 0;
+            hashCode = Hash(hashCode, value1);
+            hashCode = Hash(hashCode, value2);
+            hashCode = Hash(hashCode, value3);
+            hashCode = Hash(hashCode, value4);
+            hashCode = Hash(hashCode, value5);
+            return hashCode;
+        }
+
+        public static int Combine<T1, T2, T3, T4, T5, T6>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6)
+        {
+            int hashCode = 0;
+            hashCode = Hash(hashCode, value1);
+            hashCode = Hash(hashCode, value2);
+            hashCode = Hash(hashCode, value3);
+            hashCode = Hash(hashCode, value4);
+            hashCode = Hash(hashCode, value5);
+            hashCode = Hash(hashCode, value6);
+            return hashCode;
+        }
+
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7)
+        {
+            int hashCode = 0;
+            hashCode = Hash(hashCode, value1);
+            hashCode = Hash(hashCode, value2);
+            hashCode = Hash(hashCode, value3);
+            hashCode = Hash(hashCode, value4);
+            hashCode = Hash(hashCode, value5);
+            hashCode = Hash(hashCode, value6);
+            hashCode = Hash(hashCode, value7);
+            return hashCode;
+        }
+
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8)
+        {
+            int hashCode = 0;
+            hashCode = Hash(hashCode, value1);
+            hashCode = Hash(hashCode, value2);
+            hashCode = Hash(hashCode, value3);
+            hashCode = Hash(hashCode, value4);
+            hashCode = Hash(hashCode, value5);
+            hashCode = Hash(hashCode, value6);
+            hashCode = Hash(hashCode, value7);
+            hashCode = Hash(hashCode, value8);
+            return hashCode;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int Hash<T>(int hashCode, T value)
+        {
+            unchecked
+            {
+                return (hashCode * 397) ^ (value?.GetHashCode() ?? 0);
+            }
+        }
+
+#pragma warning disable CS0809 // Obsolete member 'HashCode.GetHashCode()' overrides non-obsolete member 'object.GetHashCode()'
+        [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", error: true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => throw new NotSupportedException();
+
+        [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes.", error: true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => throw new NotSupportedException();
+#pragma warning restore CS0809 // Obsolete member 'HashCode.GetHashCode()' overrides non-obsolete member 'object.GetHashCode()'
+    }
+}

--- a/src/BenchmarkDotNet/Jobs/Argument.cs
+++ b/src/BenchmarkDotNet/Jobs/Argument.cs
@@ -3,12 +3,28 @@ using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Jobs
 {
-    public abstract class Argument
+    public abstract class Argument: IEquatable<Argument>
     {
-        [PublicAPI] public string TextRepresentation { get; protected set; }
+        [PublicAPI] public string TextRepresentation { get; }
+
+        protected Argument(string value)
+        {
+            TextRepresentation = value;
+        }
 
         // CharacteristicPresenters call ToString(), this is why we need this override
         public override string ToString() => TextRepresentation;
+
+        public bool Equals(Argument other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return TextRepresentation == other.TextRepresentation;
+        }
+
+        public override bool Equals(object obj) => Equals(obj as Argument);
+
+        public override int GetHashCode() => HashCode.Combine(TextRepresentation);
     }
 
     /// <summary>
@@ -17,12 +33,10 @@ namespace BenchmarkDotNet.Jobs
     /// </summary>
     public class MonoArgument : Argument
     {
-        public MonoArgument(string value)
+        public MonoArgument(string value) : base(value)
         {
             if (value == "--llvm" || value == "--nollvm")
                 throw new NotSupportedException("Please use job.Env.Jit to specify Jit in explicit way");
-
-            TextRepresentation = value;
         }
     }
 
@@ -33,6 +47,6 @@ namespace BenchmarkDotNet.Jobs
     [PublicAPI]
     public class MsBuildArgument : Argument
     {
-        public MsBuildArgument(string value) => TextRepresentation = value;
+        public MsBuildArgument(string value) : base(value) { }
     }
 }

--- a/src/BenchmarkDotNet/Jobs/EnvironmentVariable.cs
+++ b/src/BenchmarkDotNet/Jobs/EnvironmentVariable.cs
@@ -33,6 +33,12 @@ namespace BenchmarkDotNet.Jobs
             return Equals((EnvironmentVariable) obj);
         }
 
-        public override int GetHashCode() => HashCode.Combine(Key, Value);
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Key.GetHashCode() * 397) ^ Value.GetHashCode();
+            }
+        }
     }
 }

--- a/src/BenchmarkDotNet/Jobs/EnvironmentVariable.cs
+++ b/src/BenchmarkDotNet/Jobs/EnvironmentVariable.cs
@@ -33,12 +33,6 @@ namespace BenchmarkDotNet.Jobs
             return Equals((EnvironmentVariable) obj);
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (Key.GetHashCode() * 397) ^ Value.GetHashCode();
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(Key, Value);
     }
 }

--- a/src/BenchmarkDotNet/Jobs/GcMode.cs
+++ b/src/BenchmarkDotNet/Jobs/GcMode.cs
@@ -123,7 +123,6 @@ namespace BenchmarkDotNet.Jobs
                 && other.Server == Server;
 
         public override int GetHashCode()
-            => AllowVeryLargeObjects.GetHashCode() ^ Concurrent.GetHashCode() ^ CpuGroups.GetHashCode() ^ Force.GetHashCode() ^ NoAffinitize.GetHashCode() ^
-               RetainVm.GetHashCode() ^ Server.GetHashCode();
+            => HashCode.Combine(AllowVeryLargeObjects, Concurrent, CpuGroups, Force, NoAffinitize, RetainVm, Server);
     }
 }

--- a/src/BenchmarkDotNet/Jobs/GcMode.cs
+++ b/src/BenchmarkDotNet/Jobs/GcMode.cs
@@ -122,8 +122,6 @@ namespace BenchmarkDotNet.Jobs
                 && other.RetainVm == RetainVm
                 && other.Server == Server;
 
-        public override int GetHashCode()
-            => AllowVeryLargeObjects.GetHashCode() ^ Concurrent.GetHashCode() ^ CpuGroups.GetHashCode() ^ Force.GetHashCode() ^ NoAffinitize.GetHashCode() ^
-               RetainVm.GetHashCode() ^ Server.GetHashCode();
+        public override int GetHashCode() => HashCode.Combine(AllowVeryLargeObjects, Concurrent, CpuGroups, Force, NoAffinitize, RetainVm, Server);
     }
 }

--- a/src/BenchmarkDotNet/Jobs/GcMode.cs
+++ b/src/BenchmarkDotNet/Jobs/GcMode.cs
@@ -122,6 +122,8 @@ namespace BenchmarkDotNet.Jobs
                 && other.RetainVm == RetainVm
                 && other.Server == Server;
 
-        public override int GetHashCode() => HashCode.Combine(AllowVeryLargeObjects, Concurrent, CpuGroups, Force, NoAffinitize, RetainVm, Server);
+        public override int GetHashCode()
+            => AllowVeryLargeObjects.GetHashCode() ^ Concurrent.GetHashCode() ^ CpuGroups.GetHashCode() ^ Force.GetHashCode() ^ NoAffinitize.GetHashCode() ^
+               RetainVm.GetHashCode() ^ Server.GetHashCode();
     }
 }

--- a/src/BenchmarkDotNet/Jobs/NugetReference.cs
+++ b/src/BenchmarkDotNet/Jobs/NugetReference.cs
@@ -43,7 +43,10 @@ namespace BenchmarkDotNet.Jobs
                    PackageVersion == other.PackageVersion;
         }
 
-        public override int GetHashCode() => HashCode.Combine(PackageName, PackageVersion);
+        public override int GetHashCode()
+        {
+            return 557888800 + EqualityComparer<string>.Default.GetHashCode(PackageName) + EqualityComparer<string>.Default.GetHashCode(PackageVersion).GetHashCode();
+        }
 
         public override string ToString() => $"{PackageName}{(string.IsNullOrWhiteSpace(PackageVersion) ? string.Empty : $" {PackageVersion}")}";
 

--- a/src/BenchmarkDotNet/Jobs/NugetReference.cs
+++ b/src/BenchmarkDotNet/Jobs/NugetReference.cs
@@ -43,10 +43,7 @@ namespace BenchmarkDotNet.Jobs
                    PackageVersion == other.PackageVersion;
         }
 
-        public override int GetHashCode()
-        {
-            return 557888800 + EqualityComparer<string>.Default.GetHashCode(PackageName) + EqualityComparer<string>.Default.GetHashCode(PackageVersion).GetHashCode();
-        }
+        public override int GetHashCode() => HashCode.Combine(PackageName, PackageVersion);
 
         public override string ToString() => $"{PackageName}{(string.IsNullOrWhiteSpace(PackageVersion) ? string.Empty : $" {PackageVersion}")}";
 

--- a/src/BenchmarkDotNet/Jobs/NugetReferenceList.cs
+++ b/src/BenchmarkDotNet/Jobs/NugetReferenceList.cs
@@ -65,16 +65,10 @@ namespace BenchmarkDotNet.Jobs
 
         public override int GetHashCode()
         {
-            unchecked
-            {
-                int hashCode = 0;
-                foreach (var nuGetReference in references)
-                {
-                    hashCode = hashCode * 397 + nuGetReference.GetHashCode();
-                }
-
-                return hashCode;
-            }
+            var hashCode = new HashCode();
+            foreach (var reference in references)
+                hashCode.Add(reference);
+            return hashCode.ToHashCode();
         }
 
         private class PackageNameComparer : IComparer<NuGetReference>

--- a/src/BenchmarkDotNet/Jobs/NugetReferenceList.cs
+++ b/src/BenchmarkDotNet/Jobs/NugetReferenceList.cs
@@ -65,10 +65,16 @@ namespace BenchmarkDotNet.Jobs
 
         public override int GetHashCode()
         {
-            var hashCode = new HashCode();
-            foreach (var reference in references)
-                hashCode.Add(reference);
-            return hashCode.ToHashCode();
+            unchecked
+            {
+                int hashCode = 0;
+                foreach (var nuGetReference in references)
+                {
+                    hashCode = hashCode * 397 + nuGetReference.GetHashCode();
+                }
+
+                return hashCode;
+            }
         }
 
         private class PackageNameComparer : IComparer<NuGetReference>

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -80,16 +80,21 @@ namespace BenchmarkDotNet.Reports
 
         public override bool Equals(object obj) => obj is SummaryStyle summary && Equals(summary);
 
-        public override int GetHashCode() =>
-            HashCode.Combine(
-                PrintUnitsInHeader,
-                PrintUnitsInContent,
-                PrintZeroValuesInContent,
-                MaxParameterColumnWidth,
-                SizeUnit,
-                CodeSizeUnit,
-                TimeUnit,
-                RatioStyle);
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = PrintUnitsInHeader.GetHashCode();
+                hashCode = (hashCode * 397) ^ PrintUnitsInContent.GetHashCode();
+                hashCode = (hashCode * 397) ^ PrintZeroValuesInContent.GetHashCode();
+                hashCode = (hashCode * 397) ^ (SizeUnit != null ? SizeUnit.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (CodeSizeUnit != null ? CodeSizeUnit.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (TimeUnit != null ? TimeUnit.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ MaxParameterColumnWidth;
+                hashCode = (hashCode * 397) ^ RatioStyle.GetHashCode();
+                return hashCode;
+            }
+        }
 
         public static bool operator ==(SummaryStyle left, SummaryStyle right) => Equals(left, right);
 

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -80,21 +80,16 @@ namespace BenchmarkDotNet.Reports
 
         public override bool Equals(object obj) => obj is SummaryStyle summary && Equals(summary);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = PrintUnitsInHeader.GetHashCode();
-                hashCode = (hashCode * 397) ^ PrintUnitsInContent.GetHashCode();
-                hashCode = (hashCode * 397) ^ PrintZeroValuesInContent.GetHashCode();
-                hashCode = (hashCode * 397) ^ (SizeUnit != null ? SizeUnit.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (CodeSizeUnit != null ? CodeSizeUnit.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (TimeUnit != null ? TimeUnit.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ MaxParameterColumnWidth;
-                hashCode = (hashCode * 397) ^ RatioStyle.GetHashCode();
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() =>
+            HashCode.Combine(
+                PrintUnitsInHeader,
+                PrintUnitsInContent,
+                PrintZeroValuesInContent,
+                MaxParameterColumnWidth,
+                SizeUnit,
+                CodeSizeUnit,
+                TimeUnit,
+                RatioStyle);
 
         public static bool operator ==(SummaryStyle left, SummaryStyle right) => Equals(left, right);
 

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -80,21 +80,16 @@ namespace BenchmarkDotNet.Reports
 
         public override bool Equals(object obj) => obj is SummaryStyle summary && Equals(summary);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = PrintUnitsInHeader.GetHashCode();
-                hashCode = (hashCode * 397) ^ PrintUnitsInContent.GetHashCode();
-                hashCode = (hashCode * 397) ^ PrintZeroValuesInContent.GetHashCode();
-                hashCode = (hashCode * 397) ^ (SizeUnit != null ? SizeUnit.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (CodeSizeUnit != null ? CodeSizeUnit.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (TimeUnit != null ? TimeUnit.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ MaxParameterColumnWidth;
-                hashCode = (hashCode * 397) ^ RatioStyle.GetHashCode();
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() =>
+            HashCode.Combine(
+                PrintUnitsInHeader,
+                PrintUnitsInContent,
+                PrintZeroValuesInContent,
+                SizeUnit,
+                CodeSizeUnit,
+                TimeUnit,
+                MaxParameterColumnWidth,
+                RatioStyle);
 
         public static bool operator ==(SummaryStyle left, SummaryStyle right) => Equals(left, right);
 

--- a/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
@@ -69,9 +69,9 @@ namespace BenchmarkDotNet.Running
             {
                 var hashCode = new HashCode();
                 hashCode.Add(obj.GetToolchain());
-                hashCode.Add(obj.GetRuntime().GetType().MetadataToken);
+                hashCode.Add(obj.GetRuntime());
                 hashCode.Add(obj.Descriptor.Type.Assembly.Location);
-                hashCode.Add(obj.Descriptor.AdditionalLogic ?? string.Empty);
+                hashCode.Add(obj.Descriptor.AdditionalLogic);
                 hashCode.Add(obj.Descriptor.WorkloadMethod.GetCustomAttributes(false).OfType<STAThreadAttribute>().Any());
                 var job = obj.Job;
                 hashCode.Add(job.Environment.Jit);

--- a/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
@@ -67,30 +67,24 @@ namespace BenchmarkDotNet.Running
 
             public int GetHashCode(BenchmarkCase obj)
             {
+                var hashCode = new HashCode();
+                hashCode.Add(obj.GetToolchain());
+                hashCode.Add(obj.GetRuntime().GetType().MetadataToken);
+                hashCode.Add(obj.Descriptor.Type.Assembly.Location);
+                hashCode.Add(obj.Descriptor.AdditionalLogic);
+                hashCode.Add(obj.Descriptor.WorkloadMethod.GetCustomAttributes(false).OfType<STAThreadAttribute>().Any());
+
                 var job = obj.Job;
+                hashCode.Add(job.Environment.Jit);
+                hashCode.Add(job.Environment.Platform);
+                hashCode.Add(job.Environment.LargeAddressAware);
+                hashCode.Add(job.Environment.Gc);
+                hashCode.Add(job.Infrastructure.BuildConfiguration);
+                hashCode.Add(job.Environment.Gc);
+                hashCode.Add(job.Infrastructure.Arguments);
+                hashCode.Add(job.Infrastructure.NuGetReferences);
 
-                int hashCode = obj.GetToolchain().GetHashCode();
-
-                hashCode ^=  GetRuntime(job).GetType().MetadataToken;
-
-                hashCode ^= obj.Descriptor.Type.Assembly.Location.GetHashCode();
-                hashCode ^= (int)job.Environment.Jit;
-                hashCode ^= (int)job.Environment.Platform;
-                hashCode ^= job.Environment.LargeAddressAware.GetHashCode();
-                hashCode ^= job.Environment.Gc.GetHashCode();
-
-                if (job.Infrastructure.BuildConfiguration != null)
-                    hashCode ^= job.Infrastructure.BuildConfiguration.GetHashCode();
-                if (job.Infrastructure.Arguments != null && job.Infrastructure.Arguments.Any())
-                    hashCode ^= job.Infrastructure.Arguments.GetHashCode();
-                if (job.Infrastructure.NuGetReferences != null)
-                    hashCode ^= job.Infrastructure.NuGetReferences.GetHashCode();
-                if (!string.IsNullOrEmpty(obj.Descriptor.AdditionalLogic))
-                    hashCode ^= obj.Descriptor.AdditionalLogic.GetHashCode();
-
-                hashCode ^= obj.Descriptor.WorkloadMethod.GetCustomAttributes(false).OfType<STAThreadAttribute>().Any().GetHashCode();
-
-                return hashCode;
+                return hashCode.ToHashCode();
             }
 
             private static Runtime GetRuntime(Job job)

--- a/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
@@ -81,8 +81,7 @@ namespace BenchmarkDotNet.Running
                 hashCode.Add(job.Environment.Gc);
                 hashCode.Add(job.Infrastructure.BuildConfiguration);
                 hashCode.Add(job.Environment.Gc);
-                foreach (var arg in job.Infrastructure.Arguments ?? Array.Empty<Argument>())
-                    hashCode.Add(arg);
+                hashCode.Add(job.Infrastructure.Arguments);
                 hashCode.Add(job.Infrastructure.NuGetReferences);
 
                 return hashCode.ToHashCode();

--- a/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
@@ -79,8 +79,10 @@ namespace BenchmarkDotNet.Running
                 hashCode.Add(job.Environment.LargeAddressAware);
                 hashCode.Add(job.Environment.Gc);
                 hashCode.Add(job.Infrastructure.BuildConfiguration);
-                hashCode.Add(job.Infrastructure.Arguments);
-                hashCode.Add(job.Infrastructure.NuGetReferences);
+                foreach (var arg in job.Infrastructure.Arguments ?? Array.Empty<Argument>())
+                    hashCode.Add(arg);
+                foreach (var reference in job.Infrastructure.NuGetReferences ?? Array.Empty<NuGetReference>())
+                    hashCode.Add(reference);
                 return hashCode.ToHashCode();
             }
 

--- a/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
@@ -67,24 +67,30 @@ namespace BenchmarkDotNet.Running
 
             public int GetHashCode(BenchmarkCase obj)
             {
-                var hashCode = new HashCode();
-                hashCode.Add(obj.GetToolchain());
-                hashCode.Add(obj.GetRuntime().GetType().MetadataToken);
-                hashCode.Add(obj.Descriptor.Type.Assembly.Location);
-                hashCode.Add(obj.Descriptor.AdditionalLogic);
-                hashCode.Add(obj.Descriptor.WorkloadMethod.GetCustomAttributes(false).OfType<STAThreadAttribute>().Any());
-
                 var job = obj.Job;
-                hashCode.Add(job.Environment.Jit);
-                hashCode.Add(job.Environment.Platform);
-                hashCode.Add(job.Environment.LargeAddressAware);
-                hashCode.Add(job.Environment.Gc);
-                hashCode.Add(job.Infrastructure.BuildConfiguration);
-                hashCode.Add(job.Environment.Gc);
-                hashCode.Add(job.Infrastructure.Arguments);
-                hashCode.Add(job.Infrastructure.NuGetReferences);
 
-                return hashCode.ToHashCode();
+                int hashCode = obj.GetToolchain().GetHashCode();
+
+                hashCode ^=  GetRuntime(job).GetType().MetadataToken;
+
+                hashCode ^= obj.Descriptor.Type.Assembly.Location.GetHashCode();
+                hashCode ^= (int)job.Environment.Jit;
+                hashCode ^= (int)job.Environment.Platform;
+                hashCode ^= job.Environment.LargeAddressAware.GetHashCode();
+                hashCode ^= job.Environment.Gc.GetHashCode();
+
+                if (job.Infrastructure.BuildConfiguration != null)
+                    hashCode ^= job.Infrastructure.BuildConfiguration.GetHashCode();
+                if (job.Infrastructure.Arguments != null && job.Infrastructure.Arguments.Any())
+                    hashCode ^= job.Infrastructure.Arguments.GetHashCode();
+                if (job.Infrastructure.NuGetReferences != null)
+                    hashCode ^= job.Infrastructure.NuGetReferences.GetHashCode();
+                if (!string.IsNullOrEmpty(obj.Descriptor.AdditionalLogic))
+                    hashCode ^= obj.Descriptor.AdditionalLogic.GetHashCode();
+
+                hashCode ^= obj.Descriptor.WorkloadMethod.GetCustomAttributes(false).OfType<STAThreadAttribute>().Any().GetHashCode();
+
+                return hashCode;
             }
 
             private static Runtime GetRuntime(Job job)

--- a/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
@@ -67,30 +67,21 @@ namespace BenchmarkDotNet.Running
 
             public int GetHashCode(BenchmarkCase obj)
             {
+                var hashCode = new HashCode();
+                hashCode.Add(obj.GetToolchain());
+                hashCode.Add(obj.GetRuntime().GetType().MetadataToken);
+                hashCode.Add(obj.Descriptor.Type.Assembly.Location);
+                hashCode.Add(obj.Descriptor.AdditionalLogic ?? string.Empty);
+                hashCode.Add(obj.Descriptor.WorkloadMethod.GetCustomAttributes(false).OfType<STAThreadAttribute>().Any());
                 var job = obj.Job;
-
-                int hashCode = obj.GetToolchain().GetHashCode();
-
-                hashCode ^=  GetRuntime(job).GetType().MetadataToken;
-
-                hashCode ^= obj.Descriptor.Type.Assembly.Location.GetHashCode();
-                hashCode ^= (int)job.Environment.Jit;
-                hashCode ^= (int)job.Environment.Platform;
-                hashCode ^= job.Environment.LargeAddressAware.GetHashCode();
-                hashCode ^= job.Environment.Gc.GetHashCode();
-
-                if (job.Infrastructure.BuildConfiguration != null)
-                    hashCode ^= job.Infrastructure.BuildConfiguration.GetHashCode();
-                if (job.Infrastructure.Arguments != null && job.Infrastructure.Arguments.Any())
-                    hashCode ^= job.Infrastructure.Arguments.GetHashCode();
-                if (job.Infrastructure.NuGetReferences != null)
-                    hashCode ^= job.Infrastructure.NuGetReferences.GetHashCode();
-                if (!string.IsNullOrEmpty(obj.Descriptor.AdditionalLogic))
-                    hashCode ^= obj.Descriptor.AdditionalLogic.GetHashCode();
-
-                hashCode ^= obj.Descriptor.WorkloadMethod.GetCustomAttributes(false).OfType<STAThreadAttribute>().Any().GetHashCode();
-
-                return hashCode;
+                hashCode.Add(job.Environment.Jit);
+                hashCode.Add(job.Environment.Platform);
+                hashCode.Add(job.Environment.LargeAddressAware);
+                hashCode.Add(job.Environment.Gc);
+                hashCode.Add(job.Infrastructure.BuildConfiguration);
+                hashCode.Add(job.Infrastructure.Arguments);
+                hashCode.Add(job.Infrastructure.NuGetReferences);
+                return hashCode.ToHashCode();
             }
 
             private static Runtime GetRuntime(Job job)

--- a/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkPartitioner.cs
@@ -81,7 +81,8 @@ namespace BenchmarkDotNet.Running
                 hashCode.Add(job.Environment.Gc);
                 hashCode.Add(job.Infrastructure.BuildConfiguration);
                 hashCode.Add(job.Environment.Gc);
-                hashCode.Add(job.Infrastructure.Arguments);
+                foreach (var arg in job.Infrastructure.Arguments ?? Array.Empty<Argument>())
+                    hashCode.Add(arg);
                 hashCode.Add(job.Infrastructure.NuGetReferences);
 
                 return hashCode.ToHashCode();

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -183,9 +183,6 @@ namespace BenchmarkDotNet.Toolchains.CsProj
                 && PackagesPath == other.PackagesPath;
 
         public override int GetHashCode()
-            => TargetFrameworkMoniker.GetHashCode()
-                ^ (RuntimeFrameworkVersion?.GetHashCode() ?? 0)
-                ^ (CliPath?.GetHashCode() ?? 0)
-                ^ (PackagesPath?.GetHashCode() ?? 0);
+            => HashCode.Combine(TargetFrameworkMoniker, RuntimeFrameworkVersion, CliPath, PackagesPath);
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -183,6 +183,9 @@ namespace BenchmarkDotNet.Toolchains.CsProj
                 && PackagesPath == other.PackagesPath;
 
         public override int GetHashCode()
-            => HashCode.Combine(TargetFrameworkMoniker, RuntimeFrameworkVersion, CliPath, PackagesPath);
+            => TargetFrameworkMoniker.GetHashCode()
+                ^ (RuntimeFrameworkVersion?.GetHashCode() ?? 0)
+                ^ (CliPath?.GetHashCode() ?? 0)
+                ^ (PackagesPath?.GetHashCode() ?? 0);
     }
 }

--- a/src/BenchmarkDotNet/Validators/ReturnValueValidator.cs
+++ b/src/BenchmarkDotNet/Validators/ReturnValueValidator.cs
@@ -83,18 +83,13 @@ namespace BenchmarkDotNet.Validators
                 if (obj.Count == 0)
                     return 0;
 
-                unchecked
+                var hashCode = new HashCode();
+                foreach (var instance in obj.Items.OrderBy(i => i.Name))
                 {
-                    int result = 0;
-
-                    foreach (var paramInstance in obj.Items.OrderBy(i => i.Name))
-                    {
-                        result = (result * 397) ^ paramInstance.Name.GetHashCode();
-                        result = (result * 397) ^ (paramInstance.Value?.GetHashCode() ?? 0);
-                    }
-
-                    return result;
+                    hashCode.Add(instance.Name);
+                    hashCode.Add(instance.Value);
                 }
+                return hashCode.ToHashCode();
             }
         }
 

--- a/src/BenchmarkDotNet/Validators/ReturnValueValidator.cs
+++ b/src/BenchmarkDotNet/Validators/ReturnValueValidator.cs
@@ -83,13 +83,18 @@ namespace BenchmarkDotNet.Validators
                 if (obj.Count == 0)
                     return 0;
 
-                var hashCode = new HashCode();
-                foreach (var instance in obj.Items.OrderBy(i => i.Name))
+                unchecked
                 {
-                    hashCode.Add(instance.Name);
-                    hashCode.Add(instance.Value);
+                    int result = 0;
+
+                    foreach (var paramInstance in obj.Items.OrderBy(i => i.Name))
+                    {
+                        result = (result * 397) ^ paramInstance.Name.GetHashCode();
+                        result = (result * 397) ^ (paramInstance.Value?.GetHashCode() ?? 0);
+                    }
+
+                    return result;
                 }
-                return hashCode.ToHashCode();
             }
         }
 

--- a/src/BenchmarkDotNet/Validators/ValidationError.cs
+++ b/src/BenchmarkDotNet/Validators/ValidationError.cs
@@ -40,17 +40,7 @@ namespace BenchmarkDotNet.Validators
             return Equals((ValidationError)obj);
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = IsCritical.GetHashCode();
-                hashCode = (hashCode * 397) ^ (Message != null ? Message.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (BenchmarkCase != null ? BenchmarkCase.GetHashCode() : 0);
-                return hashCode;
-            }
-        }
-
+        public override int GetHashCode() => HashCode.Combine(IsCritical, Message, BenchmarkCase);
 
         public static bool operator ==(ValidationError left, ValidationError right) => Equals(left, right);
 


### PR DESCRIPTION
This simplifies the code, fixes 1 bug and improves performance.

If an additional dependency has any disadvantages, we can easily copy its files. This dependency consists of 2 files: `HashCode` and `BitOperations` (2 one-line methods)