### PR TITLE
Fix #2167 - Give main page a title. Then the tab displays 'Home | Be…'

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
+---
+title: Home
+---
 <h3 align="center">
 
   ![](logo/logo-wide.png)


### PR DESCRIPTION
Fix #2167

I was unable to remove the vertical bar, so I make it important like for the other pages that show '<title> | BenchmarkDotNet' in the tab.

Give the main page a title. Then the tab displays 'Home | BenchmarkDotNet'.

