### PR TITLE
Fix missing import on Debug build

### DIFF
--- a/src/BenchmarkDotNet/Reports/Measurement.cs
+++ b/src/BenchmarkDotNet/Reports/Measurement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;


### PR DESCRIPTION
A recent change removed this import which is only used on debug builds, this PR adds the import back.