### PR TITLE
Changed console color for Help from DarkGreen to Green

### DIFF
--- a/src/BenchmarkDotNet/Loggers/ConsoleLogger.cs
+++ b/src/BenchmarkDotNet/Loggers/ConsoleLogger.cs
@@ -73,7 +73,7 @@ namespace BenchmarkDotNet.Loggers
             new Dictionary<LogKind, ConsoleColor>
             {
                 { LogKind.Default, ConsoleColor.Gray },
-                { LogKind.Help, ConsoleColor.DarkGreen },
+                { LogKind.Help, ConsoleColor.Green },
                 { LogKind.Header, ConsoleColor.Magenta },
                 { LogKind.Result, ConsoleColor.DarkCyan },
                 { LogKind.Statistic, ConsoleColor.Cyan },


### PR DESCRIPTION
I had a look at the other colors but with only 16 colors available on the `ConsoleColor` enum, there isn't much I can do.

For now I changed the color for Help from DarkGreen to Green, which makes it a lot more readable.