### PR TITLE
[wasm] Use `test-main.mjs` for net8 runtimes .

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmExecutor.cs
@@ -55,7 +55,12 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
         private static Process CreateProcess(BenchmarkCase benchmarkCase, ArtifactsPaths artifactsPaths, string args, IResolver resolver)
         {
             WasmRuntime runtime = (WasmRuntime)benchmarkCase.GetRuntime();
-            string mainJs = runtime.RuntimeMoniker < RuntimeMoniker.WasmNet70 ? "main.js" : "test-main.js";
+            string mainJs = runtime.RuntimeMoniker switch
+            {
+                < RuntimeMoniker.WasmNet70 => "main.js",
+                RuntimeMoniker.WasmNet70 => "test-main.js",
+                _ => "test-main.mjs"
+            };
 
             var start = new ProcessStartInfo
             {

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -20,7 +20,12 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
         {
             Aot = aot;
             CustomRuntimePack = customRuntimePack;
-            MainJS = (targetFrameworkMoniker == "net5.0" || targetFrameworkMoniker == "net6.0") ? "main.js" : "test-main.js";
+            MainJS = targetFrameworkMoniker switch
+            {
+                "net5.0" or "net6.0" => "main.js",
+                "net7.0" => "test-main.js",
+                _ => "test-main.mjs"
+            };
         }
 
         protected override void GenerateProject(BuildPartition buildPartition, ArtifactsPaths artifactsPaths, ILogger logger)


### PR DESCRIPTION
TODO: the older `--wasmMainJS` parameter should probably be re-introduced so we don't have to do this for every change in filename.