### PR TITLE
UnresolvedDiagnoser needs to have an Id as well

### DIFF
--- a/src/BenchmarkDotNet/Diagnosers/UnresolvedDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/UnresolvedDiagnoser.cs
@@ -19,7 +19,7 @@ namespace BenchmarkDotNet.Diagnosers
 
         public RunMode GetRunMode(BenchmarkCase benchmarkCase) => RunMode.None;
 
-        public IEnumerable<string> Ids => Array.Empty<string>();
+        public IEnumerable<string> Ids => new string[] { nameof(UnresolvedDiagnoser) };
         public IEnumerable<IExporter> Exporters => Array.Empty<IExporter>();
         public IEnumerable<IAnalyser> Analysers => Array.Empty<IAnalyser>();
         public void Handle(HostSignal signal, DiagnoserActionParameters parameters) { }


### PR DESCRIPTION
A fix for bug reported offline by @KrzysztofCwalina

otherwise CompositeDiagnoser.DisplayResults throws:

https://github.com/dotnet/BenchmarkDotNet/blob/e715d5bb63984fca65120d9a497f7d16395f9e5b/src/BenchmarkDotNet/Diagnosers/CompositeDiagnoser.cs#L47