### PR TITLE
feat: add text justification style

### DIFF
--- a/src/BenchmarkDotNet/Exporters/MarkdownExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/MarkdownExporter.cs
@@ -170,7 +170,7 @@ namespace BenchmarkDotNet.Exporters
                 }
 
                 logger.WriteLineStatistic(string.Join("",
-                    table.Columns.Where(c => c.NeedToShow).Select(column => new string('-', column.Width) + GetJustificationIndicator(column.Justify) + "|")));
+                    table.Columns.Where(c => c.NeedToShow).Select(column => new string('-', column.Width) + GetHeaderSeparatorIndicator(column.OriginalColumn.IsNumeric) + "|")));
             }
 
             int rowCounter = 0;
@@ -202,17 +202,9 @@ namespace BenchmarkDotNet.Exporters
             }
         }
 
-        private static string GetJustificationIndicator(SummaryTable.SummaryTableColumn.TextJustification textJustification)
+        private static string GetHeaderSeparatorIndicator(bool isNumeric)
         {
-            switch (textJustification)
-            {
-                case SummaryTable.SummaryTableColumn.TextJustification.Left:
-                    return " ";
-                case SummaryTable.SummaryTableColumn.TextJustification.Right:
-                    return ":";
-                default:
-                    return " ";
-            }
+            return isNumeric ? ":" : " ";
         }
     }
 }

--- a/src/BenchmarkDotNet/Exporters/MarkdownExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/MarkdownExporter.cs
@@ -79,8 +79,8 @@ namespace BenchmarkDotNet.Exporters
         [PublicAPI] protected string CodeBlockStart = "```";
         [PublicAPI] protected string CodeBlockEnd = "```";
         [PublicAPI] protected MarkdownHighlightStrategy StartOfGroupHighlightStrategy = MarkdownHighlightStrategy.None;
-        [PublicAPI] protected string TableHeaderSeparator = " |";
-        [PublicAPI] protected string TableColumnSeparator = " |";
+        [PublicAPI] protected string TableHeaderSeparator = " | ";
+        [PublicAPI] protected string TableColumnSeparator = " | ";
         [PublicAPI] protected bool UseHeaderSeparatingRow = true;
         [PublicAPI] protected bool ColumnsStartWithSeparator;
         [PublicAPI] protected string BoldMarkupFormat = "**{0}**";
@@ -166,11 +166,13 @@ namespace BenchmarkDotNet.Exporters
             {
                 if (ColumnsStartWithSeparator)
                 {
-                    logger.WriteStatistic(TableHeaderSeparator.TrimStart());
+                    logger.WriteStatistic(TableHeaderSeparator.TrimStart().TrimEnd() + "-");
                 }
 
                 logger.WriteLineStatistic(string.Join("",
-                    table.Columns.Where(c => c.NeedToShow).Select(column => new string('-', column.Width) + GetHeaderSeparatorIndicator(column.OriginalColumn.IsNumeric) + "|")));
+                    table.Columns.Where(c => c.NeedToShow).Select(column =>
+                        new string('-', column.Width - 1) + GetHeaderSeparatorIndicator(column.OriginalColumn.IsNumeric) +
+                        GetHeaderSeparatorColumnDivider(column.Index, table.ColumnCount))));
             }
 
             int rowCounter = 0;
@@ -205,6 +207,12 @@ namespace BenchmarkDotNet.Exporters
         private static string GetHeaderSeparatorIndicator(bool isNumeric)
         {
             return isNumeric ? ":" : " ";
+        }
+
+        private static string GetHeaderSeparatorColumnDivider(int columnIndex, int columnCount)
+        {
+            var isLastColumn = columnIndex != columnCount - 1;
+            return isLastColumn ? "|-" : "|";
         }
     }
 }

--- a/src/BenchmarkDotNet/Exporters/MarkdownExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/MarkdownExporter.cs
@@ -156,18 +156,12 @@ namespace BenchmarkDotNet.Exporters
                 logger.WriteLine();
             }
 
-            if (ColumnsStartWithSeparator)
-            {
-                logger.WriteStatistic(TableHeaderSeparator.TrimStart());
-            }
+            logger.WriteStatistic(ColumnsStartWithSeparator ? TableColumnSeparator.TrimStart() : " ");
 
             table.PrintLine(table.FullHeader, logger, string.Empty, TableHeaderSeparator);
             if (UseHeaderSeparatingRow)
             {
-                if (ColumnsStartWithSeparator)
-                {
-                    logger.WriteStatistic(TableHeaderSeparator.TrimStart().TrimEnd() + "-");
-                }
+                logger.WriteStatistic(ColumnsStartWithSeparator ? TableHeaderSeparator.TrimStart().TrimEnd() + "-" : "-");
 
                 logger.WriteLineStatistic(string.Join("",
                     table.Columns.Where(c => c.NeedToShow).Select(column =>
@@ -183,8 +177,8 @@ namespace BenchmarkDotNet.Exporters
                 if (rowCounter > 0 && table.FullContentStartOfLogicalGroup[rowCounter] && table.SeparateLogicalGroups)
                 {
                     // Print logical separator
-                    if (ColumnsStartWithSeparator)
-                        logger.WriteStatistic(TableColumnSeparator.TrimStart());
+                    logger.WriteStatistic(ColumnsStartWithSeparator ? TableColumnSeparator.TrimStart() : " ");
+
                     table.PrintLine(separatorLine, logger, string.Empty, TableColumnSeparator, highlightRow, false, StartOfGroupHighlightStrategy,
                         BoldMarkupFormat, false);
                 }
@@ -195,8 +189,8 @@ namespace BenchmarkDotNet.Exporters
                     highlightRow = !highlightRow;
                 }
 
-                if (ColumnsStartWithSeparator)
-                    logger.WriteStatistic(TableColumnSeparator.TrimStart());
+
+                logger.WriteStatistic(ColumnsStartWithSeparator ? TableColumnSeparator.TrimStart() : " ");
 
                 table.PrintLine(line, logger, string.Empty, TableColumnSeparator, highlightRow, table.FullContentStartOfHighlightGroup[rowCounter],
                     StartOfGroupHighlightStrategy, BoldMarkupFormat, EscapeHtml);

--- a/src/BenchmarkDotNet/Exporters/MarkdownExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/MarkdownExporter.cs
@@ -156,7 +156,7 @@ namespace BenchmarkDotNet.Exporters
                 logger.WriteLine();
             }
 
-            logger.WriteStatistic(ColumnsStartWithSeparator ? TableColumnSeparator.TrimStart() : " ");
+            logger.WriteStatistic(ColumnsStartWithSeparator ? TableHeaderSeparator.TrimStart() : " ");
 
             table.PrintLine(table.FullHeader, logger, string.Empty, TableHeaderSeparator);
             if (UseHeaderSeparatingRow)

--- a/src/BenchmarkDotNet/Helpers/HashCode.cs
+++ b/src/BenchmarkDotNet/Helpers/HashCode.cs
@@ -109,6 +109,22 @@ namespace BenchmarkDotNet
             return hashCode;
         }
 
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8, T9>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8,
+            T9 value9)
+        {
+            int hashCode = 0;
+            hashCode = Hash(hashCode, value1);
+            hashCode = Hash(hashCode, value2);
+            hashCode = Hash(hashCode, value3);
+            hashCode = Hash(hashCode, value4);
+            hashCode = Hash(hashCode, value5);
+            hashCode = Hash(hashCode, value6);
+            hashCode = Hash(hashCode, value7);
+            hashCode = Hash(hashCode, value8);
+            hashCode = Hash(hashCode, value9);
+            return hashCode;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int Hash<T>(int hashCode, T value)
         {
@@ -128,7 +144,8 @@ namespace BenchmarkDotNet
         }
 
 #pragma warning disable CS0809 // Obsolete member 'HashCode.GetHashCode()' overrides non-obsolete member 'object.GetHashCode()'
-        [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", error: true)]
+        [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.",
+            error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() => throw new NotSupportedException();
 

--- a/src/BenchmarkDotNet/Helpers/HashCode.cs
+++ b/src/BenchmarkDotNet/Helpers/HashCode.cs
@@ -109,8 +109,8 @@ namespace BenchmarkDotNet
             return hashCode;
         }
 
-        public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8, T9>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8,
-            T9 value9)
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7,
+            T8 value8, T9 value9, T10 value10)
         {
             int hashCode = 0;
             hashCode = Hash(hashCode, value1);
@@ -122,6 +122,7 @@ namespace BenchmarkDotNet
             hashCode = Hash(hashCode, value7);
             hashCode = Hash(hashCode, value8);
             hashCode = Hash(hashCode, value9);
+            hashCode = Hash(hashCode, value10);
             return hashCode;
         }
 

--- a/src/BenchmarkDotNet/Reports/Summary.cs
+++ b/src/BenchmarkDotNet/Reports/Summary.cs
@@ -65,7 +65,7 @@ namespace BenchmarkDotNet.Reports
             BenchmarksCases = Orderer.GetSummaryOrder(reports.Select(report => report.BenchmarkCase).ToImmutableArray(), this).ToImmutableArray(); // we sort it first
             Reports = BenchmarksCases.Select(b => ReportMap[b]).ToImmutableArray(); // we use sorted collection to re-create reports list
             BaseliningStrategy = BaseliningStrategy.Create(BenchmarksCases);
-            Style = summaryStyle ?? GetConfiguredSummaryStyleOrDefaultOne(BenchmarksCases).WithCultureInfo(cultureInfo);
+            Style = (summaryStyle ?? GetConfiguredSummaryStyleOrDefaultOne(BenchmarksCases)).WithCultureInfo(cultureInfo);
             Table = GetTable(Style);
             AllRuntimes = BuildAllRuntimes(HostEnvironmentInfo, Reports);
         }

--- a/src/BenchmarkDotNet/Reports/Summary.cs
+++ b/src/BenchmarkDotNet/Reports/Summary.cs
@@ -47,7 +47,8 @@ namespace BenchmarkDotNet.Reports
             TimeSpan totalTime,
             CultureInfo cultureInfo,
             ImmutableArray<ValidationError> validationErrors,
-            ImmutableArray<IColumnHidingRule> columnHidingRules)
+            ImmutableArray<IColumnHidingRule> columnHidingRules,
+            SummaryStyle summaryStyle = null)
         {
             Title = title;
             ResultsDirectoryPath = resultsDirectoryPath;
@@ -64,7 +65,7 @@ namespace BenchmarkDotNet.Reports
             BenchmarksCases = Orderer.GetSummaryOrder(reports.Select(report => report.BenchmarkCase).ToImmutableArray(), this).ToImmutableArray(); // we sort it first
             Reports = BenchmarksCases.Select(b => ReportMap[b]).ToImmutableArray(); // we use sorted collection to re-create reports list
             BaseliningStrategy = BaseliningStrategy.Create(BenchmarksCases);
-            Style = GetConfiguredSummaryStyleOrDefaultOne(BenchmarksCases).WithCultureInfo(cultureInfo);
+            Style = summaryStyle ?? GetConfiguredSummaryStyleOrDefaultOne(BenchmarksCases).WithCultureInfo(cultureInfo);
             Table = GetTable(Style);
             AllRuntimes = BuildAllRuntimes(HostEnvironmentInfo, Reports);
         }

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -26,11 +26,13 @@ namespace BenchmarkDotNet.Reports
         public CultureInfo CultureInfo { get; }
 
         public RatioStyle RatioStyle { get; }
-        public TextJustification DefaultTextJustification { get; }
+
+        public TextJustification TextColumnJustification { get; }
+        public TextJustification NumericColumnJustification { get; }
 
         public SummaryStyle(CultureInfo? cultureInfo, bool printUnitsInHeader, SizeUnit sizeUnit, TimeUnit timeUnit, bool printUnitsInContent = true,
             bool printZeroValuesInContent = false, int maxParameterColumnWidth = DefaultMaxParameterColumnWidth, RatioStyle ratioStyle = RatioStyle.Value,
-            TextJustification defaultTextJustification = TextJustification.Left)
+            TextJustification textColumnJustification = TextJustification.Left, TextJustification numericColumnJustification = TextJustification.Left)
         {
             if (maxParameterColumnWidth < DefaultMaxParameterColumnWidth)
                 throw new ArgumentOutOfRangeException(nameof(maxParameterColumnWidth), $"{DefaultMaxParameterColumnWidth} is the minimum.");
@@ -40,36 +42,37 @@ namespace BenchmarkDotNet.Reports
             PrintUnitsInContent = printUnitsInContent;
             SizeUnit = sizeUnit;
             TimeUnit = timeUnit;
-            PrintZeroValuesInContent = printZeroValuesInContent;
             MaxParameterColumnWidth = maxParameterColumnWidth;
             RatioStyle = ratioStyle;
             CodeSizeUnit = SizeUnit.B;
-            DefaultTextJustification = defaultTextJustification;
+            PrintZeroValuesInContent = printZeroValuesInContent;
+            TextColumnJustification = textColumnJustification;
+            NumericColumnJustification = numericColumnJustification;
         }
 
         public SummaryStyle WithTimeUnit(TimeUnit timeUnit)
             => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, timeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth,
-                RatioStyle, DefaultTextJustification);
+                RatioStyle, TextColumnJustification, NumericColumnJustification);
 
         public SummaryStyle WithSizeUnit(SizeUnit sizeUnit)
             => new SummaryStyle(CultureInfo, PrintUnitsInHeader, sizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth,
-                RatioStyle, DefaultTextJustification);
+                RatioStyle, TextColumnJustification, NumericColumnJustification);
 
         public SummaryStyle WithZeroMetricValuesInContent()
             => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, printZeroValuesInContent: true,
-                MaxParameterColumnWidth, RatioStyle, DefaultTextJustification);
+                MaxParameterColumnWidth, RatioStyle, TextColumnJustification, NumericColumnJustification);
 
         public SummaryStyle WithMaxParameterColumnWidth(int maxParameterColumnWidth)
             => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, maxParameterColumnWidth,
-                RatioStyle, DefaultTextJustification);
+                RatioStyle, TextColumnJustification, NumericColumnJustification);
 
         public SummaryStyle WithCultureInfo(CultureInfo cultureInfo)
             => new SummaryStyle(cultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth,
-                RatioStyle, DefaultTextJustification);
+                RatioStyle, TextColumnJustification, NumericColumnJustification);
 
         public SummaryStyle WithRatioStyle(RatioStyle ratioStyle)
             => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth,
-                ratioStyle, DefaultTextJustification);
+                ratioStyle, TextColumnJustification, NumericColumnJustification);
 
         public bool Equals(SummaryStyle other)
         {
@@ -86,7 +89,8 @@ namespace BenchmarkDotNet.Reports
                    && Equals(TimeUnit, other.TimeUnit)
                    && MaxParameterColumnWidth == other.MaxParameterColumnWidth
                    && RatioStyle == other.RatioStyle
-                   && DefaultTextJustification == other.DefaultTextJustification;
+                   && TextColumnJustification == other.TextColumnJustification
+                   && NumericColumnJustification == other.NumericColumnJustification;
         }
 
         public override bool Equals(object obj) => obj is SummaryStyle summary && Equals(summary);
@@ -101,7 +105,8 @@ namespace BenchmarkDotNet.Reports
                 TimeUnit,
                 MaxParameterColumnWidth,
                 RatioStyle,
-                DefaultTextJustification);
+                TextColumnJustification,
+                NumericColumnJustification);
 
         public static bool operator ==(SummaryStyle left, SummaryStyle right) => Equals(left, right);
 

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -32,7 +32,7 @@ namespace BenchmarkDotNet.Reports
 
         public SummaryStyle(CultureInfo? cultureInfo, bool printUnitsInHeader, SizeUnit sizeUnit, TimeUnit timeUnit, bool printUnitsInContent = true,
             bool printZeroValuesInContent = false, int maxParameterColumnWidth = DefaultMaxParameterColumnWidth, RatioStyle ratioStyle = RatioStyle.Value,
-            TextJustification textColumnJustification = TextJustification.Left, TextJustification numericColumnJustification = TextJustification.Left)
+            TextJustification textColumnJustification = TextJustification.Left, TextJustification numericColumnJustification = TextJustification.Right)
         {
             if (maxParameterColumnWidth < DefaultMaxParameterColumnWidth)
                 throw new ArgumentOutOfRangeException(nameof(maxParameterColumnWidth), $"{DefaultMaxParameterColumnWidth} is the minimum.");

--- a/src/BenchmarkDotNet/Reports/SummaryStyle.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryStyle.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Helpers;
 using Perfolizer.Horology;
+using static BenchmarkDotNet.Reports.SummaryTable.SummaryTableColumn;
 
 // ReSharper disable MemberCanBePrivate.Global
 
@@ -10,7 +11,9 @@ namespace BenchmarkDotNet.Reports
 {
     public class SummaryStyle : IEquatable<SummaryStyle>
     {
-        public static readonly SummaryStyle Default = new SummaryStyle(DefaultCultureInfo.Instance, printUnitsInHeader: false, printUnitsInContent: true, printZeroValuesInContent: false, sizeUnit: null, timeUnit: null);
+        public static readonly SummaryStyle Default = new SummaryStyle(DefaultCultureInfo.Instance, printUnitsInHeader: false, printUnitsInContent: true,
+            printZeroValuesInContent: false, sizeUnit: null, timeUnit: null);
+
         internal const int DefaultMaxParameterColumnWidth = 15 + 5; // 5 is for postfix " [15]"
 
         public bool PrintUnitsInHeader { get; }
@@ -23,9 +26,11 @@ namespace BenchmarkDotNet.Reports
         public CultureInfo CultureInfo { get; }
 
         public RatioStyle RatioStyle { get; }
+        public TextJustification DefaultTextJustification { get; }
 
         public SummaryStyle(CultureInfo? cultureInfo, bool printUnitsInHeader, SizeUnit sizeUnit, TimeUnit timeUnit, bool printUnitsInContent = true,
-            bool printZeroValuesInContent = false, int maxParameterColumnWidth = DefaultMaxParameterColumnWidth, RatioStyle ratioStyle = RatioStyle.Value)
+            bool printZeroValuesInContent = false, int maxParameterColumnWidth = DefaultMaxParameterColumnWidth, RatioStyle ratioStyle = RatioStyle.Value,
+            TextJustification defaultTextJustification = TextJustification.Left)
         {
             if (maxParameterColumnWidth < DefaultMaxParameterColumnWidth)
                 throw new ArgumentOutOfRangeException(nameof(maxParameterColumnWidth), $"{DefaultMaxParameterColumnWidth} is the minimum.");
@@ -39,25 +44,32 @@ namespace BenchmarkDotNet.Reports
             MaxParameterColumnWidth = maxParameterColumnWidth;
             RatioStyle = ratioStyle;
             CodeSizeUnit = SizeUnit.B;
+            DefaultTextJustification = defaultTextJustification;
         }
 
         public SummaryStyle WithTimeUnit(TimeUnit timeUnit)
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, timeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, timeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth,
+                RatioStyle, DefaultTextJustification);
 
         public SummaryStyle WithSizeUnit(SizeUnit sizeUnit)
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, sizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, sizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth,
+                RatioStyle, DefaultTextJustification);
 
         public SummaryStyle WithZeroMetricValuesInContent()
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, printZeroValuesInContent: true, MaxParameterColumnWidth, RatioStyle);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, printZeroValuesInContent: true,
+                MaxParameterColumnWidth, RatioStyle, DefaultTextJustification);
 
         public SummaryStyle WithMaxParameterColumnWidth(int maxParameterColumnWidth)
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, maxParameterColumnWidth, RatioStyle);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, maxParameterColumnWidth,
+                RatioStyle, DefaultTextJustification);
 
         public SummaryStyle WithCultureInfo(CultureInfo cultureInfo)
-            => new SummaryStyle(cultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, RatioStyle);
+            => new SummaryStyle(cultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth,
+                RatioStyle, DefaultTextJustification);
 
         public SummaryStyle WithRatioStyle(RatioStyle ratioStyle)
-            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth, ratioStyle);
+            => new SummaryStyle(CultureInfo, PrintUnitsInHeader, SizeUnit, TimeUnit, PrintUnitsInContent, PrintZeroValuesInContent, MaxParameterColumnWidth,
+                ratioStyle, DefaultTextJustification);
 
         public bool Equals(SummaryStyle other)
         {
@@ -73,7 +85,8 @@ namespace BenchmarkDotNet.Reports
                    && Equals(CodeSizeUnit, other.CodeSizeUnit)
                    && Equals(TimeUnit, other.TimeUnit)
                    && MaxParameterColumnWidth == other.MaxParameterColumnWidth
-                   && RatioStyle == other.RatioStyle;
+                   && RatioStyle == other.RatioStyle
+                   && DefaultTextJustification == other.DefaultTextJustification;
         }
 
         public override bool Equals(object obj) => obj is SummaryStyle summary && Equals(summary);
@@ -87,7 +100,8 @@ namespace BenchmarkDotNet.Reports
                 CodeSizeUnit,
                 TimeUnit,
                 MaxParameterColumnWidth,
-                RatioStyle);
+                RatioStyle,
+                DefaultTextJustification);
 
         public static bool operator ==(SummaryStyle left, SummaryStyle right) => Equals(left, right);
 

--- a/src/BenchmarkDotNet/Reports/SummaryTable.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTable.cs
@@ -55,6 +55,7 @@ namespace BenchmarkDotNet.Reports
                     .Select(r => r.GcStats.GetBytesAllocatedPerOperation(r.BenchmarkCase).Value)
                     .ToArray()));
             }
+            EffectiveSummaryStyle = style;
 
             var columns = summary.GetColumns();
             ColumnCount = columns.Length;
@@ -96,8 +97,6 @@ namespace BenchmarkDotNet.Reports
                 bool hide = summary.ColumnHidingRules.Any(rule => rule.NeedToHide(column));
                 Columns[i] = new SummaryTableColumn(this, i, column, hide);
             }
-
-            EffectiveSummaryStyle = style;
         }
 
         public class SummaryTableColumn
@@ -123,7 +122,7 @@ namespace BenchmarkDotNet.Reports
                 IsDefault = table.IsDefault[index];
                 OriginalColumn = column;
 
-                Justify = column.IsNumeric ? TextJustification.Right : TextJustification.Left;
+                Justify = table.EffectiveSummaryStyle.DefaultTextJustification;
 
                 bool needToShow = column.AlwaysShow || Content.Distinct().Count() > 1;
                 NeedToShow = !hide && needToShow;

--- a/src/BenchmarkDotNet/Reports/SummaryTable.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTable.cs
@@ -122,7 +122,7 @@ namespace BenchmarkDotNet.Reports
                 IsDefault = table.IsDefault[index];
                 OriginalColumn = column;
 
-                Justify = table.EffectiveSummaryStyle.DefaultTextJustification;
+                Justify = column.IsNumeric ? table.EffectiveSummaryStyle.NumericColumnJustification : table.EffectiveSummaryStyle.TextColumnJustification;
 
                 bool needToShow = column.AlwaysShow || Content.Distinct().Count() > 1;
                 NeedToShow = !hide && needToShow;

--- a/src/BenchmarkDotNet/Reports/SummaryTableExtensions.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTableExtensions.cs
@@ -83,7 +83,8 @@ namespace BenchmarkDotNet.Reports
         private static string BuildStandardText(SummaryTable table, string[] line, string leftDel, string rightDel, int columnIndex)
         {
             var buffer = GetClearBuffer();
-            var columnJustification = table.Columns[columnIndex].Justify;
+            var isBuildingHeader = table.FullHeader[columnIndex] == line[columnIndex];
+            var columnJustification = isBuildingHeader ? SummaryTable.SummaryTableColumn.TextJustification.Left : table.Columns[columnIndex].Justify;
 
             buffer.Append(leftDel);
             if (columnJustification == SummaryTable.SummaryTableColumn.TextJustification.Right)
@@ -106,7 +107,8 @@ namespace BenchmarkDotNet.Reports
         private static string BuildBoldText(SummaryTable table, string[] line, string leftDel, string rightDel, int columnIndex, string boldMarkupFormat)
         {
             var buffer = GetClearBuffer();
-            var columnJustification = table.Columns[columnIndex].Justify;
+            var isBuildingHeader = table.FullHeader[columnIndex] == line[columnIndex];
+            var columnJustification = isBuildingHeader ? SummaryTable.SummaryTableColumn.TextJustification.Left : table.Columns[columnIndex].Justify;
 
             buffer.Append(leftDel);
             if (columnJustification == SummaryTable.SummaryTableColumn.TextJustification.Right)

--- a/src/BenchmarkDotNet/Reports/SummaryTableExtensions.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTableExtensions.cs
@@ -48,7 +48,8 @@ namespace BenchmarkDotNet.Reports
         }
 
         public static void PrintLine(this SummaryTable table, string[] line, ILogger logger, string leftDel, string rightDel,
-                                     bool highlightRow, bool startOfGroup, MarkdownExporter.MarkdownHighlightStrategy startOfGroupHighlightStrategy, string boldMarkupFormat, bool escapeHtml)
+            bool highlightRow, bool startOfGroup, MarkdownExporter.MarkdownHighlightStrategy startOfGroupHighlightStrategy, string boldMarkupFormat,
+            bool escapeHtml)
         {
             for (int columnIndex = 0; columnIndex < table.ColumnCount; columnIndex++)
             {
@@ -82,10 +83,20 @@ namespace BenchmarkDotNet.Reports
         private static string BuildStandardText(SummaryTable table, string[] line, string leftDel, string rightDel, int columnIndex)
         {
             var buffer = GetClearBuffer();
+            var columnJustification = table.Columns[columnIndex].Justify;
 
             buffer.Append(leftDel);
-            PadLeft(table, line, leftDel, rightDel, columnIndex, buffer);
+            if (columnJustification == SummaryTable.SummaryTableColumn.TextJustification.Right)
+            {
+                AddPadding(table, line, leftDel, rightDel, columnIndex, buffer);
+            }
+
             buffer.Append(line[columnIndex]);
+
+            if (columnJustification == SummaryTable.SummaryTableColumn.TextJustification.Left)
+            {
+                AddPadding(table, line, leftDel, rightDel, columnIndex, buffer);
+            }
             buffer.Append(rightDel);
 
             return buffer.ToString();
@@ -94,10 +105,20 @@ namespace BenchmarkDotNet.Reports
         private static string BuildBoldText(SummaryTable table, string[] line, string leftDel, string rightDel, int columnIndex, string boldMarkupFormat)
         {
             var buffer = GetClearBuffer();
+            var columnJustification = table.Columns[columnIndex].Justify;
 
             buffer.Append(leftDel);
-            PadLeft(table, line, leftDel, rightDel, columnIndex, buffer);
+            if (columnJustification == SummaryTable.SummaryTableColumn.TextJustification.Right)
+            {
+                AddPadding(table, line, leftDel, rightDel, columnIndex, buffer);
+            }
+
             buffer.AppendFormat(boldMarkupFormat, line[columnIndex]);
+
+            if (columnJustification == SummaryTable.SummaryTableColumn.TextJustification.Left)
+            {
+                AddPadding(table, line, leftDel, rightDel, columnIndex, buffer);
+            }
             buffer.Append(rightDel);
 
             return buffer.ToString();
@@ -116,7 +137,7 @@ namespace BenchmarkDotNet.Reports
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void PadLeft(SummaryTable table, string[] line, string leftDel, string rightDel, int columnIndex, StringBuilder buffer)
+        private static void AddPadding(SummaryTable table, string[] line, string leftDel, string rightDel, int columnIndex, StringBuilder buffer)
         {
             const char space = ' ';
             const int extraWidth = 2; // " |".Length is not included in the column's Width

--- a/src/BenchmarkDotNet/Reports/SummaryTableExtensions.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTableExtensions.cs
@@ -97,7 +97,8 @@ namespace BenchmarkDotNet.Reports
             {
                 AddPadding(table, line, leftDel, rightDel, columnIndex, buffer);
             }
-            buffer.Append(rightDel);
+            var isLastColumn = columnIndex == table.ColumnCount - 1;
+            buffer.Append(isLastColumn ? rightDel.TrimEnd() : rightDel);
 
             return buffer.ToString();
         }
@@ -119,7 +120,8 @@ namespace BenchmarkDotNet.Reports
             {
                 AddPadding(table, line, leftDel, rightDel, columnIndex, buffer);
             }
-            buffer.Append(rightDel);
+            var isLastColumn = columnIndex == table.ColumnCount - 1;
+            buffer.Append(isLastColumn ? rightDel.TrimEnd() : rightDel);
 
             return buffer.ToString();
         }

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfBool.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfBool.verified.txt
@@ -7,9 +7,9 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty |     Mean |   Error |  StdDev |
---------- |-------------- |---------:|--------:|--------:|
-Benchmark | False         | 102.0 ns | 6.09 ns | 1.58 ns | ^
-Benchmark | True          | 202.0 ns | 6.09 ns | 1.58 ns | ^
+ Method    | ParamProperty | Mean     | Error   | StdDev  |
+---------- |-------------- |---------:|--------:|--------:|
+ Benchmark | False         | 102.0 ns | 6.09 ns | 1.58 ns | ^
+ Benchmark | True          | 202.0 ns | 6.09 ns | 1.58 ns | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfBool.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfBool.verified.txt
@@ -7,9 +7,9 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty | Mean     | Error   | StdDev  | 
+Method    | ParamProperty |     Mean |   Error |  StdDev |
 --------- |-------------- |---------:|--------:|--------:|
-Benchmark | False         | 102.0 ns | 6.09 ns | 1.58 ns |  ^
-Benchmark | True          | 202.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | False         | 102.0 ns | 6.09 ns | 1.58 ns | ^
+Benchmark | True          | 202.0 ns | 6.09 ns | 1.58 ns | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfBool.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfBool.verified.txt
@@ -7,9 +7,9 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-    Method | ParamProperty |     Mean |   Error |  StdDev |
----------- |-------------- |---------:|--------:|--------:|
- Benchmark |         False | 102.0 ns | 6.09 ns | 1.58 ns | ^
- Benchmark |          True | 202.0 ns | 6.09 ns | 1.58 ns | ^
+Method    | ParamProperty | Mean     | Error   | StdDev  | 
+--------- |-------------- |---------:|--------:|--------:|
+Benchmark | False         | 102.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | True          | 202.0 ns | 6.09 ns | 1.58 ns |  ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfEnum.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfEnum.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty | Mean     | Error   | StdDev  | 
+Method    | ParamProperty |     Mean |   Error |  StdDev |
 --------- |-------------- |---------:|--------:|--------:|
-Benchmark | A             | 102.0 ns | 6.09 ns | 1.58 ns |  ^
-Benchmark | B             | 202.0 ns | 6.09 ns | 1.58 ns |  ^
-Benchmark | C             | 302.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | A             | 102.0 ns | 6.09 ns | 1.58 ns | ^
+Benchmark | B             | 202.0 ns | 6.09 ns | 1.58 ns | ^
+Benchmark | C             | 302.0 ns | 6.09 ns | 1.58 ns | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfEnum.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfEnum.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty |     Mean |   Error |  StdDev |
---------- |-------------- |---------:|--------:|--------:|
-Benchmark | A             | 102.0 ns | 6.09 ns | 1.58 ns | ^
-Benchmark | B             | 202.0 ns | 6.09 ns | 1.58 ns | ^
-Benchmark | C             | 302.0 ns | 6.09 ns | 1.58 ns | ^
+ Method    | ParamProperty | Mean     | Error   | StdDev  |
+---------- |-------------- |---------:|--------:|--------:|
+ Benchmark | A             | 102.0 ns | 6.09 ns | 1.58 ns | ^
+ Benchmark | B             | 202.0 ns | 6.09 ns | 1.58 ns | ^
+ Benchmark | C             | 302.0 ns | 6.09 ns | 1.58 ns | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfEnum.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfEnum.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-    Method | ParamProperty |     Mean |   Error |  StdDev |
----------- |-------------- |---------:|--------:|--------:|
- Benchmark |             A | 102.0 ns | 6.09 ns | 1.58 ns | ^
- Benchmark |             B | 202.0 ns | 6.09 ns | 1.58 ns | ^
- Benchmark |             C | 302.0 ns | 6.09 ns | 1.58 ns | ^
+Method    | ParamProperty | Mean     | Error   | StdDev  | 
+--------- |-------------- |---------:|--------:|--------:|
+Benchmark | A             | 102.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | B             | 202.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | C             | 302.0 ns | 6.09 ns | 1.58 ns |  ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfNullableBool.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfNullableBool.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-    Method | ParamProperty |     Mean |   Error |  StdDev |
----------- |-------------- |---------:|--------:|--------:|
- Benchmark |             ? | 102.0 ns | 6.09 ns | 1.58 ns | ^
- Benchmark |         False | 202.0 ns | 6.09 ns | 1.58 ns | ^
- Benchmark |          True | 302.0 ns | 6.09 ns | 1.58 ns | ^
+Method    | ParamProperty | Mean     | Error   | StdDev  | 
+--------- |-------------- |---------:|--------:|--------:|
+Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | False         | 202.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | True          | 302.0 ns | 6.09 ns | 1.58 ns |  ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfNullableBool.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfNullableBool.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty |     Mean |   Error |  StdDev |
---------- |-------------- |---------:|--------:|--------:|
-Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns | ^
-Benchmark | False         | 202.0 ns | 6.09 ns | 1.58 ns | ^
-Benchmark | True          | 302.0 ns | 6.09 ns | 1.58 ns | ^
+ Method    | ParamProperty | Mean     | Error   | StdDev  |
+---------- |-------------- |---------:|--------:|--------:|
+ Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns | ^
+ Benchmark | False         | 202.0 ns | 6.09 ns | 1.58 ns | ^
+ Benchmark | True          | 302.0 ns | 6.09 ns | 1.58 ns | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfNullableBool.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfNullableBool.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty | Mean     | Error   | StdDev  | 
+Method    | ParamProperty |     Mean |   Error |  StdDev |
 --------- |-------------- |---------:|--------:|--------:|
-Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns |  ^
-Benchmark | False         | 202.0 ns | 6.09 ns | 1.58 ns |  ^
-Benchmark | True          | 302.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns | ^
+Benchmark | False         | 202.0 ns | 6.09 ns | 1.58 ns | ^
+Benchmark | True          | 302.0 ns | 6.09 ns | 1.58 ns | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfNullableEnum.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfNullableEnum.verified.txt
@@ -7,11 +7,11 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-    Method | ParamProperty |     Mean |   Error |  StdDev |
----------- |-------------- |---------:|--------:|--------:|
- Benchmark |             ? | 102.0 ns | 6.09 ns | 1.58 ns | ^
- Benchmark |             A | 202.0 ns | 6.09 ns | 1.58 ns | ^
- Benchmark |             B | 302.0 ns | 6.09 ns | 1.58 ns | ^
- Benchmark |             C | 402.0 ns | 6.09 ns | 1.58 ns | ^
+Method    | ParamProperty | Mean     | Error   | StdDev  | 
+--------- |-------------- |---------:|--------:|--------:|
+Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | A             | 202.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | B             | 302.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | C             | 402.0 ns | 6.09 ns | 1.58 ns |  ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfNullableEnum.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfNullableEnum.verified.txt
@@ -7,11 +7,11 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty |     Mean |   Error |  StdDev |
---------- |-------------- |---------:|--------:|--------:|
-Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns | ^
-Benchmark | A             | 202.0 ns | 6.09 ns | 1.58 ns | ^
-Benchmark | B             | 302.0 ns | 6.09 ns | 1.58 ns | ^
-Benchmark | C             | 402.0 ns | 6.09 ns | 1.58 ns | ^
+ Method    | ParamProperty | Mean     | Error   | StdDev  |
+---------- |-------------- |---------:|--------:|--------:|
+ Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns | ^
+ Benchmark | A             | 202.0 ns | 6.09 ns | 1.58 ns | ^
+ Benchmark | B             | 302.0 ns | 6.09 ns | 1.58 ns | ^
+ Benchmark | C             | 402.0 ns | 6.09 ns | 1.58 ns | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfNullableEnum.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithAllValuesOfNullableEnum.verified.txt
@@ -7,11 +7,11 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty | Mean     | Error   | StdDev  | 
+Method    | ParamProperty |     Mean |   Error |  StdDev |
 --------- |-------------- |---------:|--------:|--------:|
-Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns |  ^
-Benchmark | A             | 202.0 ns | 6.09 ns | 1.58 ns |  ^
-Benchmark | B             | 302.0 ns | 6.09 ns | 1.58 ns |  ^
-Benchmark | C             | 402.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns | ^
+Benchmark | A             | 202.0 ns | 6.09 ns | 1.58 ns | ^
+Benchmark | B             | 302.0 ns | 6.09 ns | 1.58 ns | ^
+Benchmark | C             | 402.0 ns | 6.09 ns | 1.58 ns | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedFlagsEnumError.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedFlagsEnumError.verified.txt
@@ -7,9 +7,9 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-    Method | ParamProperty |     Mean |   Error |  StdDev |
----------- |-------------- |---------:|--------:|--------:|
- Benchmark |             0 | 102.0 ns | 6.09 ns | 1.58 ns |
+Method    | ParamProperty | Mean     | Error   | StdDev  | 
+--------- |-------------- |---------:|--------:|--------:|
+Benchmark | 0             | 102.0 ns | 6.09 ns | 1.58 ns | 
 
 Errors: 1
 * Unable to use TestFlagsEnum with [ParamsAllValues], because it's flags enum.

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedFlagsEnumError.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedFlagsEnumError.verified.txt
@@ -7,9 +7,9 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty |     Mean |   Error |  StdDev |
---------- |-------------- |---------:|--------:|--------:|
-Benchmark | 0             | 102.0 ns | 6.09 ns | 1.58 ns |
+ Method    | ParamProperty | Mean     | Error   | StdDev  |
+---------- |-------------- |---------:|--------:|--------:|
+ Benchmark | 0             | 102.0 ns | 6.09 ns | 1.58 ns |
 
 Errors: 1
 * Unable to use TestFlagsEnum with [ParamsAllValues], because it's flags enum.

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedFlagsEnumError.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedFlagsEnumError.verified.txt
@@ -7,9 +7,9 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty | Mean     | Error   | StdDev  | 
+Method    | ParamProperty |     Mean |   Error |  StdDev |
 --------- |-------------- |---------:|--------:|--------:|
-Benchmark | 0             | 102.0 ns | 6.09 ns | 1.58 ns | 
+Benchmark | 0             | 102.0 ns | 6.09 ns | 1.58 ns |
 
 Errors: 1
 * Unable to use TestFlagsEnum with [ParamsAllValues], because it's flags enum.

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedNullableTypeError.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedNullableTypeError.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-    Method | ParamProperty |     Mean |   Error |  StdDev |
----------- |-------------- |---------:|--------:|--------:|
- Benchmark |             ? | 102.0 ns | 6.09 ns | 1.58 ns | ^
- Benchmark |             0 | 202.0 ns | 6.09 ns | 1.58 ns | ^
+Method    | ParamProperty | Mean     | Error   | StdDev  | 
+--------- |-------------- |---------:|--------:|--------:|
+Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | 0             | 202.0 ns | 6.09 ns | 1.58 ns |  ^
 
 Errors: 1
 * Type Int32 cannot be used with [ParamsAllValues], allowed types are: bool, enum types and nullable type for another allowed type.

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedNullableTypeError.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedNullableTypeError.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty | Mean     | Error   | StdDev  | 
+Method    | ParamProperty |     Mean |   Error |  StdDev |
 --------- |-------------- |---------:|--------:|--------:|
-Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns |  ^
-Benchmark | 0             | 202.0 ns | 6.09 ns | 1.58 ns |  ^
+Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns | ^
+Benchmark | 0             | 202.0 ns | 6.09 ns | 1.58 ns | ^
 
 Errors: 1
 * Type Int32 cannot be used with [ParamsAllValues], allowed types are: bool, enum types and nullable type for another allowed type.

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedNullableTypeError.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedNullableTypeError.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty |     Mean |   Error |  StdDev |
---------- |-------------- |---------:|--------:|--------:|
-Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns | ^
-Benchmark | 0             | 202.0 ns | 6.09 ns | 1.58 ns | ^
+ Method    | ParamProperty | Mean     | Error   | StdDev  |
+---------- |-------------- |---------:|--------:|--------:|
+ Benchmark | ?             | 102.0 ns | 6.09 ns | 1.58 ns | ^
+ Benchmark | 0             | 202.0 ns | 6.09 ns | 1.58 ns | ^
 
 Errors: 1
 * Type Int32 cannot be used with [ParamsAllValues], allowed types are: bool, enum types and nullable type for another allowed type.

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedTypeError.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedTypeError.verified.txt
@@ -7,9 +7,9 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty |     Mean |   Error |  StdDev |
---------- |-------------- |---------:|--------:|--------:|
-Benchmark | 0             | 102.0 ns | 6.09 ns | 1.58 ns |
+ Method    | ParamProperty | Mean     | Error   | StdDev  |
+---------- |-------------- |---------:|--------:|--------:|
+ Benchmark | 0             | 102.0 ns | 6.09 ns | 1.58 ns |
 
 Errors: 1
 * Type Int32 cannot be used with [ParamsAllValues], allowed types are: bool, enum types and nullable type for another allowed type.

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedTypeError.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedTypeError.verified.txt
@@ -7,9 +7,9 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method    | ParamProperty | Mean     | Error   | StdDev  | 
+Method    | ParamProperty |     Mean |   Error |  StdDev |
 --------- |-------------- |---------:|--------:|--------:|
-Benchmark | 0             | 102.0 ns | 6.09 ns | 1.58 ns | 
+Benchmark | 0             | 102.0 ns | 6.09 ns | 1.58 ns |
 
 Errors: 1
 * Type Int32 cannot be used with [ParamsAllValues], allowed types are: bool, enum types and nullable type for another allowed type.

--- a/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedTypeError.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Attributes/VerifiedFiles/ParamsAllValuesVerifyTests.BenchmarkShouldProduceSummary_WithNotAllowedTypeError.verified.txt
@@ -7,9 +7,9 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-    Method | ParamProperty |     Mean |   Error |  StdDev |
----------- |-------------- |---------:|--------:|--------:|
- Benchmark |             0 | 102.0 ns | 6.09 ns | 1.58 ns |
+Method    | ParamProperty | Mean     | Error   | StdDev  | 
+--------- |-------------- |---------:|--------:|--------:|
+Benchmark | 0             | 102.0 ns | 6.09 ns | 1.58 ns | 
 
 Errors: 1
 * Type Int32 cannot be used with [ParamsAllValues], allowed types are: bool, enum types and nullable type for another allowed type.

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_Invariant.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_Invariant.verified.txt
@@ -429,7 +429,7 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 {noformat}
-| Method ||Mean     ||Error ||StdDev   ||P67      ||
+||Method ||Mean     ||Error ||StdDev   ||P67      ||
 | Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 | Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_Invariant.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_Invariant.verified.txt
@@ -13,9 +13,9 @@ WarmupCount=15
 ....
 [options="header"]
 |===
-|Method  |Mean      |Error  |StdDev    |P67       
-|Foo     |1.000 ns  |NA     |0.000 ns  |1.000 ns  
-|Bar     |1.000 ns  |NA     |0.000 ns  |1.000 ns  
+|Method  |      Mean|  Error|    StdDev|       P67
+|Foo     |  1.000 ns|     NA|  0.000 ns|  1.000 ns
+|Bar     |  1.000 ns|     NA|  0.000 ns|  1.000 ns
 |===
 ############################################
 HtmlExporter
@@ -410,10 +410,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-Method | Mean     | Error | StdDev   | P67      | 
+Method |     Mean | Error |   StdDev |      P67 |
 ------ |---------:|------:|---------:|---------:|
-Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
-Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 MarkdownExporter-atlassian
 ############################################
@@ -429,9 +429,9 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 {noformat}
-||Method ||Mean     ||Error ||StdDev   ||P67      ||
-| Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
-| Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+||Method ||    Mean ||Error ||  StdDev ||     P67 ||
+| Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+| Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 MarkdownExporter-console
 ############################################
@@ -445,10 +445,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-| Method | Mean     | Error | StdDev   | P67      | 
+| Method |     Mean | Error |   StdDev |      P67 |
 |------- |---------:|------:|---------:|---------:|
-| Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
-| Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+| Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+| Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 MarkdownExporter-github
 ############################################
@@ -464,10 +464,10 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 ```
-| Method | Mean     | Error | StdDev   | P67      | 
+| Method |     Mean | Error |   StdDev |      P67 |
 |------- |---------:|------:|---------:|---------:|
-| Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
-| Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+| Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+| Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 MarkdownExporter-stackoverflow
 ############################################
@@ -481,10 +481,10 @@ MarkdownExporter-stackoverflow
     Job=LongRun  IterationCount=100  LaunchCount=3  
     WarmupCount=15  
 
-    Method | Mean     | Error | StdDev   | P67      | 
+    Method |     Mean | Error |   StdDev |      P67 |
     ------ |---------:|------:|---------:|---------:|
-    Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
-    Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+    Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+    Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 PlainExporter
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_Invariant.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_Invariant.verified.txt
@@ -13,9 +13,9 @@ WarmupCount=15
 ....
 [options="header"]
 |===
-|  Method|      Mean|  Error|    StdDev|       P67
-|     Foo|  1.000 ns|     NA|  0.000 ns|  1.000 ns
-|     Bar|  1.000 ns|     NA|  0.000 ns|  1.000 ns
+|Method  |Mean      |Error  |StdDev    |P67       
+|Foo     |1.000 ns  |NA     |0.000 ns  |1.000 ns  
+|Bar     |1.000 ns  |NA     |0.000 ns  |1.000 ns  
 |===
 ############################################
 HtmlExporter
@@ -410,10 +410,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
- Method |     Mean | Error |   StdDev |      P67 |
-------- |---------:|------:|---------:|---------:|
-    Foo | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-    Bar | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+Method | Mean     | Error | StdDev   | P67      | 
+------ |---------:|------:|---------:|---------:|
+Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
 ############################################
 MarkdownExporter-atlassian
 ############################################
@@ -429,9 +429,9 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 {noformat}
-||Method ||    Mean ||Error ||  StdDev ||     P67 ||
-|    Foo | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-|    Bar | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+||Method ||Mean     ||Error ||StdDev   ||P67      ||
+| Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+| Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
 ############################################
 MarkdownExporter-console
 ############################################
@@ -445,10 +445,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-| Method |     Mean | Error |   StdDev |      P67 |
+| Method | Mean     | Error | StdDev   | P67      | 
 |------- |---------:|------:|---------:|---------:|
-|    Foo | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-|    Bar | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+| Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+| Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
 ############################################
 MarkdownExporter-github
 ############################################
@@ -464,10 +464,10 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 ```
-| Method |     Mean | Error |   StdDev |      P67 |
+| Method | Mean     | Error | StdDev   | P67      | 
 |------- |---------:|------:|---------:|---------:|
-|    Foo | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-|    Bar | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+| Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+| Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
 ############################################
 MarkdownExporter-stackoverflow
 ############################################
@@ -481,10 +481,10 @@ MarkdownExporter-stackoverflow
     Job=LongRun  IterationCount=100  LaunchCount=3  
     WarmupCount=15  
 
-     Method |     Mean | Error |   StdDev |      P67 |
-    ------- |---------:|------:|---------:|---------:|
-        Foo | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-        Bar | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+    Method | Mean     | Error | StdDev   | P67      | 
+    ------ |---------:|------:|---------:|---------:|
+    Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+    Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
 ############################################
 PlainExporter
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_Invariant.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_Invariant.verified.txt
@@ -13,7 +13,7 @@ WarmupCount=15
 ....
 [options="header"]
 |===
-|Method  |      Mean|  Error|    StdDev|       P67
+|Method  |Mean      |Error  |StdDev    |P67       
 |Foo     |  1.000 ns|     NA|  0.000 ns|  1.000 ns
 |Bar     |  1.000 ns|     NA|  0.000 ns|  1.000 ns
 |===
@@ -410,10 +410,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-Method |     Mean | Error |   StdDev |      P67 |
------- |---------:|------:|---------:|---------:|
-Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+ Method | Mean     | Error | StdDev   | P67      |
+------- |---------:|------:|---------:|---------:|
+ Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+ Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 MarkdownExporter-atlassian
 ############################################
@@ -429,7 +429,7 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 {noformat}
-||Method ||    Mean ||Error ||  StdDev ||     P67 ||
+| Method ||Mean     ||Error ||StdDev   ||P67      ||
 | Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 | Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
@@ -445,7 +445,7 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-| Method |     Mean | Error |   StdDev |      P67 |
+| Method | Mean     | Error | StdDev   | P67      |
 |------- |---------:|------:|---------:|---------:|
 | Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 | Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
@@ -464,7 +464,7 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 ```
-| Method |     Mean | Error |   StdDev |      P67 |
+| Method | Mean     | Error | StdDev   | P67      |
 |------- |---------:|------:|---------:|---------:|
 | Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 | Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
@@ -481,10 +481,10 @@ MarkdownExporter-stackoverflow
     Job=LongRun  IterationCount=100  LaunchCount=3  
     WarmupCount=15  
 
-    Method |     Mean | Error |   StdDev |      P67 |
-    ------ |---------:|------:|---------:|---------:|
-    Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-    Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+     Method | Mean     | Error | StdDev   | P67      |
+    ------- |---------:|------:|---------:|---------:|
+     Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+     Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 PlainExporter
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_en-US.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_en-US.verified.txt
@@ -429,7 +429,7 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 {noformat}
-| Method ||Mean     ||Error ||StdDev   ||P67      ||
+||Method ||Mean     ||Error ||StdDev   ||P67      ||
 | Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 | Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_en-US.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_en-US.verified.txt
@@ -13,9 +13,9 @@ WarmupCount=15
 ....
 [options="header"]
 |===
-|Method  |Mean      |Error  |StdDev    |P67       
-|Foo     |1.000 ns  |NA     |0.000 ns  |1.000 ns  
-|Bar     |1.000 ns  |NA     |0.000 ns  |1.000 ns  
+|Method  |      Mean|  Error|    StdDev|       P67
+|Foo     |  1.000 ns|     NA|  0.000 ns|  1.000 ns
+|Bar     |  1.000 ns|     NA|  0.000 ns|  1.000 ns
 |===
 ############################################
 HtmlExporter
@@ -410,10 +410,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-Method | Mean     | Error | StdDev   | P67      | 
+Method |     Mean | Error |   StdDev |      P67 |
 ------ |---------:|------:|---------:|---------:|
-Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
-Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 MarkdownExporter-atlassian
 ############################################
@@ -429,9 +429,9 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 {noformat}
-||Method ||Mean     ||Error ||StdDev   ||P67      ||
-| Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
-| Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+||Method ||    Mean ||Error ||  StdDev ||     P67 ||
+| Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+| Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 MarkdownExporter-console
 ############################################
@@ -445,10 +445,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-| Method | Mean     | Error | StdDev   | P67      | 
+| Method |     Mean | Error |   StdDev |      P67 |
 |------- |---------:|------:|---------:|---------:|
-| Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
-| Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+| Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+| Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 MarkdownExporter-github
 ############################################
@@ -464,10 +464,10 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 ```
-| Method | Mean     | Error | StdDev   | P67      | 
+| Method |     Mean | Error |   StdDev |      P67 |
 |------- |---------:|------:|---------:|---------:|
-| Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
-| Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+| Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+| Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 MarkdownExporter-stackoverflow
 ############################################
@@ -481,10 +481,10 @@ MarkdownExporter-stackoverflow
     Job=LongRun  IterationCount=100  LaunchCount=3  
     WarmupCount=15  
 
-    Method | Mean     | Error | StdDev   | P67      | 
+    Method |     Mean | Error |   StdDev |      P67 |
     ------ |---------:|------:|---------:|---------:|
-    Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
-    Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+    Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+    Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 PlainExporter
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_en-US.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_en-US.verified.txt
@@ -13,9 +13,9 @@ WarmupCount=15
 ....
 [options="header"]
 |===
-|  Method|      Mean|  Error|    StdDev|       P67
-|     Foo|  1.000 ns|     NA|  0.000 ns|  1.000 ns
-|     Bar|  1.000 ns|     NA|  0.000 ns|  1.000 ns
+|Method  |Mean      |Error  |StdDev    |P67       
+|Foo     |1.000 ns  |NA     |0.000 ns  |1.000 ns  
+|Bar     |1.000 ns  |NA     |0.000 ns  |1.000 ns  
 |===
 ############################################
 HtmlExporter
@@ -410,10 +410,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
- Method |     Mean | Error |   StdDev |      P67 |
-------- |---------:|------:|---------:|---------:|
-    Foo | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-    Bar | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+Method | Mean     | Error | StdDev   | P67      | 
+------ |---------:|------:|---------:|---------:|
+Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
 ############################################
 MarkdownExporter-atlassian
 ############################################
@@ -429,9 +429,9 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 {noformat}
-||Method ||    Mean ||Error ||  StdDev ||     P67 ||
-|    Foo | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-|    Bar | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+||Method ||Mean     ||Error ||StdDev   ||P67      ||
+| Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+| Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
 ############################################
 MarkdownExporter-console
 ############################################
@@ -445,10 +445,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-| Method |     Mean | Error |   StdDev |      P67 |
+| Method | Mean     | Error | StdDev   | P67      | 
 |------- |---------:|------:|---------:|---------:|
-|    Foo | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-|    Bar | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+| Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+| Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
 ############################################
 MarkdownExporter-github
 ############################################
@@ -464,10 +464,10 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 ```
-| Method |     Mean | Error |   StdDev |      P67 |
+| Method | Mean     | Error | StdDev   | P67      | 
 |------- |---------:|------:|---------:|---------:|
-|    Foo | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-|    Bar | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+| Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+| Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
 ############################################
 MarkdownExporter-stackoverflow
 ############################################
@@ -481,10 +481,10 @@ MarkdownExporter-stackoverflow
     Job=LongRun  IterationCount=100  LaunchCount=3  
     WarmupCount=15  
 
-     Method |     Mean | Error |   StdDev |      P67 |
-    ------- |---------:|------:|---------:|---------:|
-        Foo | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-        Bar | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+    Method | Mean     | Error | StdDev   | P67      | 
+    ------ |---------:|------:|---------:|---------:|
+    Foo    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
+    Bar    | 1.000 ns | NA    | 0.000 ns | 1.000 ns | 
 ############################################
 PlainExporter
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_en-US.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_en-US.verified.txt
@@ -13,7 +13,7 @@ WarmupCount=15
 ....
 [options="header"]
 |===
-|Method  |      Mean|  Error|    StdDev|       P67
+|Method  |Mean      |Error  |StdDev    |P67       
 |Foo     |  1.000 ns|     NA|  0.000 ns|  1.000 ns
 |Bar     |  1.000 ns|     NA|  0.000 ns|  1.000 ns
 |===
@@ -410,10 +410,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-Method |     Mean | Error |   StdDev |      P67 |
------- |---------:|------:|---------:|---------:|
-Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+ Method | Mean     | Error | StdDev   | P67      |
+------- |---------:|------:|---------:|---------:|
+ Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+ Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 MarkdownExporter-atlassian
 ############################################
@@ -429,7 +429,7 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 {noformat}
-||Method ||    Mean ||Error ||  StdDev ||     P67 ||
+| Method ||Mean     ||Error ||StdDev   ||P67      ||
 | Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 | Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
@@ -445,7 +445,7 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-| Method |     Mean | Error |   StdDev |      P67 |
+| Method | Mean     | Error | StdDev   | P67      |
 |------- |---------:|------:|---------:|---------:|
 | Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 | Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
@@ -464,7 +464,7 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 ```
-| Method |     Mean | Error |   StdDev |      P67 |
+| Method | Mean     | Error | StdDev   | P67      |
 |------- |---------:|------:|---------:|---------:|
 | Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 | Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
@@ -481,10 +481,10 @@ MarkdownExporter-stackoverflow
     Job=LongRun  IterationCount=100  LaunchCount=3  
     WarmupCount=15  
 
-    Method |     Mean | Error |   StdDev |      P67 |
-    ------ |---------:|------:|---------:|---------:|
-    Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
-    Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+     Method | Mean     | Error | StdDev   | P67      |
+    ------- |---------:|------:|---------:|---------:|
+     Foo    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
+     Bar    | 1.000 ns |    NA | 0.000 ns | 1.000 ns |
 ############################################
 PlainExporter
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_ru-RU.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_ru-RU.verified.txt
@@ -429,7 +429,7 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 {noformat}
-| Method ||Mean     ||Error ||StdDev   ||P67      ||
+||Method ||Mean     ||Error ||StdDev   ||P67      ||
 | Foo    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
 | Bar    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_ru-RU.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_ru-RU.verified.txt
@@ -13,9 +13,9 @@ WarmupCount=15
 ....
 [options="header"]
 |===
-|  Method|      Mean|  Error|    StdDev|       P67
-|     Foo|  1,000 ns|     NA|  0,000 ns|  1,000 ns
-|     Bar|  1,000 ns|     NA|  0,000 ns|  1,000 ns
+|Method  |Mean      |Error  |StdDev    |P67       
+|Foo     |1,000 ns  |NA     |0,000 ns  |1,000 ns  
+|Bar     |1,000 ns  |NA     |0,000 ns  |1,000 ns  
 |===
 ############################################
 HtmlExporter
@@ -410,10 +410,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
- Method |     Mean | Error |   StdDev |      P67 |
-------- |---------:|------:|---------:|---------:|
-    Foo | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
-    Bar | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+Method | Mean     | Error | StdDev   | P67      | 
+------ |---------:|------:|---------:|---------:|
+Foo    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
+Bar    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
 ############################################
 MarkdownExporter-atlassian
 ############################################
@@ -429,9 +429,9 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 {noformat}
-||Method ||    Mean ||Error ||  StdDev ||     P67 ||
-|    Foo | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
-|    Bar | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+||Method ||Mean     ||Error ||StdDev   ||P67      ||
+| Foo    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
+| Bar    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
 ############################################
 MarkdownExporter-console
 ############################################
@@ -445,10 +445,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-| Method |     Mean | Error |   StdDev |      P67 |
+| Method | Mean     | Error | StdDev   | P67      | 
 |------- |---------:|------:|---------:|---------:|
-|    Foo | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
-|    Bar | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+| Foo    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
+| Bar    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
 ############################################
 MarkdownExporter-github
 ############################################
@@ -464,10 +464,10 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 ```
-| Method |     Mean | Error |   StdDev |      P67 |
+| Method | Mean     | Error | StdDev   | P67      | 
 |------- |---------:|------:|---------:|---------:|
-|    Foo | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
-|    Bar | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+| Foo    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
+| Bar    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
 ############################################
 MarkdownExporter-stackoverflow
 ############################################
@@ -481,10 +481,10 @@ MarkdownExporter-stackoverflow
     Job=LongRun  IterationCount=100  LaunchCount=3  
     WarmupCount=15  
 
-     Method |     Mean | Error |   StdDev |      P67 |
-    ------- |---------:|------:|---------:|---------:|
-        Foo | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
-        Bar | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+    Method | Mean     | Error | StdDev   | P67      | 
+    ------ |---------:|------:|---------:|---------:|
+    Foo    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
+    Bar    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
 ############################################
 PlainExporter
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_ru-RU.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_ru-RU.verified.txt
@@ -13,9 +13,9 @@ WarmupCount=15
 ....
 [options="header"]
 |===
-|Method  |Mean      |Error  |StdDev    |P67       
-|Foo     |1,000 ns  |NA     |0,000 ns  |1,000 ns  
-|Bar     |1,000 ns  |NA     |0,000 ns  |1,000 ns  
+|Method  |      Mean|  Error|    StdDev|       P67
+|Foo     |  1,000 ns|     NA|  0,000 ns|  1,000 ns
+|Bar     |  1,000 ns|     NA|  0,000 ns|  1,000 ns
 |===
 ############################################
 HtmlExporter
@@ -410,10 +410,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-Method | Mean     | Error | StdDev   | P67      | 
+Method |     Mean | Error |   StdDev |      P67 |
 ------ |---------:|------:|---------:|---------:|
-Foo    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
-Bar    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
+Foo    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+Bar    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
 ############################################
 MarkdownExporter-atlassian
 ############################################
@@ -429,9 +429,9 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 {noformat}
-||Method ||Mean     ||Error ||StdDev   ||P67      ||
-| Foo    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
-| Bar    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
+||Method ||    Mean ||Error ||  StdDev ||     P67 ||
+| Foo    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+| Bar    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
 ############################################
 MarkdownExporter-console
 ############################################
@@ -445,10 +445,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-| Method | Mean     | Error | StdDev   | P67      | 
+| Method |     Mean | Error |   StdDev |      P67 |
 |------- |---------:|------:|---------:|---------:|
-| Foo    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
-| Bar    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
+| Foo    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+| Bar    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
 ############################################
 MarkdownExporter-github
 ############################################
@@ -464,10 +464,10 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 ```
-| Method | Mean     | Error | StdDev   | P67      | 
+| Method |     Mean | Error |   StdDev |      P67 |
 |------- |---------:|------:|---------:|---------:|
-| Foo    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
-| Bar    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
+| Foo    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+| Bar    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
 ############################################
 MarkdownExporter-stackoverflow
 ############################################
@@ -481,10 +481,10 @@ MarkdownExporter-stackoverflow
     Job=LongRun  IterationCount=100  LaunchCount=3  
     WarmupCount=15  
 
-    Method | Mean     | Error | StdDev   | P67      | 
+    Method |     Mean | Error |   StdDev |      P67 |
     ------ |---------:|------:|---------:|---------:|
-    Foo    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
-    Bar    | 1,000 ns | NA    | 0,000 ns | 1,000 ns | 
+    Foo    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+    Bar    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
 ############################################
 PlainExporter
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_ru-RU.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_ru-RU.verified.txt
@@ -13,7 +13,7 @@ WarmupCount=15
 ....
 [options="header"]
 |===
-|Method  |      Mean|  Error|    StdDev|       P67
+|Method  |Mean      |Error  |StdDev    |P67       
 |Foo     |  1,000 ns|     NA|  0,000 ns|  1,000 ns
 |Bar     |  1,000 ns|     NA|  0,000 ns|  1,000 ns
 |===
@@ -410,10 +410,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-Method |     Mean | Error |   StdDev |      P67 |
------- |---------:|------:|---------:|---------:|
-Foo    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
-Bar    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+ Method | Mean     | Error | StdDev   | P67      |
+------- |---------:|------:|---------:|---------:|
+ Foo    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+ Bar    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
 ############################################
 MarkdownExporter-atlassian
 ############################################
@@ -429,7 +429,7 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 {noformat}
-||Method ||    Mean ||Error ||  StdDev ||     P67 ||
+| Method ||Mean     ||Error ||StdDev   ||P67      ||
 | Foo    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
 | Bar    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
 ############################################
@@ -445,7 +445,7 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
 Job=LongRun  IterationCount=100  LaunchCount=3  
 WarmupCount=15  
 
-| Method |     Mean | Error |   StdDev |      P67 |
+| Method | Mean     | Error | StdDev   | P67      |
 |------- |---------:|------:|---------:|---------:|
 | Foo    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
 | Bar    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
@@ -464,7 +464,7 @@ Job=LongRun  IterationCount=100  LaunchCount=3
 WarmupCount=15  
 
 ```
-| Method |     Mean | Error |   StdDev |      P67 |
+| Method | Mean     | Error | StdDev   | P67      |
 |------- |---------:|------:|---------:|---------:|
 | Foo    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
 | Bar    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
@@ -481,10 +481,10 @@ MarkdownExporter-stackoverflow
     Job=LongRun  IterationCount=100  LaunchCount=3  
     WarmupCount=15  
 
-    Method |     Mean | Error |   StdDev |      P67 |
-    ------ |---------:|------:|---------:|---------:|
-    Foo    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
-    Bar    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+     Method | Mean     | Error | StdDev   | P67      |
+    ------- |---------:|------:|---------:|---------:|
+     Foo    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
+     Bar    | 1,000 ns |    NA | 0,000 ns | 1,000 ns |
 ############################################
 PlainExporter
 ############################################

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Escape_ParamsAndArguments.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Escape_ParamsAndArguments.verified.txt
@@ -7,13 +7,13 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method | StringParam | charArg |     Mean |   Error |  StdDev |
------- |------------ |-------- |---------:|--------:|--------:|
-Foo    | \t          | \t      | 102.0 ns | 6.09 ns | 1.58 ns | ^
-Foo    | \t          | \n      | 202.0 ns | 6.09 ns | 1.58 ns | ^
-Bar    | \t          | ?       | 302.0 ns | 6.09 ns | 1.58 ns | ^
-Foo    | \n          | \t      | 402.0 ns | 6.09 ns | 1.58 ns | ^
-Foo    | \n          | \n      | 502.0 ns | 6.09 ns | 1.58 ns | ^
-Bar    | \n          | ?       | 602.0 ns | 6.09 ns | 1.58 ns | ^
+ Method | StringParam | charArg | Mean     | Error   | StdDev  |
+------- |------------ |-------- |---------:|--------:|--------:|
+ Foo    | \t          | \t      | 102.0 ns | 6.09 ns | 1.58 ns | ^
+ Foo    | \t          | \n      | 202.0 ns | 6.09 ns | 1.58 ns | ^
+ Bar    | \t          | ?       | 302.0 ns | 6.09 ns | 1.58 ns | ^
+ Foo    | \n          | \t      | 402.0 ns | 6.09 ns | 1.58 ns | ^
+ Foo    | \n          | \n      | 502.0 ns | 6.09 ns | 1.58 ns | ^
+ Bar    | \n          | ?       | 602.0 ns | 6.09 ns | 1.58 ns | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Escape_ParamsAndArguments.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Escape_ParamsAndArguments.verified.txt
@@ -7,13 +7,13 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method | StringParam | charArg | Mean     | Error   | StdDev  | 
+Method | StringParam | charArg |     Mean |   Error |  StdDev |
 ------ |------------ |-------- |---------:|--------:|--------:|
-Foo    | \t          | \t      | 102.0 ns | 6.09 ns | 1.58 ns |  ^
-Foo    | \t          | \n      | 202.0 ns | 6.09 ns | 1.58 ns |  ^
-Bar    | \t          | ?       | 302.0 ns | 6.09 ns | 1.58 ns |  ^
-Foo    | \n          | \t      | 402.0 ns | 6.09 ns | 1.58 ns |  ^
-Foo    | \n          | \n      | 502.0 ns | 6.09 ns | 1.58 ns |  ^
-Bar    | \n          | ?       | 602.0 ns | 6.09 ns | 1.58 ns |  ^
+Foo    | \t          | \t      | 102.0 ns | 6.09 ns | 1.58 ns | ^
+Foo    | \t          | \n      | 202.0 ns | 6.09 ns | 1.58 ns | ^
+Bar    | \t          | ?       | 302.0 ns | 6.09 ns | 1.58 ns | ^
+Foo    | \n          | \t      | 402.0 ns | 6.09 ns | 1.58 ns | ^
+Foo    | \n          | \n      | 502.0 ns | 6.09 ns | 1.58 ns | ^
+Bar    | \n          | ?       | 602.0 ns | 6.09 ns | 1.58 ns | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Escape_ParamsAndArguments.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Escape_ParamsAndArguments.verified.txt
@@ -7,13 +7,13 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
- Method | StringParam | charArg |     Mean |   Error |  StdDev |
-------- |------------ |-------- |---------:|--------:|--------:|
-    Foo |          \t |      \t | 102.0 ns | 6.09 ns | 1.58 ns | ^
-    Foo |          \t |      \n | 202.0 ns | 6.09 ns | 1.58 ns | ^
-    Bar |          \t |       ? | 302.0 ns | 6.09 ns | 1.58 ns | ^
-    Foo |          \n |      \t | 402.0 ns | 6.09 ns | 1.58 ns | ^
-    Foo |          \n |      \n | 502.0 ns | 6.09 ns | 1.58 ns | ^
-    Bar |          \n |       ? | 602.0 ns | 6.09 ns | 1.58 ns | ^
+Method | StringParam | charArg | Mean     | Error   | StdDev  | 
+------ |------------ |-------- |---------:|--------:|--------:|
+Foo    | \t          | \t      | 102.0 ns | 6.09 ns | 1.58 ns |  ^
+Foo    | \t          | \n      | 202.0 ns | 6.09 ns | 1.58 ns |  ^
+Bar    | \t          | ?       | 302.0 ns | 6.09 ns | 1.58 ns |  ^
+Foo    | \n          | \t      | 402.0 ns | 6.09 ns | 1.58 ns |  ^
+Foo    | \n          | \n      | 502.0 ns | 6.09 ns | 1.58 ns |  ^
+Bar    | \n          | ?       | 602.0 ns | 6.09 ns | 1.58 ns |  ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Invalid_TwoJobBaselines.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Invalid_TwoJobBaselines.verified.txt
@@ -8,13 +8,13 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
- Method |  Job |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank |                LogicalGroup | Baseline |
-------- |----- |---------:|--------:|--------:|------:|--------:|-----:|---------------------------- |--------- |
-    Foo | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Invalid_TwoJobBaselines.Foo |      Yes |
-    Foo | Job2 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    2 | Invalid_TwoJobBaselines.Foo |      Yes |
-        |      |          |         |         |       |         |      |                             |          |
-    Bar | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Invalid_TwoJobBaselines.Bar |      Yes |
-    Bar | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 | Invalid_TwoJobBaselines.Bar |      Yes |
+Method | Job  | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup                | Baseline | 
+------ |----- |---------:|--------:|--------:|------:|--------:|-----:|---------------------------- |--------- |
+Foo    | Job1 | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | Invalid_TwoJobBaselines.Foo | Yes      | 
+Foo    | Job2 | 302.0 ns | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 2    | Invalid_TwoJobBaselines.Foo | Yes      | 
+       |      |          |         |         |       |         |      |                             |          | 
+Bar    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | Invalid_TwoJobBaselines.Bar | Yes      | 
+Bar    | Job2 | 402.0 ns | 6.09 ns | 1.58 ns | 1.99  | 0.01    | 2    | Invalid_TwoJobBaselines.Bar | Yes      | 
 
 Errors: 2
 * Only 1 job in a group can have "Baseline = true" applied to it, group Invalid_TwoJobBaselines.Foo in class Invalid_TwoJobBaselines has 2

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Invalid_TwoJobBaselines.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Invalid_TwoJobBaselines.verified.txt
@@ -8,13 +8,13 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup                | Baseline | 
+Method | Job  |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup                | Baseline |
 ------ |----- |---------:|--------:|--------:|------:|--------:|-----:|---------------------------- |--------- |
-Foo    | Job1 | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | Invalid_TwoJobBaselines.Foo | Yes      | 
-Foo    | Job2 | 302.0 ns | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 2    | Invalid_TwoJobBaselines.Foo | Yes      | 
-       |      |          |         |         |       |         |      |                             |          | 
-Bar    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | Invalid_TwoJobBaselines.Bar | Yes      | 
-Bar    | Job2 | 402.0 ns | 6.09 ns | 1.58 ns | 1.99  | 0.01    | 2    | Invalid_TwoJobBaselines.Bar | Yes      | 
+Foo    | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Invalid_TwoJobBaselines.Foo | Yes      |
+Foo    | Job2 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    2 | Invalid_TwoJobBaselines.Foo | Yes      |
+       |      |          |         |         |       |         |      |                             |          |
+Bar    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Invalid_TwoJobBaselines.Bar | Yes      |
+Bar    | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 | Invalid_TwoJobBaselines.Bar | Yes      |
 
 Errors: 2
 * Only 1 job in a group can have "Baseline = true" applied to it, group Invalid_TwoJobBaselines.Foo in class Invalid_TwoJobBaselines has 2

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Invalid_TwoJobBaselines.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Invalid_TwoJobBaselines.verified.txt
@@ -8,13 +8,13 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup                | Baseline |
------- |----- |---------:|--------:|--------:|------:|--------:|-----:|---------------------------- |--------- |
-Foo    | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Invalid_TwoJobBaselines.Foo | Yes      |
-Foo    | Job2 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    2 | Invalid_TwoJobBaselines.Foo | Yes      |
-       |      |          |         |         |       |         |      |                             |          |
-Bar    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Invalid_TwoJobBaselines.Bar | Yes      |
-Bar    | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 | Invalid_TwoJobBaselines.Bar | Yes      |
+ Method | Job  | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup                | Baseline |
+------- |----- |---------:|--------:|--------:|------:|--------:|-----:|---------------------------- |--------- |
+ Foo    | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Invalid_TwoJobBaselines.Foo | Yes      |
+ Foo    | Job2 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    2 | Invalid_TwoJobBaselines.Foo | Yes      |
+        |      |          |         |         |       |         |      |                             |          |
+ Bar    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Invalid_TwoJobBaselines.Bar | Yes      |
+ Bar    | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 | Invalid_TwoJobBaselines.Bar | Yes      |
 
 Errors: 2
 * Only 1 job in a group can have "Baseline = true" applied to it, group Invalid_TwoJobBaselines.Foo in class Invalid_TwoJobBaselines has 2

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Invalid_TwoMethodBaselines.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Invalid_TwoMethodBaselines.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline | 
+Method |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
 ------ |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-Foo    | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | DefaultJob   | Yes      | 
-Bar    | 202.0 ns | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | DefaultJob   | Yes      | 
+Foo    | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | DefaultJob   | Yes      |
+Bar    | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | DefaultJob   | Yes      |
 
 Errors: 1
 * Only 1 benchmark method in a group can have "Baseline = true" applied to it, group DefaultJob in class Invalid_TwoMethodBaselines has 2

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Invalid_TwoMethodBaselines.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Invalid_TwoMethodBaselines.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
------- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-Foo    | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | DefaultJob   | Yes      |
-Bar    | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | DefaultJob   | Yes      |
+ Method | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
+------- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
+ Foo    | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | DefaultJob   | Yes      |
+ Bar    | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | DefaultJob   | Yes      |
 
 Errors: 1
 * Only 1 benchmark method in a group can have "Baseline = true" applied to it, group DefaultJob in class Invalid_TwoMethodBaselines has 2

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Invalid_TwoMethodBaselines.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_Invalid_TwoMethodBaselines.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
- Method |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
-------- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-    Foo | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |   DefaultJob |      Yes |
-    Bar | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 |   DefaultJob |      Yes |
+Method | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline | 
+------ |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
+Foo    | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | DefaultJob   | Yes      | 
+Bar    | 202.0 ns | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | DefaultJob   | Yes      | 
 
 Errors: 1
 * Only 1 benchmark method in a group can have "Baseline = true" applied to it, group DefaultJob in class Invalid_TwoMethodBaselines has 2

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_JobBaseline_MethodsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_JobBaseline_MethodsJobs.verified.txt
@@ -8,15 +8,15 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup                 | Baseline | 
+Method | Job  |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup                 | Baseline |
 ------ |----- |---------:|--------:|--------:|------:|--------:|-----:|----------------------------- |--------- |
-Base   | Job1 | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | JobBaseline_MethodsJobs.Base | Yes      | 
-Base   | Job2 | 402.0 ns | 6.09 ns | 1.58 ns | 3.94  | 0.05    | 2    | JobBaseline_MethodsJobs.Base | No       | 
-       |      |          |         |         |       |         |      |                              |          | 
-Foo    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | JobBaseline_MethodsJobs.Foo  | Yes      | 
-Foo    | Job2 | 502.0 ns | 6.09 ns | 1.58 ns | 2.49  | 0.01    | 2    | JobBaseline_MethodsJobs.Foo  | No       | 
-       |      |          |         |         |       |         |      |                              |          | 
-Bar    | Job1 | 302.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | JobBaseline_MethodsJobs.Bar  | Yes      | 
-Bar    | Job2 | 602.0 ns | 6.09 ns | 1.58 ns | 1.99  | 0.01    | 2    | JobBaseline_MethodsJobs.Bar  | No       | 
+Base   | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | JobBaseline_MethodsJobs.Base | Yes      |
+Base   | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    2 | JobBaseline_MethodsJobs.Base | No       |
+       |      |          |         |         |       |         |      |                              |          |
+Foo    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | JobBaseline_MethodsJobs.Foo  | Yes      |
+Foo    | Job2 | 502.0 ns | 6.09 ns | 1.58 ns |  2.49 |    0.01 |    2 | JobBaseline_MethodsJobs.Foo  | No       |
+       |      |          |         |         |       |         |      |                              |          |
+Bar    | Job1 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | JobBaseline_MethodsJobs.Bar  | Yes      |
+Bar    | Job2 | 602.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 | JobBaseline_MethodsJobs.Bar  | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_JobBaseline_MethodsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_JobBaseline_MethodsJobs.verified.txt
@@ -8,15 +8,15 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
- Method |  Job |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank |                 LogicalGroup | Baseline |
-------- |----- |---------:|--------:|--------:|------:|--------:|-----:|----------------------------- |--------- |
-   Base | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | JobBaseline_MethodsJobs.Base |      Yes |
-   Base | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    2 | JobBaseline_MethodsJobs.Base |       No |
-        |      |          |         |         |       |         |      |                              |          |
-    Foo | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  JobBaseline_MethodsJobs.Foo |      Yes |
-    Foo | Job2 | 502.0 ns | 6.09 ns | 1.58 ns |  2.49 |    0.01 |    2 |  JobBaseline_MethodsJobs.Foo |       No |
-        |      |          |         |         |       |         |      |                              |          |
-    Bar | Job1 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  JobBaseline_MethodsJobs.Bar |      Yes |
-    Bar | Job2 | 602.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 |  JobBaseline_MethodsJobs.Bar |       No |
+Method | Job  | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup                 | Baseline | 
+------ |----- |---------:|--------:|--------:|------:|--------:|-----:|----------------------------- |--------- |
+Base   | Job1 | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | JobBaseline_MethodsJobs.Base | Yes      | 
+Base   | Job2 | 402.0 ns | 6.09 ns | 1.58 ns | 3.94  | 0.05    | 2    | JobBaseline_MethodsJobs.Base | No       | 
+       |      |          |         |         |       |         |      |                              |          | 
+Foo    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | JobBaseline_MethodsJobs.Foo  | Yes      | 
+Foo    | Job2 | 502.0 ns | 6.09 ns | 1.58 ns | 2.49  | 0.01    | 2    | JobBaseline_MethodsJobs.Foo  | No       | 
+       |      |          |         |         |       |         |      |                              |          | 
+Bar    | Job1 | 302.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | JobBaseline_MethodsJobs.Bar  | Yes      | 
+Bar    | Job2 | 602.0 ns | 6.09 ns | 1.58 ns | 1.99  | 0.01    | 2    | JobBaseline_MethodsJobs.Bar  | No       | 
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_JobBaseline_MethodsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_JobBaseline_MethodsJobs.verified.txt
@@ -8,15 +8,15 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup                 | Baseline |
------- |----- |---------:|--------:|--------:|------:|--------:|-----:|----------------------------- |--------- |
-Base   | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | JobBaseline_MethodsJobs.Base | Yes      |
-Base   | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    2 | JobBaseline_MethodsJobs.Base | No       |
-       |      |          |         |         |       |         |      |                              |          |
-Foo    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | JobBaseline_MethodsJobs.Foo  | Yes      |
-Foo    | Job2 | 502.0 ns | 6.09 ns | 1.58 ns |  2.49 |    0.01 |    2 | JobBaseline_MethodsJobs.Foo  | No       |
-       |      |          |         |         |       |         |      |                              |          |
-Bar    | Job1 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | JobBaseline_MethodsJobs.Bar  | Yes      |
-Bar    | Job2 | 602.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 | JobBaseline_MethodsJobs.Bar  | No       |
+ Method | Job  | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup                 | Baseline |
+------- |----- |---------:|--------:|--------:|------:|--------:|-----:|----------------------------- |--------- |
+ Base   | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | JobBaseline_MethodsJobs.Base | Yes      |
+ Base   | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    2 | JobBaseline_MethodsJobs.Base | No       |
+        |      |          |         |         |       |         |      |                              |          |
+ Foo    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | JobBaseline_MethodsJobs.Foo  | Yes      |
+ Foo    | Job2 | 502.0 ns | 6.09 ns | 1.58 ns |  2.49 |    0.01 |    2 | JobBaseline_MethodsJobs.Foo  | No       |
+        |      |          |         |         |       |         |      |                              |          |
+ Bar    | Job1 | 302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | JobBaseline_MethodsJobs.Bar  | Yes      |
+ Bar    | Job2 | 602.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 | JobBaseline_MethodsJobs.Bar  | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_JobBaseline_MethodsParamsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_JobBaseline_MethodsParamsJobs.verified.txt
@@ -8,24 +8,24 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup                                  | Baseline |
------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------------------------------------- |--------- |
-Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-JobBaseline_MethodsParamsJobs.Base  | Yes      | ^
-Base   | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    2 | [Param=2]-JobBaseline_MethodsParamsJobs.Base  | No       |
-       |      |       |            |         |         |       |         |      |                                               |          |
-Foo    | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-JobBaseline_MethodsParamsJobs.Foo   | Yes      |
-Foo    | Job2 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |  2.49 |    0.01 |    2 | [Param=2]-JobBaseline_MethodsParamsJobs.Foo   | No       |
-       |      |       |            |         |         |       |         |      |                                               |          |
-Bar    | Job1 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-JobBaseline_MethodsParamsJobs.Bar   | Yes      |
-Bar    | Job2 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 | [Param=2]-JobBaseline_MethodsParamsJobs.Bar   | No       |
-       |      |       |            |         |         |       |         |      |                                               |          |
-Base   | Job1 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-JobBaseline_MethodsParamsJobs.Base | Yes      | ^
-Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.43 |    0.00 |    2 | [Param=10]-JobBaseline_MethodsParamsJobs.Base | No       |
-       |      |       |            |         |         |       |         |      |                                               |          |
-Foo    | Job1 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-JobBaseline_MethodsParamsJobs.Foo  | Yes      |
-Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.37 |    0.00 |    2 | [Param=10]-JobBaseline_MethodsParamsJobs.Foo  | No       |
-       |      |       |            |         |         |       |         |      |                                               |          |
-Bar    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-JobBaseline_MethodsParamsJobs.Bar  | Yes      |
-Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |    2 | [Param=10]-JobBaseline_MethodsParamsJobs.Bar  | No       |
+ Method | Job  | Param | Mean       | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup                                  | Baseline |
+------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------------------------------------- |--------- |
+ Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-JobBaseline_MethodsParamsJobs.Base  | Yes      | ^
+ Base   | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    2 | [Param=2]-JobBaseline_MethodsParamsJobs.Base  | No       |
+        |      |       |            |         |         |       |         |      |                                               |          |
+ Foo    | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-JobBaseline_MethodsParamsJobs.Foo   | Yes      |
+ Foo    | Job2 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |  2.49 |    0.01 |    2 | [Param=2]-JobBaseline_MethodsParamsJobs.Foo   | No       |
+        |      |       |            |         |         |       |         |      |                                               |          |
+ Bar    | Job1 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-JobBaseline_MethodsParamsJobs.Bar   | Yes      |
+ Bar    | Job2 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 | [Param=2]-JobBaseline_MethodsParamsJobs.Bar   | No       |
+        |      |       |            |         |         |       |         |      |                                               |          |
+ Base   | Job1 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-JobBaseline_MethodsParamsJobs.Base | Yes      | ^
+ Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.43 |    0.00 |    2 | [Param=10]-JobBaseline_MethodsParamsJobs.Base | No       |
+        |      |       |            |         |         |       |         |      |                                               |          |
+ Foo    | Job1 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-JobBaseline_MethodsParamsJobs.Foo  | Yes      |
+ Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.37 |    0.00 |    2 | [Param=10]-JobBaseline_MethodsParamsJobs.Foo  | No       |
+        |      |       |            |         |         |       |         |      |                                               |          |
+ Bar    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-JobBaseline_MethodsParamsJobs.Bar  | Yes      |
+ Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |    2 | [Param=10]-JobBaseline_MethodsParamsJobs.Bar  | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_JobBaseline_MethodsParamsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_JobBaseline_MethodsParamsJobs.verified.txt
@@ -8,24 +8,24 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param | Mean       | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup                                  | Baseline | 
+Method | Job  | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup                                  | Baseline |
 ------ |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------------------------------------- |--------- |
-Base   | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]-JobBaseline_MethodsParamsJobs.Base  | Yes      |  ^
-Base   | Job2 | 2     | 402.0 ns   | 6.09 ns | 1.58 ns | 3.94  | 0.05    | 2    | [Param=2]-JobBaseline_MethodsParamsJobs.Base  | No       | 
-       |      |       |            |         |         |       |         |      |                                               |          | 
-Foo    | Job1 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]-JobBaseline_MethodsParamsJobs.Foo   | Yes      | 
-Foo    | Job2 | 2     | 502.0 ns   | 6.09 ns | 1.58 ns | 2.49  | 0.01    | 2    | [Param=2]-JobBaseline_MethodsParamsJobs.Foo   | No       | 
-       |      |       |            |         |         |       |         |      |                                               |          | 
-Bar    | Job1 | 2     | 302.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]-JobBaseline_MethodsParamsJobs.Bar   | Yes      | 
-Bar    | Job2 | 2     | 602.0 ns   | 6.09 ns | 1.58 ns | 1.99  | 0.01    | 2    | [Param=2]-JobBaseline_MethodsParamsJobs.Bar   | No       | 
-       |      |       |            |         |         |       |         |      |                                               |          | 
-Base   | Job1 | 10    | 702.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]-JobBaseline_MethodsParamsJobs.Base | Yes      |  ^
-Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns | 1.43  | 0.00    | 2    | [Param=10]-JobBaseline_MethodsParamsJobs.Base | No       | 
-       |      |       |            |         |         |       |         |      |                                               |          | 
-Foo    | Job1 | 10    | 802.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]-JobBaseline_MethodsParamsJobs.Foo  | Yes      | 
-Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns | 1.37  | 0.00    | 2    | [Param=10]-JobBaseline_MethodsParamsJobs.Foo  | No       | 
-       |      |       |            |         |         |       |         |      |                                               |          | 
-Bar    | Job1 | 10    | 902.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]-JobBaseline_MethodsParamsJobs.Bar  | Yes      | 
-Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns | 1.33  | 0.00    | 2    | [Param=10]-JobBaseline_MethodsParamsJobs.Bar  | No       | 
+Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-JobBaseline_MethodsParamsJobs.Base  | Yes      | ^
+Base   | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    2 | [Param=2]-JobBaseline_MethodsParamsJobs.Base  | No       |
+       |      |       |            |         |         |       |         |      |                                               |          |
+Foo    | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-JobBaseline_MethodsParamsJobs.Foo   | Yes      |
+Foo    | Job2 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |  2.49 |    0.01 |    2 | [Param=2]-JobBaseline_MethodsParamsJobs.Foo   | No       |
+       |      |       |            |         |         |       |         |      |                                               |          |
+Bar    | Job1 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-JobBaseline_MethodsParamsJobs.Bar   | Yes      |
+Bar    | Job2 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 | [Param=2]-JobBaseline_MethodsParamsJobs.Bar   | No       |
+       |      |       |            |         |         |       |         |      |                                               |          |
+Base   | Job1 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-JobBaseline_MethodsParamsJobs.Base | Yes      | ^
+Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.43 |    0.00 |    2 | [Param=10]-JobBaseline_MethodsParamsJobs.Base | No       |
+       |      |       |            |         |         |       |         |      |                                               |          |
+Foo    | Job1 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-JobBaseline_MethodsParamsJobs.Foo  | Yes      |
+Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.37 |    0.00 |    2 | [Param=10]-JobBaseline_MethodsParamsJobs.Foo  | No       |
+       |      |       |            |         |         |       |         |      |                                               |          |
+Bar    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-JobBaseline_MethodsParamsJobs.Bar  | Yes      |
+Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |    2 | [Param=10]-JobBaseline_MethodsParamsJobs.Bar  | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_JobBaseline_MethodsParamsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_JobBaseline_MethodsParamsJobs.verified.txt
@@ -8,24 +8,24 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
- Method |  Job | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank |                                  LogicalGroup | Baseline |
-------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------------------------------------- |--------- |
-   Base | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  [Param=2]-JobBaseline_MethodsParamsJobs.Base |      Yes | ^
-   Base | Job2 |     2 |   402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    2 |  [Param=2]-JobBaseline_MethodsParamsJobs.Base |       No |
-        |      |       |            |         |         |       |         |      |                                               |          |
-    Foo | Job1 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |   [Param=2]-JobBaseline_MethodsParamsJobs.Foo |      Yes |
-    Foo | Job2 |     2 |   502.0 ns | 6.09 ns | 1.58 ns |  2.49 |    0.01 |    2 |   [Param=2]-JobBaseline_MethodsParamsJobs.Foo |       No |
-        |      |       |            |         |         |       |         |      |                                               |          |
-    Bar | Job1 |     2 |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |   [Param=2]-JobBaseline_MethodsParamsJobs.Bar |      Yes |
-    Bar | Job2 |     2 |   602.0 ns | 6.09 ns | 1.58 ns |  1.99 |    0.01 |    2 |   [Param=2]-JobBaseline_MethodsParamsJobs.Bar |       No |
-        |      |       |            |         |         |       |         |      |                                               |          |
-   Base | Job1 |    10 |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-JobBaseline_MethodsParamsJobs.Base |      Yes | ^
-   Base | Job2 |    10 | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.43 |    0.00 |    2 | [Param=10]-JobBaseline_MethodsParamsJobs.Base |       No |
-        |      |       |            |         |         |       |         |      |                                               |          |
-    Foo | Job1 |    10 |   802.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  [Param=10]-JobBaseline_MethodsParamsJobs.Foo |      Yes |
-    Foo | Job2 |    10 | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.37 |    0.00 |    2 |  [Param=10]-JobBaseline_MethodsParamsJobs.Foo |       No |
-        |      |       |            |         |         |       |         |      |                                               |          |
-    Bar | Job1 |    10 |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  [Param=10]-JobBaseline_MethodsParamsJobs.Bar |      Yes |
-    Bar | Job2 |    10 | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |    2 |  [Param=10]-JobBaseline_MethodsParamsJobs.Bar |       No |
+Method | Job  | Param | Mean       | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup                                  | Baseline | 
+------ |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------------------------------------- |--------- |
+Base   | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]-JobBaseline_MethodsParamsJobs.Base  | Yes      |  ^
+Base   | Job2 | 2     | 402.0 ns   | 6.09 ns | 1.58 ns | 3.94  | 0.05    | 2    | [Param=2]-JobBaseline_MethodsParamsJobs.Base  | No       | 
+       |      |       |            |         |         |       |         |      |                                               |          | 
+Foo    | Job1 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]-JobBaseline_MethodsParamsJobs.Foo   | Yes      | 
+Foo    | Job2 | 2     | 502.0 ns   | 6.09 ns | 1.58 ns | 2.49  | 0.01    | 2    | [Param=2]-JobBaseline_MethodsParamsJobs.Foo   | No       | 
+       |      |       |            |         |         |       |         |      |                                               |          | 
+Bar    | Job1 | 2     | 302.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]-JobBaseline_MethodsParamsJobs.Bar   | Yes      | 
+Bar    | Job2 | 2     | 602.0 ns   | 6.09 ns | 1.58 ns | 1.99  | 0.01    | 2    | [Param=2]-JobBaseline_MethodsParamsJobs.Bar   | No       | 
+       |      |       |            |         |         |       |         |      |                                               |          | 
+Base   | Job1 | 10    | 702.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]-JobBaseline_MethodsParamsJobs.Base | Yes      |  ^
+Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns | 1.43  | 0.00    | 2    | [Param=10]-JobBaseline_MethodsParamsJobs.Base | No       | 
+       |      |       |            |         |         |       |         |      |                                               |          | 
+Foo    | Job1 | 10    | 802.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]-JobBaseline_MethodsParamsJobs.Foo  | Yes      | 
+Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns | 1.37  | 0.00    | 2    | [Param=10]-JobBaseline_MethodsParamsJobs.Foo  | No       | 
+       |      |       |            |         |         |       |         |      |                                               |          | 
+Bar    | Job1 | 10    | 902.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]-JobBaseline_MethodsParamsJobs.Bar  | Yes      | 
+Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns | 1.33  | 0.00    | 2    | [Param=10]-JobBaseline_MethodsParamsJobs.Bar  | No       | 
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_Methods.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_Methods.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
- Method |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
-------- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-   Base | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |   DefaultJob |      Yes |
-    Foo | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 |   DefaultJob |       No |
-    Bar | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 |   DefaultJob |       No |
+Method | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline | 
+------ |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
+Base   | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | DefaultJob   | Yes      | 
+Foo    | 202.0 ns | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | DefaultJob   | No       | 
+Bar    | 302.0 ns | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 3    | DefaultJob   | No       | 
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_Methods.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_Methods.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline | 
+Method |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
 ------ |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-Base   | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | DefaultJob   | Yes      | 
-Foo    | 202.0 ns | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | DefaultJob   | No       | 
-Bar    | 302.0 ns | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 3    | DefaultJob   | No       | 
+Base   | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | DefaultJob   | Yes      |
+Foo    | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | DefaultJob   | No       |
+Bar    | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | DefaultJob   | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_Methods.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_Methods.verified.txt
@@ -7,10 +7,10 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
------- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-Base   | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | DefaultJob   | Yes      |
-Foo    | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | DefaultJob   | No       |
-Bar    | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | DefaultJob   | No       |
+ Method | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
+------- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
+ Base   | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | DefaultJob   | Yes      |
+ Foo    | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | DefaultJob   | No       |
+ Bar    | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | DefaultJob   | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsJobs.verified.txt
@@ -8,14 +8,14 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
------- |----- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-Base   | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Job1         | Yes      |
-Foo    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | Job1         | No       |
-Bar    | Job1 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | Job1         | No       |
-       |      |          |         |         |       |         |      |              |          |
-Base   | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Job2         | Yes      |
-Foo    | Job2 | 502.0 ns | 6.09 ns | 1.58 ns |  1.25 |    0.00 |    2 | Job2         | No       |
-Bar    | Job2 | 602.0 ns | 6.09 ns | 1.58 ns |  1.50 |    0.00 |    3 | Job2         | No       |
+ Method | Job  | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
+------- |----- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
+ Base   | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Job1         | Yes      |
+ Foo    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | Job1         | No       |
+ Bar    | Job1 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | Job1         | No       |
+        |      |          |         |         |       |         |      |              |          |
+ Base   | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Job2         | Yes      |
+ Foo    | Job2 | 502.0 ns | 6.09 ns | 1.58 ns |  1.25 |    0.00 |    2 | Job2         | No       |
+ Bar    | Job2 | 602.0 ns | 6.09 ns | 1.58 ns |  1.50 |    0.00 |    3 | Job2         | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsJobs.verified.txt
@@ -8,14 +8,14 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline | 
+Method | Job  |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
 ------ |----- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-Base   | Job1 | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | Job1         | Yes      | 
-Foo    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | Job1         | No       | 
-Bar    | Job1 | 302.0 ns | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 3    | Job1         | No       | 
-       |      |          |         |         |       |         |      |              |          | 
-Base   | Job2 | 402.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | Job2         | Yes      | 
-Foo    | Job2 | 502.0 ns | 6.09 ns | 1.58 ns | 1.25  | 0.00    | 2    | Job2         | No       | 
-Bar    | Job2 | 602.0 ns | 6.09 ns | 1.58 ns | 1.50  | 0.00    | 3    | Job2         | No       | 
+Base   | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Job1         | Yes      |
+Foo    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | Job1         | No       |
+Bar    | Job1 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | Job1         | No       |
+       |      |          |         |         |       |         |      |              |          |
+Base   | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | Job2         | Yes      |
+Foo    | Job2 | 502.0 ns | 6.09 ns | 1.58 ns |  1.25 |    0.00 |    2 | Job2         | No       |
+Bar    | Job2 | 602.0 ns | 6.09 ns | 1.58 ns |  1.50 |    0.00 |    3 | Job2         | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsJobs.verified.txt
@@ -8,14 +8,14 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
- Method |  Job |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
-------- |----- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-   Base | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |         Job1 |      Yes |
-    Foo | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 |         Job1 |       No |
-    Bar | Job1 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 |         Job1 |       No |
-        |      |          |         |         |       |         |      |              |          |
-   Base | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |         Job2 |      Yes |
-    Foo | Job2 | 502.0 ns | 6.09 ns | 1.58 ns |  1.25 |    0.00 |    2 |         Job2 |       No |
-    Bar | Job2 | 602.0 ns | 6.09 ns | 1.58 ns |  1.50 |    0.00 |    3 |         Job2 |       No |
+Method | Job  | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline | 
+------ |----- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
+Base   | Job1 | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | Job1         | Yes      | 
+Foo    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | Job1         | No       | 
+Bar    | Job1 | 302.0 ns | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 3    | Job1         | No       | 
+       |      |          |         |         |       |         |      |              |          | 
+Base   | Job2 | 402.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | Job2         | Yes      | 
+Foo    | Job2 | 502.0 ns | 6.09 ns | 1.58 ns | 1.25  | 0.00    | 2    | Job2         | No       | 
+Bar    | Job2 | 602.0 ns | 6.09 ns | 1.58 ns | 1.50  | 0.00    | 3    | Job2         | No       | 
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsParams.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsParams.verified.txt
@@ -7,14 +7,14 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
- Method | Param |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank |          LogicalGroup | Baseline |
-------- |------ |---------:|--------:|--------:|------:|--------:|-----:|---------------------- |--------- |
-   Base |     2 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  [Param=2]-DefaultJob |      Yes | ^
-    Foo |     2 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 |  [Param=2]-DefaultJob |       No |
-    Bar |     2 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 |  [Param=2]-DefaultJob |       No |
-        |       |          |         |         |       |         |      |                       |          |
-   Base |    10 | 402.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-DefaultJob |      Yes | ^
-    Foo |    10 | 502.0 ns | 6.09 ns | 1.58 ns |  1.25 |    0.00 |    2 | [Param=10]-DefaultJob |       No |
-    Bar |    10 | 602.0 ns | 6.09 ns | 1.58 ns |  1.50 |    0.00 |    3 | [Param=10]-DefaultJob |       No |
+Method | Param | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup          | Baseline | 
+------ |------ |---------:|--------:|--------:|------:|--------:|-----:|---------------------- |--------- |
+Base   | 2     | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]-DefaultJob  | Yes      |  ^
+Foo    | 2     | 202.0 ns | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | [Param=2]-DefaultJob  | No       | 
+Bar    | 2     | 302.0 ns | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 3    | [Param=2]-DefaultJob  | No       | 
+       |       |          |         |         |       |         |      |                       |          | 
+Base   | 10    | 402.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]-DefaultJob | Yes      |  ^
+Foo    | 10    | 502.0 ns | 6.09 ns | 1.58 ns | 1.25  | 0.00    | 2    | [Param=10]-DefaultJob | No       | 
+Bar    | 10    | 602.0 ns | 6.09 ns | 1.58 ns | 1.50  | 0.00    | 3    | [Param=10]-DefaultJob | No       | 
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsParams.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsParams.verified.txt
@@ -7,14 +7,14 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method | Param | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup          | Baseline | 
+Method | Param |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup          | Baseline |
 ------ |------ |---------:|--------:|--------:|------:|--------:|-----:|---------------------- |--------- |
-Base   | 2     | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]-DefaultJob  | Yes      |  ^
-Foo    | 2     | 202.0 ns | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | [Param=2]-DefaultJob  | No       | 
-Bar    | 2     | 302.0 ns | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 3    | [Param=2]-DefaultJob  | No       | 
-       |       |          |         |         |       |         |      |                       |          | 
-Base   | 10    | 402.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]-DefaultJob | Yes      |  ^
-Foo    | 10    | 502.0 ns | 6.09 ns | 1.58 ns | 1.25  | 0.00    | 2    | [Param=10]-DefaultJob | No       | 
-Bar    | 10    | 602.0 ns | 6.09 ns | 1.58 ns | 1.50  | 0.00    | 3    | [Param=10]-DefaultJob | No       | 
+Base   | 2     | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-DefaultJob  | Yes      | ^
+Foo    | 2     | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | [Param=2]-DefaultJob  | No       |
+Bar    | 2     | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | [Param=2]-DefaultJob  | No       |
+       |       |          |         |         |       |         |      |                       |          |
+Base   | 10    | 402.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-DefaultJob | Yes      | ^
+Foo    | 10    | 502.0 ns | 6.09 ns | 1.58 ns |  1.25 |    0.00 |    2 | [Param=10]-DefaultJob | No       |
+Bar    | 10    | 602.0 ns | 6.09 ns | 1.58 ns |  1.50 |    0.00 |    3 | [Param=10]-DefaultJob | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsParams.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsParams.verified.txt
@@ -7,14 +7,14 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   DefaultJob : extra output line
 
 
-Method | Param |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup          | Baseline |
------- |------ |---------:|--------:|--------:|------:|--------:|-----:|---------------------- |--------- |
-Base   | 2     | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-DefaultJob  | Yes      | ^
-Foo    | 2     | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | [Param=2]-DefaultJob  | No       |
-Bar    | 2     | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | [Param=2]-DefaultJob  | No       |
-       |       |          |         |         |       |         |      |                       |          |
-Base   | 10    | 402.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-DefaultJob | Yes      | ^
-Foo    | 10    | 502.0 ns | 6.09 ns | 1.58 ns |  1.25 |    0.00 |    2 | [Param=10]-DefaultJob | No       |
-Bar    | 10    | 602.0 ns | 6.09 ns | 1.58 ns |  1.50 |    0.00 |    3 | [Param=10]-DefaultJob | No       |
+ Method | Param | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup          | Baseline |
+------- |------ |---------:|--------:|--------:|------:|--------:|-----:|---------------------- |--------- |
+ Base   | 2     | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-DefaultJob  | Yes      | ^
+ Foo    | 2     | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | [Param=2]-DefaultJob  | No       |
+ Bar    | 2     | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | [Param=2]-DefaultJob  | No       |
+        |       |          |         |         |       |         |      |                       |          |
+ Base   | 10    | 402.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-DefaultJob | Yes      | ^
+ Foo    | 10    | 502.0 ns | 6.09 ns | 1.58 ns |  1.25 |    0.00 |    2 | [Param=10]-DefaultJob | No       |
+ Bar    | 10    | 602.0 ns | 6.09 ns | 1.58 ns |  1.50 |    0.00 |    3 | [Param=10]-DefaultJob | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsParamsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsParamsJobs.verified.txt
@@ -8,22 +8,22 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param | Mean       | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup    | Baseline | 
+Method | Job  | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup    | Baseline |
 ------ |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------- |--------- |
-Base   | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]-Job1  | Yes      |  ^
-Foo    | Job1 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | [Param=2]-Job1  | No       | 
-Bar    | Job1 | 2     | 302.0 ns   | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 3    | [Param=2]-Job1  | No       | 
-       |      |       |            |         |         |       |         |      |                 |          | 
-Base   | Job2 | 2     | 402.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]-Job2  | Yes      | 
-Foo    | Job2 | 2     | 502.0 ns   | 6.09 ns | 1.58 ns | 1.25  | 0.00    | 2    | [Param=2]-Job2  | No       | 
-Bar    | Job2 | 2     | 602.0 ns   | 6.09 ns | 1.58 ns | 1.50  | 0.00    | 3    | [Param=2]-Job2  | No       | 
-       |      |       |            |         |         |       |         |      |                 |          | 
-Base   | Job1 | 10    | 702.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]-Job1 | Yes      |  ^
-Foo    | Job1 | 10    | 802.0 ns   | 6.09 ns | 1.58 ns | 1.14  | 0.00    | 2    | [Param=10]-Job1 | No       | 
-Bar    | Job1 | 10    | 902.0 ns   | 6.09 ns | 1.58 ns | 1.28  | 0.00    | 3    | [Param=10]-Job1 | No       | 
-       |      |       |            |         |         |       |         |      |                 |          | 
-Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]-Job2 | Yes      | 
-Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns | 1.10  | 0.00    | 2    | [Param=10]-Job2 | No       | 
-Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns | 1.20  | 0.00    | 3    | [Param=10]-Job2 | No       | 
+Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-Job1  | Yes      | ^
+Foo    | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | [Param=2]-Job1  | No       |
+Bar    | Job1 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | [Param=2]-Job1  | No       |
+       |      |       |            |         |         |       |         |      |                 |          |
+Base   | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-Job2  | Yes      |
+Foo    | Job2 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |  1.25 |    0.00 |    2 | [Param=2]-Job2  | No       |
+Bar    | Job2 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |  1.50 |    0.00 |    3 | [Param=2]-Job2  | No       |
+       |      |       |            |         |         |       |         |      |                 |          |
+Base   | Job1 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-Job1 | Yes      | ^
+Foo    | Job1 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |    2 | [Param=10]-Job1 | No       |
+Bar    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |  1.28 |    0.00 |    3 | [Param=10]-Job1 | No       |
+       |      |       |            |         |         |       |         |      |                 |          |
+Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-Job2 | Yes      |
+Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.10 |    0.00 |    2 | [Param=10]-Job2 | No       |
+Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |    3 | [Param=10]-Job2 | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsParamsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsParamsJobs.verified.txt
@@ -8,22 +8,22 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup    | Baseline |
------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------- |--------- |
-Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-Job1  | Yes      | ^
-Foo    | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | [Param=2]-Job1  | No       |
-Bar    | Job1 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | [Param=2]-Job1  | No       |
-       |      |       |            |         |         |       |         |      |                 |          |
-Base   | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-Job2  | Yes      |
-Foo    | Job2 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |  1.25 |    0.00 |    2 | [Param=2]-Job2  | No       |
-Bar    | Job2 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |  1.50 |    0.00 |    3 | [Param=2]-Job2  | No       |
-       |      |       |            |         |         |       |         |      |                 |          |
-Base   | Job1 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-Job1 | Yes      | ^
-Foo    | Job1 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |    2 | [Param=10]-Job1 | No       |
-Bar    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |  1.28 |    0.00 |    3 | [Param=10]-Job1 | No       |
-       |      |       |            |         |         |       |         |      |                 |          |
-Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-Job2 | Yes      |
-Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.10 |    0.00 |    2 | [Param=10]-Job2 | No       |
-Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |    3 | [Param=10]-Job2 | No       |
+ Method | Job  | Param | Mean       | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup    | Baseline |
+------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------- |--------- |
+ Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-Job1  | Yes      | ^
+ Foo    | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | [Param=2]-Job1  | No       |
+ Bar    | Job1 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | [Param=2]-Job1  | No       |
+        |      |       |            |         |         |       |         |      |                 |          |
+ Base   | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]-Job2  | Yes      |
+ Foo    | Job2 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |  1.25 |    0.00 |    2 | [Param=2]-Job2  | No       |
+ Bar    | Job2 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |  1.50 |    0.00 |    3 | [Param=2]-Job2  | No       |
+        |      |       |            |         |         |       |         |      |                 |          |
+ Base   | Job1 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-Job1 | Yes      | ^
+ Foo    | Job1 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |    2 | [Param=10]-Job1 | No       |
+ Bar    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |  1.28 |    0.00 |    3 | [Param=10]-Job1 | No       |
+        |      |       |            |         |         |       |         |      |                 |          |
+ Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-Job2 | Yes      |
+ Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.10 |    0.00 |    2 | [Param=10]-Job2 | No       |
+ Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |    3 | [Param=10]-Job2 | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsParamsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodBaseline_MethodsParamsJobs.verified.txt
@@ -8,22 +8,22 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
- Method |  Job | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank |    LogicalGroup | Baseline |
-------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------- |--------- |
-   Base | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  [Param=2]-Job1 |      Yes | ^
-    Foo | Job1 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 |  [Param=2]-Job1 |       No |
-    Bar | Job1 |     2 |   302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 |  [Param=2]-Job1 |       No |
-        |      |       |            |         |         |       |         |      |                 |          |
-   Base | Job2 |     2 |   402.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  [Param=2]-Job2 |      Yes |
-    Foo | Job2 |     2 |   502.0 ns | 6.09 ns | 1.58 ns |  1.25 |    0.00 |    2 |  [Param=2]-Job2 |       No |
-    Bar | Job2 |     2 |   602.0 ns | 6.09 ns | 1.58 ns |  1.50 |    0.00 |    3 |  [Param=2]-Job2 |       No |
-        |      |       |            |         |         |       |         |      |                 |          |
-   Base | Job1 |    10 |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-Job1 |      Yes | ^
-    Foo | Job1 |    10 |   802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |    2 | [Param=10]-Job1 |       No |
-    Bar | Job1 |    10 |   902.0 ns | 6.09 ns | 1.58 ns |  1.28 |    0.00 |    3 | [Param=10]-Job1 |       No |
-        |      |       |            |         |         |       |         |      |                 |          |
-   Base | Job2 |    10 | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]-Job2 |      Yes |
-    Foo | Job2 |    10 | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.10 |    0.00 |    2 | [Param=10]-Job2 |       No |
-    Bar | Job2 |    10 | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |    3 | [Param=10]-Job2 |       No |
+Method | Job  | Param | Mean       | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup    | Baseline | 
+------ |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------- |--------- |
+Base   | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]-Job1  | Yes      |  ^
+Foo    | Job1 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | [Param=2]-Job1  | No       | 
+Bar    | Job1 | 2     | 302.0 ns   | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 3    | [Param=2]-Job1  | No       | 
+       |      |       |            |         |         |       |         |      |                 |          | 
+Base   | Job2 | 2     | 402.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]-Job2  | Yes      | 
+Foo    | Job2 | 2     | 502.0 ns   | 6.09 ns | 1.58 ns | 1.25  | 0.00    | 2    | [Param=2]-Job2  | No       | 
+Bar    | Job2 | 2     | 602.0 ns   | 6.09 ns | 1.58 ns | 1.50  | 0.00    | 3    | [Param=2]-Job2  | No       | 
+       |      |       |            |         |         |       |         |      |                 |          | 
+Base   | Job1 | 10    | 702.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]-Job1 | Yes      |  ^
+Foo    | Job1 | 10    | 802.0 ns   | 6.09 ns | 1.58 ns | 1.14  | 0.00    | 2    | [Param=10]-Job1 | No       | 
+Bar    | Job1 | 10    | 902.0 ns   | 6.09 ns | 1.58 ns | 1.28  | 0.00    | 3    | [Param=10]-Job1 | No       | 
+       |      |       |            |         |         |       |         |      |                 |          | 
+Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]-Job2 | Yes      | 
+Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns | 1.10  | 0.00    | 2    | [Param=10]-Job2 | No       | 
+Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns | 1.20  | 0.00    | 3    | [Param=10]-Job2 | No       | 
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodJobBaseline_MethodsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodJobBaseline_MethodsJobs.verified.txt
@@ -8,11 +8,11 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
------- |----- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-Foo    | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | *            | Yes      |
-Bar    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | *            | No       |
-Foo    | Job2 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | *            | No       |
-Bar    | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    4 | *            | No       |
+ Method | Job  | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
+------- |----- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
+ Foo    | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | *            | Yes      |
+ Bar    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | *            | No       |
+ Foo    | Job2 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | *            | No       |
+ Bar    | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    4 | *            | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodJobBaseline_MethodsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodJobBaseline_MethodsJobs.verified.txt
@@ -8,11 +8,11 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
- Method |  Job |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
-------- |----- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-    Foo | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |            * |      Yes |
-    Bar | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 |            * |       No |
-    Foo | Job2 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 |            * |       No |
-    Bar | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    4 |            * |       No |
+Method | Job  | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline | 
+------ |----- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
+Foo    | Job1 | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | *            | Yes      | 
+Bar    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | *            | No       | 
+Foo    | Job2 | 302.0 ns | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 3    | *            | No       | 
+Bar    | Job2 | 402.0 ns | 6.09 ns | 1.58 ns | 3.94  | 0.05    | 4    | *            | No       | 
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodJobBaseline_MethodsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodJobBaseline_MethodsJobs.verified.txt
@@ -8,11 +8,11 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline | 
+Method | Job  |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
 ------ |----- |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-Foo    | Job1 | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | *            | Yes      | 
-Bar    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | *            | No       | 
-Foo    | Job2 | 302.0 ns | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 3    | *            | No       | 
-Bar    | Job2 | 402.0 ns | 6.09 ns | 1.58 ns | 3.94  | 0.05    | 4    | *            | No       | 
+Foo    | Job1 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | *            | Yes      |
+Bar    | Job1 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | *            | No       |
+Foo    | Job2 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | *            | No       |
+Bar    | Job2 | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    4 | *            | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodJobBaseline_MethodsJobsParams.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodJobBaseline_MethodsJobsParams.verified.txt
@@ -8,16 +8,16 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
- Method |  Job | Param |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
-------- |----- |------ |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-    Foo | Job1 |     2 | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |    [Param=2] |      Yes | ^
-    Bar | Job1 |     2 | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 |    [Param=2] |       No |
-    Foo | Job2 |     2 | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 |    [Param=2] |       No |
-    Bar | Job2 |     2 | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    4 |    [Param=2] |       No |
-        |      |       |          |         |         |       |         |      |              |          |
-    Foo | Job1 |    10 | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |   [Param=10] |      Yes | ^
-    Bar | Job1 |    10 | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |    2 |   [Param=10] |       No |
-    Foo | Job2 |    10 | 702.0 ns | 6.09 ns | 1.58 ns |  1.40 |    0.00 |    3 |   [Param=10] |       No |
-    Bar | Job2 |    10 | 802.0 ns | 6.09 ns | 1.58 ns |  1.60 |    0.00 |    4 |   [Param=10] |       No |
+Method | Job  | Param | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline | 
+------ |----- |------ |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
+Foo    | Job1 | 2     | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]    | Yes      |  ^
+Bar    | Job1 | 2     | 202.0 ns | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | [Param=2]    | No       | 
+Foo    | Job2 | 2     | 302.0 ns | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 3    | [Param=2]    | No       | 
+Bar    | Job2 | 2     | 402.0 ns | 6.09 ns | 1.58 ns | 3.94  | 0.05    | 4    | [Param=2]    | No       | 
+       |      |       |          |         |         |       |         |      |              |          | 
+Foo    | Job1 | 10    | 502.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]   | Yes      |  ^
+Bar    | Job1 | 10    | 602.0 ns | 6.09 ns | 1.58 ns | 1.20  | 0.00    | 2    | [Param=10]   | No       | 
+Foo    | Job2 | 10    | 702.0 ns | 6.09 ns | 1.58 ns | 1.40  | 0.00    | 3    | [Param=10]   | No       | 
+Bar    | Job2 | 10    | 802.0 ns | 6.09 ns | 1.58 ns | 1.60  | 0.00    | 4    | [Param=10]   | No       | 
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodJobBaseline_MethodsJobsParams.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodJobBaseline_MethodsJobsParams.verified.txt
@@ -8,16 +8,16 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline | 
+Method | Job  | Param |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
 ------ |----- |------ |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-Foo    | Job1 | 2     | 102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=2]    | Yes      |  ^
-Bar    | Job1 | 2     | 202.0 ns | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | [Param=2]    | No       | 
-Foo    | Job2 | 2     | 302.0 ns | 6.09 ns | 1.58 ns | 2.96  | 0.03    | 3    | [Param=2]    | No       | 
-Bar    | Job2 | 2     | 402.0 ns | 6.09 ns | 1.58 ns | 3.94  | 0.05    | 4    | [Param=2]    | No       | 
-       |      |       |          |         |         |       |         |      |              |          | 
-Foo    | Job1 | 10    | 502.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | [Param=10]   | Yes      |  ^
-Bar    | Job1 | 10    | 602.0 ns | 6.09 ns | 1.58 ns | 1.20  | 0.00    | 2    | [Param=10]   | No       | 
-Foo    | Job2 | 10    | 702.0 ns | 6.09 ns | 1.58 ns | 1.40  | 0.00    | 3    | [Param=10]   | No       | 
-Bar    | Job2 | 10    | 802.0 ns | 6.09 ns | 1.58 ns | 1.60  | 0.00    | 4    | [Param=10]   | No       | 
+Foo    | Job1 | 2     | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]    | Yes      | ^
+Bar    | Job1 | 2     | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | [Param=2]    | No       |
+Foo    | Job2 | 2     | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | [Param=2]    | No       |
+Bar    | Job2 | 2     | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    4 | [Param=2]    | No       |
+       |      |       |          |         |         |       |         |      |              |          |
+Foo    | Job1 | 10    | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]   | Yes      | ^
+Bar    | Job1 | 10    | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |    2 | [Param=10]   | No       |
+Foo    | Job2 | 10    | 702.0 ns | 6.09 ns | 1.58 ns |  1.40 |    0.00 |    3 | [Param=10]   | No       |
+Bar    | Job2 | 10    | 802.0 ns | 6.09 ns | 1.58 ns |  1.60 |    0.00 |    4 | [Param=10]   | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodJobBaseline_MethodsJobsParams.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_MethodJobBaseline_MethodsJobsParams.verified.txt
@@ -8,16 +8,16 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param |     Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
------- |----- |------ |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
-Foo    | Job1 | 2     | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]    | Yes      | ^
-Bar    | Job1 | 2     | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | [Param=2]    | No       |
-Foo    | Job2 | 2     | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | [Param=2]    | No       |
-Bar    | Job2 | 2     | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    4 | [Param=2]    | No       |
-       |      |       |          |         |         |       |         |      |              |          |
-Foo    | Job1 | 10    | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]   | Yes      | ^
-Bar    | Job1 | 10    | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |    2 | [Param=10]   | No       |
-Foo    | Job2 | 10    | 702.0 ns | 6.09 ns | 1.58 ns |  1.40 |    0.00 |    3 | [Param=10]   | No       |
-Bar    | Job2 | 10    | 802.0 ns | 6.09 ns | 1.58 ns |  1.60 |    0.00 |    4 | [Param=10]   | No       |
+ Method | Job  | Param | Mean     | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup | Baseline |
+------- |----- |------ |---------:|--------:|--------:|------:|--------:|-----:|------------- |--------- |
+ Foo    | Job1 | 2     | 102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=2]    | Yes      | ^
+ Bar    | Job1 | 2     | 202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | [Param=2]    | No       |
+ Foo    | Job2 | 2     | 302.0 ns | 6.09 ns | 1.58 ns |  2.96 |    0.03 |    3 | [Param=2]    | No       |
+ Bar    | Job2 | 2     | 402.0 ns | 6.09 ns | 1.58 ns |  3.94 |    0.05 |    4 | [Param=2]    | No       |
+        |      |       |          |         |         |       |         |      |              |          |
+ Foo    | Job1 | 10    | 502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | [Param=10]   | Yes      | ^
+ Bar    | Job1 | 10    | 602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |    2 | [Param=10]   | No       |
+ Foo    | Job2 | 10    | 702.0 ns | 6.09 ns | 1.58 ns |  1.40 |    0.00 |    3 | [Param=10]   | No       |
+ Bar    | Job2 | 10    | 802.0 ns | 6.09 ns | 1.58 ns |  1.60 |    0.00 |    4 | [Param=10]   | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs.verified.txt
@@ -8,19 +8,19 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param | Mean       | Error   | StdDev  | Rank | LogicalGroup | Baseline | 
+Method | Job  | Param |       Mean |   Error |  StdDev | Rank | LogicalGroup | Baseline |
 ------ |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
-Base   | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1    | *            | No       |  ^
-Foo    | Job1 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 2    | *            | No       | 
-Bar    | Job1 | 2     | 302.0 ns   | 6.09 ns | 1.58 ns | 3    | *            | No       | 
-Base   | Job2 | 2     | 402.0 ns   | 6.09 ns | 1.58 ns | 4    | *            | No       | 
-Foo    | Job2 | 2     | 502.0 ns   | 6.09 ns | 1.58 ns | 5    | *            | No       | 
-Bar    | Job2 | 2     | 602.0 ns   | 6.09 ns | 1.58 ns | 6    | *            | No       | 
-Base   | Job1 | 10    | 702.0 ns   | 6.09 ns | 1.58 ns | 7    | *            | No       |  ^
-Foo    | Job1 | 10    | 802.0 ns   | 6.09 ns | 1.58 ns | 8    | *            | No       | 
-Bar    | Job1 | 10    | 902.0 ns   | 6.09 ns | 1.58 ns | 9    | *            | No       | 
-Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns | 10   | *            | No       | 
-Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns | 11   | *            | No       | 
-Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns | 12   | *            | No       | 
+Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |    1 | *            | No       | ^
+Foo    | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |    2 | *            | No       |
+Bar    | Job1 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |    3 | *            | No       |
+Base   | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |    4 | *            | No       |
+Foo    | Job2 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |    5 | *            | No       |
+Bar    | Job2 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |    6 | *            | No       |
+Base   | Job1 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |    7 | *            | No       | ^
+Foo    | Job1 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |    8 | *            | No       |
+Bar    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |    9 | *            | No       |
+Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |   10 | *            | No       |
+Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |   11 | *            | No       |
+Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |   12 | *            | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs.verified.txt
@@ -8,19 +8,19 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
- Method |  Job | Param |       Mean |   Error |  StdDev | Rank | LogicalGroup | Baseline |
-------- |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
-   Base | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |    1 |            * |       No | ^
-    Foo | Job1 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |    2 |            * |       No |
-    Bar | Job1 |     2 |   302.0 ns | 6.09 ns | 1.58 ns |    3 |            * |       No |
-   Base | Job2 |     2 |   402.0 ns | 6.09 ns | 1.58 ns |    4 |            * |       No |
-    Foo | Job2 |     2 |   502.0 ns | 6.09 ns | 1.58 ns |    5 |            * |       No |
-    Bar | Job2 |     2 |   602.0 ns | 6.09 ns | 1.58 ns |    6 |            * |       No |
-   Base | Job1 |    10 |   702.0 ns | 6.09 ns | 1.58 ns |    7 |            * |       No | ^
-    Foo | Job1 |    10 |   802.0 ns | 6.09 ns | 1.58 ns |    8 |            * |       No |
-    Bar | Job1 |    10 |   902.0 ns | 6.09 ns | 1.58 ns |    9 |            * |       No |
-   Base | Job2 |    10 | 1,002.0 ns | 6.09 ns | 1.58 ns |   10 |            * |       No |
-    Foo | Job2 |    10 | 1,102.0 ns | 6.09 ns | 1.58 ns |   11 |            * |       No |
-    Bar | Job2 |    10 | 1,202.0 ns | 6.09 ns | 1.58 ns |   12 |            * |       No |
+Method | Job  | Param | Mean       | Error   | StdDev  | Rank | LogicalGroup | Baseline | 
+------ |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
+Base   | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1    | *            | No       |  ^
+Foo    | Job1 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 2    | *            | No       | 
+Bar    | Job1 | 2     | 302.0 ns   | 6.09 ns | 1.58 ns | 3    | *            | No       | 
+Base   | Job2 | 2     | 402.0 ns   | 6.09 ns | 1.58 ns | 4    | *            | No       | 
+Foo    | Job2 | 2     | 502.0 ns   | 6.09 ns | 1.58 ns | 5    | *            | No       | 
+Bar    | Job2 | 2     | 602.0 ns   | 6.09 ns | 1.58 ns | 6    | *            | No       | 
+Base   | Job1 | 10    | 702.0 ns   | 6.09 ns | 1.58 ns | 7    | *            | No       |  ^
+Foo    | Job1 | 10    | 802.0 ns   | 6.09 ns | 1.58 ns | 8    | *            | No       | 
+Bar    | Job1 | 10    | 902.0 ns   | 6.09 ns | 1.58 ns | 9    | *            | No       | 
+Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns | 10   | *            | No       | 
+Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns | 11   | *            | No       | 
+Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns | 12   | *            | No       | 
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs.verified.txt
@@ -8,19 +8,19 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param |       Mean |   Error |  StdDev | Rank | LogicalGroup | Baseline |
------- |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
-Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |    1 | *            | No       | ^
-Foo    | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |    2 | *            | No       |
-Bar    | Job1 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |    3 | *            | No       |
-Base   | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |    4 | *            | No       |
-Foo    | Job2 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |    5 | *            | No       |
-Bar    | Job2 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |    6 | *            | No       |
-Base   | Job1 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |    7 | *            | No       | ^
-Foo    | Job1 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |    8 | *            | No       |
-Bar    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |    9 | *            | No       |
-Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |   10 | *            | No       |
-Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |   11 | *            | No       |
-Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |   12 | *            | No       |
+ Method | Job  | Param | Mean       | Error   | StdDev  | Rank | LogicalGroup | Baseline |
+------- |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
+ Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |    1 | *            | No       | ^
+ Foo    | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |    2 | *            | No       |
+ Bar    | Job1 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |    3 | *            | No       |
+ Base   | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |    4 | *            | No       |
+ Foo    | Job2 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |    5 | *            | No       |
+ Bar    | Job2 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |    6 | *            | No       |
+ Base   | Job1 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |    7 | *            | No       | ^
+ Foo    | Job1 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |    8 | *            | No       |
+ Bar    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |    9 | *            | No       |
+ Base   | Job2 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |   10 | *            | No       |
+ Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |   11 | *            | No       |
+ Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |   12 | *            | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByAll.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByAll.verified.txt
@@ -8,38 +8,38 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
- Method |  Job | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank |                                                    LogicalGroup | Baseline |
-------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------------------------------------------------------- |--------- |
-     A1 | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=2]-CatA |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A1 | Job1 |    10 |   502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=10]-CatA |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A1 | Job2 |     2 |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=2]-CatA |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A1 | Job2 |    10 |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=10]-CatA |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A2 | Job1 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=2]-CatA |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A2 | Job1 |    10 |   602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=10]-CatA |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A2 | Job2 |     2 |   402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=2]-CatA |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     A2 | Job2 |    10 |   802.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=10]-CatA |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B1 | Job1 |     2 |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=2]-CatB |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B1 | Job1 |    10 | 1,302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=10]-CatB |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B1 | Job2 |     2 | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=2]-CatB |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B1 | Job2 |    10 | 1,502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=10]-CatB |      Yes | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B2 | Job1 |     2 | 1,002.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=2]-CatB |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B2 | Job1 |    10 | 1,402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=10]-CatB |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B2 | Job2 |     2 | 1,202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 |  NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=2]-CatB |       No | ^
-        |      |       |            |         |         |       |         |      |                                                                 |          |
-     B2 | Job2 |    10 | 1,602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=10]-CatB |       No | ^
+Method | Job  | Param | Mean       | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup                                                    | Baseline | 
+------ |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------------------------------------------------------- |--------- |
+A1     | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=2]-CatA  | Yes      |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+A1     | Job1 | 10    | 502.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=10]-CatA | Yes      |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+A1     | Job2 | 2     | 302.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=2]-CatA  | Yes      |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+A1     | Job2 | 10    | 702.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=10]-CatA | Yes      |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+A2     | Job1 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=2]-CatA  | No       |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+A2     | Job1 | 10    | 602.0 ns   | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=10]-CatA | No       |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+A2     | Job2 | 2     | 402.0 ns   | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=2]-CatA  | No       |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+A2     | Job2 | 10    | 802.0 ns   | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=10]-CatA | No       |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+B1     | Job1 | 2     | 902.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=2]-CatB  | Yes      |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+B1     | Job1 | 10    | 1,302.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=10]-CatB | Yes      |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+B1     | Job2 | 2     | 1,102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=2]-CatB  | Yes      |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+B1     | Job2 | 10    | 1,502.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=10]-CatB | Yes      |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+B2     | Job1 | 2     | 1,002.0 ns | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=2]-CatB  | No       |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+B2     | Job1 | 10    | 1,402.0 ns | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=10]-CatB | No       |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+B2     | Job2 | 2     | 1,202.0 ns | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=2]-CatB  | No       |  ^
+       |      |       |            |         |         |       |         |      |                                                                 |          | 
+B2     | Job2 | 10    | 1,602.0 ns | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=10]-CatB | No       |  ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByAll.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByAll.verified.txt
@@ -8,38 +8,38 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param | Mean       | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup                                                    | Baseline | 
+Method | Job  | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup                                                    | Baseline |
 ------ |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------------------------------------------------------- |--------- |
-A1     | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=2]-CatA  | Yes      |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-A1     | Job1 | 10    | 502.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=10]-CatA | Yes      |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-A1     | Job2 | 2     | 302.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=2]-CatA  | Yes      |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-A1     | Job2 | 10    | 702.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=10]-CatA | Yes      |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-A2     | Job1 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=2]-CatA  | No       |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-A2     | Job1 | 10    | 602.0 ns   | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=10]-CatA | No       |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-A2     | Job2 | 2     | 402.0 ns   | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=2]-CatA  | No       |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-A2     | Job2 | 10    | 802.0 ns   | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=10]-CatA | No       |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-B1     | Job1 | 2     | 902.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=2]-CatB  | Yes      |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-B1     | Job1 | 10    | 1,302.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=10]-CatB | Yes      |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-B1     | Job2 | 2     | 1,102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=2]-CatB  | Yes      |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-B1     | Job2 | 10    | 1,502.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=10]-CatB | Yes      |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-B2     | Job1 | 2     | 1,002.0 ns | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=2]-CatB  | No       |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-B2     | Job1 | 10    | 1,402.0 ns | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=10]-CatB | No       |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-B2     | Job2 | 2     | 1,202.0 ns | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=2]-CatB  | No       |  ^
-       |      |       |            |         |         |       |         |      |                                                                 |          | 
-B2     | Job2 | 10    | 1,602.0 ns | 6.09 ns | 1.58 ns | ?     | ?       | 1    | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=10]-CatB | No       |  ^
+A1     | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=2]-CatA  | Yes      | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+A1     | Job1 | 10    |   502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=10]-CatA | Yes      | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+A1     | Job2 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=2]-CatA  | Yes      | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+A1     | Job2 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=10]-CatA | Yes      | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+A2     | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=2]-CatA  | No       | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+A2     | Job1 | 10    |   602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=10]-CatA | No       | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+A2     | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=2]-CatA  | No       | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+A2     | Job2 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=10]-CatA | No       | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+B1     | Job1 | 2     |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=2]-CatB  | Yes      | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+B1     | Job1 | 10    | 1,302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=10]-CatB | Yes      | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+B1     | Job2 | 2     | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=2]-CatB  | Yes      | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+B1     | Job2 | 10    | 1,502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=10]-CatB | Yes      | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+B2     | Job1 | 2     | 1,002.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=2]-CatB  | No       | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+B2     | Job1 | 10    | 1,402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=10]-CatB | No       | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+B2     | Job2 | 2     | 1,202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=2]-CatB  | No       | ^
+       |      |       |            |         |         |       |         |      |                                                                 |          |
+B2     | Job2 | 10    | 1,602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=10]-CatB | No       | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByAll.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByAll.verified.txt
@@ -8,38 +8,38 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup                                                    | Baseline |
------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------------------------------------------------------- |--------- |
-A1     | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=2]-CatA  | Yes      | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-A1     | Job1 | 10    |   502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=10]-CatA | Yes      | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-A1     | Job2 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=2]-CatA  | Yes      | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-A1     | Job2 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=10]-CatA | Yes      | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-A2     | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=2]-CatA  | No       | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-A2     | Job1 | 10    |   602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=10]-CatA | No       | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-A2     | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=2]-CatA  | No       | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-A2     | Job2 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=10]-CatA | No       | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-B1     | Job1 | 2     |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=2]-CatB  | Yes      | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-B1     | Job1 | 10    | 1,302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=10]-CatB | Yes      | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-B1     | Job2 | 2     | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=2]-CatB  | Yes      | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-B1     | Job2 | 10    | 1,502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=10]-CatB | Yes      | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-B2     | Job1 | 2     | 1,002.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=2]-CatB  | No       | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-B2     | Job1 | 10    | 1,402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=10]-CatB | No       | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-B2     | Job2 | 2     | 1,202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=2]-CatB  | No       | ^
-       |      |       |            |         |         |       |         |      |                                                                 |          |
-B2     | Job2 | 10    | 1,602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=10]-CatB | No       | ^
+ Method | Job  | Param | Mean       | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup                                                    | Baseline |
+------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|---------------------------------------------------------------- |--------- |
+ A1     | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=2]-CatA  | Yes      | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ A1     | Job1 | 10    |   502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job1-[Param=10]-CatA | Yes      | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ A1     | Job2 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=2]-CatA  | Yes      | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ A1     | Job2 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A1-Job2-[Param=10]-CatA | Yes      | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ A2     | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=2]-CatA  | No       | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ A2     | Job1 | 10    |   602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job1-[Param=10]-CatA | No       | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ A2     | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=2]-CatA  | No       | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ A2     | Job2 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.A2-Job2-[Param=10]-CatA | No       | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ B1     | Job1 | 2     |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=2]-CatB  | Yes      | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ B1     | Job1 | 10    | 1,302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job1-[Param=10]-CatB | Yes      | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ B1     | Job2 | 2     | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=2]-CatB  | Yes      | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ B1     | Job2 | 10    | 1,502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B1-Job2-[Param=10]-CatB | Yes      | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ B2     | Job1 | 2     | 1,002.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=2]-CatB  | No       | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ B2     | Job1 | 10    | 1,402.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job1-[Param=10]-CatB | No       | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ B2     | Job2 | 2     | 1,202.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=2]-CatB  | No       | ^
+        |      |       |            |         |         |       |         |      |                                                                 |          |
+ B2     | Job2 | 10    | 1,602.0 ns | 6.09 ns | 1.58 ns |     ? |       ? |    1 | NoBaseline_MethodsParamsJobs_GroupByAll.B2-Job2-[Param=10]-CatB | No       | ^
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByCategory.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByCategory.verified.txt
@@ -8,30 +8,30 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param | Mean       | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup         | Baseline | 
+Method | Job  | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup         | Baseline |
 ------ |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|--------------------- |--------- |
-A1     | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatA-[Param=2]-Job1  | Yes      |  ^
-A2     | Job1 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | CatA-[Param=2]-Job1  | No       | 
-       |      |       |            |         |         |       |         |      |                      |          | 
-A1     | Job2 | 2     | 302.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatA-[Param=2]-Job2  | Yes      | 
-A2     | Job2 | 2     | 402.0 ns   | 6.09 ns | 1.58 ns | 1.33  | 0.00    | 2    | CatA-[Param=2]-Job2  | No       | 
-       |      |       |            |         |         |       |         |      |                      |          | 
-A1     | Job1 | 10    | 502.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatA-[Param=10]-Job1 | Yes      |  ^
-A2     | Job1 | 10    | 602.0 ns   | 6.09 ns | 1.58 ns | 1.20  | 0.00    | 2    | CatA-[Param=10]-Job1 | No       | 
-       |      |       |            |         |         |       |         |      |                      |          | 
-A1     | Job2 | 10    | 702.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatA-[Param=10]-Job2 | Yes      | 
-A2     | Job2 | 10    | 802.0 ns   | 6.09 ns | 1.58 ns | 1.14  | 0.00    | 2    | CatA-[Param=10]-Job2 | No       | 
-       |      |       |            |         |         |       |         |      |                      |          | 
-B1     | Job1 | 2     | 902.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatB-[Param=2]-Job1  | Yes      |  ^
-B2     | Job1 | 2     | 1,002.0 ns | 6.09 ns | 1.58 ns | 1.11  | 0.00    | 2    | CatB-[Param=2]-Job1  | No       | 
-       |      |       |            |         |         |       |         |      |                      |          | 
-B1     | Job2 | 2     | 1,102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatB-[Param=2]-Job2  | Yes      | 
-B2     | Job2 | 2     | 1,202.0 ns | 6.09 ns | 1.58 ns | 1.09  | 0.00    | 2    | CatB-[Param=2]-Job2  | No       | 
-       |      |       |            |         |         |       |         |      |                      |          | 
-B1     | Job1 | 10    | 1,302.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatB-[Param=10]-Job1 | Yes      |  ^
-B2     | Job1 | 10    | 1,402.0 ns | 6.09 ns | 1.58 ns | 1.08  | 0.00    | 2    | CatB-[Param=10]-Job1 | No       | 
-       |      |       |            |         |         |       |         |      |                      |          | 
-B1     | Job2 | 10    | 1,502.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatB-[Param=10]-Job2 | Yes      | 
-B2     | Job2 | 10    | 1,602.0 ns | 6.09 ns | 1.58 ns | 1.07  | 0.00    | 2    | CatB-[Param=10]-Job2 | No       | 
+A1     | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=2]-Job1  | Yes      | ^
+A2     | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | CatA-[Param=2]-Job1  | No       |
+       |      |       |            |         |         |       |         |      |                      |          |
+A1     | Job2 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=2]-Job2  | Yes      |
+A2     | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |    2 | CatA-[Param=2]-Job2  | No       |
+       |      |       |            |         |         |       |         |      |                      |          |
+A1     | Job1 | 10    |   502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=10]-Job1 | Yes      | ^
+A2     | Job1 | 10    |   602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |    2 | CatA-[Param=10]-Job1 | No       |
+       |      |       |            |         |         |       |         |      |                      |          |
+A1     | Job2 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=10]-Job2 | Yes      |
+A2     | Job2 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |    2 | CatA-[Param=10]-Job2 | No       |
+       |      |       |            |         |         |       |         |      |                      |          |
+B1     | Job1 | 2     |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=2]-Job1  | Yes      | ^
+B2     | Job1 | 2     | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.11 |    0.00 |    2 | CatB-[Param=2]-Job1  | No       |
+       |      |       |            |         |         |       |         |      |                      |          |
+B1     | Job2 | 2     | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=2]-Job2  | Yes      |
+B2     | Job2 | 2     | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.09 |    0.00 |    2 | CatB-[Param=2]-Job2  | No       |
+       |      |       |            |         |         |       |         |      |                      |          |
+B1     | Job1 | 10    | 1,302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=10]-Job1 | Yes      | ^
+B2     | Job1 | 10    | 1,402.0 ns | 6.09 ns | 1.58 ns |  1.08 |    0.00 |    2 | CatB-[Param=10]-Job1 | No       |
+       |      |       |            |         |         |       |         |      |                      |          |
+B1     | Job2 | 10    | 1,502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=10]-Job2 | Yes      |
+B2     | Job2 | 10    | 1,602.0 ns | 6.09 ns | 1.58 ns |  1.07 |    0.00 |    2 | CatB-[Param=10]-Job2 | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByCategory.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByCategory.verified.txt
@@ -8,30 +8,30 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
- Method |  Job | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank |         LogicalGroup | Baseline |
-------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|--------------------- |--------- |
-     A1 | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  CatA-[Param=2]-Job1 |      Yes | ^
-     A2 | Job1 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 |  CatA-[Param=2]-Job1 |       No |
-        |      |       |            |         |         |       |         |      |                      |          |
-     A1 | Job2 |     2 |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  CatA-[Param=2]-Job2 |      Yes |
-     A2 | Job2 |     2 |   402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |    2 |  CatA-[Param=2]-Job2 |       No |
-        |      |       |            |         |         |       |         |      |                      |          |
-     A1 | Job1 |    10 |   502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=10]-Job1 |      Yes | ^
-     A2 | Job1 |    10 |   602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |    2 | CatA-[Param=10]-Job1 |       No |
-        |      |       |            |         |         |       |         |      |                      |          |
-     A1 | Job2 |    10 |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=10]-Job2 |      Yes |
-     A2 | Job2 |    10 |   802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |    2 | CatA-[Param=10]-Job2 |       No |
-        |      |       |            |         |         |       |         |      |                      |          |
-     B1 | Job1 |     2 |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  CatB-[Param=2]-Job1 |      Yes | ^
-     B2 | Job1 |     2 | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.11 |    0.00 |    2 |  CatB-[Param=2]-Job1 |       No |
-        |      |       |            |         |         |       |         |      |                      |          |
-     B1 | Job2 |     2 | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 |  CatB-[Param=2]-Job2 |      Yes |
-     B2 | Job2 |     2 | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.09 |    0.00 |    2 |  CatB-[Param=2]-Job2 |       No |
-        |      |       |            |         |         |       |         |      |                      |          |
-     B1 | Job1 |    10 | 1,302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=10]-Job1 |      Yes | ^
-     B2 | Job1 |    10 | 1,402.0 ns | 6.09 ns | 1.58 ns |  1.08 |    0.00 |    2 | CatB-[Param=10]-Job1 |       No |
-        |      |       |            |         |         |       |         |      |                      |          |
-     B1 | Job2 |    10 | 1,502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=10]-Job2 |      Yes |
-     B2 | Job2 |    10 | 1,602.0 ns | 6.09 ns | 1.58 ns |  1.07 |    0.00 |    2 | CatB-[Param=10]-Job2 |       No |
+Method | Job  | Param | Mean       | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup         | Baseline | 
+------ |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|--------------------- |--------- |
+A1     | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatA-[Param=2]-Job1  | Yes      |  ^
+A2     | Job1 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 1.98  | 0.02    | 2    | CatA-[Param=2]-Job1  | No       | 
+       |      |       |            |         |         |       |         |      |                      |          | 
+A1     | Job2 | 2     | 302.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatA-[Param=2]-Job2  | Yes      | 
+A2     | Job2 | 2     | 402.0 ns   | 6.09 ns | 1.58 ns | 1.33  | 0.00    | 2    | CatA-[Param=2]-Job2  | No       | 
+       |      |       |            |         |         |       |         |      |                      |          | 
+A1     | Job1 | 10    | 502.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatA-[Param=10]-Job1 | Yes      |  ^
+A2     | Job1 | 10    | 602.0 ns   | 6.09 ns | 1.58 ns | 1.20  | 0.00    | 2    | CatA-[Param=10]-Job1 | No       | 
+       |      |       |            |         |         |       |         |      |                      |          | 
+A1     | Job2 | 10    | 702.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatA-[Param=10]-Job2 | Yes      | 
+A2     | Job2 | 10    | 802.0 ns   | 6.09 ns | 1.58 ns | 1.14  | 0.00    | 2    | CatA-[Param=10]-Job2 | No       | 
+       |      |       |            |         |         |       |         |      |                      |          | 
+B1     | Job1 | 2     | 902.0 ns   | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatB-[Param=2]-Job1  | Yes      |  ^
+B2     | Job1 | 2     | 1,002.0 ns | 6.09 ns | 1.58 ns | 1.11  | 0.00    | 2    | CatB-[Param=2]-Job1  | No       | 
+       |      |       |            |         |         |       |         |      |                      |          | 
+B1     | Job2 | 2     | 1,102.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatB-[Param=2]-Job2  | Yes      | 
+B2     | Job2 | 2     | 1,202.0 ns | 6.09 ns | 1.58 ns | 1.09  | 0.00    | 2    | CatB-[Param=2]-Job2  | No       | 
+       |      |       |            |         |         |       |         |      |                      |          | 
+B1     | Job1 | 10    | 1,302.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatB-[Param=10]-Job1 | Yes      |  ^
+B2     | Job1 | 10    | 1,402.0 ns | 6.09 ns | 1.58 ns | 1.08  | 0.00    | 2    | CatB-[Param=10]-Job1 | No       | 
+       |      |       |            |         |         |       |         |      |                      |          | 
+B1     | Job2 | 10    | 1,502.0 ns | 6.09 ns | 1.58 ns | 1.00  | 0.00    | 1    | CatB-[Param=10]-Job2 | Yes      | 
+B2     | Job2 | 10    | 1,602.0 ns | 6.09 ns | 1.58 ns | 1.07  | 0.00    | 2    | CatB-[Param=10]-Job2 | No       | 
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByCategory.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByCategory.verified.txt
@@ -8,30 +8,30 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param |       Mean |   Error |  StdDev | Ratio | RatioSD | Rank | LogicalGroup         | Baseline |
------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|--------------------- |--------- |
-A1     | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=2]-Job1  | Yes      | ^
-A2     | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | CatA-[Param=2]-Job1  | No       |
-       |      |       |            |         |         |       |         |      |                      |          |
-A1     | Job2 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=2]-Job2  | Yes      |
-A2     | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |    2 | CatA-[Param=2]-Job2  | No       |
-       |      |       |            |         |         |       |         |      |                      |          |
-A1     | Job1 | 10    |   502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=10]-Job1 | Yes      | ^
-A2     | Job1 | 10    |   602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |    2 | CatA-[Param=10]-Job1 | No       |
-       |      |       |            |         |         |       |         |      |                      |          |
-A1     | Job2 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=10]-Job2 | Yes      |
-A2     | Job2 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |    2 | CatA-[Param=10]-Job2 | No       |
-       |      |       |            |         |         |       |         |      |                      |          |
-B1     | Job1 | 2     |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=2]-Job1  | Yes      | ^
-B2     | Job1 | 2     | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.11 |    0.00 |    2 | CatB-[Param=2]-Job1  | No       |
-       |      |       |            |         |         |       |         |      |                      |          |
-B1     | Job2 | 2     | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=2]-Job2  | Yes      |
-B2     | Job2 | 2     | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.09 |    0.00 |    2 | CatB-[Param=2]-Job2  | No       |
-       |      |       |            |         |         |       |         |      |                      |          |
-B1     | Job1 | 10    | 1,302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=10]-Job1 | Yes      | ^
-B2     | Job1 | 10    | 1,402.0 ns | 6.09 ns | 1.58 ns |  1.08 |    0.00 |    2 | CatB-[Param=10]-Job1 | No       |
-       |      |       |            |         |         |       |         |      |                      |          |
-B1     | Job2 | 10    | 1,502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=10]-Job2 | Yes      |
-B2     | Job2 | 10    | 1,602.0 ns | 6.09 ns | 1.58 ns |  1.07 |    0.00 |    2 | CatB-[Param=10]-Job2 | No       |
+ Method | Job  | Param | Mean       | Error   | StdDev  | Ratio | RatioSD | Rank | LogicalGroup         | Baseline |
+------- |----- |------ |-----------:|--------:|--------:|------:|--------:|-----:|--------------------- |--------- |
+ A1     | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=2]-Job1  | Yes      | ^
+ A2     | Job1 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |  1.98 |    0.02 |    2 | CatA-[Param=2]-Job1  | No       |
+        |      |       |            |         |         |       |         |      |                      |          |
+ A1     | Job2 | 2     |   302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=2]-Job2  | Yes      |
+ A2     | Job2 | 2     |   402.0 ns | 6.09 ns | 1.58 ns |  1.33 |    0.00 |    2 | CatA-[Param=2]-Job2  | No       |
+        |      |       |            |         |         |       |         |      |                      |          |
+ A1     | Job1 | 10    |   502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=10]-Job1 | Yes      | ^
+ A2     | Job1 | 10    |   602.0 ns | 6.09 ns | 1.58 ns |  1.20 |    0.00 |    2 | CatA-[Param=10]-Job1 | No       |
+        |      |       |            |         |         |       |         |      |                      |          |
+ A1     | Job2 | 10    |   702.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatA-[Param=10]-Job2 | Yes      |
+ A2     | Job2 | 10    |   802.0 ns | 6.09 ns | 1.58 ns |  1.14 |    0.00 |    2 | CatA-[Param=10]-Job2 | No       |
+        |      |       |            |         |         |       |         |      |                      |          |
+ B1     | Job1 | 2     |   902.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=2]-Job1  | Yes      | ^
+ B2     | Job1 | 2     | 1,002.0 ns | 6.09 ns | 1.58 ns |  1.11 |    0.00 |    2 | CatB-[Param=2]-Job1  | No       |
+        |      |       |            |         |         |       |         |      |                      |          |
+ B1     | Job2 | 2     | 1,102.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=2]-Job2  | Yes      |
+ B2     | Job2 | 2     | 1,202.0 ns | 6.09 ns | 1.58 ns |  1.09 |    0.00 |    2 | CatB-[Param=2]-Job2  | No       |
+        |      |       |            |         |         |       |         |      |                      |          |
+ B1     | Job1 | 10    | 1,302.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=10]-Job1 | Yes      | ^
+ B2     | Job1 | 10    | 1,402.0 ns | 6.09 ns | 1.58 ns |  1.08 |    0.00 |    2 | CatB-[Param=10]-Job1 | No       |
+        |      |       |            |         |         |       |         |      |                      |          |
+ B1     | Job2 | 10    | 1,502.0 ns | 6.09 ns | 1.58 ns |  1.00 |    0.00 |    1 | CatB-[Param=10]-Job2 | Yes      |
+ B2     | Job2 | 10    | 1,602.0 ns | 6.09 ns | 1.58 ns |  1.07 |    0.00 |    2 | CatB-[Param=10]-Job2 | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByJob.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByJob.verified.txt
@@ -8,20 +8,20 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
- Method |  Job | Param |       Mean |   Error |  StdDev | Rank | LogicalGroup | Baseline |
-------- |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
-   Base | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |    1 |         Job1 |       No | ^
-   Base | Job1 |    10 |   302.0 ns | 6.09 ns | 1.58 ns |    2 |         Job1 |       No | ^
-    Foo | Job1 |     2 |   502.0 ns | 6.09 ns | 1.58 ns |    3 |         Job1 |       No | ^
-    Bar | Job1 |     2 |   602.0 ns | 6.09 ns | 1.58 ns |    4 |         Job1 |       No |
-    Foo | Job1 |    10 |   902.0 ns | 6.09 ns | 1.58 ns |    5 |         Job1 |       No | ^
-    Bar | Job1 |    10 | 1,002.0 ns | 6.09 ns | 1.58 ns |    6 |         Job1 |       No |
-        |      |       |            |         |         |      |              |          |
-   Base | Job2 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |    1 |         Job2 |       No | ^
-   Base | Job2 |    10 |   402.0 ns | 6.09 ns | 1.58 ns |    2 |         Job2 |       No | ^
-    Foo | Job2 |     2 |   702.0 ns | 6.09 ns | 1.58 ns |    3 |         Job2 |       No | ^
-    Bar | Job2 |     2 |   802.0 ns | 6.09 ns | 1.58 ns |    4 |         Job2 |       No |
-    Foo | Job2 |    10 | 1,102.0 ns | 6.09 ns | 1.58 ns |    5 |         Job2 |       No | ^
-    Bar | Job2 |    10 | 1,202.0 ns | 6.09 ns | 1.58 ns |    6 |         Job2 |       No |
+Method | Job  | Param | Mean       | Error   | StdDev  | Rank | LogicalGroup | Baseline | 
+------ |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
+Base   | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1    | Job1         | No       |  ^
+Base   | Job1 | 10    | 302.0 ns   | 6.09 ns | 1.58 ns | 2    | Job1         | No       |  ^
+Foo    | Job1 | 2     | 502.0 ns   | 6.09 ns | 1.58 ns | 3    | Job1         | No       |  ^
+Bar    | Job1 | 2     | 602.0 ns   | 6.09 ns | 1.58 ns | 4    | Job1         | No       | 
+Foo    | Job1 | 10    | 902.0 ns   | 6.09 ns | 1.58 ns | 5    | Job1         | No       |  ^
+Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns | 6    | Job1         | No       | 
+       |      |       |            |         |         |      |              |          | 
+Base   | Job2 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 1    | Job2         | No       |  ^
+Base   | Job2 | 10    | 402.0 ns   | 6.09 ns | 1.58 ns | 2    | Job2         | No       |  ^
+Foo    | Job2 | 2     | 702.0 ns   | 6.09 ns | 1.58 ns | 3    | Job2         | No       |  ^
+Bar    | Job2 | 2     | 802.0 ns   | 6.09 ns | 1.58 ns | 4    | Job2         | No       | 
+Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns | 5    | Job2         | No       |  ^
+Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns | 6    | Job2         | No       | 
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByJob.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByJob.verified.txt
@@ -8,20 +8,20 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param | Mean       | Error   | StdDev  | Rank | LogicalGroup | Baseline | 
+Method | Job  | Param |       Mean |   Error |  StdDev | Rank | LogicalGroup | Baseline |
 ------ |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
-Base   | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1    | Job1         | No       |  ^
-Base   | Job1 | 10    | 302.0 ns   | 6.09 ns | 1.58 ns | 2    | Job1         | No       |  ^
-Foo    | Job1 | 2     | 502.0 ns   | 6.09 ns | 1.58 ns | 3    | Job1         | No       |  ^
-Bar    | Job1 | 2     | 602.0 ns   | 6.09 ns | 1.58 ns | 4    | Job1         | No       | 
-Foo    | Job1 | 10    | 902.0 ns   | 6.09 ns | 1.58 ns | 5    | Job1         | No       |  ^
-Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns | 6    | Job1         | No       | 
-       |      |       |            |         |         |      |              |          | 
-Base   | Job2 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 1    | Job2         | No       |  ^
-Base   | Job2 | 10    | 402.0 ns   | 6.09 ns | 1.58 ns | 2    | Job2         | No       |  ^
-Foo    | Job2 | 2     | 702.0 ns   | 6.09 ns | 1.58 ns | 3    | Job2         | No       |  ^
-Bar    | Job2 | 2     | 802.0 ns   | 6.09 ns | 1.58 ns | 4    | Job2         | No       | 
-Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns | 5    | Job2         | No       |  ^
-Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns | 6    | Job2         | No       | 
+Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |    1 | Job1         | No       | ^
+Base   | Job1 | 10    |   302.0 ns | 6.09 ns | 1.58 ns |    2 | Job1         | No       | ^
+Foo    | Job1 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |    3 | Job1         | No       | ^
+Bar    | Job1 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |    4 | Job1         | No       |
+Foo    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |    5 | Job1         | No       | ^
+Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |    6 | Job1         | No       |
+       |      |       |            |         |         |      |              |          |
+Base   | Job2 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |    1 | Job2         | No       | ^
+Base   | Job2 | 10    |   402.0 ns | 6.09 ns | 1.58 ns |    2 | Job2         | No       | ^
+Foo    | Job2 | 2     |   702.0 ns | 6.09 ns | 1.58 ns |    3 | Job2         | No       | ^
+Bar    | Job2 | 2     |   802.0 ns | 6.09 ns | 1.58 ns |    4 | Job2         | No       |
+Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |    5 | Job2         | No       | ^
+Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |    6 | Job2         | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByJob.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByJob.verified.txt
@@ -8,20 +8,20 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param |       Mean |   Error |  StdDev | Rank | LogicalGroup | Baseline |
------- |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
-Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |    1 | Job1         | No       | ^
-Base   | Job1 | 10    |   302.0 ns | 6.09 ns | 1.58 ns |    2 | Job1         | No       | ^
-Foo    | Job1 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |    3 | Job1         | No       | ^
-Bar    | Job1 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |    4 | Job1         | No       |
-Foo    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |    5 | Job1         | No       | ^
-Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |    6 | Job1         | No       |
-       |      |       |            |         |         |      |              |          |
-Base   | Job2 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |    1 | Job2         | No       | ^
-Base   | Job2 | 10    |   402.0 ns | 6.09 ns | 1.58 ns |    2 | Job2         | No       | ^
-Foo    | Job2 | 2     |   702.0 ns | 6.09 ns | 1.58 ns |    3 | Job2         | No       | ^
-Bar    | Job2 | 2     |   802.0 ns | 6.09 ns | 1.58 ns |    4 | Job2         | No       |
-Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |    5 | Job2         | No       | ^
-Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |    6 | Job2         | No       |
+ Method | Job  | Param | Mean       | Error   | StdDev  | Rank | LogicalGroup | Baseline |
+------- |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
+ Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |    1 | Job1         | No       | ^
+ Base   | Job1 | 10    |   302.0 ns | 6.09 ns | 1.58 ns |    2 | Job1         | No       | ^
+ Foo    | Job1 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |    3 | Job1         | No       | ^
+ Bar    | Job1 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |    4 | Job1         | No       |
+ Foo    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |    5 | Job1         | No       | ^
+ Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |    6 | Job1         | No       |
+        |      |       |            |         |         |      |              |          |
+ Base   | Job2 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |    1 | Job2         | No       | ^
+ Base   | Job2 | 10    |   402.0 ns | 6.09 ns | 1.58 ns |    2 | Job2         | No       | ^
+ Foo    | Job2 | 2     |   702.0 ns | 6.09 ns | 1.58 ns |    3 | Job2         | No       | ^
+ Bar    | Job2 | 2     |   802.0 ns | 6.09 ns | 1.58 ns |    4 | Job2         | No       |
+ Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |    5 | Job2         | No       | ^
+ Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |    6 | Job2         | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByMethod.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByMethod.verified.txt
@@ -8,21 +8,21 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param |       Mean |   Error |  StdDev | Rank | LogicalGroup                                    | Baseline |
------- |----- |------ |-----------:|--------:|--------:|-----:|------------------------------------------------ |--------- |
-Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |    1 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       | ^
-Base   | Job2 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |    2 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       |
-Base   | Job1 | 10    |   302.0 ns | 6.09 ns | 1.58 ns |    3 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       | ^
-Base   | Job2 | 10    |   402.0 ns | 6.09 ns | 1.58 ns |    4 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       |
-       |      |       |            |         |         |      |                                                 |          |
-Foo    | Job1 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |    1 | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       | ^
-Foo    | Job2 | 2     |   702.0 ns | 6.09 ns | 1.58 ns |    2 | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       |
-Foo    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |    3 | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       | ^
-Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |    4 | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       |
-       |      |       |            |         |         |      |                                                 |          |
-Bar    | Job1 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |    1 | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       | ^
-Bar    | Job2 | 2     |   802.0 ns | 6.09 ns | 1.58 ns |    2 | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       |
-Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |    3 | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       | ^
-Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |    4 | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       |
+ Method | Job  | Param | Mean       | Error   | StdDev  | Rank | LogicalGroup                                    | Baseline |
+------- |----- |------ |-----------:|--------:|--------:|-----:|------------------------------------------------ |--------- |
+ Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |    1 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       | ^
+ Base   | Job2 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |    2 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       |
+ Base   | Job1 | 10    |   302.0 ns | 6.09 ns | 1.58 ns |    3 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       | ^
+ Base   | Job2 | 10    |   402.0 ns | 6.09 ns | 1.58 ns |    4 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       |
+        |      |       |            |         |         |      |                                                 |          |
+ Foo    | Job1 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |    1 | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       | ^
+ Foo    | Job2 | 2     |   702.0 ns | 6.09 ns | 1.58 ns |    2 | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       |
+ Foo    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |    3 | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       | ^
+ Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |    4 | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       |
+        |      |       |            |         |         |      |                                                 |          |
+ Bar    | Job1 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |    1 | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       | ^
+ Bar    | Job2 | 2     |   802.0 ns | 6.09 ns | 1.58 ns |    2 | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       |
+ Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |    3 | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       | ^
+ Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |    4 | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByMethod.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByMethod.verified.txt
@@ -8,21 +8,21 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
- Method |  Job | Param |       Mean |   Error |  StdDev | Rank |                                    LogicalGroup | Baseline |
-------- |----- |------ |-----------:|--------:|--------:|-----:|------------------------------------------------ |--------- |
-   Base | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |    1 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base |       No | ^
-   Base | Job2 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |    2 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base |       No |
-   Base | Job1 |    10 |   302.0 ns | 6.09 ns | 1.58 ns |    3 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base |       No | ^
-   Base | Job2 |    10 |   402.0 ns | 6.09 ns | 1.58 ns |    4 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base |       No |
-        |      |       |            |         |         |      |                                                 |          |
-    Foo | Job1 |     2 |   502.0 ns | 6.09 ns | 1.58 ns |    1 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Foo |       No | ^
-    Foo | Job2 |     2 |   702.0 ns | 6.09 ns | 1.58 ns |    2 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Foo |       No |
-    Foo | Job1 |    10 |   902.0 ns | 6.09 ns | 1.58 ns |    3 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Foo |       No | ^
-    Foo | Job2 |    10 | 1,102.0 ns | 6.09 ns | 1.58 ns |    4 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Foo |       No |
-        |      |       |            |         |         |      |                                                 |          |
-    Bar | Job1 |     2 |   602.0 ns | 6.09 ns | 1.58 ns |    1 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Bar |       No | ^
-    Bar | Job2 |     2 |   802.0 ns | 6.09 ns | 1.58 ns |    2 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Bar |       No |
-    Bar | Job1 |    10 | 1,002.0 ns | 6.09 ns | 1.58 ns |    3 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Bar |       No | ^
-    Bar | Job2 |    10 | 1,202.0 ns | 6.09 ns | 1.58 ns |    4 |  NoBaseline_MethodsParamsJobs_GroupByMethod.Bar |       No |
+Method | Job  | Param | Mean       | Error   | StdDev  | Rank | LogicalGroup                                    | Baseline | 
+------ |----- |------ |-----------:|--------:|--------:|-----:|------------------------------------------------ |--------- |
+Base   | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1    | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       |  ^
+Base   | Job2 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 2    | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       | 
+Base   | Job1 | 10    | 302.0 ns   | 6.09 ns | 1.58 ns | 3    | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       |  ^
+Base   | Job2 | 10    | 402.0 ns   | 6.09 ns | 1.58 ns | 4    | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       | 
+       |      |       |            |         |         |      |                                                 |          | 
+Foo    | Job1 | 2     | 502.0 ns   | 6.09 ns | 1.58 ns | 1    | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       |  ^
+Foo    | Job2 | 2     | 702.0 ns   | 6.09 ns | 1.58 ns | 2    | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       | 
+Foo    | Job1 | 10    | 902.0 ns   | 6.09 ns | 1.58 ns | 3    | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       |  ^
+Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns | 4    | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       | 
+       |      |       |            |         |         |      |                                                 |          | 
+Bar    | Job1 | 2     | 602.0 ns   | 6.09 ns | 1.58 ns | 1    | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       |  ^
+Bar    | Job2 | 2     | 802.0 ns   | 6.09 ns | 1.58 ns | 2    | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       | 
+Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns | 3    | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       |  ^
+Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns | 4    | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       | 
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByMethod.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByMethod.verified.txt
@@ -8,21 +8,21 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param | Mean       | Error   | StdDev  | Rank | LogicalGroup                                    | Baseline | 
+Method | Job  | Param |       Mean |   Error |  StdDev | Rank | LogicalGroup                                    | Baseline |
 ------ |----- |------ |-----------:|--------:|--------:|-----:|------------------------------------------------ |--------- |
-Base   | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1    | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       |  ^
-Base   | Job2 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 2    | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       | 
-Base   | Job1 | 10    | 302.0 ns   | 6.09 ns | 1.58 ns | 3    | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       |  ^
-Base   | Job2 | 10    | 402.0 ns   | 6.09 ns | 1.58 ns | 4    | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       | 
-       |      |       |            |         |         |      |                                                 |          | 
-Foo    | Job1 | 2     | 502.0 ns   | 6.09 ns | 1.58 ns | 1    | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       |  ^
-Foo    | Job2 | 2     | 702.0 ns   | 6.09 ns | 1.58 ns | 2    | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       | 
-Foo    | Job1 | 10    | 902.0 ns   | 6.09 ns | 1.58 ns | 3    | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       |  ^
-Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns | 4    | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       | 
-       |      |       |            |         |         |      |                                                 |          | 
-Bar    | Job1 | 2     | 602.0 ns   | 6.09 ns | 1.58 ns | 1    | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       |  ^
-Bar    | Job2 | 2     | 802.0 ns   | 6.09 ns | 1.58 ns | 2    | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       | 
-Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns | 3    | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       |  ^
-Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns | 4    | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       | 
+Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |    1 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       | ^
+Base   | Job2 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |    2 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       |
+Base   | Job1 | 10    |   302.0 ns | 6.09 ns | 1.58 ns |    3 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       | ^
+Base   | Job2 | 10    |   402.0 ns | 6.09 ns | 1.58 ns |    4 | NoBaseline_MethodsParamsJobs_GroupByMethod.Base | No       |
+       |      |       |            |         |         |      |                                                 |          |
+Foo    | Job1 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |    1 | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       | ^
+Foo    | Job2 | 2     |   702.0 ns | 6.09 ns | 1.58 ns |    2 | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       |
+Foo    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |    3 | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       | ^
+Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |    4 | NoBaseline_MethodsParamsJobs_GroupByMethod.Foo  | No       |
+       |      |       |            |         |         |      |                                                 |          |
+Bar    | Job1 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |    1 | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       | ^
+Bar    | Job2 | 2     |   802.0 ns | 6.09 ns | 1.58 ns |    2 | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       |
+Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |    3 | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       | ^
+Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |    4 | NoBaseline_MethodsParamsJobs_GroupByMethod.Bar  | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByParams.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByParams.verified.txt
@@ -8,20 +8,20 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param | Mean       | Error   | StdDev  | Rank | LogicalGroup | Baseline | 
+Method | Job  | Param |       Mean |   Error |  StdDev | Rank | LogicalGroup | Baseline |
 ------ |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
-Base   | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1    | [Param=2]    | No       |  ^
-Base   | Job2 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 2    | [Param=2]    | No       | 
-Foo    | Job1 | 2     | 502.0 ns   | 6.09 ns | 1.58 ns | 3    | [Param=2]    | No       | 
-Bar    | Job1 | 2     | 602.0 ns   | 6.09 ns | 1.58 ns | 4    | [Param=2]    | No       | 
-Foo    | Job2 | 2     | 702.0 ns   | 6.09 ns | 1.58 ns | 5    | [Param=2]    | No       | 
-Bar    | Job2 | 2     | 802.0 ns   | 6.09 ns | 1.58 ns | 6    | [Param=2]    | No       | 
-       |      |       |            |         |         |      |              |          | 
-Base   | Job1 | 10    | 302.0 ns   | 6.09 ns | 1.58 ns | 1    | [Param=10]   | No       |  ^
-Base   | Job2 | 10    | 402.0 ns   | 6.09 ns | 1.58 ns | 2    | [Param=10]   | No       | 
-Foo    | Job1 | 10    | 902.0 ns   | 6.09 ns | 1.58 ns | 3    | [Param=10]   | No       | 
-Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns | 4    | [Param=10]   | No       | 
-Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns | 5    | [Param=10]   | No       | 
-Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns | 6    | [Param=10]   | No       | 
+Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |    1 | [Param=2]    | No       | ^
+Base   | Job2 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |    2 | [Param=2]    | No       |
+Foo    | Job1 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |    3 | [Param=2]    | No       |
+Bar    | Job1 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |    4 | [Param=2]    | No       |
+Foo    | Job2 | 2     |   702.0 ns | 6.09 ns | 1.58 ns |    5 | [Param=2]    | No       |
+Bar    | Job2 | 2     |   802.0 ns | 6.09 ns | 1.58 ns |    6 | [Param=2]    | No       |
+       |      |       |            |         |         |      |              |          |
+Base   | Job1 | 10    |   302.0 ns | 6.09 ns | 1.58 ns |    1 | [Param=10]   | No       | ^
+Base   | Job2 | 10    |   402.0 ns | 6.09 ns | 1.58 ns |    2 | [Param=10]   | No       |
+Foo    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |    3 | [Param=10]   | No       |
+Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |    4 | [Param=10]   | No       |
+Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |    5 | [Param=10]   | No       |
+Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |    6 | [Param=10]   | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByParams.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByParams.verified.txt
@@ -8,20 +8,20 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
- Method |  Job | Param |       Mean |   Error |  StdDev | Rank | LogicalGroup | Baseline |
-------- |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
-   Base | Job1 |     2 |   102.0 ns | 6.09 ns | 1.58 ns |    1 |    [Param=2] |       No | ^
-   Base | Job2 |     2 |   202.0 ns | 6.09 ns | 1.58 ns |    2 |    [Param=2] |       No |
-    Foo | Job1 |     2 |   502.0 ns | 6.09 ns | 1.58 ns |    3 |    [Param=2] |       No |
-    Bar | Job1 |     2 |   602.0 ns | 6.09 ns | 1.58 ns |    4 |    [Param=2] |       No |
-    Foo | Job2 |     2 |   702.0 ns | 6.09 ns | 1.58 ns |    5 |    [Param=2] |       No |
-    Bar | Job2 |     2 |   802.0 ns | 6.09 ns | 1.58 ns |    6 |    [Param=2] |       No |
-        |      |       |            |         |         |      |              |          |
-   Base | Job1 |    10 |   302.0 ns | 6.09 ns | 1.58 ns |    1 |   [Param=10] |       No | ^
-   Base | Job2 |    10 |   402.0 ns | 6.09 ns | 1.58 ns |    2 |   [Param=10] |       No |
-    Foo | Job1 |    10 |   902.0 ns | 6.09 ns | 1.58 ns |    3 |   [Param=10] |       No |
-    Bar | Job1 |    10 | 1,002.0 ns | 6.09 ns | 1.58 ns |    4 |   [Param=10] |       No |
-    Foo | Job2 |    10 | 1,102.0 ns | 6.09 ns | 1.58 ns |    5 |   [Param=10] |       No |
-    Bar | Job2 |    10 | 1,202.0 ns | 6.09 ns | 1.58 ns |    6 |   [Param=10] |       No |
+Method | Job  | Param | Mean       | Error   | StdDev  | Rank | LogicalGroup | Baseline | 
+------ |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
+Base   | Job1 | 2     | 102.0 ns   | 6.09 ns | 1.58 ns | 1    | [Param=2]    | No       |  ^
+Base   | Job2 | 2     | 202.0 ns   | 6.09 ns | 1.58 ns | 2    | [Param=2]    | No       | 
+Foo    | Job1 | 2     | 502.0 ns   | 6.09 ns | 1.58 ns | 3    | [Param=2]    | No       | 
+Bar    | Job1 | 2     | 602.0 ns   | 6.09 ns | 1.58 ns | 4    | [Param=2]    | No       | 
+Foo    | Job2 | 2     | 702.0 ns   | 6.09 ns | 1.58 ns | 5    | [Param=2]    | No       | 
+Bar    | Job2 | 2     | 802.0 ns   | 6.09 ns | 1.58 ns | 6    | [Param=2]    | No       | 
+       |      |       |            |         |         |      |              |          | 
+Base   | Job1 | 10    | 302.0 ns   | 6.09 ns | 1.58 ns | 1    | [Param=10]   | No       |  ^
+Base   | Job2 | 10    | 402.0 ns   | 6.09 ns | 1.58 ns | 2    | [Param=10]   | No       | 
+Foo    | Job1 | 10    | 902.0 ns   | 6.09 ns | 1.58 ns | 3    | [Param=10]   | No       | 
+Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns | 4    | [Param=10]   | No       | 
+Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns | 5    | [Param=10]   | No       | 
+Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns | 6    | [Param=10]   | No       | 
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByParams.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/MarkdownExporterVerifyTests.GroupExporterTest_NoBaseline_MethodsParamsJobs_GroupByParams.verified.txt
@@ -8,20 +8,20 @@ Frequency: 2531248 Hz, Resolution: 395.0620 ns, Timer: TSC
   Job2   : extra output line
 
 
-Method | Job  | Param |       Mean |   Error |  StdDev | Rank | LogicalGroup | Baseline |
------- |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
-Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |    1 | [Param=2]    | No       | ^
-Base   | Job2 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |    2 | [Param=2]    | No       |
-Foo    | Job1 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |    3 | [Param=2]    | No       |
-Bar    | Job1 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |    4 | [Param=2]    | No       |
-Foo    | Job2 | 2     |   702.0 ns | 6.09 ns | 1.58 ns |    5 | [Param=2]    | No       |
-Bar    | Job2 | 2     |   802.0 ns | 6.09 ns | 1.58 ns |    6 | [Param=2]    | No       |
-       |      |       |            |         |         |      |              |          |
-Base   | Job1 | 10    |   302.0 ns | 6.09 ns | 1.58 ns |    1 | [Param=10]   | No       | ^
-Base   | Job2 | 10    |   402.0 ns | 6.09 ns | 1.58 ns |    2 | [Param=10]   | No       |
-Foo    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |    3 | [Param=10]   | No       |
-Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |    4 | [Param=10]   | No       |
-Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |    5 | [Param=10]   | No       |
-Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |    6 | [Param=10]   | No       |
+ Method | Job  | Param | Mean       | Error   | StdDev  | Rank | LogicalGroup | Baseline |
+------- |----- |------ |-----------:|--------:|--------:|-----:|------------- |--------- |
+ Base   | Job1 | 2     |   102.0 ns | 6.09 ns | 1.58 ns |    1 | [Param=2]    | No       | ^
+ Base   | Job2 | 2     |   202.0 ns | 6.09 ns | 1.58 ns |    2 | [Param=2]    | No       |
+ Foo    | Job1 | 2     |   502.0 ns | 6.09 ns | 1.58 ns |    3 | [Param=2]    | No       |
+ Bar    | Job1 | 2     |   602.0 ns | 6.09 ns | 1.58 ns |    4 | [Param=2]    | No       |
+ Foo    | Job2 | 2     |   702.0 ns | 6.09 ns | 1.58 ns |    5 | [Param=2]    | No       |
+ Bar    | Job2 | 2     |   802.0 ns | 6.09 ns | 1.58 ns |    6 | [Param=2]    | No       |
+        |      |       |            |         |         |      |              |          |
+ Base   | Job1 | 10    |   302.0 ns | 6.09 ns | 1.58 ns |    1 | [Param=10]   | No       | ^
+ Base   | Job2 | 10    |   402.0 ns | 6.09 ns | 1.58 ns |    2 | [Param=10]   | No       |
+ Foo    | Job1 | 10    |   902.0 ns | 6.09 ns | 1.58 ns |    3 | [Param=10]   | No       |
+ Bar    | Job1 | 10    | 1,002.0 ns | 6.09 ns | 1.58 ns |    4 | [Param=10]   | No       |
+ Foo    | Job2 | 10    | 1,102.0 ns | 6.09 ns | 1.58 ns |    5 | [Param=10]   | No       |
+ Bar    | Job2 | 10    | 1,202.0 ns | 6.09 ns | 1.58 ns |    6 | [Param=10]   | No       |
 
 Errors: 0

--- a/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
+++ b/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
@@ -74,9 +74,11 @@ namespace BenchmarkDotNet.Tests.Mocks
             ImmutableArray<IColumnHidingRule>.Empty);
 
         public static SummaryStyle CreateSummaryStyle(bool printUnitsInHeader = false, bool printUnitsInContent = true, bool printZeroValuesInContent = false,
-            SizeUnit sizeUnit = null, TimeUnit timeUnit = null, TextJustification defaultTextJustification = TextJustification.Left)
+            SizeUnit sizeUnit = null, TimeUnit timeUnit = null, TextJustification textColumnJustification = TextJustification.Left,
+            TextJustification numericColumnJustification = TextJustification.Left)
             => new SummaryStyle(DefaultCultureInfo.Instance, printUnitsInHeader, sizeUnit, timeUnit, printUnitsInContent: printUnitsInContent,
-                printZeroValuesInContent: printZeroValuesInContent, defaultTextJustification: defaultTextJustification);
+                printZeroValuesInContent: printZeroValuesInContent, textColumnJustification: textColumnJustification,
+                numericColumnJustification: numericColumnJustification);
 
         private static ImmutableArray<BenchmarkReport> CreateReports(IConfig config)
             => CreateBenchmarks<MockBenchmarkClass>(config).Select(CreateSimpleReport).ToImmutableArray();

--- a/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
+++ b/tests/BenchmarkDotNet.Tests/Mocks/MockFactory.cs
@@ -6,12 +6,15 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Helpers;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Tests.Builders;
 using BenchmarkDotNet.Toolchains;
 using BenchmarkDotNet.Toolchains.Results;
 using BenchmarkDotNet.Validators;
+using Perfolizer.Horology;
+using static BenchmarkDotNet.Reports.SummaryTable.SummaryTableColumn;
 
 namespace BenchmarkDotNet.Tests.Mocks
 {
@@ -33,40 +36,47 @@ namespace BenchmarkDotNet.Tests.Mocks
         }
 
         public static Summary CreateSummary(IConfig config) => new Summary(
-                "MockSummary",
-                CreateReports(config),
-                new HostEnvironmentInfoBuilder().WithoutDotNetSdkVersion().Build(),
-                string.Empty,
-                string.Empty,
-                TimeSpan.FromMinutes(1),
-                config.CultureInfo,
-                ImmutableArray<ValidationError>.Empty,
-                ImmutableArray<IColumnHidingRule>.Empty);
+            "MockSummary",
+            CreateReports(config),
+            new HostEnvironmentInfoBuilder().WithoutDotNetSdkVersion().Build(),
+            string.Empty,
+            string.Empty,
+            TimeSpan.FromMinutes(1),
+            config.CultureInfo,
+            ImmutableArray<ValidationError>.Empty,
+            ImmutableArray<IColumnHidingRule>.Empty,
+            config.SummaryStyle);
+
 
         public static Summary CreateSummary(IConfig config, bool hugeSd, Metric[] metrics)
             => CreateSummary<MockBenchmarkClass>(config, hugeSd, metrics);
 
         public static Summary CreateSummary<TBenchmark>(IConfig config, bool hugeSd, Metric[] metrics) => new Summary(
-                "MockSummary",
-                CreateBenchmarks<TBenchmark>(config).Select(b => CreateReport(b, hugeSd, metrics)).ToImmutableArray(),
-                new HostEnvironmentInfoBuilder().Build(),
-                string.Empty,
-                string.Empty,
-                TimeSpan.FromMinutes(1),
-                TestCultureInfo.Instance,
-                ImmutableArray<ValidationError>.Empty,
-                ImmutableArray<IColumnHidingRule>.Empty);
+            "MockSummary",
+            CreateBenchmarks<TBenchmark>(config).Select(b => CreateReport(b, hugeSd, metrics)).ToImmutableArray(),
+            new HostEnvironmentInfoBuilder().Build(),
+            string.Empty,
+            string.Empty,
+            TimeSpan.FromMinutes(1),
+            TestCultureInfo.Instance,
+            ImmutableArray<ValidationError>.Empty,
+            ImmutableArray<IColumnHidingRule>.Empty);
 
         public static Summary CreateSummary<TBenchmark>(IConfig config, bool hugeSd, Func<BenchmarkCase, Metric[]> metricsBuilder) => new Summary(
-                "MockSummary",
-                CreateBenchmarks<TBenchmark>(config).Select(b => CreateReport(b, hugeSd, metricsBuilder(b))).ToImmutableArray(),
-                new HostEnvironmentInfoBuilder().Build(),
-                string.Empty,
-                string.Empty,
-                TimeSpan.FromMinutes(1),
-                TestCultureInfo.Instance,
-                ImmutableArray<ValidationError>.Empty,
-                ImmutableArray<IColumnHidingRule>.Empty);
+            "MockSummary",
+            CreateBenchmarks<TBenchmark>(config).Select(b => CreateReport(b, hugeSd, metricsBuilder(b))).ToImmutableArray(),
+            new HostEnvironmentInfoBuilder().Build(),
+            string.Empty,
+            string.Empty,
+            TimeSpan.FromMinutes(1),
+            TestCultureInfo.Instance,
+            ImmutableArray<ValidationError>.Empty,
+            ImmutableArray<IColumnHidingRule>.Empty);
+
+        public static SummaryStyle CreateSummaryStyle(bool printUnitsInHeader = false, bool printUnitsInContent = true, bool printZeroValuesInContent = false,
+            SizeUnit sizeUnit = null, TimeUnit timeUnit = null, TextJustification defaultTextJustification = TextJustification.Left)
+            => new SummaryStyle(DefaultCultureInfo.Instance, printUnitsInHeader, sizeUnit, timeUnit, printUnitsInContent: printUnitsInContent,
+                printZeroValuesInContent: printZeroValuesInContent, defaultTextJustification: defaultTextJustification);
 
         private static ImmutableArray<BenchmarkReport> CreateReports(IConfig config)
             => CreateBenchmarks<MockBenchmarkClass>(config).Select(CreateSimpleReport).ToImmutableArray();

--- a/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
@@ -48,9 +48,7 @@ namespace BenchmarkDotNet.Tests.Reports
         [Fact]
         public void NumericColumnIsRightJustified()
         {
-            var config = ManualConfig.Create(DefaultConfig.Instance);
-
-            config.SummaryStyle = MockFactory.CreateSummaryStyle(numericColumnJustification: SummaryTable.SummaryTableColumn.TextJustification.Right);
+            var config = ManualConfig.Create(DefaultConfig.Instance).AddColumn(StatisticColumn.Mean);
             var summary = MockFactory.CreateSummary(config);
             var table = new SummaryTable(summary);
 
@@ -61,11 +59,32 @@ namespace BenchmarkDotNet.Tests.Reports
         public void TextColumnIsLeftJustified()
         {
             var config = ManualConfig.Create(DefaultConfig.Instance).AddColumn(new ParamColumn("Param"));
-            config.SummaryStyle = MockFactory.CreateSummaryStyle(textColumnJustification: SummaryTable.SummaryTableColumn.TextJustification.Left);
             var summary = MockFactory.CreateSummary(config);
             var table = new SummaryTable(summary);
 
             Assert.Equal(SummaryTable.SummaryTableColumn.TextJustification.Left, table.Columns.First(c => c.Header == "Param").Justify);
+        }
+
+        [Fact]
+        public void NumericColumnWithLeftJustification()
+        {
+            var config = ManualConfig.Create(DefaultConfig.Instance).AddColumn(StatisticColumn.Mean);
+            config.SummaryStyle = MockFactory.CreateSummaryStyle(numericColumnJustification: SummaryTable.SummaryTableColumn.TextJustification.Left);
+            var summary = MockFactory.CreateSummary(config);
+            var table = new SummaryTable(summary);
+
+            Assert.Equal(SummaryTable.SummaryTableColumn.TextJustification.Left, table.Columns.First(c => c.Header == "Mean").Justify);
+        }
+
+        [Fact]
+        public void TextColumnWithRightJustification()
+        {
+            var config = ManualConfig.Create(DefaultConfig.Instance).AddColumn(new ParamColumn("Param"));
+            config.SummaryStyle = MockFactory.CreateSummaryStyle(textColumnJustification: SummaryTable.SummaryTableColumn.TextJustification.Right);
+            var summary = MockFactory.CreateSummary(config);
+            var table = new SummaryTable(summary);
+
+            Assert.Equal(SummaryTable.SummaryTableColumn.TextJustification.Right, table.Columns.First(c => c.Header == "Param").Justify);
         }
 
         [Fact] // Issue #1070

--- a/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
@@ -46,19 +46,21 @@ namespace BenchmarkDotNet.Tests.Reports
         }
 
         [Fact]
-        public void NumericColumnIsRightJustified()
+        public void RightJustificationWorks()
         {
-            var config = ManualConfig.Create(DefaultConfig.Instance).AddColumn(StatisticColumn.Mean);
+            var config = ManualConfig.Create(DefaultConfig.Instance).AddColumn(new ParamColumn("Param"));
+            config.SummaryStyle = MockFactory.CreateSummaryStyle(defaultTextJustification: SummaryTable.SummaryTableColumn.TextJustification.Right);
             var summary = MockFactory.CreateSummary(config);
             var table = new SummaryTable(summary);
 
-            Assert.Equal(SummaryTable.SummaryTableColumn.TextJustification.Right, table.Columns.First(c => c.Header == "Mean").Justify);
+            Assert.Equal(SummaryTable.SummaryTableColumn.TextJustification.Right, table.Columns.First(c => c.Header == "Param").Justify);
         }
 
         [Fact]
-        public void TextColumnIsLeftJustified()
+        public void LeftJustificationWorks()
         {
             var config = ManualConfig.Create(DefaultConfig.Instance).AddColumn(new ParamColumn("Param"));
+            config.SummaryStyle = MockFactory.CreateSummaryStyle(defaultTextJustification: SummaryTable.SummaryTableColumn.TextJustification.Left);
             var summary = MockFactory.CreateSummary(config);
             var table = new SummaryTable(summary);
 

--- a/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
@@ -46,21 +46,22 @@ namespace BenchmarkDotNet.Tests.Reports
         }
 
         [Fact]
-        public void RightJustificationWorks()
+        public void NumericColumnIsRightJustified()
         {
-            var config = ManualConfig.Create(DefaultConfig.Instance).AddColumn(new ParamColumn("Param"));
-            config.SummaryStyle = MockFactory.CreateSummaryStyle(defaultTextJustification: SummaryTable.SummaryTableColumn.TextJustification.Right);
+            var config = ManualConfig.Create(DefaultConfig.Instance);
+
+            config.SummaryStyle = MockFactory.CreateSummaryStyle(numericColumnJustification: SummaryTable.SummaryTableColumn.TextJustification.Right);
             var summary = MockFactory.CreateSummary(config);
             var table = new SummaryTable(summary);
 
-            Assert.Equal(SummaryTable.SummaryTableColumn.TextJustification.Right, table.Columns.First(c => c.Header == "Param").Justify);
+            Assert.Equal(SummaryTable.SummaryTableColumn.TextJustification.Right, table.Columns.First(c => c.Header == "Mean").Justify);
         }
 
         [Fact]
-        public void LeftJustificationWorks()
+        public void TextColumnIsLeftJustified()
         {
             var config = ManualConfig.Create(DefaultConfig.Instance).AddColumn(new ParamColumn("Param"));
-            config.SummaryStyle = MockFactory.CreateSummaryStyle(defaultTextJustification: SummaryTable.SummaryTableColumn.TextJustification.Left);
+            config.SummaryStyle = MockFactory.CreateSummaryStyle(textColumnJustification: SummaryTable.SummaryTableColumn.TextJustification.Left);
             var summary = MockFactory.CreateSummary(config);
             var table = new SummaryTable(summary);
 


### PR DESCRIPTION
Hi, thanks for reviewing my pull request. This pull request intends to fix [https://github.com/dotnet/BenchmarkDotNet/issues/1995](this issue)

Here are some key points worth mentioning:
1- After initial investigation, I found that Justify property in "SummaryTableColumn" class does not have impact on aligning the contents of summary table. It only effects the header separator of table. (See the first attachment please)

2- I managed to add the "DefaultTextJustification" property to "SummaryStyle" and use the style to set "Justify" property inside "SummaryTableColumn". I changed the "BuildStandardText" and "BuildBoldText" methods to use "Justify" property.

3- Since I changed how the Justify Property was being initialized and the previous value was only used inside "GetJustificationIndicator" method, I changed the method to read from "IsNumeric" value of passed column. Exactly like the previous value of "Justify" property

4- I modified SummaryTableTests class and added a new method to MockFactory class to test the new style. CreateSummary method inside MockFactory did not used the specified style of config object and directly called the constructor of Summary class where style was initialized with default instance. So I added a new parameter for style.

5- Finally I modified methods "SummaryStyle" class and added a new method in "HashCode" struct to support the newly added style "DefaultTextJustification".

6- You can see the final result in second attachment.

![Justify not working on columns](https://github.com/dotnet/BenchmarkDotNet/assets/46107508/05fbc9e3-1fae-4cc0-b090-94c4f0e61d03)
![after changes](https://github.com/dotnet/BenchmarkDotNet/assets/46107508/a2fd37cb-c134-4bac-a978-1165dd42e542)
