### PR TITLE
Issue2394 multiple markdown exporters not possible even with different names

### DIFF
--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using BenchmarkDotNet.Analysers;
+﻿using BenchmarkDotNet.Analysers;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
@@ -9,6 +6,9 @@ using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Validators;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 
 namespace BenchmarkDotNet.Configs
 {
@@ -109,28 +109,28 @@ namespace BenchmarkDotNet.Configs
                 configAnalyse.Add(conclusion);
             }
 
-            var mergeDictionary = new Dictionary<System.Type, IExporter>();
+            var mergeDictionary = new Dictionary<string, IExporter>();
 
             foreach (var exporter in exporters)
             {
-                var exporterType = exporter.GetType();
-                if (mergeDictionary.ContainsKey(exporterType))
+                var exporterName = exporter.Name;
+                if (mergeDictionary.ContainsKey(exporterName))
                 {
-                    AddWarning($"The exporter {exporterType} is already present in configuration. There may be unexpected results.");
+                    AddWarning($"The exporter {exporterName} is already present in configuration. There may be unexpected results.");
                 }
-                mergeDictionary[exporterType] = exporter;
+                mergeDictionary[exporterName] = exporter;
             }
 
 
             foreach (var diagnoser in uniqueDiagnosers)
                 foreach (var exporter in diagnoser.Exporters)
                 {
-                    var exporterType = exporter.GetType();
-                    if (mergeDictionary.ContainsKey(exporterType))
+                    var exporterName = exporter.Name;
+                    if (mergeDictionary.ContainsKey(exporterName))
                     {
-                        AddWarning($"The exporter {exporterType} of {diagnoser.GetType().Name} is already present in configuration. There may be unexpected results.");
+                        AddWarning($"The exporter {exporterName} of {diagnoser.GetType().Name} is already present in configuration. There may be unexpected results.");
                     }
-                    mergeDictionary[exporterType] = exporter;
+                    mergeDictionary[exporterName] = exporter;
                 }
 
             var result = mergeDictionary.Values.ToList();
@@ -143,7 +143,7 @@ namespace BenchmarkDotNet.Configs
             if (hardwareCounterDiagnoser != default(IHardwareCountersDiagnoser) && disassemblyDiagnoser != default(DisassemblyDiagnoser))
                 result.Add(new InstructionPointerExporter(hardwareCounterDiagnoser, disassemblyDiagnoser));
 
-            for (int i = result.Count - 1; i >=0; i--)
+            for (int i = result.Count - 1; i >= 0; i--)
                 if (result[i] is IExporterDependencies exporterDependencies)
                     foreach (var dependency in exporterDependencies.Dependencies)
                         /*
@@ -165,7 +165,7 @@ namespace BenchmarkDotNet.Configs
                          *  "The CsvMeasurementsExporter is already present in the configuration. There may be unexpected results of RPlotExporter.
                          *
                          */
-                        if (!result.Any(exporter=> exporter.GetType() == dependency.GetType()))
+                        if (!result.Any(exporter => exporter.GetType() == dependency.GetType()))
                             result.Insert(i, dependency); // All the exporter dependencies should be added before the exporter
                         else
                         {
@@ -186,9 +186,9 @@ namespace BenchmarkDotNet.Configs
                     builder.Add(analyser);
 
             foreach (var diagnoser in uniqueDiagnosers)
-            foreach (var analyser in diagnoser.Analysers)
-                if (!builder.Contains(analyser))
-                    builder.Add(analyser);
+                foreach (var analyser in diagnoser.Analysers)
+                    if (!builder.Contains(analyser))
+                        builder.Add(analyser);
 
             return builder.ToImmutable();
         }

--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -1,4 +1,7 @@
-﻿using BenchmarkDotNet.Analysers;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using BenchmarkDotNet.Analysers;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
@@ -6,9 +9,6 @@ using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Validators;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 
 namespace BenchmarkDotNet.Configs
 {

--- a/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
@@ -144,6 +144,19 @@ namespace BenchmarkDotNet.Tests.Configs
         }
 
         [Fact]
+        public void MultipleExportersOfSameTypeWithDifferentNamesAreAccepted()
+        {
+            var mutable = ManualConfig.CreateEmpty();
+
+            mutable.AddExporter(MarkdownExporter.GitHub);
+            mutable.AddExporter(MarkdownExporter.Atlassian);
+
+            var final = ImmutableConfigBuilder.Create(mutable);
+
+            Assert.Equal(2, final.GetExporters().Count());
+        }
+
+        [Fact]
         public void DuplicateAnalyzersAreExcluded()
         {
             var mutable = ManualConfig.CreateEmpty();
@@ -380,7 +393,7 @@ namespace BenchmarkDotNet.Tests.Configs
             var leftAddedToTheRight = ManualConfig.Create(right);
             leftAddedToTheRight.Add(left);
 
-            return new[]{ rightAddedToLeft.CreateImmutableConfig(), leftAddedToTheRight.CreateImmutableConfig() };
+            return new[] { rightAddedToLeft.CreateImmutableConfig(), leftAddedToTheRight.CreateImmutableConfig() };
         }
 
         public class TestExporter : IExporter, IExporterDependencies


### PR DESCRIPTION
Changed merging of exporters to check for duplicates by exporter.Name instead of the System.Type.

Added a test to verify that two MarkdownExporters with different named (GitHub and Atlassian) are accepted and both present in the final list (count is 2).

The original that removes duplicates still passes.

Fixes #2394 