### PR TITLE
Allow custom runtimes to use Executor

### DIFF
--- a/src/BenchmarkDotNet/Environments/Runtimes/CustomRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CustomRuntime.cs
@@ -1,0 +1,12 @@
+using BenchmarkDotNet.Jobs;
+
+namespace BenchmarkDotNet.Environments
+{
+    public abstract class CustomRuntime : Runtime
+    {
+        protected CustomRuntime(RuntimeMoniker runtimeMoniker, string msBuildMoniker, string displayName)
+            : base(runtimeMoniker, msBuildMoniker, displayName)
+        {
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -149,7 +149,9 @@ namespace BenchmarkDotNet.Toolchains
                     start.WorkingDirectory = artifactsPaths.BinariesDirectoryPath;
                     break;
                 default:
-                    throw new NotSupportedException("Runtime = " + runtime);
+                    start.FileName = exePath;
+                    start.Arguments = args;
+                    break;
             }
             return start;
         }

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -148,10 +148,12 @@ namespace BenchmarkDotNet.Toolchains
                     start.Arguments = args;
                     start.WorkingDirectory = artifactsPaths.BinariesDirectoryPath;
                     break;
-                default:
+                case CustomRuntime _:
                     start.FileName = exePath;
                     start.Arguments = args;
                     break;
+                default:
+                    throw new NotSupportedException("Runtime = " + runtime);
             }
             return start;
         }


### PR DESCRIPTION
Hello folks! This PR makes a small change to `Executor` to allow it be used for custom runtimes. The only downside I can see is that  the current `NotSupportedException` is probably a useful reminder when adding built-in runtimes, to ensure the correct behaviour is added or re-used here.

My use-case: I've written a custom runtime, and currently I need to copy/paste all of `Executor` and its supporting classes into my own codebase, which seems a bit redundant when all I really want to change are these 3 lines. Of course this particular setup for `ProcessStartInfo` is not applicable for every custom runtime - but at least it allows `Executor` to be used for those runtimes for which this is applicable.

But of course you'll have a better view of whether this change is a good idea and / or acceptable.