### PR TITLE
Fix building doc specifying .net 4.6.2 as requirement

### DIFF
--- a/docs/articles/contributing/building.md
+++ b/docs/articles/contributing/building.md
@@ -4,7 +4,7 @@ There are two recommended options to build BenchmarkDotNet from source:
 
 ## Visual Studio
 
-- [Visual Studio](https://www.visualstudio.com/downloads/) (Community, Professional, Enterprise) with .NET 4.6.1 SDK and F# support.
+- [Visual Studio](https://www.visualstudio.com/downloads/) (Community, Professional, Enterprise) with .NET 4.6.2 SDK and F# support.
 
 - [.NET 5 SDK](https://dotnet.microsoft.com/download).
 


### PR DESCRIPTION
As I'm following the [building](https://benchmarkdotnet.org/articles/contributing/building.html) documentation to locally build the project, I find out that .net `4.6.2` is required, not `4.6.1`.

This aims to fix that documentation.