### PR TITLE
Add support for MonoVM to MemoryDiagnoser

### DIFF
--- a/src/BenchmarkDotNet/Engines/Engine.cs
+++ b/src/BenchmarkDotNet/Engines/Engine.cs
@@ -267,7 +267,7 @@ namespace BenchmarkDotNet.Engines
 
         private static void EnableMonitoring()
         {
-            if (RuntimeInformation.IsMono) // Monitoring is not available in Mono, see http://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-in-mono
+            if (RuntimeInformation.IsOldMono) // Monitoring is not available in Mono, see http://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-in-mono
                 return;
 
             if (RuntimeInformation.IsFullFramework)

--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -132,7 +132,11 @@ namespace BenchmarkDotNet.Engines
 
         private static long GetAllocatedBytes()
         {
-            if (RuntimeInformation.IsMono) // Monitoring is not available in Mono, see http://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-
+            if (RuntimeInformation.IsOldMono) // Monitoring is not available in Mono, see http://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-
+                return 0;
+
+            // we have no tests for WASM and don't want to risk introducing a new bug (https://github.com/dotnet/BenchmarkDotNet/issues/2226)
+            if (RuntimeInformation.IsWasm)
                 return 0;
 
             // "This instance Int64 property returns the number of bytes that have been allocated by a specific

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -57,6 +57,11 @@ namespace BenchmarkDotNet.IntegrationTests
             long objectAllocationOverhead = IntPtr.Size * 2; // pointer to method table + object header word
             long arraySizeOverhead = IntPtr.Size; // array length
 
+            if (toolchain is MonoToolchain)
+            {
+                objectAllocationOverhead += IntPtr.Size;
+            }
+
             AssertAllocations(toolchain, typeof(AccurateAllocations), new Dictionary<string, long>
             {
                 { nameof(AccurateAllocations.EightBytesArray), 8 + objectAllocationOverhead + arraySizeOverhead },

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -23,6 +23,7 @@ using BenchmarkDotNet.Toolchains.NativeAot;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using Xunit;
 using Xunit.Abstractions;
+using BenchmarkDotNet.Toolchains.Mono;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
@@ -34,7 +35,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
         public static IEnumerable<object[]> GetToolchains()
         {
-            if (RuntimeInformation.IsMono) // https://github.com/mono/mono/issues/8397
+            if (RuntimeInformation.IsOldMono) // https://github.com/mono/mono/issues/8397
                 yield break;
 
             yield return new object[] { Job.Default.GetToolchain() };
@@ -76,6 +77,15 @@ namespace BenchmarkDotNet.IntegrationTests
                 NativeAotToolchain.CreateBuilder()
                     .UseNuGet("7.0.0", "https://api.nuget.org/v3/index.json")
                     .ToToolchain());
+        }
+
+        [FactDotNetCoreOnly("We don't want to test MonoVM twice (for .NET Framework 4.6.2 and .NET 7.0)")]
+        public void MemoryDiagnoserSupportsModernMono()
+        {
+            if (ContinuousIntegration.IsAppVeyorOnWindows())
+                return; // timeouts
+
+            MemoryDiagnoserIsAccurate(MonoToolchain.Mono70);
         }
 
         public class AllocatingGlobalSetupAndCleanup


### PR DESCRIPTION
Sample results:

```ini
BenchmarkDotNet=v0.13.2.20221209-develop, OS=Windows 11 (10.0.22621.819)
AMD Ryzen Threadripper PRO 3945WX 12-Cores, 1 CPU, 24 logical and 12 physical cores
.NET SDK=8.0.100-alpha.1.22558.1
  [Host]     : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
  Job-TPQNZV : .NET 7.0.0 (7.0.22.42610) using MonoVM, X64 VectorSize=128

Runtime=Mono with .NET 7.0  Toolchain=Mono with .NET 7.0
```

|           Method |     Mean |     Error |    StdDev |   Gen0 |   Gen1 |   Gen2 | Allocated |
|----------------- |---------:|----------:|----------:|-------:|-------:|-------:|----------:|
| 'new byte[10kB]' | 5.751 us | 0.1126 us | 0.1156 us | 0.5798 | 0.5798 | 0.5798 |    9.8 KB |