### PR TITLE
use ImmutableConfig when doing apples-to-apples comparison

### DIFF
--- a/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
@@ -114,7 +114,7 @@ namespace BenchmarkDotNet.Running
 
             if (effectiveConfig.Options.HasFlag(ConfigOptions.ApplesToApples))
             {
-                return ApplesToApples(effectiveConfig, benchmarksToFilter, logger, options);
+                return ApplesToApples(ImmutableConfigBuilder.Create(effectiveConfig), benchmarksToFilter, logger, options);
             }
 
             var filteredBenchmarks = TypeFilter.Filter(effectiveConfig, benchmarksToFilter);
@@ -140,7 +140,7 @@ namespace BenchmarkDotNet.Running
             printer.Print(testNames, nonNullLogger);
         }
 
-        private IEnumerable<Summary> ApplesToApples(ManualConfig effectiveConfig, IReadOnlyList<Type> benchmarksToFilter, ILogger logger, CommandLineOptions options)
+        private IEnumerable<Summary> ApplesToApples(ImmutableConfig effectiveConfig, IReadOnlyList<Type> benchmarksToFilter, ILogger logger, CommandLineOptions options)
         {
             var jobs = effectiveConfig.GetJobs().ToArray();
             if (jobs.Length <= 1)


### PR DESCRIPTION
We need to filter out the mutator jobs:

https://github.com/dotnet/BenchmarkDotNet/blob/761590eb1a0ab813e4c53ccfa8903608ae31cb12/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs#L221-L222

before performing:

https://github.com/dotnet/BenchmarkDotNet/blob/21a29406406aeca1cdfa195fa86ac28d04ba8e33/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs#L157

As for configs like dotnet/performance (an instance of `IConfig` passed to switcher) and command like this:

```cmd
dotnet run -c Release -f net7.0 --filter *String.IndexOfAny --apples --profiler ETW --runtimes net7.0 net8.0 --iterationCount 20
```

I was getting 3 instead of 2 jobs and an error (for a perfectly valid command).

Related to https://github.com/dotnet/runtime/issues/77906 which I am trying to diagnose in automated way ;)