### PR TITLE
Add Android specific GetNetCoreVersion Runtime Information capabilities.

### DIFF
--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -278,21 +278,28 @@ namespace BenchmarkDotNet.Portability
 
         private static string GetNetCoreVersion()
         {
-            var coreclrAssemblyInfo = FileVersionInfo.GetVersionInfo(typeof(object).GetTypeInfo().Assembly.Location);
-            var corefxAssemblyInfo = FileVersionInfo.GetVersionInfo(typeof(Regex).GetTypeInfo().Assembly.Location);
-
-            if (CoreRuntime.TryGetVersion(out var version) && version >= new Version(5, 0))
+            if (IsAndroid())
             {
-                // after the merge of dotnet/corefx and dotnet/coreclr into dotnet/runtime the version should always be the same
-                Debug.Assert(coreclrAssemblyInfo.FileVersion == corefxAssemblyInfo.FileVersion);
-
-                return $".NET {version} ({coreclrAssemblyInfo.FileVersion})";
+                return $".NET {Environment.Version}";
             }
             else
             {
-                string runtimeVersion = version != default ? version.ToString() : "?";
+                var coreclrAssemblyInfo = FileVersionInfo.GetVersionInfo(typeof(object).GetTypeInfo().Assembly.Location);
+                var corefxAssemblyInfo = FileVersionInfo.GetVersionInfo(typeof(Regex).GetTypeInfo().Assembly.Location);
 
-                return $".NET Core {runtimeVersion} (CoreCLR {coreclrAssemblyInfo.FileVersion}, CoreFX {corefxAssemblyInfo.FileVersion})";
+                if (CoreRuntime.TryGetVersion(out var version) && version >= new Version(5, 0))
+                {
+                    // after the merge of dotnet/corefx and dotnet/coreclr into dotnet/runtime the version should always be the same
+                    Debug.Assert(coreclrAssemblyInfo.FileVersion == corefxAssemblyInfo.FileVersion);
+
+                    return $".NET {version} ({coreclrAssemblyInfo.FileVersion})";
+                }
+                else
+                {
+                    string runtimeVersion = version != default ? version.ToString() : "?";
+
+                    return $".NET Core {runtimeVersion} (CoreCLR {coreclrAssemblyInfo.FileVersion}, CoreFX {corefxAssemblyInfo.FileVersion})";
+                }
             }
         }
 


### PR DESCRIPTION
This adds an Android specific way to get the NetCore version of the runtime being used via Environment.Version. This is necessary because Android apps don't uncompress the downloaded apk's which causes FileNotFound errors. To double check the precision, I ran this locally. After testing the Environment.Version vs the FileVersion from the PrivateCoreLib.dll, it does appears that the Environment.Version is not as precise. The results from the test were Envirornment.Version giving 7.0.3 while the FileVersion gave 7.0.323.6910.