### PR TITLE
Remove allowMultiple=true from column attributes

### DIFF
--- a/src/BenchmarkDotNet/Attributes/Columns/BaselineColumnAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/Columns/BaselineColumnAttribute.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using BenchmarkDotNet.Columns;
+﻿using BenchmarkDotNet.Columns;
 
 namespace BenchmarkDotNet.Attributes
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
     public class BaselineColumnAttribute : ColumnConfigBaseAttribute
     {
         public BaselineColumnAttribute() : base(BaselineColumn.Default) { }

--- a/src/BenchmarkDotNet/Attributes/Columns/BaselineColumnAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/Columns/BaselineColumnAttribute.cs
@@ -3,7 +3,7 @@ using BenchmarkDotNet.Columns;
 
 namespace BenchmarkDotNet.Attributes
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
     public class BaselineColumnAttribute : ColumnConfigBaseAttribute
     {
         public BaselineColumnAttribute() : base(BaselineColumn.Default) { }

--- a/src/BenchmarkDotNet/Attributes/Columns/LogicalGroupColumnAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/Columns/LogicalGroupColumnAttribute.cs
@@ -3,7 +3,7 @@ using BenchmarkDotNet.Columns;
 
 namespace BenchmarkDotNet.Attributes
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
     public class LogicalGroupColumnAttribute : ColumnConfigBaseAttribute
     {
         public LogicalGroupColumnAttribute() : base(LogicalGroupColumn.Default) { }

--- a/src/BenchmarkDotNet/Attributes/Columns/LogicalGroupColumnAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/Columns/LogicalGroupColumnAttribute.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using BenchmarkDotNet.Columns;
+﻿using BenchmarkDotNet.Columns;
 
 namespace BenchmarkDotNet.Attributes
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
     public class LogicalGroupColumnAttribute : ColumnConfigBaseAttribute
     {
         public LogicalGroupColumnAttribute() : base(LogicalGroupColumn.Default) { }


### PR DESCRIPTION
We can remove attributes because **ColumnConfigBaseAttribute** already has
```C#
[AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
```