### PR TITLE
Fix PlatformNotSupportedException thrown on Android in ConsoleTitler

### DIFF
--- a/samples/BenchmarkDotNet.Samples.Forms/BenchmarkDotNet.Samples.Forms.csproj
+++ b/samples/BenchmarkDotNet.Samples.Forms/BenchmarkDotNet.Samples.Forms.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.530" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.2" />
   </ItemGroup>

--- a/src/BenchmarkDotNet/Running/ConsoleTitler.cs
+++ b/src/BenchmarkDotNet/Running/ConsoleTitler.cs
@@ -20,10 +20,17 @@ namespace BenchmarkDotNet.Running
 
         public ConsoleTitler(string initialTitle)
         {
-            // Return without enabling if Console output is redirected.
-            if (Console.IsOutputRedirected)
+            try
             {
-                return;
+                // Return without enabling if Console output is redirected.
+                if (Console.IsOutputRedirected)
+                {
+                    return;
+                }
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // Ignore the exception. Some platforms do not support Console.IsOutputRedirected.
             }
 
             try


### PR DESCRIPTION
Previously on the Android platform, and possibly other platforms, the ConsoleTitler threw a PlatformNotSupportedException when checking if console output is redirected and prevented benchmarks from running. This is fixed by catching and ignoring the PlatformNotSupportedException. The try-catch around Console.Title is still used to determine if the platform supports console retitling. This seemed more appropriate in the event that the platform doesn't support checking if output is redirected but supports retitling, even though it is unlikely.

Additionally removes the Forms sample project's Immutable package reference. BenchmarkDotNet has a dependency on Immutable 5.0.0 and this reference was causing package downgrade warnings that were treated as errors:

```
error NU1605: Warning As Error: Detected package downgrade: System.Collections.Immutable from 5.0.0 to 1.7.0. Reference the package directly from the project to select a different version.
error NU1605:  BenchmarkDotNet.Samples.Forms -> BenchmarkDotNet -> Microsoft.Diagnostics.Runtime 2.2.332302 -> System.Collections.Immutable (>= 5.0.0)
error NU1605:  BenchmarkDotNet.Samples.Forms -> System.Collections.Immutable (>= 1.7.0)
error NU1605: Warning As Error: Detected package downgrade: System.Collections.Immutable from 5.0.0 to 1.7.0. Reference the package directly from the project to select a different version.
error NU1605:  BenchmarkDotNet.Samples.Forms -> BenchmarkDotNet -> Microsoft.CodeAnalysis.CSharp 4.1.0 -> Microsoft.CodeAnalysis.Common 4.1.0 -> System.Collections.Immutable (>= 5.0.0)
error NU1605:  BenchmarkDotNet.Samples.Forms -> System.Collections.Immutable (>= 1.7.0)
```

Fixes #2389 