### PR TITLE
Add the args parameter to RunAll and RunAllJoined

### DIFF
--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -17,7 +17,7 @@
     <EmbeddedResource Include="Environments\microarchitectures.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.4.3" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Gee.External.Capstone" Version="2.3.0" />
     <PackageReference Include="Iced" Version="1.17.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.2.332302" />

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -86,6 +86,31 @@ namespace BenchmarkDotNet.ConsoleArguments
             return result;
         }
 
+        internal static bool TryUpdateArgs(string[]? args, out string[]? updatedArgs, Action<CommandLineOptions> updater)
+        {
+            (bool isSuccess, CommandLineOptions options) result = default;
+
+            ILogger logger = NullLogger.Instance;
+            using (var parser = CreateParser(logger))
+            {
+                parser
+                    .ParseArguments<CommandLineOptions>(args)
+                    .WithParsed(options => result = Validate(options, logger) ? (true, options) : (false, default))
+                    .WithNotParsed(errors => result = (false,  default));
+
+                if (!result.isSuccess)
+                {
+                    updatedArgs = null;
+                    return false;
+                }
+
+                updater(result.options);
+
+                updatedArgs = parser.FormatCommandLine(result.options, settings => settings.SkipDefault = true).Split();
+                return true;
+            }
+        }
+
         private static Parser CreateParser(ILogger logger)
             => new Parser(settings =>
             {

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -86,7 +86,7 @@ namespace BenchmarkDotNet.ConsoleArguments
             return result;
         }
 
-        internal static bool TryUpdateArgs(string[]? args, out string[]? updatedArgs, Action<CommandLineOptions> updater)
+        internal static bool TryUpdateArgs(string[] args, out string[]? updatedArgs, Action<CommandLineOptions> updater)
         {
             (bool isSuccess, CommandLineOptions options) result = default;
 

--- a/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
@@ -55,6 +55,7 @@ namespace BenchmarkDotNet.Running
         /// </summary>
         [PublicAPI] public IEnumerable<Summary> RunAll(IConfig? config = null, string[]? args = null)
         {
+            args ??= Array.Empty<string>();
             if (ConfigParser.TryUpdateArgs(args, out var updatedArgs, options => options.Filters = new[] { "*" }))
                 args = updatedArgs;
 
@@ -66,6 +67,7 @@ namespace BenchmarkDotNet.Running
         /// </summary>
         [PublicAPI] public Summary RunAllJoined(IConfig? config = null, string[]? args = null)
         {
+            args ??= Array.Empty<string>();
             if (ConfigParser.TryUpdateArgs(args, out var updatedArgs, options => (options.Join, options.Filters) = (true, new[] { "*" })))
                 args = updatedArgs;
 

--- a/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
@@ -53,12 +53,24 @@ namespace BenchmarkDotNet.Running
         /// <summary>
         /// Run all available benchmarks.
         /// </summary>
-        [PublicAPI] public IEnumerable<Summary> RunAll(IConfig? config = null) => Run(new[] { "--filter", "*" }, config);
+        [PublicAPI] public IEnumerable<Summary> RunAll(IConfig? config = null, string[]? args = null)
+        {
+            if (ConfigParser.TryUpdateArgs(args, out var updatedArgs, options => options.Filters = new[] { "*" }))
+                args = updatedArgs;
+
+            return Run(args, config);
+        }
 
         /// <summary>
         /// Run all available benchmarks and join them to a single summary
         /// </summary>
-        [PublicAPI] public Summary RunAllJoined(IConfig? config = null) => Run(new[] { "--filter", "*", "--join" }, config).Single();
+        [PublicAPI] public Summary RunAllJoined(IConfig? config = null, string[]? args = null)
+        {
+            if (ConfigParser.TryUpdateArgs(args, out var updatedArgs, options => (options.Join, options.Filters) = (true, new[] { "*" })))
+                args = updatedArgs;
+
+            return Run(args, config).Single();
+        }
 
         [PublicAPI]
         public IEnumerable<Summary> Run(string[]? args = null, IConfig? config = null)

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -586,5 +586,31 @@ namespace BenchmarkDotNet.Tests
                 Assert.False(job.Accuracy.EvaluateOverhead);
             }
         }
+
+        [Theory]
+        [InlineData("--filter abc", "--filter *")]
+        [InlineData("-f abc", "--filter *")]
+        [InlineData("-f *", "--filter *")]
+        [InlineData("--runtime net7.0 --join", "--filter * --runtime net7.0 --join")]
+        [InlineData("--join abc", "--filter * --join")]
+        public void CheckUpdateValidArgs(string strArgs, string expected)
+        {
+            var args = strArgs.Split();
+            _ = ConfigParser.TryUpdateArgs(args, out var updatedArgs, options => options.Filters = new[] { "*" });
+
+            Assert.Equal(expected.Split(), updatedArgs);
+        }
+
+        [Theory]
+        [InlineData("--filter abc -f abc")]
+        [InlineData("--runtimes net")]
+        public void CheckUpdateInvalidArgs(string strArgs)
+        {
+            var args = strArgs.Split();
+            bool isSuccess = ConfigParser.TryUpdateArgs(args, out var updatedArgs, options => options.Filters = new[] { "*" });
+
+            Assert.Null(updatedArgs);
+            Assert.False(isSuccess);
+        }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -591,7 +591,7 @@ namespace BenchmarkDotNet.Tests
         [InlineData("--filter abc", "--filter *")]
         [InlineData("-f abc", "--filter *")]
         [InlineData("-f *", "--filter *")]
-        [InlineData("--runtime net7.0 --join", "--filter * --runtime net7.0 --join")]
+        [InlineData("--runtimes net7.0 --join", "--filter * --join --runtimes net7.0")]
         [InlineData("--join abc", "--filter * --join")]
         public void CheckUpdateValidArgs(string strArgs, string expected)
         {


### PR DESCRIPTION
Only these methods do not contain the `args` parameter.

What order of parameters should be used? (I did not break backward compatibility)
```
BenchmarkSwitcher
    RunAll(IConfig config, string[] args)  NEW
    RunAllJoined(IConfig config, string[] args) NEW
    Run(string[] args, IConfig config)
BenchmarkRunner
    Run<T>(IConfig config, string[] args)
    Run(Type, IConfig config, string[] args)
    Run(Type[], IConfig config, string[] args)
    Run(Assembly, IConfig config, string[] args)
```

I upgrade the library version because we need `settings.SkipDefault = true` (since version 2.7).