### PR TITLE
IComparable fallback for Tuple/ValueTuple

### DIFF
--- a/src/BenchmarkDotNet/Parameters/ParameterComparer.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterComparer.cs
@@ -28,7 +28,16 @@ namespace BenchmarkDotNet.Parameters
             if (x != null && y != null && x.GetType() == y.GetType() &&
                 x is IComparable xComparable)
             {
-                return xComparable.CompareTo(y);
+                try
+                {
+                    return xComparable.CompareTo(y);
+                }
+                // Some types, such as Tuple and ValueTuple, have a fallible CompareTo implementation which can throw if the inner items don't implement IComparable.
+                // See: https://github.com/dotnet/BenchmarkDotNet/issues/2346
+                // For now, catch and ignore the exception, and fallback to string comparison below.
+                catch (ArgumentException)
+                {
+                }
             }
 
             // Anything else.

--- a/src/BenchmarkDotNet/Parameters/ParameterComparer.cs
+++ b/src/BenchmarkDotNet/Parameters/ParameterComparer.cs
@@ -35,7 +35,7 @@ namespace BenchmarkDotNet.Parameters
                 // Some types, such as Tuple and ValueTuple, have a fallible CompareTo implementation which can throw if the inner items don't implement IComparable.
                 // See: https://github.com/dotnet/BenchmarkDotNet/issues/2346
                 // For now, catch and ignore the exception, and fallback to string comparison below.
-                catch (ArgumentException)
+                catch (ArgumentException ex) when (ex.Message.Contains("At least one object must implement IComparable."))
                 {
                 }
             }

--- a/tests/BenchmarkDotNet.Tests/ParameterComparerTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ParameterComparerTests.cs
@@ -157,6 +157,70 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(4, ((ComplexParameter)sortedData[3].Items[0].Value).Value);
         }
 
+        [Fact]
+        public void ValueTupleWithNonIComparableInnerTypesComparisionTest()
+        {
+            var comparer = ParameterComparer.Instance;
+            var originalData = new[]
+            {
+                new ParameterInstances(new[]
+                {
+                    new ParameterInstance(sharedDefinition, (new ComplexNonIComparableParameter(), 1), null)
+                }),
+                new ParameterInstances(new[]
+                {
+                    new ParameterInstance(sharedDefinition, (new ComplexNonIComparableParameter(), 3), null)
+                }),
+                new ParameterInstances(new[]
+                {
+                    new ParameterInstance(sharedDefinition, (new ComplexNonIComparableParameter(), 2), null)
+                }),
+                new ParameterInstances(new[]
+                {
+                    new ParameterInstance(sharedDefinition, (new ComplexNonIComparableParameter(), 4), null)
+                })
+            };
+
+            var sortedData = originalData.OrderBy(d => d, comparer).ToArray();
+
+            Assert.Equal(1, (((ComplexNonIComparableParameter, int))sortedData[0].Items[0].Value).Item2);
+            Assert.Equal(2, (((ComplexNonIComparableParameter, int))sortedData[1].Items[0].Value).Item2);
+            Assert.Equal(3, (((ComplexNonIComparableParameter, int))sortedData[2].Items[0].Value).Item2);
+            Assert.Equal(4, (((ComplexNonIComparableParameter, int))sortedData[3].Items[0].Value).Item2);
+        }
+
+        [Fact]
+        public void TupleWithNonIComparableInnerTypesComparisionTest()
+        {
+            var comparer = ParameterComparer.Instance;
+            var originalData = new[]
+            {
+                new ParameterInstances(new[]
+                {
+                    new ParameterInstance(sharedDefinition, Tuple.Create(new ComplexNonIComparableParameter(), 1), null)
+                }),
+                new ParameterInstances(new[]
+                {
+                    new ParameterInstance(sharedDefinition, Tuple.Create(new ComplexNonIComparableParameter(), 3), null)
+                }),
+                new ParameterInstances(new[]
+                {
+                    new ParameterInstance(sharedDefinition, Tuple.Create(new ComplexNonIComparableParameter(), 2), null)
+                }),
+                new ParameterInstances(new[]
+                {
+                    new ParameterInstance(sharedDefinition, Tuple.Create(new ComplexNonIComparableParameter(), 4), null)
+                })
+            };
+
+            var sortedData = originalData.OrderBy(d => d, comparer).ToArray();
+
+            Assert.Equal(1, ((Tuple<ComplexNonIComparableParameter, int>)sortedData[0].Items[0].Value).Item2);
+            Assert.Equal(2, ((Tuple<ComplexNonIComparableParameter, int>)sortedData[1].Items[0].Value).Item2);
+            Assert.Equal(3, ((Tuple<ComplexNonIComparableParameter, int>)sortedData[2].Items[0].Value).Item2);
+            Assert.Equal(4, ((Tuple<ComplexNonIComparableParameter, int>)sortedData[3].Items[0].Value).Item2);
+        }
+
         private class ComplexParameter : IComparable<ComplexParameter>, IComparable
         {
             public ComplexParameter(int value, string name)
@@ -198,6 +262,10 @@ namespace BenchmarkDotNet.Tests
 
                 return CompareTo(other);
             }
+        }
+
+        private class ComplexNonIComparableParameter
+        {
         }
     }
 }


### PR DESCRIPTION
Currently, I'm doing a specific check for the particular exception that occurs in the linked issue (there's no better way currently for the reasons discussed in the issue). We could also just catch any exception in `CompareTo` as an alternative.

Closes #2346 