### PR TITLE
JitStatsDiagnoser

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.Windows/InliningDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/InliningDiagnoser.cs
@@ -1,12 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
 using Microsoft.Diagnostics.Tracing.Session;
 
 namespace BenchmarkDotNet.Diagnostics.Windows
 {
-    public class InliningDiagnoser : JitDiagnoser<object>
+    public class InliningDiagnoser : JitDiagnoser<object>, IProfiler
     {
         private static readonly string LogSeparator = new string('-', 20);
 
@@ -42,6 +43,8 @@ namespace BenchmarkDotNet.Diagnostics.Windows
         }
 
         public override IEnumerable<string> Ids => new[] { nameof(InliningDiagnoser) };
+
+        public string ShortName => "inlining";
 
         protected override void AttachToEvents(TraceEventSession session, BenchmarkCase benchmarkCase)
         {

--- a/src/BenchmarkDotNet.Diagnostics.Windows/InliningDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/InliningDiagnoser.cs
@@ -6,7 +6,7 @@ using Microsoft.Diagnostics.Tracing.Session;
 
 namespace BenchmarkDotNet.Diagnostics.Windows
 {
-    public class InliningDiagnoser : JitDiagnoser
+    public class InliningDiagnoser : JitDiagnoser<object>
     {
         private static readonly string LogSeparator = new string('-', 20);
 

--- a/src/BenchmarkDotNet.Diagnostics.Windows/JitDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/JitDiagnoser.cs
@@ -11,7 +11,7 @@ using Microsoft.Diagnostics.Tracing.Parsers;
 
 namespace BenchmarkDotNet.Diagnostics.Windows
 {
-    public abstract class JitDiagnoser : EtwDiagnoser<object>, IDiagnoser
+    public abstract class JitDiagnoser<TStats> : EtwDiagnoser<TStats>, IDiagnoser where TStats : new()
     {
         protected override ulong EventType => (ulong)ClrTraceEventParser.Keywords.JitTracing;
 

--- a/src/BenchmarkDotNet.Diagnostics.Windows/JitStatsDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/JitStatsDiagnoser.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Session;
+
+namespace BenchmarkDotNet.Diagnostics.Windows
+{
+    public class JitStatsDiagnoser : JitDiagnoser<JitStats>, IProfiler
+    {
+        public override IEnumerable<string> Ids => new[] { nameof(JitStatsDiagnoser) };
+
+        public string ShortName => "jit";
+
+        protected override ulong EventType => (ulong)(ClrTraceEventParser.Keywords.Jit | ClrTraceEventParser.Keywords.Compilation);
+
+        public override IEnumerable<Metric> ProcessResults(DiagnoserResults results)
+        {
+            if (BenchmarkToProcess.TryGetValue(results.BenchmarkCase, out int pid))
+            {
+                if (StatsPerProcess.TryGetValue(pid, out JitStats jitStats))
+                {
+                    yield return new Metric(MethodsJittedDescriptor.Instance, jitStats.MethodsCompiled);
+                    yield return new Metric(MethodsTieredDescriptor.Instance, jitStats.MethodsTiered);
+                    yield return new Metric(JitAllocatedMemoryDescriptor.Instance, jitStats.MemoryAllocated);
+                }
+            }
+        }
+
+        protected override void AttachToEvents(TraceEventSession session, BenchmarkCase benchmarkCase)
+        {
+            session.Source.Clr.MethodJittingStarted += methodData =>
+            {
+                if (StatsPerProcess.TryGetValue(methodData.ProcessID, out JitStats jitStats))
+                {
+                    Interlocked.Increment(ref jitStats.MethodsCompiled);
+                }
+            };
+
+            session.Source.Clr.MethodMemoryAllocatedForJitCode += memoryAllocated =>
+            {
+                if (StatsPerProcess.TryGetValue(memoryAllocated.ProcessID, out JitStats jitStats))
+                {
+                    Interlocked.Add(ref jitStats.MemoryAllocated, memoryAllocated.AllocatedSizeForJitCode);
+                }
+            };
+
+            session.Source.Clr.TieredCompilationBackgroundJitStart += tieredData =>
+            {
+                if (StatsPerProcess.TryGetValue(tieredData.ProcessID, out JitStats jitStats))
+                {
+                    Interlocked.Increment(ref jitStats.MethodsTiered);
+                }
+            };
+        }
+
+        private sealed class MethodsJittedDescriptor : IMetricDescriptor
+        {
+            internal static readonly MethodsJittedDescriptor Instance = new ();
+
+            public string Id => nameof(MethodsJittedDescriptor);
+            public string DisplayName => "Methods JITted";
+            public string Legend => "Total number of methods JITted during entire benchmark execution (including warmup).";
+            public bool TheGreaterTheBetter => false;
+            public string NumberFormat => "N0";
+            public UnitType UnitType => UnitType.Dimensionless;
+            public string Unit => "Count";
+            public int PriorityInCategory => 0;
+        }
+
+        private sealed class MethodsTieredDescriptor : IMetricDescriptor
+        {
+            internal static readonly MethodsTieredDescriptor Instance = new ();
+
+            public string Id => nameof(MethodsTieredDescriptor);
+            public string DisplayName => "Methods Tiered";
+            public string Legend => "Total number of methods re-compiled by Tiered JIT during entire benchmark execution (including warmup).";
+            public bool TheGreaterTheBetter => false;
+            public string NumberFormat => "N0";
+            public UnitType UnitType => UnitType.Dimensionless;
+            public string Unit => "Count";
+            public int PriorityInCategory => 0;
+        }
+
+        private sealed class JitAllocatedMemoryDescriptor : IMetricDescriptor
+        {
+            internal static readonly JitAllocatedMemoryDescriptor Instance = new ();
+
+            public string Id => nameof(JitAllocatedMemoryDescriptor);
+            public string DisplayName => "JIT allocated memory";
+            public string Legend => "Total memory allocated by the JIT during entire benchmark execution (including warmup).";
+            public bool TheGreaterTheBetter => false;
+            public string NumberFormat => "N0";
+            public UnitType UnitType => UnitType.Size;
+            public string Unit => SizeUnit.B.Name;
+            public int PriorityInCategory => 0;
+        }
+    }
+
+    public sealed class JitStats
+    {
+        public long MethodsCompiled;
+        public long MethodsTiered;
+        public long MemoryAllocated;
+    }
+}

--- a/src/BenchmarkDotNet.Diagnostics.Windows/TailCallDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/TailCallDiagnoser.cs
@@ -9,7 +9,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
     /// See <see href="https://blogs.msdn.microsoft.com/clrcodegeneration/2009/05/11/jit-etw-tracing-in-net-framework-4/">MSDN blog post about JIT tracing events</see>
     /// and <see href="https://georgeplotnikov.github.io/articles/tale-tail-call-dotnet">detailed blog post by George Plotnikov</see> for more info
     /// </summary>
-    public class TailCallDiagnoser : JitDiagnoser
+    public class TailCallDiagnoser : JitDiagnoser<object>
     {
         private static readonly string LogSeparator = new string('-', 20);
 

--- a/src/BenchmarkDotNet.Diagnostics.Windows/TailCallDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/TailCallDiagnoser.cs
@@ -2,6 +2,7 @@
 using BenchmarkDotNet.Running;
 using Microsoft.Diagnostics.Tracing.Session;
 using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Diagnosers;
 
 namespace BenchmarkDotNet.Diagnostics.Windows
 {
@@ -9,7 +10,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
     /// See <see href="https://blogs.msdn.microsoft.com/clrcodegeneration/2009/05/11/jit-etw-tracing-in-net-framework-4/">MSDN blog post about JIT tracing events</see>
     /// and <see href="https://georgeplotnikov.github.io/articles/tale-tail-call-dotnet">detailed blog post by George Plotnikov</see> for more info
     /// </summary>
-    public class TailCallDiagnoser : JitDiagnoser<object>
+    public class TailCallDiagnoser : JitDiagnoser<object>, IProfiler
     {
         private static readonly string LogSeparator = new string('-', 20);
 
@@ -31,6 +32,8 @@ namespace BenchmarkDotNet.Diagnostics.Windows
         }
 
         public override IEnumerable<string> Ids => new[] { nameof(TailCallDiagnoser) };
+
+        public string ShortName => "tail";
 
         protected override void AttachToEvents(TraceEventSession traceEventSession, BenchmarkCase benchmarkCase)
         {

--- a/src/BenchmarkDotNet/Diagnosers/DiagnosersLoader.cs
+++ b/src/BenchmarkDotNet/Diagnosers/DiagnosersLoader.cs
@@ -73,6 +73,7 @@ namespace BenchmarkDotNet.Diagnosers
                 return new[]
                 {
                     CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.InliningDiagnoser"),
+                    CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.JitStatsDiagnoser"),
                     CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.EtwProfiler"),
                     CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.ConcurrencyVisualizerProfiler"),
                     CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.NativeMemoryProfiler")

--- a/src/BenchmarkDotNet/Diagnosers/DiagnosersLoader.cs
+++ b/src/BenchmarkDotNet/Diagnosers/DiagnosersLoader.cs
@@ -73,6 +73,7 @@ namespace BenchmarkDotNet.Diagnosers
                 return new[]
                 {
                     CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.InliningDiagnoser"),
+                    CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.TailCallDiagnoser"),
                     CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.JitStatsDiagnoser"),
                     CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.EtwProfiler"),
                     CreateDiagnoser(diagnosticsAssembly, "BenchmarkDotNet.Diagnostics.Windows.ConcurrencyVisualizerProfiler"),


### PR DESCRIPTION
I'm currently working on improving System.CommandLine (mainly design, but also perf).

One of the things unique about S.CL is that it's typically used just once, during process startup time. So what matters is the number of JIT compilations. I've implemented this simple diagnoser that prints simple JIT stats.

Sample usage:

```cmd
dotnet run -c Release -f net7.0 --filter *IntroBasic.Sleep --profiler jit
```

| Method |     Mean |    Error |   StdDev | Methods JITted | Methods Tiered | JIT allocated memory |
|------- |---------:|---------:|---------:|---------------:|---------------:|---------------------:|
|  Sleep | 15.53 ms | 0.034 ms | 0.032 ms |          1,102 |             15 |            221,736 B |

@AndyAyersMS @kunalspathak @stephentoub @EgorBo @kouvel I am opened to extending it, but I need your feedback before I invest my time. I know that PerfView offers more:

![image](https://user-images.githubusercontent.com/6011991/211826462-035ec88b-b0f2-461f-9455-7b91759a24e4.png)
