### PR TITLE
Improve getting started guide

### DIFF
--- a/docs/articles/guides/getting-started.md
+++ b/docs/articles/guides/getting-started.md
@@ -1,16 +1,14 @@
 # Getting started
-
 To get started with BenchmarkDotNet, please follow these steps. 
 
 ## Step 1. Create a project
 Create a new console application.
 
 ## Step 2. Installation
-
 Install BenchmarkDotNet via the NuGet package: [BenchmarkDotNet](https://www.nuget.org/packages/BenchmarkDotNet/)
 
-```
-PM> Install-Package BenchmarkDotNet
+```cmd
+> dotnet add package BenchmarkDotNet
 ```
 
 Read more about BenchmarkDotNet NuGet packages: @docs.nuget
@@ -58,39 +56,50 @@ namespace MyBenchmarks
 }
 ```
 
-The `BenchmarkRunner.Run<Md5VsSha256>()` call runs your benchmarks and print results to console output.
+The `BenchmarkRunner.Run<Md5VsSha256>()` call runs your benchmarks and prints results to the console.
 
-## Step 4. View results
+## Step 4. Run benchmarks
+Start your console application to run the benchmarks. The application must be built in the Release configuration.
+
+```cmd
+> dotnet run -c Release
+```
+
+## Step 5. View results
 View the results. Here is an example of output from the above benchmark:
 
 ```
-BenchmarkDotNet=v0.11.3, OS=Windows 10.0.17134.472 (1803/April2018Update/Redstone4)
-Intel Core i7-2630QM CPU 2.00GHz (Sandy Bridge), 1 CPU, 8 logical and 4 physical cores
-Frequency=1948699 Hz, Resolution=513.1629 ns, Timer=TSC
-.NET Core SDK=2.1.502
-  [Host]     : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT
-  DefaultJob : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT
+BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19045.2251)
+Intel Core i7-4770HQ CPU 2.20GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
+.NET SDK=7.0.100
+  [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+  DefaultJob : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
 
 
-| Method |      Mean |     Error |    StdDev |
-|------- |----------:|----------:|----------:|
-| Sha256 | 100.90 us | 0.5070 us | 0.4494 us |
-|    Md5 |  37.66 us | 0.1290 us | 0.1207 us |
+| Method |     Mean |    Error |   StdDev |
+|------- |---------:|---------:|---------:|
+| Sha256 | 51.57 us | 0.311 us | 0.291 us |
+|    Md5 | 21.91 us | 0.138 us | 0.129 us |
 ```
 
+## Step 6. Analyze results
+BenchmarkDotNet will automatically create basic reports in the `.\BenchmarkDotNet.Artifacts\results` folder that can be shared and analyzed. 
 
-## Step 5. Analyze results
+To help analyze performance in further depth, you can configure your benchmark to collect and output more detailed information. Benchmark configuration can be conveniently changed by adding attributes to the class containing your benchmarks. For example:
 
-Analyze it. In your bin directory, you can find a lot of useful files with detailed information. For example:
+* [Diagnosers](../configs/diagnosers.md)
+  * GC allocations: `[MemoryDiagnoser]`
+  * Code size and disassembly: `[DisassemblyDiagnoser]`
+  * Threading statistics: `[ThreadingDiagnoser]`
+* [Exporters](../configs/exporters.md)
+  * CSV reports with raw data: `[CsvMeasurementsExporter]`
+  * JSON reports with raw data: `[JsonExporter]`
+  * Plots (if you have installed R): `[RPlotExporter]`
 
-* Csv reports with raw data: `Md5VsSha256-report.csv`, `Md5VsSha256-runs.csv`
-* Markdown reports:  `Md5VsSha256-report-default.md`, `Md5VsSha256-report-stackoverflow.md`, `Md5VsSha256-report-github.md`
-    * Plain report and log: `Md5VsSha256-report.txt`, `Md5VsSha256.log`
-    * Plots (if you have installed R): `Md5VsSha256-barplot.png`, `Md5VsSha256-boxplot.png`, and so on.
+For more information, see [Configs](../configs/configs.md).
 
 ## Next steps
-
-BenchmarkDotNet provides a lot of features which help to high-quality performance research.
-If you want to know more about BenchmarkDotNet features, checkout the [Overview](../overview.md) page.
-If you want have any questions, checkout the [FAQ](../faq.md) page.
-If you didn't find answer for your question on this page, [ask it on gitter](https://gitter.im/dotnet/BenchmarkDotNet) or [create an issue](https://github.com/dotnet/BenchmarkDotNet/issues).
+BenchmarkDotNet provides features which aid high-quality performance research.
+If you want to know more about BenchmarkDotNet features, check out the [Overview](../overview.md) page.
+If you have any questions, check out the [FAQ](../faq.md) page.
+If you didn't find an answer for your question on this page, [ask it on Gitter](https://gitter.im/dotnet/BenchmarkDotNet) or [create an issue on GitHub](https://github.com/dotnet/BenchmarkDotNet/issues).

--- a/docs/articles/guides/how-to-run.md
+++ b/docs/articles/guides/how-to-run.md
@@ -32,24 +32,3 @@ dotnet run -c Release -- --job short --runtimes net472 net7.0 --filter *Benchmar
 ```
 
 The most important thing about `BenchmarkSwitcher` is that you need to pass the `args` from `Main` to the `Run` method. If you don't, it won't parse the arguments.
-
-
-## Url
-
-You can also run a benchmark directly from the internet:
-
-```cs
-string url = "<E.g. direct link to raw content of a gist>";
-var summary = BenchmarkRunner.RunUrl(url);
-```
-
-**Note:** it works only for Full .NET Framework. It's not recommended to use this approach.
-
-## Source
-
-```cs
-string benchmarkSource = "public class MyBenchmarkClass { ...";
-var summary = BenchmarkRunner.RunSource(benchmarkSource);
-```
-
-**Note:** it works only for Full .NET Framework. It's not recommended to use this approach.

--- a/docs/articles/overview.md
+++ b/docs/articles/overview.md
@@ -15,7 +15,7 @@ Create new console application and install the [BenchmarkDotNet](https://www.nug
 * *Languages:* C#, F#, VB
 
 ## Design a benchmark
-Create a new console application, write a class with methods that you want to measure and mark them with the `Benchmark` attribute. In the following example, we 
+Create a new console application, write a class with methods that you want to measure, and mark them with the `Benchmark` attribute. In the following example, we 
 compare the [MD5](https://en.wikipedia.org/wiki/MD5) and [SHA256](https://en.wikipedia.org/wiki/SHA-2) cryptographic hash functions:
 
 ```cs
@@ -57,71 +57,71 @@ namespace MyBenchmarks
 }
 ```
 
-The `BenchmarkRunner.Run<Md5VsSha256>()` call runs your benchmarks and print results to console output.
+The `BenchmarkRunner.Run<Md5VsSha256>()` call runs your benchmarks and prints results to the console.
 
-Notice, that you should use only the `Release` configuration for your benchmarks.
-Otherwise, the results will not correspond to reality.
-If you forgot to change the configuration, BenchmarkDotNet will print a warning.
+Note that BenchmarkDotNet will only run benchmarks if the application is built in the Release configuration.
+This is to prevent unoptimized code from being benchmarked.
+BenchmarkDotNet will issue an error if you forget to change the configuration.
 
 ## Benchmark results
 
 ```
-BenchmarkDotNet=v0.11.3, OS=Windows 10.0.17134.472 (1803/April2018Update/Redstone4)
-Intel Core i7-2630QM CPU 2.00GHz (Sandy Bridge), 1 CPU, 8 logical and 4 physical cores
-Frequency=1948699 Hz, Resolution=513.1629 ns, Timer=TSC
-.NET Core SDK=2.1.502
-  [Host]     : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT
-  DefaultJob : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT
+BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19045.2251)
+Intel Core i7-4770HQ CPU 2.20GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
+.NET SDK=7.0.100
+  [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+  DefaultJob : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
 
 
-| Method |      Mean |     Error |    StdDev |
-|------- |----------:|----------:|----------:|
-| Sha256 | 100.90 us | 0.5070 us | 0.4494 us |
-|    Md5 |  37.66 us | 0.1290 us | 0.1207 us |
+| Method |     Mean |    Error |   StdDev |
+|------- |---------:|---------:|---------:|
+| Sha256 | 51.57 us | 0.311 us | 0.291 us |
+|    Md5 | 21.91 us | 0.138 us | 0.129 us |
 ```
 
 ## Jobs
 
-You can check several environments at once. For example, you can compare performance of Full .NET Framework, .NET Core, Mono and NativeAOT. Just add the `ClrJob`, `MonoJob`, `CoreJob`, attributes before the class declaration (it requires .NET SDK and Mono to be installed and added to $PATH):
+BenchmarkDotNet can benchmark your code in several environments at once. For example, to compare your benchmark's performance in .NET Framework, .NET Core, Mono and NativeAOT, you can add `SimpleJob` attributes to the benchmark class:
 
 ```cs
-[ClrJob, MonoJob, CoreJob]
+[SimpleJob(RuntimeMoniker.Net481)]
+[SimpleJob(RuntimeMoniker.Net70)]
+[SimpleJob(RuntimeMoniker.NativeAot70)]
+[SimpleJob(RuntimeMoniker.Mono)]
 public class Md5VsSha256
 ```
 
 Example of the result:
 
-```ini
-BenchmarkDotNet=v0.11.0, OS=Windows 10.0.16299.309 (1709/FallCreatorsUpdate/Redstone3)
-Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
-Frequency=3507504 Hz, Resolution=285.1030 ns, Timer=TSC
-.NET Core SDK=2.1.300-preview1-008174
-  [Host]     : .NET Core 2.1.0-preview1-26216-03 (CoreCLR 4.6.26216.04, CoreFX 4.6.26216.02), 64bit RyuJIT
-  Job-YRHGTP : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0
-  Core       : .NET Core 2.1.0-preview1-26216-03 (CoreCLR 4.6.26216.04, CoreFX 4.6.26216.02), 64bit RyuJIT
-  CoreRT     : .NET CoreRT 1.0.26414.01, 64bit AOT
-  Mono       : Mono 5.10.0 (Visual Studio), 64bit 
+```
+BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19045.2251)
+Intel Core i7-4770HQ CPU 2.20GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
+.NET SDK=7.0.100
+  [Host]               : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+  .NET 7.0             : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+  .NET Framework 4.8.1 : .NET Framework 4.8.1 (4.8.9037.0), X64 RyuJIT VectorSize=256
+  Mono                 : Mono 6.12.0 (Visual Studio), X64 VectorSize=128
+  NativeAOT 7.0        : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
 
-| Method | Runtime |       Mean |     Error |    StdDev |
-|------- |-------- |-----------:|----------:|----------:|
-| Sha256 |     Clr |  75.780 us | 1.0445 us | 0.9771 us |
-| Sha256 |    Core |  41.134 us | 0.2185 us | 0.1937 us |
-| Sha256 |  CoreRT |  40.895 us | 0.0804 us | 0.0628 us |
-| Sha256 |    Mono | 141.377 us | 0.5598 us | 0.5236 us |
-|        |         |            |           |           |
-|    Md5 |     Clr |  18.575 us | 0.0727 us | 0.0644 us |
-|    Md5 |    Core |  17.562 us | 0.0436 us | 0.0408 us |
-|    Md5 |  CoreRT |  17.447 us | 0.0293 us | 0.0244 us |
-|    Md5 |    Mono |  34.500 us | 0.1553 us | 0.1452 us |
+| Method |                  Job |              Runtime |      Mean |    Error |   StdDev |
+|------- |--------------------- |--------------------- |----------:|---------:|---------:|
+| Sha256 |             .NET 7.0 |             .NET 7.0 |  51.90 us | 0.341 us | 0.302 us |
+|    Md5 |             .NET 7.0 |             .NET 7.0 |  21.96 us | 0.052 us | 0.049 us |
+| Sha256 | .NET Framework 4.8.1 | .NET Framework 4.8.1 | 206.33 us | 2.069 us | 1.834 us |
+|    Md5 | .NET Framework 4.8.1 | .NET Framework 4.8.1 |  23.28 us | 0.094 us | 0.083 us |
+| Sha256 |                 Mono |                 Mono | 167.70 us | 1.216 us | 1.137 us |
+|    Md5 |                 Mono |                 Mono |  42.12 us | 0.145 us | 0.136 us |
+| Sha256 |        NativeAOT 7.0 |        NativeAOT 7.0 |  51.45 us | 0.226 us | 0.200 us |
+|    Md5 |        NativeAOT 7.0 |        NativeAOT 7.0 |  21.88 us | 0.050 us | 0.041 us |
 ```
 
-There are a lot of predefined jobs which you can use. For example, you can compare `LegacyJitX86` vs `LegacyJitX64` vs `RyuJitX64`:
+There are many predefined job attributes which you can use. For example, you can compare `LegacyJitX86`, `LegacyJitX64`, and `RyuJitX64`:
 
 ```cs
 [LegacyJitX86Job, LegacyJitX64Job, RyuJitX64Job]
 ```
 
-Or you can define own jobs:
+Or, you can define your own jobs:
 
 ```cs
 [Config(typeof(Config))]
@@ -131,22 +131,22 @@ public class Md5VsSha256
     {
         public Config()
         {
-            Add(new Job(EnvMode.LegacyJitX86, EnvMode.Clr, RunMode.Dry)
-                {
-                    Env = { Runtime = Runtime.Clr },
-                    Run = { LaunchCount = 3, WarmupCount = 5, IterationCount = 10 },
-                    Accuracy = { MaxStdErrRelative = 0.01 }
-                }));
+            AddJob(new Job(Job.Dry)
+            {
+                Environment = { Jit = Jit.LegacyJit, Platform = Platform.X64 },
+                Run = { LaunchCount = 3, WarmupCount = 5, IterationCount = 10 },
+                Accuracy = { MaxRelativeError = 0.01 }
+            });
         }
     }
 ```
 
-Read more:  [Jobs](configs/jobs.md), [Configs](configs/configs.md)
+Read more: [Jobs](configs/jobs.md), [Configs](configs/configs.md)
 
 
 ## Columns
 
-You can also add custom columns to the summary table:
+You can add columns to the summary table:
 
 ```cs
 [MinColumn, MaxColumn]
@@ -158,13 +158,13 @@ public class Md5VsSha256
 | Sha256 | 131.3200 us | 4.6744 us | 129.8216 us | 147.7630 us |
 | Md5    | 26.2847 us  | 0.4424 us | 25.8442 us  | 27.4258 us  |
 
-Of course, you can define own columns based on full benchmark summary.
+You can also define custom columns based on the full benchmark summary.
 
-Read more:  [Columns](configs/columns.md)
+Read more: [Columns](configs/columns.md)
 
 ## Exporters
 
-You can export result of your benchmark in different formats:
+You can export the results of your benchmark in different formats:
 
 ```cs
 [MarkdownExporter, AsciiDocExporter, HtmlExporter, CsvExporter, RPlotExporter]
@@ -175,11 +175,11 @@ If you have installed R, `RPlotExporter` will generate a lot of nice plots:
 
 ![](../images/v0.12.0/rplot.png)
 
-Read more:  [Exporters](configs/exporters.md)
+Read more: [Exporters](configs/exporters.md)
 
 ## Baseline
 
-In order to scale your results you need to mark one of your benchmark methods as a `Baseline`:
+To view the relative performance of your benchmarks, mark one of your benchmark methods as the `Baseline`:
 
 ```cs
 public class Sleeps
@@ -195,7 +195,7 @@ public class Sleeps
 }
 ```
 
-As a result, you will have additional column in the summary table:
+A new column will be added to the summary table:
 
 | Method  | Median      | StdDev    | Ratio |
 | ------- | ----------- | --------- | ------ |
@@ -203,11 +203,11 @@ As a result, you will have additional column in the summary table:
 | Time150 | 150.2093 ms | 0.1034 ms | 1.50   |
 | Time50  | 50.2509 ms  | 0.1153 ms | 0.50   |
 
-Read more:  [Baselines](features/baselines.md)
+Read more: [Baselines](features/baselines.md)
 
 ## Params
 
-You can mark one or several fields or properties in your class by the `Params` attribute. In this attribute, you can specify set of values. As a result, you will get results for each combination of params values.
+You can mark one or several fields or properties in your class with the `Params` attribute. In this attribute, you can specify a set of values. BenchmarkDotNet will run benchmarks for each combination of params values.
 
 ```cs
 public class IntroParams
@@ -226,6 +226,7 @@ public class IntroParams
 }
 ```
 
+
 | Method    | Median      | StdDev    | A    | B    |
 | --------- | ----------- | --------- | ---- | ---- |
 | Benchmark | 115.3325 ms | 0.0242 ms | 100  | 10   |
@@ -233,11 +234,11 @@ public class IntroParams
 | Benchmark | 215.3024 ms | 0.0375 ms | 200  | 10   |
 | Benchmark | 225.2710 ms | 0.0434 ms | 200  | 20   |
 
-Read more:  [Parameterization](features/parameterization.md)
+Read more: [Parameterization](features/parameterization.md)
 
 ## Languages
 
-You can also write you benchmarks on `F#` or `VB`. Examples:
+You can also write benchmarks in `F#` or `VB`.
 
 ```fs
 type StringKeyComparison () =
@@ -277,15 +278,16 @@ End Class
 
 ## Diagnostics
 
-A **diagnoser** can attach to your benchmark and get some useful info.
+A diagnoser can attach to your benchmarks and collect additional information.
 
-The current Diagnosers are:
+Examples of diagnosers built in to BenchmarkDotNet are:
 
-- GC and Memory Allocation (`MemoryDiagnoser`) which is cross platform, built-in and **is not enabled by default anymore**.
-- JIT Inlining Events (`InliningDiagnoser`). You can find this diagnoser in a separated package with diagnosers for Windows (`BenchmarkDotNet.Diagnostics.Windows`): [![NuGet](https://img.shields.io/nuget/v/BenchmarkDotNet.svg)](https://www.nuget.org/packages/BenchmarkDotNet.Diagnostics.Windows/)
+- Garbge collection and allocation statistics (`MemoryDiagnoser`).
+- Lock contention and thread pool statistics (`ThreadingDiagnoser`), which is only available on .NET Core 3.0+. 
+- JIT inlining events (`InliningDiagnoser`). You can find this diagnoser in a separated package with diagnosers for Windows (`BenchmarkDotNet.Diagnostics.Windows`): [![NuGet](https://img.shields.io/nuget/v/BenchmarkDotNet.svg)](https://www.nuget.org/packages/BenchmarkDotNet.Diagnostics.Windows/)
 
 
-Below is a sample output from the `MemoryDiagnoser`, note the extra columns on the right-hand side (`Gen 0` and `Allocated`):
+Below is a sample benchmark using `MemoryDiagnoser`. Note the extra columns on the right-hand side (`Gen 0` and `Allocated`):
 
 ```
     Method |       Mean |    StdDev |  Gen 0 | Allocated |
@@ -294,21 +296,16 @@ Below is a sample output from the `MemoryDiagnoser`, note the extra columns on t
       LINQ | 83.0435 ns | 1.0103 ns | 0.0069 |      32 B | 
 ```
 
-Read more:  [Diagnosers](configs/diagnosers.md)
+Read more: [Diagnosers](configs/diagnosers.md)
 
 ## BenchmarkRunner
 
-There are several ways to run your benchmarks: you can use an existing class, run a benchmark based on code from internet or based on source code:
+There are several ways to run your benchmarks.
 
 ```cs
 var summary = BenchmarkRunner.Run<MyBenchmarkClass>();
 var summary = BenchmarkRunner.Run(typeof(MyBenchmarkClass));
-
-string url = "<E.g. direct link to a gist>";
-var summary = BenchmarkRunner.RunUrl(url);
-
-string benchmarkSource = "public class MyBenchmarkClass { ...";
-var summary = BenchmarkRunner.RunSource(benchmarkSource);
+var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 ```
 
-Read more:  [HowToRun](guides/how-to-run.md)
+Read more: [How to run your benchmarks](guides/how-to-run.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ title: Home
 </h3>
 
 <h3 align="center">
-  <a href="#features">Features</a>
+  <a href="#Features">Features</a>
   <span> · </span>
   <a href="https://benchmarkdotnet.org/articles/guides/getting-started.html">Getting started</a>
   <span> · </span>
@@ -30,12 +30,12 @@ title: Home
 
 **BenchmarkDotNet** helps you to transform methods into benchmarks, track their performance, and share reproducible measurement experiments.
 It's no harder than writing unit tests!
-Under the hood, it performs a lot of [magic](#automation) that guarantees [reliable and precise](#reliability) results thanks to the [perfolizer](https://github.com/AndreyAkinshin/perfolizer) statistical engine.
+Under the hood, it performs a lot of [magic](#Automation) that guarantees [reliable and precise](#Reliability) results thanks to the [perfolizer](https://github.com/AndreyAkinshin/perfolizer) statistical engine.
 BenchmarkDotNet protects you from popular benchmarking mistakes and warns you if something is wrong with your benchmark design or obtained measurements.
-The results are presented in a [user-friendly](#friendliness) form that highlights all the important facts about your experiment.
+The results are presented in a [user-friendly](#Friendliness) form that highlights all the important facts about your experiment.
 The library is adopted by [13400+ projects](#who-uses-benchmarkdotnet) including .NET Runtime and supported by the [.NET Foundation](https://dotnetfoundation.org).
 
-It's [easy](#simplicity) to start writing benchmarks, check out an example
+It's [easy](#Simplicity) to start writing benchmarks, check out an example
   (copy-pastable version is [here](https://benchmarkdotnet.org/articles/guides/getting-started.html)):
 
 ```cs
@@ -79,7 +79,7 @@ Intel Core i7-7700K CPU 4.20GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cor
   [Host]       : .NET Framework 4.7.2 (4.7.3468.0), X64 RyuJIT
   Net472       : .NET Framework 4.7.2 (4.7.3468.0), X64 RyuJIT
   NetCoreApp30 : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), X64 RyuJIT
-  CoreRt30     : .NET CoreRT 1.0.28231.02 @Commit: 741d61493c560ba96e8151f9e56876d4d3828489, X64 AOT
+  NativeAot70  : .NET 7.0.0-preview.4.22172.7, X64 NativeAOT
   Mono         : Mono 6.4.0 (Visual Studio), X64
 
 
@@ -87,22 +87,22 @@ Intel Core i7-7700K CPU 4.20GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cor
 |------- |-------------- |------ |-----------:|----------:|----------:|------:|
 | Sha256 |    .NET 4.7.2 |  1000 |   7.735 us | 0.1913 us | 0.4034 us |  1.00 |
 | Sha256 | .NET Core 3.0 |  1000 |   3.989 us | 0.0796 us | 0.0745 us |  0.50 |
-| Sha256 |    CoreRt 3.0 |  1000 |   4.091 us | 0.0811 us | 0.1562 us |  0.53 |
+| Sha256 | NativeAOT 7.0 |  1000 |   4.091 us | 0.0811 us | 0.1562 us |  0.53 |
 | Sha256 |          Mono |  1000 |  13.117 us | 0.2485 us | 0.5019 us |  1.70 |
 |        |               |       |            |           |           |       |
 |    Md5 |    .NET 4.7.2 |  1000 |   2.872 us | 0.0552 us | 0.0737 us |  1.00 |
 |    Md5 | .NET Core 3.0 |  1000 |   1.848 us | 0.0348 us | 0.0326 us |  0.64 |
-|    Md5 |    CoreRt 3.0 |  1000 |   1.817 us | 0.0359 us | 0.0427 us |  0.63 |
+|    Md5 | NativeAOT 7.0 |  1000 |   1.817 us | 0.0359 us | 0.0427 us |  0.63 |
 |    Md5 |          Mono |  1000 |   3.574 us | 0.0678 us | 0.0753 us |  1.24 |
 |        |               |       |            |           |           |       |
 | Sha256 |    .NET 4.7.2 | 10000 |  74.509 us | 1.5787 us | 4.6052 us |  1.00 |
 | Sha256 | .NET Core 3.0 | 10000 |  36.049 us | 0.7151 us | 1.0025 us |  0.49 |
-| Sha256 |    CoreRt 3.0 | 10000 |  36.253 us | 0.7076 us | 0.7571 us |  0.49 |
+| Sha256 | NativeAOT 7.0 | 10000 |  36.253 us | 0.7076 us | 0.7571 us |  0.49 |
 | Sha256 |          Mono | 10000 | 116.350 us | 2.2555 us | 3.0110 us |  1.58 |
 |        |               |       |            |           |           |       |
 |    Md5 |    .NET 4.7.2 | 10000 |  17.308 us | 0.3361 us | 0.4250 us |  1.00 |
 |    Md5 | .NET Core 3.0 | 10000 |  15.726 us | 0.2064 us | 0.1930 us |  0.90 |
-|    Md5 |    CoreRt 3.0 | 10000 |  15.627 us | 0.2631 us | 0.2461 us |  0.89 |
+|    Md5 | NativeAOT 7.0 | 10000 |  15.627 us | 0.2631 us | 0.2461 us |  0.89 |
 |    Md5 |          Mono | 10000 |  30.205 us | 0.5868 us | 0.6522 us |  1.74 |
 
 ```
@@ -132,7 +132,7 @@ For example, if you want to [parameterize](https://benchmarkdotnet.org/articles/
   and run benchmarks for each case.
 If you want to compare benchmarks with each other,
   mark one of the benchmark as the [baseline](https://benchmarkdotnet.org/articles/features/baselines.html)
-  via `[Benchmark(baseline: true)]`: BenchmarkDotNet will compare it with all of the other benchmarks.
+  via `[Benchmark(Baseline = true)]`: BenchmarkDotNet will compare it with all of the other benchmarks.
 If you want to compare performance in different environments, use [jobs](https://benchmarkdotnet.org/articles/configs/jobs.html).
 For example, you can run all the benchmarks on .NET Core 3.0 and Mono via
   `[SimpleJob(RuntimeMoniker.NetCoreApp30)]` and `[SimpleJob(RuntimeMoniker.Mono)]`.
@@ -141,15 +141,15 @@ If you don't like attributes, you can call most of the APIs via the fluent style
 
 ```cs
 ManualConfig.CreateEmpty() // A configuration for our benchmarks
-    .With(Job.Default // Adding first job
-            .With(ClrRuntime.Net472) // .NET Framework 4.7.2
-            .With(Platform.X64) // Run as x64 application
-            .With(Jit.LegacyJit) // Use LegacyJIT instead of the default RyuJIT
-            .WithGcServer(true) // Use Server GC
-    ).With(Job.Default // Adding second job
-            .AsBaseline() // It will be marked as baseline
-            .WithEnvironmentVariable("Key", "Value") // Setting an environment variable
-            .WithWarmupCount(0) // Disable warm-up stage
+    .AddJob(Job.Default // Adding first job
+        .WithRuntime(ClrRuntime.Net472) // .NET Framework 4.7.2
+        .WithPlatform(Platform.X64) // Run as x64 application
+        .WithJit(Jit.LegacyJit) // Use LegacyJIT instead of the default RyuJIT
+        .WithGcServer(true) // Use Server GC
+    ).AddJob(Job.Default // Adding second job
+        .AsBaseline() // It will be marked as baseline
+        .WithEnvironmentVariable("Key", "Value") // Setting an environment variable
+        .WithWarmupCount(0) // Disable warm-up stage
     );
 ```
 


### PR DESCRIPTION
- Adjust the instructions and examples to reflect more modern .NET
- Add a section about how to run the benchmarks (making sure you use Release)
- Fix the "Analyze" section, which was misleading, and add more useful information