### PR TITLE
Use out-of-process disassembler with InProcessEmitToolchain

### DIFF
--- a/tests/BenchmarkDotNet.Tests/XUnit/EnvRequirement.cs
+++ b/tests/BenchmarkDotNet.Tests/XUnit/EnvRequirement.cs
@@ -8,5 +8,6 @@ public enum EnvRequirement
     FullFrameworkOnly,
     NonFullFramework,
     DotNetCoreOnly,
-    DotNetCore30Only
+    DotNetCore30Only,
+    X86X64Only
 }

--- a/tests/BenchmarkDotNet.Tests/XUnit/EnvRequirementChecker.cs
+++ b/tests/BenchmarkDotNet.Tests/XUnit/EnvRequirementChecker.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using JetBrains.Annotations;
 using BdnRuntimeInformation = BenchmarkDotNet.Portability.RuntimeInformation;
@@ -22,6 +23,7 @@ public static class EnvRequirementChecker
         EnvRequirement.NonFullFramework => !BdnRuntimeInformation.IsFullFramework ? null : "Non-Full .NET Framework test",
         EnvRequirement.DotNetCoreOnly => BdnRuntimeInformation.IsNetCore ? null : ".NET/.NET Core-only test",
         EnvRequirement.DotNetCore30Only => IsRuntime(RuntimeMoniker.NetCoreApp30) ? null : ".NET Core 3.0-only test",
+        EnvRequirement.X86X64Only => BdnRuntimeInformation.GetCurrentPlatform() is Platform.X64 or Platform.X86 ? null : "x86- or x64-only test",
         _ => throw new ArgumentOutOfRangeException(nameof(requirement), requirement, "Unknown value")
     };
 


### PR DESCRIPTION
Fixes #2383

This is kind of a hacky workaround to make it work on Windows x64/x86. When ClrMd fixes it on their end (https://github.com/dotnet/diagnostics/issues/4108) we should be able to make it work on every platform.