### PR TITLE
[chore]: fix error message

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/Toolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/Toolchain.cs
@@ -64,7 +64,7 @@ namespace BenchmarkDotNet.Toolchains
             if (string.IsNullOrEmpty(customDotNetCliPath) && !HostEnvironmentInfo.GetCurrent().IsDotNetCliInstalled())
             {
                 validationError = new ValidationError(true,
-                    $"BenchmarkDotNet requires dotnet sdk to be installed or path to local dotnet cli provided in explicit way using `--cli` argument, benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
+                    $"BenchmarkDotNet requires dotnet SDK to be installed or path to local dotnet cli provided in explicit way using `--cli` argument, benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
                     benchmarkCase);
 
                 return true;

--- a/src/BenchmarkDotNet/Toolchains/Toolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/Toolchain.cs
@@ -64,7 +64,7 @@ namespace BenchmarkDotNet.Toolchains
             if (string.IsNullOrEmpty(customDotNetCliPath) && !HostEnvironmentInfo.GetCurrent().IsDotNetCliInstalled())
             {
                 validationError = new ValidationError(true,
-                    $"BenchmarkDotNet requires dotnet cli to be installed or path to local dotnet cli provided in explicit way using `--cli` argument, benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
+                    $"BenchmarkDotNet requires dotnet sdk to be installed or path to local dotnet cli provided in explicit way using `--cli` argument, benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
                     benchmarkCase);
 
                 return true;


### PR DESCRIPTION
Fixes #2378

Changed validation error message from:

```text 
"BenchmarkDotNet requires dotnet cli to be installed"
```

to

```text
"BenchmarkDotNet requires dotnet sdk to be installed"
```

