### PR TITLE
`AggressiveOptimization` in `InProcess` toolchains

### DIFF
--- a/src/BenchmarkDotNet/Helpers/Reflection.Emit/MethodBuilderExtensions.cs
+++ b/src/BenchmarkDotNet/Helpers/Reflection.Emit/MethodBuilderExtensions.cs
@@ -37,5 +37,14 @@ namespace BenchmarkDotNet.Helpers.Reflection.Emit
 
             return methodBuilder;
         }
+
+        public static MethodBuilder SetAggressiveOptimizationImplementationFlag(this MethodBuilder methodBuilder)
+        {
+            // AggressiveOptimization is not available in netstandard2.0, so just use the value casted to enum.
+            methodBuilder.SetImplementationFlags(
+                methodBuilder.GetMethodImplementationFlags() | (MethodImplAttributes) 512);
+
+            return methodBuilder;
+        }
     }
 }

--- a/src/BenchmarkDotNet/Helpers/Reflection.Emit/MethodBuilderExtensions.cs
+++ b/src/BenchmarkDotNet/Helpers/Reflection.Emit/MethodBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BenchmarkDotNet.Portability;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -40,9 +41,8 @@ namespace BenchmarkDotNet.Helpers.Reflection.Emit
 
         public static MethodBuilder SetAggressiveOptimizationImplementationFlag(this MethodBuilder methodBuilder)
         {
-            // AggressiveOptimization is not available in netstandard2.0, so just use the value casted to enum.
             methodBuilder.SetImplementationFlags(
-                methodBuilder.GetMethodImplementationFlags() | (MethodImplAttributes) 512);
+                methodBuilder.GetMethodImplementationFlags() | CodeGenHelper.AggressiveOptimizationOptionForEmit);
 
             return methodBuilder;
         }

--- a/src/BenchmarkDotNet/Portability/CodeGen.cs
+++ b/src/BenchmarkDotNet/Portability/CodeGen.cs
@@ -1,0 +1,12 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace BenchmarkDotNet.Portability
+{
+    public static class CodeGenHelper
+    {
+        // AggressiveOptimization is not available in netstandard2.0, so just use the value casted to enum.
+        public const MethodImplOptions AggressiveOptimizationOption = (MethodImplOptions) 512;
+        public const MethodImplAttributes AggressiveOptimizationOptionForEmit = (MethodImplAttributes) 512;
+    }
+}

--- a/src/BenchmarkDotNet/Templates/BenchmarkType.txt
+++ b/src/BenchmarkDotNet/Templates/BenchmarkType.txt
@@ -113,9 +113,7 @@
 
         private BenchmarkDotNet.Engines.Consumer consumer = new BenchmarkDotNet.Engines.Consumer();
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -125,9 +123,7 @@
             }
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -137,9 +133,7 @@
             }
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -149,9 +143,7 @@
             }
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -175,9 +167,7 @@
 
 #elif RETURNS_NON_CONSUMABLE_STRUCT_$ID$
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -189,9 +179,7 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(result);
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -203,9 +191,7 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(result);
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -217,9 +203,7 @@
             NonGenericKeepAliveWithoutBoxing(result);
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -250,9 +234,7 @@
 
 #elif RETURNS_BYREF_$ID$
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -264,9 +246,7 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(value);
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -280,9 +260,7 @@
 
         private $WorkloadMethodReturnType$ workloadDefaultValueHolder = default($WorkloadMethodReturnType$);
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -294,9 +272,7 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(ref alias);
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -321,9 +297,7 @@
         }
 #elif RETURNS_BYREF_READONLY_$ID$
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -335,9 +309,7 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(value);
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -351,9 +323,7 @@
 
         private $WorkloadMethodReturnType$ workloadDefaultValueHolder = default($WorkloadMethodReturnType$);
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -365,9 +335,7 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxingReadonly(alias);
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -392,9 +360,7 @@
         }
 #elif RETURNS_VOID_$ID$
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -404,9 +370,7 @@
             }
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -416,9 +380,7 @@
             }
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -428,9 +390,7 @@
             }
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
-#endif
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$

--- a/src/BenchmarkDotNet/Templates/BenchmarkType.txt
+++ b/src/BenchmarkDotNet/Templates/BenchmarkType.txt
@@ -113,7 +113,7 @@
 
         private BenchmarkDotNet.Engines.Consumer consumer = new BenchmarkDotNet.Engines.Consumer();
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -123,7 +123,7 @@
             }
         }
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -133,7 +133,7 @@
             }
         }
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -143,7 +143,7 @@
             }
         }
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -167,7 +167,7 @@
 
 #elif RETURNS_NON_CONSUMABLE_STRUCT_$ID$
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -179,7 +179,7 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(result);
         }
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -191,7 +191,7 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(result);
         }
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -203,7 +203,7 @@
             NonGenericKeepAliveWithoutBoxing(result);
         }
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -234,7 +234,7 @@
 
 #elif RETURNS_BYREF_$ID$
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -246,7 +246,7 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(value);
         }
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -260,7 +260,7 @@
 
         private $WorkloadMethodReturnType$ workloadDefaultValueHolder = default($WorkloadMethodReturnType$);
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -272,7 +272,7 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(ref alias);
         }
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -297,7 +297,7 @@
         }
 #elif RETURNS_BYREF_READONLY_$ID$
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -309,7 +309,7 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxing(value);
         }
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -323,7 +323,7 @@
 
         private $WorkloadMethodReturnType$ workloadDefaultValueHolder = default($WorkloadMethodReturnType$);
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -335,7 +335,7 @@
             BenchmarkDotNet.Engines.DeadCodeEliminationHelper.KeepAliveWithoutBoxingReadonly(alias);
         }
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -360,7 +360,7 @@
         }
 #elif RETURNS_VOID_$ID$
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void OverheadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -370,7 +370,7 @@
             }
         }
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void OverheadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -380,7 +380,7 @@
             }
         }
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void WorkloadActionUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$
@@ -390,7 +390,7 @@
             }
         }
 
-        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.AggressiveOptimization)]
+        [System.Runtime.CompilerServices.MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
         private void WorkloadActionNoUnroll(System.Int64 invokeCount)
         {
             $LoadArguments$

--- a/src/BenchmarkDotNet/Toolchains/InProcess/Emit/Implementation/Emitters/RunnableEmitter.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/Emit/Implementation/Emitters/RunnableEmitter.cs
@@ -654,13 +654,14 @@ namespace BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation
             }
 
             // .method private hidebysig
-            //    instance void OverheadActionUnroll(int64 invokeCount) cil managed
+            //    instance void OverheadActionUnroll(int64 invokeCount) cil managed aggressiveoptimization
             var toArg = new EmitParameterInfo(0, InvokeCountParamName, typeof(long));
             var actionMethodBuilder = runnableBuilder.DefineNonVirtualInstanceMethod(
                 methodName,
                 MethodAttributes.Private,
                 EmitParameterInfo.CreateReturnVoidParameter(),
-                toArg);
+                toArg)
+                .SetAggressiveOptimizationImplementationFlag();
             toArg.SetMember(actionMethodBuilder);
 
             // Emit impl

--- a/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/BenchmarkAction.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/BenchmarkAction.cs
@@ -14,7 +14,8 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
 
         /// <summary>Gets or sets invoke multiple times callback.</summary>
         /// <value>Invoke multiple times callback.</value>
-        public Action<long> InvokeMultiple { get; protected set; }
+        public Action<long> InvokeUnroll { get; protected set; }
+        public Action<long> InvokeNoUnroll{ get; protected set; }
 
         /// <summary>Gets the last run result.</summary>
         /// <value>The last run result.</value>

--- a/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/BenchmarkActionFactory_Implementations.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/BenchmarkActionFactory_Implementations.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BenchmarkDotNet.Portability;
+using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -15,9 +16,6 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
     /// <summary>Helper class that creates <see cref="BenchmarkAction"/> instances. </summary>
     public static partial class BenchmarkActionFactory
     {
-        // Not available in netstandard2.0, so just use the value casted to enum.
-        public const MethodImplOptions AggressiveOptimization = (MethodImplOptions) 512;
-
         internal class BenchmarkActionVoid : BenchmarkActionBase
         {
             private readonly Action callback;
@@ -36,14 +34,14 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
             private static void OverheadStatic() { }
             private void OverheadInstance() { }
 
-            [MethodImpl(AggressiveOptimization)]
+            [MethodImpl(CodeGenHelper.AggressiveOptimizationOption)]
             private void WorkloadActionUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
                     unrolledCallback();
             }
 
-            [MethodImpl(AggressiveOptimization)]
+            [MethodImpl(CodeGenHelper.AggressiveOptimizationOption)]
             private void WorkloadActionNoUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
@@ -72,14 +70,14 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
 
             private void InvokeSingleHardcoded() => result = callback();
 
-            [MethodImpl(AggressiveOptimization)]
+            [MethodImpl(CodeGenHelper.AggressiveOptimizationOption)]
             private void WorkloadActionUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
                     result = unrolledCallback();
             }
 
-            [MethodImpl(AggressiveOptimization)]
+            [MethodImpl(CodeGenHelper.AggressiveOptimizationOption)]
             private void WorkloadActionNoUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
@@ -122,14 +120,14 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
             // must be kept in sync with TaskDeclarationsProvider.TargetMethodDelegate
             private void ExecuteBlocking() => startTaskCallback.Invoke().GetAwaiter().GetResult();
 
-            [MethodImpl(AggressiveOptimization)]
+            [MethodImpl(CodeGenHelper.AggressiveOptimizationOption)]
             private void WorkloadActionUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
                     unrolledCallback();
             }
 
-            [MethodImpl(AggressiveOptimization)]
+            [MethodImpl(CodeGenHelper.AggressiveOptimizationOption)]
             private void WorkloadActionNoUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
@@ -171,14 +169,14 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
 
             private void InvokeSingleHardcoded() => result = callback();
 
-            [MethodImpl(AggressiveOptimization)]
+            [MethodImpl(CodeGenHelper.AggressiveOptimizationOption)]
             private void WorkloadActionUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
                     result = unrolledCallback();
             }
 
-            [MethodImpl(AggressiveOptimization)]
+            [MethodImpl(CodeGenHelper.AggressiveOptimizationOption)]
             private void WorkloadActionNoUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
@@ -223,14 +221,14 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
 
             private void InvokeSingleHardcoded() => result = callback();
 
-            [MethodImpl(AggressiveOptimization)]
+            [MethodImpl(CodeGenHelper.AggressiveOptimizationOption)]
             private void WorkloadActionUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
                     result = unrolledCallback();
             }
 
-            [MethodImpl(AggressiveOptimization)]
+            [MethodImpl(CodeGenHelper.AggressiveOptimizationOption)]
             private void WorkloadActionNoUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)

--- a/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/BenchmarkActionFactory_Implementations.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/BenchmarkActionFactory_Implementations.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
@@ -14,6 +15,9 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
     /// <summary>Helper class that creates <see cref="BenchmarkAction"/> instances. </summary>
     public static partial class BenchmarkActionFactory
     {
+        // Not available in netstandard2.0, so just use the value casted to enum.
+        public const MethodImplOptions AggressiveOptimization = (MethodImplOptions) 512;
+
         internal class BenchmarkActionVoid : BenchmarkActionBase
         {
             private readonly Action callback;
@@ -25,16 +29,25 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
                 InvokeSingle = callback;
 
                 unrolledCallback = Unroll(callback, unrollFactor);
-                InvokeMultiple = InvokeMultipleHardcoded;
+                InvokeUnroll = WorkloadActionUnroll;
+                InvokeNoUnroll = WorkloadActionNoUnroll;
             }
 
             private static void OverheadStatic() { }
             private void OverheadInstance() { }
 
-            private void InvokeMultipleHardcoded(long repeatCount)
+            [MethodImpl(AggressiveOptimization)]
+            private void WorkloadActionUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
                     unrolledCallback();
+            }
+
+            [MethodImpl(AggressiveOptimization)]
+            private void WorkloadActionNoUnroll(long repeatCount)
+            {
+                for (long i = 0; i < repeatCount; i++)
+                    callback();
             }
         }
 
@@ -50,7 +63,8 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
                 InvokeSingle = InvokeSingleHardcoded;
 
                 unrolledCallback = Unroll(callback, unrollFactor);
-                InvokeMultiple = InvokeMultipleHardcoded;
+                InvokeUnroll = WorkloadActionUnroll;
+                InvokeNoUnroll = WorkloadActionNoUnroll;
             }
 
             private static T OverheadStatic() => default;
@@ -58,10 +72,18 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
 
             private void InvokeSingleHardcoded() => result = callback();
 
-            private void InvokeMultipleHardcoded(long repeatCount)
+            [MethodImpl(AggressiveOptimization)]
+            private void WorkloadActionUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
                     result = unrolledCallback();
+            }
+
+            [MethodImpl(AggressiveOptimization)]
+            private void WorkloadActionNoUnroll(long repeatCount)
+            {
+                for (long i = 0; i < repeatCount; i++)
+                    result = callback();
             }
 
             public override object LastRunResult => result;
@@ -89,7 +111,8 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
                 InvokeSingle = callback;
 
                 unrolledCallback = Unroll(callback, unrollFactor);
-                InvokeMultiple = InvokeMultipleHardcoded;
+                InvokeUnroll = WorkloadActionUnroll;
+                InvokeNoUnroll = WorkloadActionNoUnroll;
 
             }
 
@@ -99,10 +122,18 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
             // must be kept in sync with TaskDeclarationsProvider.TargetMethodDelegate
             private void ExecuteBlocking() => startTaskCallback.Invoke().GetAwaiter().GetResult();
 
-            private void InvokeMultipleHardcoded(long repeatCount)
+            [MethodImpl(AggressiveOptimization)]
+            private void WorkloadActionUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
                     unrolledCallback();
+            }
+
+            [MethodImpl(AggressiveOptimization)]
+            private void WorkloadActionNoUnroll(long repeatCount)
+            {
+                for (long i = 0; i < repeatCount; i++)
+                    callback();
             }
         }
 
@@ -129,7 +160,8 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
                 InvokeSingle = InvokeSingleHardcoded;
 
                 unrolledCallback = Unroll(callback, unrollFactor);
-                InvokeMultiple = InvokeMultipleHardcoded;
+                InvokeUnroll = WorkloadActionUnroll;
+                InvokeNoUnroll = WorkloadActionNoUnroll;
             }
 
             private T Overhead() => default;
@@ -139,10 +171,18 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
 
             private void InvokeSingleHardcoded() => result = callback();
 
-            private void InvokeMultipleHardcoded(long repeatCount)
+            [MethodImpl(AggressiveOptimization)]
+            private void WorkloadActionUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
                     result = unrolledCallback();
+            }
+
+            [MethodImpl(AggressiveOptimization)]
+            private void WorkloadActionNoUnroll(long repeatCount)
+            {
+                for (long i = 0; i < repeatCount; i++)
+                    result = callback();
             }
 
             public override object LastRunResult => result;
@@ -172,7 +212,8 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
 
 
                 unrolledCallback = Unroll(callback, unrollFactor);
-                InvokeMultiple = InvokeMultipleHardcoded;
+                InvokeUnroll = WorkloadActionUnroll;
+                InvokeNoUnroll = WorkloadActionNoUnroll;
             }
 
             private T Overhead() => default;
@@ -182,10 +223,18 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
 
             private void InvokeSingleHardcoded() => result = callback();
 
-            private void InvokeMultipleHardcoded(long repeatCount)
+            [MethodImpl(AggressiveOptimization)]
+            private void WorkloadActionUnroll(long repeatCount)
             {
                 for (long i = 0; i < repeatCount; i++)
                     result = unrolledCallback();
+            }
+
+            [MethodImpl(AggressiveOptimization)]
+            private void WorkloadActionNoUnroll(long repeatCount)
+            {
+                for (long i = 0; i < repeatCount; i++)
+                    result = callback();
             }
 
             public override object LastRunResult => result;

--- a/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitRunner.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitRunner.cs
@@ -129,21 +129,13 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
                 var engineParameters = new EngineParameters
                 {
                     Host = host,
-                    WorkloadActionNoUnroll = invocationCount =>
-                    {
-                        for (int i = 0; i < invocationCount; i++)
-                            workloadAction.InvokeSingle();
-                    },
-                    WorkloadActionUnroll = workloadAction.InvokeMultiple,
+                    WorkloadActionNoUnroll = workloadAction.InvokeNoUnroll,
+                    WorkloadActionUnroll = workloadAction.InvokeUnroll,
                     Dummy1Action = dummy1.InvokeSingle,
                     Dummy2Action = dummy2.InvokeSingle,
                     Dummy3Action = dummy3.InvokeSingle,
-                    OverheadActionNoUnroll = invocationCount =>
-                    {
-                        for (int i = 0; i < invocationCount; i++)
-                            overheadAction.InvokeSingle();
-                    },
-                    OverheadActionUnroll = overheadAction.InvokeMultiple,
+                    OverheadActionNoUnroll = overheadAction.InvokeNoUnroll,
+                    OverheadActionUnroll = overheadAction.InvokeUnroll,
                     GlobalSetupAction = globalSetupAction.InvokeSingle,
                     GlobalCleanupAction = globalCleanupAction.InvokeSingle,
                     IterationSetupAction = iterationSetupAction.InvokeSingle,

--- a/tests/BenchmarkDotNet.IntegrationTests/InProcessTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/InProcessTest.cs
@@ -157,18 +157,18 @@ namespace BenchmarkDotNet.IntegrationTests
                 {
                     benchmarkAction.InvokeSingle();
                     Assert.Equal(0, BenchmarkAllCases.Counter);
-                    benchmarkAction.InvokeMultiple(0);
+                    benchmarkAction.InvokeUnroll(0);
                     Assert.Equal(0, BenchmarkAllCases.Counter);
-                    benchmarkAction.InvokeMultiple(11);
+                    benchmarkAction.InvokeUnroll(11);
                     Assert.Equal(0, BenchmarkAllCases.Counter);
                 }
                 else
                 {
                     benchmarkAction.InvokeSingle();
                     Assert.Equal(1, BenchmarkAllCases.Counter);
-                    benchmarkAction.InvokeMultiple(0);
+                    benchmarkAction.InvokeUnroll(0);
                     Assert.Equal(1, BenchmarkAllCases.Counter);
-                    benchmarkAction.InvokeMultiple(11);
+                    benchmarkAction.InvokeUnroll(11);
                     Assert.Equal(BenchmarkAllCases.Counter, 1 + unrollFactor * 11);
                 }
 


### PR DESCRIPTION
Follow-up to #1935, fixes #1934 for in-process toolchains.