### PR TITLE
Support `--cli` argument for `CsProjClassicNetToolchain`

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -518,7 +518,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 case RuntimeMoniker.Net481:
                     return baseJob
                         .WithRuntime(runtimeMoniker.GetRuntime())
-                        .WithToolchain(CsProjClassicNetToolchain.From(runtimeId, options.RestorePath?.FullName));
+                        .WithToolchain(CsProjClassicNetToolchain.From(runtimeId, options.RestorePath?.FullName, options.CliPath?.FullName));
 
                 case RuntimeMoniker.NetCoreApp20:
                 case RuntimeMoniker.NetCoreApp21:

--- a/src/BenchmarkDotNet/Diagnosers/PerfCollectProfiler.cs
+++ b/src/BenchmarkDotNet/Diagnosers/PerfCollectProfiler.cs
@@ -196,6 +196,7 @@ namespace BenchmarkDotNet.Diagnosers
         {
             string cliPath = parameters.BenchmarkCase.GetToolchain() switch
             {
+                CsProjClassicNetToolchain classic => classic.CustomDotNetCliPath,
                 CsProjCoreToolchain core => core.CustomDotNetCliPath,
                 CoreRunToolchain coreRun => coreRun.CustomDotNetCliPath.FullName,
                 NativeAotToolchain nativeAot => nativeAot.CustomDotNetCliPath,

--- a/src/BenchmarkDotNet/Diagnosers/PerfCollectProfiler.cs
+++ b/src/BenchmarkDotNet/Diagnosers/PerfCollectProfiler.cs
@@ -196,7 +196,6 @@ namespace BenchmarkDotNet.Diagnosers
         {
             string cliPath = parameters.BenchmarkCase.GetToolchain() switch
             {
-                CsProjClassicNetToolchain classic => classic.CustomDotNetCliPath,
                 CsProjCoreToolchain core => core.CustomDotNetCliPath,
                 CoreRunToolchain coreRun => coreRun.CustomDotNetCliPath.FullName,
                 NativeAotToolchain nativeAot => nativeAot.CustomDotNetCliPath,

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjClassicNetToolchain.cs
@@ -23,16 +23,19 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         [PublicAPI] public static readonly IToolchain Net48 = new CsProjClassicNetToolchain("net48", ".NET Framework 4.8");
         [PublicAPI] public static readonly IToolchain Net481 = new CsProjClassicNetToolchain("net481", ".NET Framework 4.8.1");
 
-        private CsProjClassicNetToolchain(string targetFrameworkMoniker, string name, string packagesPath = null)
+        internal string CustomDotNetCliPath { get; }
+
+        private CsProjClassicNetToolchain(string targetFrameworkMoniker, string name, string packagesPath = null, string customDotNetCliPath = null)
             : base(name,
-                new CsProjGenerator(targetFrameworkMoniker, cliPath: null, packagesPath: packagesPath, runtimeFrameworkVersion: null, isNetCore: false),
-                new DotNetCliBuilder(targetFrameworkMoniker, customDotNetCliPath: null),
+                new CsProjGenerator(targetFrameworkMoniker, customDotNetCliPath, packagesPath, runtimeFrameworkVersion: null, isNetCore: false),
+                new DotNetCliBuilder(targetFrameworkMoniker, customDotNetCliPath),
                 new Executor())
         {
+            CustomDotNetCliPath = customDotNetCliPath;
         }
 
-        public static IToolchain From(string targetFrameworkMoniker, string packagesPath = null)
-            => new CsProjClassicNetToolchain(targetFrameworkMoniker, targetFrameworkMoniker, packagesPath);
+        public static IToolchain From(string targetFrameworkMoniker, string packagesPath = null, string customDotNetCliPath = null)
+            => new CsProjClassicNetToolchain(targetFrameworkMoniker, targetFrameworkMoniker, packagesPath, customDotNetCliPath);
 
         public override IEnumerable<ValidationError> Validate(BenchmarkCase benchmarkCase, IResolver resolver)
         {
@@ -47,7 +50,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
                     $"Classic .NET toolchain is supported only for Windows, benchmark '{benchmarkCase.DisplayInfo}' will not be executed",
                     benchmarkCase);
             }
-            else if (IsCliPathInvalid(customDotNetCliPath: null, benchmarkCase, out var invalidCliError))
+            else if (IsCliPathInvalid(CustomDotNetCliPath, benchmarkCase, out var invalidCliError))
             {
                 yield return invalidCliError;
             }


### PR DESCRIPTION
For consistency with the validation error message when dotnet SDK is not installed in the default location.