### PR TITLE
Fix a threading issue in ExceptionDiagnoser #1736

### DIFF
--- a/src/BenchmarkDotNet/Engines/ExceptionsStats.cs
+++ b/src/BenchmarkDotNet/Engines/ExceptionsStats.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 
 namespace BenchmarkDotNet.Engines
 {
@@ -7,7 +8,9 @@ namespace BenchmarkDotNet.Engines
     {
         internal const string ResultsLinePrefix = "// Exceptions: ";
 
-        internal ulong ExceptionsCount { get; private set; }
+        private long exceptionsCount;
+
+        internal long ExceptionsCount { get => exceptionsCount; }
 
         public void StartListening()
         {
@@ -21,7 +24,7 @@ namespace BenchmarkDotNet.Engines
 
         private void OnFirstChanceException(object sender, FirstChanceExceptionEventArgs e)
         {
-            ExceptionsCount++;
+            Interlocked.Increment(ref exceptionsCount);
         }
 
         public static string ToOutputLine(double exceptionCount) => $"{ResultsLinePrefix} {exceptionCount}";


### PR DESCRIPTION
When a Benchmark spawns multiple threads that throw Exceptions, FirstChanceException event handler is called concurrently. It must count Exceptions in a thread-safe way.

* Note: do not use lock keyword because that will influence Monitor lock contention count of ThreadingDiagnoser.
* Note: I changed type of ExceptionsCount property to long because there's no Interlocked.Increment overload for ulong. At the single call site, it is promoted to a double and divided by the number of total operations count to get the frequency.