### PR TITLE
bump SDK version to pick up .NET Runtime fix that should fix disassembler test issues

### DIFF
--- a/build/global.json
+++ b/build/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "7.0.200",
     "rollForward": "disable"
   }
 }


### PR DESCRIPTION
We need https://github.com/dotnet/runtime/pull/79862 to fix our disassembler tests