### PR TITLE
Improve templates

### DIFF
--- a/docs/articles/guides/dotnet-new-templates.md
+++ b/docs/articles/guides/dotnet-new-templates.md
@@ -44,10 +44,10 @@ dotnet new benchmark -lang VB
 The template projects has five additional options - all of them are optional.
 
 By default a class library project targeting `netstandard2.0` is created.
-You can specify `-f` or `--frameworks` to change targeting to one or more frameworks:
+You can specify `-f` or `--framework` to change the target framework:
 
 ```log
-dotnet new benchmark -f netstandard2.0;net472
+dotnet new benchmark -f net472
 ```
 
 The option `--console-app` creates a console app project targeting `netcoreapp3.0` with an entry point:
@@ -57,7 +57,6 @@ dotnet new benchmark --console-app
 ```
 
 This lets you run the benchmarks from console (`dotnet run`) or from your favorite IDE.
-**Note:** option `-f` or `--frameworks` will be ignored when `--console-app` is set.
 
 The option `-b` or `--benchmarkName` sets the name of the benchmark class:
 

--- a/docs/articles/guides/dotnet-new-templates.md
+++ b/docs/articles/guides/dotnet-new-templates.md
@@ -43,20 +43,20 @@ dotnet new benchmark -lang VB
 
 The template projects has five additional options - all of them are optional.
 
-By default a class library project targeting `netstandard2.0` is created.
-You can specify `-f` or `--framework` to change the target framework:
+By default a console app project targeting `net6.0` is created.
+This lets you run the benchmarks from console (`dotnet run`) or from your favorite IDE.  
+
+The option `-f` or `--framework` changes the target framework:
 
 ```log
 dotnet new benchmark -f net472
 ```
 
-The option `--console-app` creates a console app project targeting `netcoreapp3.0` with an entry point:
+You can specify `--console-app=false` to create a class library project targeting `netstandard2.0` by default:
 
 ```log
-dotnet new benchmark --console-app
+dotnet new benchmark --console-app=false
 ```
-
-This lets you run the benchmarks from console (`dotnet run`) or from your favorite IDE.
 
 The option `-b` or `--benchmarkName` sets the name of the benchmark class:
 

--- a/docs/articles/guides/dotnet-new-templates.md
+++ b/docs/articles/guides/dotnet-new-templates.md
@@ -5,7 +5,7 @@ name: BenchmarkDotNet templates
 
 # BenchmarkDotNet templates
 
-BenchmarkDotNet provides project templates to setup your benchmarks easily 
+BenchmarkDotNet provides project templates to setup your benchmarks easily.  
 The template exists for each major .NET language ([C#](https://learn.microsoft.com/dotnet/csharp/), [F#](https://learn.microsoft.com/dotnet/fsharp/) and [VB](https://learn.microsoft.com/dotnet/visual-basic/)) with equivalent features and structure.
 
 ## How to install the templates
@@ -43,7 +43,7 @@ dotnet new benchmark -lang VB
 
 The template projects has five additional options - all of them are optional.
 
-By default a class library project targeting netstandard2.0 is created.
+By default a class library project targeting `netstandard2.0` is created.
 You can specify `-f` or `--frameworks` to change targeting to one or more frameworks:
 
 ```log

--- a/templates/install-from-source.bat
+++ b/templates/install-from-source.bat
@@ -1,4 +1,14 @@
-dotnet build -c Release BenchmarkDotNet.Templates.csproj
-dotnet pack -c Release BenchmarkDotNet.Templates.csproj
-dotnet new -u BenchmarkDotNet.Templates
-dotnet new -i BenchmarkDotNet.Templates::0.0.0-* --nuget-source .\bin\Release\
+:: Run only from the folder where the batch file is located!
+
+dotnet build BenchmarkDotNet.Templates.csproj -c Release
+dotnet pack BenchmarkDotNet.Templates.csproj -c Release
+
+:: If we install the templates via a folder path, then it will have a different ID (ID=folder path).
+:: It will conflict with BDN templates from nuget.
+:: We need to install the templates via a FILE path in order to update the template from nuget.
+::
+:: https://stackoverflow.com/questions/47450531/batch-write-output-of-dir-to-a-variable
+for /f "delims=" %%a in ('dir /s /b BenchmarkDotNet.Templates*.nupkg') do set "nupkg_path=%%a"
+
+dotnet new --uninstall "BenchmarkDotNet.Templates"
+dotnet new --install "%nupkg_path%"

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json
@@ -138,7 +138,7 @@
       "type": "parameter",
       "datatype": "bool",
       "description": "If specified, the project is set up as console app.",
-      "defaultValue": "false"
+      "defaultValue": "true"
     },
     "version": {
       "type": "parameter",

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json
@@ -31,8 +31,54 @@
     },
     "framework": {
       "type": "parameter",
-      "datatype": "string",
-      "description": "The target framework for the project (e.g. netstandard2.0). Default \"net5.0\" if \"--console-app\" is true, \"netstandard2.0\" if \"--console-app\" is false",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net8.0",
+          "description": ".NET 8"
+        },
+        {
+          "choice": "net7.0",
+          "description": ".NET 7"
+        },
+        {
+          "choice": "net6.0",
+          "description": ".NET 6"
+        },
+        {
+          "choice": "netstandard2.1",
+          "description": ".NET Standard 2.1"
+        },
+        {
+          "choice": "netstandard2.0",
+          "description": ".NET Standard 2.0"
+        },
+        {
+          "choice": "net481",
+          "description": ".NET Framework 4.8.1"
+        },
+        {
+          "choice": "net48",
+          "description": ".NET Framework 4.8"
+        },
+        {
+          "choice": "net472",
+          "description": ".NET Framework 4.7.2"
+        },
+        {
+          "choice": "net471",
+          "description": ".NET Framework 4.7.1"
+        },
+        {
+          "choice": "net47",
+          "description": ".NET Framework 4.7"
+        },
+        {
+          "choice": "net462",
+          "description": ".NET Framework 4.6.2"
+        }
+      ],
       "defaultValue": ""
     },
     "frameworkDefault": {
@@ -45,7 +91,7 @@
         "cases": [
           {
             "condition": "(framework == '' && consoleApp == true)",
-            "value": "net5.0"
+            "value": "net6.0"
           },
           {
             "condition": "(framework == '' && consoleApp == false)",
@@ -98,7 +144,7 @@
       "type": "parameter",
       "datatype": "string",
       "description": "Version of BenchmarkDotNet that will be referenced.",
-      "defaultValue": "0.12.1",
+      "defaultValue": "0.13.5",
       "replaces": "$(BenchmarkDotNetVersion)"
     }
   },

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/Program.cs
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/Program.cs
@@ -1,3 +1,4 @@
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 
 namespace _BenchmarkProjectName_
@@ -6,7 +7,11 @@ namespace _BenchmarkProjectName_
     {
         public static void Main(string[] args)
         {
-            var summary = BenchmarkRunner.Run<$(BenchmarkName)>();
+            var config = DefaultConfig.Instance;
+            var summary = BenchmarkRunner.Run<$(BenchmarkName)>(config, args);
+
+            // Use this to select benchmarks from the console:
+            // var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
         }
     }
 }

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json
@@ -138,7 +138,7 @@
       "type": "parameter",
       "datatype": "bool",
       "description": "If specified, the project is set up as console app.",
-      "defaultValue": "false"
+      "defaultValue": "true"
     },
     "version": {
       "type": "parameter",

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json
@@ -31,8 +31,54 @@
     },
     "framework": {
       "type": "parameter",
-      "datatype": "string",
-      "description": "The target framework for the project (e.g. netstandard2.0). Default \"net5.0\" if \"--console-app\" is true, \"netstandard2.0\" if \"--console-app\" is false",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net8.0",
+          "description": ".NET 8"
+        },
+        {
+          "choice": "net7.0",
+          "description": ".NET 7"
+        },
+        {
+          "choice": "net6.0",
+          "description": ".NET 6"
+        },
+        {
+          "choice": "netstandard2.1",
+          "description": ".NET Standard 2.1"
+        },
+        {
+          "choice": "netstandard2.0",
+          "description": ".NET Standard 2.0"
+        },
+        {
+          "choice": "net481",
+          "description": ".NET Framework 4.8.1"
+        },
+        {
+          "choice": "net48",
+          "description": ".NET Framework 4.8"
+        },
+        {
+          "choice": "net472",
+          "description": ".NET Framework 4.7.2"
+        },
+        {
+          "choice": "net471",
+          "description": ".NET Framework 4.7.1"
+        },
+        {
+          "choice": "net47",
+          "description": ".NET Framework 4.7"
+        },
+        {
+          "choice": "net462",
+          "description": ".NET Framework 4.6.2"
+        }
+      ],
       "defaultValue": ""
     },
     "frameworkDefault": {
@@ -45,7 +91,7 @@
         "cases": [
           {
             "condition": "(framework == '' && consoleApp == true)",
-            "value": "net5.0"
+            "value": "net6.0"
           },
           {
             "condition": "(framework == '' && consoleApp == false)",
@@ -98,7 +144,7 @@
       "type": "parameter",
       "datatype": "string",
       "description": "Version of BenchmarkDotNet that will be referenced.",
-      "defaultValue": "0.12.1",
+      "defaultValue": "0.13.5",
       "replaces": "$(BenchmarkDotNetVersion)"
     }
   },

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json
@@ -138,7 +138,7 @@
       "type": "parameter",
       "datatype": "bool",
       "description": "If specified, the project is set up as console app.",
-      "defaultValue": "false"
+      "defaultValue": "true"
     },
     "version": {
       "type": "parameter",

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json
@@ -31,8 +31,54 @@
     },
     "framework": {
       "type": "parameter",
-      "datatype": "string",
-      "description": "The target framework for the project (e.g. netstandard2.0). Default \"net5.0\" if \"--console-app\" is true, \"netstandard2.0\" if \"--console-app\" is false",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net8.0",
+          "description": ".NET 8"
+        },
+        {
+          "choice": "net7.0",
+          "description": ".NET 7"
+        },
+        {
+          "choice": "net6.0",
+          "description": ".NET 6"
+        },
+        {
+          "choice": "netstandard2.1",
+          "description": ".NET Standard 2.1"
+        },
+        {
+          "choice": "netstandard2.0",
+          "description": ".NET Standard 2.0"
+        },
+        {
+          "choice": "net481",
+          "description": ".NET Framework 4.8.1"
+        },
+        {
+          "choice": "net48",
+          "description": ".NET Framework 4.8"
+        },
+        {
+          "choice": "net472",
+          "description": ".NET Framework 4.7.2"
+        },
+        {
+          "choice": "net471",
+          "description": ".NET Framework 4.7.1"
+        },
+        {
+          "choice": "net47",
+          "description": ".NET Framework 4.7"
+        },
+        {
+          "choice": "net462",
+          "description": ".NET Framework 4.6.2"
+        }
+      ],
       "defaultValue": ""
     },
     "frameworkDefault": {
@@ -45,7 +91,7 @@
         "cases": [
           {
             "condition": "(framework == '' && consoleApp == true)",
-            "value": "net5.0"
+            "value": "net6.0"
           },
           {
             "condition": "(framework == '' && consoleApp == false)",
@@ -98,7 +144,7 @@
       "type": "parameter",
       "datatype": "string",
       "description": "Version of BenchmarkDotNet that will be referenced.",
-      "defaultValue": "0.12.1",
+      "defaultValue": "0.13.5",
       "replaces": "$(BenchmarkDotNetVersion)"
     }
   },


### PR DESCRIPTION
The `framework` parameter must be of type `choice` (see the discussion with the VS developers below).

Currently:
VS doesn't display the templates at all.
Rider displays it with disabled dropdown but crashes when creating project.
![image](https://github.com/dotnet/BenchmarkDotNet/assets/19392641/f4bc1d27-5f4b-4cb9-9a75-7edb3b8ff3fc)


The `choice` type means that we have to write all the supported frameworks by hand.
I've added all version frameworks, that have not expired end-of-life:


Also we can no longer use platform-specific TFM:
```
dotnet new benchmark -f net7.0-windows
```

But it's ok because `console` use a choice too, so we cannot create platform-specific TFM:
```
dotnet new console -f net7.0-windows
// displays an error
```

More details with screenshots: https://github.com/sayedihashimi/template-sample/issues/73
<details>
<summary>IDE screenshots</summary>

VS:
![image](https://github.com/dotnet/BenchmarkDotNet/assets/19392641/5bffc3fc-d852-4a31-b122-f84820575d44)
![image](https://github.com/dotnet/BenchmarkDotNet/assets/19392641/3f0be082-0104-4497-9770-6a1f318453a1)

Rider:
![image](https://github.com/dotnet/BenchmarkDotNet/assets/19392641/7ab3e04c-5e73-4e04-8fda-e6b191a00c50)
</details>


fix #1881, fix #2149, fix #1658

the PR #1817 can be closed too?
