### PR TITLE
Add OnSummary method to Diagnoser

### DIFF
--- a/src/BenchmarkDotNet/Diagnosers/CompositeDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/CompositeDiagnoser.cs
@@ -12,7 +12,7 @@ using BenchmarkDotNet.Validators;
 
 namespace BenchmarkDotNet.Diagnosers
 {
-    public class CompositeDiagnoser : IDiagnoser
+    public class CompositeDiagnoser : IDiagnoser, IDiagnoserSummaryEx
     {
         private readonly ImmutableHashSet<IDiagnoser> diagnosers;
 
@@ -52,5 +52,13 @@ namespace BenchmarkDotNet.Diagnosers
 
         public IEnumerable<ValidationError> Validate(ValidationParameters validationParameters)
             => diagnosers.SelectMany(diagnoser => diagnoser.Validate(validationParameters));
+
+        public void OnSummary(Summary summary)
+        {
+            foreach (var diagnoser in diagnosers)
+            {
+                diagnoser.OnSummaryCallback(summary);
+            }
+        }
     }
 }

--- a/src/BenchmarkDotNet/Diagnosers/IDiagnoser.cs
+++ b/src/BenchmarkDotNet/Diagnosers/IDiagnoser.cs
@@ -29,6 +29,20 @@ namespace BenchmarkDotNet.Diagnosers
         IEnumerable<ValidationError> Validate(ValidationParameters validationParameters);
     }
 
+    public interface IDiagnoserSummaryEx : IDiagnoser
+    {
+        [PublicAPI] void OnSummary(Summary summary);
+    }
+
+    public static class DiagnoserSummaryExtensions
+    {
+        public static void OnSummaryCallback(this IDiagnoser diagnoser, Summary summary)
+        {
+            if (diagnoser is IDiagnoserSummaryEx diagnoserSummaryEx)
+                diagnoserSummaryEx.OnSummary(summary);
+        }
+    }
+
     public interface IConfigurableDiagnoser<in TConfig> : IDiagnoser
     {
         [PublicAPI] IConfigurableDiagnoser<TConfig> Configure(TConfig config);

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -318,8 +318,8 @@ namespace BenchmarkDotNet.Running
             if (config.GetDiagnosers().Any())
             {
                 logger.WriteLine();
-                config.GetCompositeDiagnoser().DisplayResults(logger);
                 config.GetCompositeDiagnoser().OnSummaryCallback(summary);
+                config.GetCompositeDiagnoser().DisplayResults(logger);
             }
 
             logger.WriteLine();

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -319,6 +319,7 @@ namespace BenchmarkDotNet.Running
             {
                 logger.WriteLine();
                 config.GetCompositeDiagnoser().DisplayResults(logger);
+                config.GetCompositeDiagnoser().OnSummaryCallback(summary);
             }
 
             logger.WriteLine();


### PR DESCRIPTION
This PR adds an `OnSummary` method to BenchmarkDotNet.Diagnoser. The purpose is to get BDN Summary object into IDiagnoser so we can process and save the summary.

To ensure backwards compatibility, it is defined as an extension interface to the original `IDiagnoser` interface and called only when a diagnoser object implements the new extension interface.