### PR TITLE
Fix Event Processors not being copied in ManualConfig.Add

### DIFF
--- a/src/BenchmarkDotNet/Configs/ConfigExtensions.cs
+++ b/src/BenchmarkDotNet/Configs/ConfigExtensions.cs
@@ -111,7 +111,7 @@ namespace BenchmarkDotNet.Configs
         [Obsolete("This method will soon be removed, please start using .AddLogicalGroupRules() instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)] public static IConfig With(this IConfig config, params BenchmarkLogicalGroupRule[] rules) => config.AddLogicalGroupRules(rules);
         [PublicAPI] public static ManualConfig AddLogicalGroupRules(this IConfig config, params BenchmarkLogicalGroupRule[] rules) => config.With(c => c.AddLogicalGroupRules(rules));
-        [PublicAPI] public static ManualConfig AddEventProcessor(this IConfig config, EventProcessor eventProcessor) => config.With(c => c.AddEventProcessor(eventProcessor));
+        [PublicAPI] public static ManualConfig AddEventProcessor(this IConfig config, params EventProcessor[] eventProcessors) => config.With(c => c.AddEventProcessor(eventProcessors));
 
         [PublicAPI] public static ManualConfig HideColumns(this IConfig config, params string[] columnNames) => config.With(c => c.HideColumns(columnNames));
         [PublicAPI] public static ManualConfig HideColumns(this IConfig config, params IColumn[] columns) => config.With(c => c.HideColumns(columns));

--- a/src/BenchmarkDotNet/Configs/ManualConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ManualConfig.cs
@@ -224,9 +224,9 @@ namespace BenchmarkDotNet.Configs
             return this;
         }
 
-        public ManualConfig AddEventProcessor(EventProcessor eventProcessor)
+        public ManualConfig AddEventProcessor(params EventProcessor[] newEventProcessors)
         {
-            this.eventProcessors.Add(eventProcessor);
+            this.eventProcessors.AddRange(newEventProcessors);
             return this;
         }
 
@@ -263,6 +263,7 @@ namespace BenchmarkDotNet.Configs
             validators.AddRange(config.GetValidators());
             hardwareCounters.AddRange(config.GetHardwareCounters());
             filters.AddRange(config.GetFilters());
+            eventProcessors.AddRange(config.GetEventProcessors());
             Orderer = config.Orderer ?? Orderer;
             CategoryDiscoverer = config.CategoryDiscoverer ?? CategoryDiscoverer;
             ArtifactsPath = config.ArtifactsPath ?? ArtifactsPath;


### PR DESCRIPTION
Also add params support for `AddEventProcessor` to be consistent with other addable things.

This addresses additional feedback from @mawosoft on the previous PR: https://github.com/dotnet/BenchmarkDotNet/pull/2420#issuecomment-1729756976