### PR TITLE
Fix job filtering

### DIFF
--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -215,7 +215,7 @@ namespace BenchmarkDotNet.Configs
         /// </summary>
         private static IReadOnlyList<Job> GetRunnableJobs(IEnumerable<Job> jobs)
         {
-            var unique = jobs.Distinct().ToArray();
+            var unique = jobs.Distinct(JobComparer.Instance).ToArray();
             var result = new List<Job>();
 
             foreach (var standardJob in unique.Where(job => !job.Meta.IsMutator && !job.Meta.IsDefault))

--- a/src/BenchmarkDotNet/Environments/BenchmarkEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet/Environments/BenchmarkEnvironmentInfo.cs
@@ -60,7 +60,7 @@ namespace BenchmarkDotNet.Environments
             ? ""
             : Configuration;
 
-        [PublicAPI] protected string GetDebuggerFlag() => HasAttachedDebugger ? " [AttachedDebugger]" : "";
+        [PublicAPI] protected string GetDebuggerFlag() => HasAttachedDebugger ? "[AttachedDebugger]" : "";
         [PublicAPI] protected string GetGcServerFlag() => IsServerGC ? "Server" : "Workstation";
         [PublicAPI] protected string GetGcConcurrentFlag() => IsConcurrentGC ? "Concurrent" : "Non-concurrent";
 

--- a/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
@@ -20,6 +20,19 @@ namespace BenchmarkDotNet.Tests.Configs
     public class ImmutableConfigTests
     {
         [Fact]
+        public void DuplicateJobsAreExcluded()
+        {
+            var mutable = ManualConfig.CreateEmpty();
+
+            mutable.AddJob(new Job());
+            mutable.AddJob(new Job());
+
+            var final = ImmutableConfigBuilder.Create(mutable);
+
+            Assert.Single(final.GetJobs());
+        }
+
+        [Fact]
         public void DuplicateColumnProvidersAreExcluded()
         {
             var mutable = ManualConfig.CreateEmpty();

--- a/tests/BenchmarkDotNet.Tests/Running/JobRuntimePropertiesComparerTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Running/JobRuntimePropertiesComparerTests.cs
@@ -95,29 +95,6 @@ namespace BenchmarkDotNet.Tests.Running
         }
 
         [Fact]
-        public void CustomNuGetJobsWithSamePackageVersionAreGroupedTogether()
-        {
-            var job1 = Job.Default.WithNuGet("AutoMapper", "7.0.1");
-            var job2 = Job.Default.WithNuGet("AutoMapper", "7.0.1");
-
-            var config = ManualConfig.Create(DefaultConfig.Instance)
-                .AddJob(job1)
-                .AddJob(job2);
-
-            var benchmarks1 = BenchmarkConverter.TypeToBenchmarks(typeof(Plain1), config);
-            var benchmarks2 = BenchmarkConverter.TypeToBenchmarks(typeof(Plain2), config);
-
-            var grouped = benchmarks1.BenchmarksCases.Union(benchmarks2.BenchmarksCases)
-                .GroupBy(benchmark => benchmark, new BenchmarkPartitioner.BenchmarkRuntimePropertiesComparer())
-                .ToArray();
-
-            Assert.Single(grouped); // 7.0.1
-
-            foreach (var grouping in grouped)
-                Assert.Equal(2 * 3 * 2, grouping.Count()); // ((job1 + job2) * (M1 + M2 + M3) * (Plain1 + Plain2)
-        }
-
-        [Fact]
         public void CustomNuGetJobsAreGroupedByPackageVersion()
         {
             var config = ManualConfig.Create(DefaultConfig.Instance)


### PR DESCRIPTION
Currently, the jobs with same reference are excluded, but if you use any `.With*` method, a new job will be created.

```C#
DefaultConfig.Instance
    .AddJob(Job.Dry)
    .AddJob(Job.Dry) // not added
    .AddJob(Job.Dry.WithRuntime(CoreRuntime.Core70))
    .AddJob(Job.Dry.WithRuntime(CoreRuntime.Core70));
```

```C#
// 1 job added
[DryJob]
[DryJob]
// 2 jobs added
[DryJob(RuntimeMoniker.Net70)]
[DryJob(RuntimeMoniker.Net70)]
```

#### Maybe we shouldn't distinct jobs at all?
https://github.com/dotnet/BenchmarkDotNet/blob/1fb1015556039664451dd101b4e2ef9501e03805/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs#L213-L218


