### PR TITLE
perfcollect: don't restore symbols for local builds

### DIFF
--- a/src/BenchmarkDotNet/Diagnosers/PerfCollectProfiler.cs
+++ b/src/BenchmarkDotNet/Diagnosers/PerfCollectProfiler.cs
@@ -194,10 +194,14 @@ namespace BenchmarkDotNet.Diagnosers
 
         private void EnsureSymbolsForNativeRuntime(DiagnoserActionParameters parameters)
         {
+            if (parameters.BenchmarkCase.GetToolchain() is CoreRunToolchain)
+            {
+                return; // it's not needed for a local build of dotnet runtime
+            }
+
             string cliPath = parameters.BenchmarkCase.GetToolchain() switch
             {
                 CsProjCoreToolchain core => core.CustomDotNetCliPath,
-                CoreRunToolchain coreRun => coreRun.CustomDotNetCliPath.FullName,
                 NativeAotToolchain nativeAot => nativeAot.CustomDotNetCliPath,
                 _ => DotNetCliCommandExecutor.DefaultDotNetCliPath.Value
             };


### PR DESCRIPTION
```cmd
sudo dotnet run -c Release -f net7.0 --filter '*perfcollect*' --corerun ~/projects/runtime/artifacts/bin/testhost/net8.0-linux-Release-x64/shared/Microsoft.NETCore.App/8.0.0/corerun
```

![image](https://github.com/dotnet/BenchmarkDotNet/assets/6011991/20f806a3-d29e-4c4d-a05d-c16c7f67c07b)



fixes #2382