### PR TITLE
Updated CsProj.txt, set CodeAnalysisTreatWarningsAsErrors=false

### DIFF
--- a/src/BenchmarkDotNet/Templates/CsProj.txt
+++ b/src/BenchmarkDotNet/Templates/CsProj.txt
@@ -11,6 +11,8 @@
     <OutputType>Exe</OutputType>
     <OutputPath>bin\$CONFIGURATIONNAME$</OutputPath>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+    <!-- Usage of System.Random can cause compilation errors if Code Analysis warnings are treated as Errors -->
+    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
     <!-- disabled due to https://github.com/dotnet/roslyn/issues/59421 -->
     <DebugSymbols>false</DebugSymbols>
     <UseSharedCompilation>false</UseSharedCompilation>


### PR DESCRIPTION
Auto-generated .CSPROJ file now uses <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors> to avoid failing toolchain compilation if consumer uses global Directory.Build.props has the same flag as true. Related issue #2312