### PR TITLE
implement full .NET 9 support

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -12,5 +12,6 @@
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
+    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
+++ b/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
@@ -106,6 +106,11 @@ namespace BenchmarkDotNet.Jobs
         Net80,
 
         /// <summary>
+        /// .NET 9.0
+        /// </summary>
+        Net90,
+
+        /// <summary>
         /// NativeAOT compiled as net6.0
         /// </summary>
         NativeAot60,
@@ -119,6 +124,11 @@ namespace BenchmarkDotNet.Jobs
         /// NativeAOT compiled as net8.0
         /// </summary>
         NativeAot80,
+
+        /// <summary>
+        /// NativeAOT compiled as net9.0
+        /// </summary>
+        NativeAot90,
 
         /// <summary>
         /// WebAssembly with default .Net version
@@ -171,6 +181,11 @@ namespace BenchmarkDotNet.Jobs
         MonoAOTLLVMNet80,
 
         /// <summary>
+        /// Mono with the Ahead of Time LLVM Compiler backend and net9.0
+        /// </summary>
+        MonoAOTLLVMNet90,
+
+        /// <summary>
         /// .NET 6 using MonoVM (not CLR which is the default)
         /// </summary>
         Mono60,
@@ -184,5 +199,10 @@ namespace BenchmarkDotNet.Jobs
         /// .NET 8 using MonoVM (not CLR which is the default)
         /// </summary>
         Mono80,
+
+        /// <summary>
+        /// .NET 9 using MonoVM (not CLR which is the default)
+        /// </summary>
+        Mono90,
     }
 }

--- a/src/BenchmarkDotNet.Diagnostics.dotTrace/DotTraceDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.dotTrace/DotTraceDiagnoser.cs
@@ -97,12 +97,14 @@ namespace BenchmarkDotNet.Diagnostics.dotTrace
                 case RuntimeMoniker.Net60:
                 case RuntimeMoniker.Net70:
                 case RuntimeMoniker.Net80:
+                case RuntimeMoniker.Net90:
                     return true;
                 case RuntimeMoniker.NotRecognized:
                 case RuntimeMoniker.Mono:
                 case RuntimeMoniker.NativeAot60:
                 case RuntimeMoniker.NativeAot70:
                 case RuntimeMoniker.NativeAot80:
+                case RuntimeMoniker.NativeAot90:
                 case RuntimeMoniker.Wasm:
                 case RuntimeMoniker.WasmNet50:
                 case RuntimeMoniker.WasmNet60:
@@ -113,9 +115,11 @@ namespace BenchmarkDotNet.Diagnostics.dotTrace
                 case RuntimeMoniker.MonoAOTLLVMNet60:
                 case RuntimeMoniker.MonoAOTLLVMNet70:
                 case RuntimeMoniker.MonoAOTLLVMNet80:
+                case RuntimeMoniker.MonoAOTLLVMNet90:
                 case RuntimeMoniker.Mono60:
                 case RuntimeMoniker.Mono70:
                 case RuntimeMoniker.Mono80:
+                case RuntimeMoniker.Mono90:
 #pragma warning disable CS0618 // Type or member is obsolete
                 case RuntimeMoniker.NetCoreApp50:
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -532,6 +532,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 case RuntimeMoniker.Net60:
                 case RuntimeMoniker.Net70:
                 case RuntimeMoniker.Net80:
+                case RuntimeMoniker.Net90:
                     return baseJob
                         .WithRuntime(runtimeMoniker.GetRuntime())
                         .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings(runtimeId, null, runtimeId, options.CliPath?.FullName, options.RestorePath?.FullName)));
@@ -547,6 +548,9 @@ namespace BenchmarkDotNet.ConsoleArguments
 
                 case RuntimeMoniker.NativeAot80:
                     return CreateAotJob(baseJob, options, runtimeMoniker, "", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json");
+
+                case RuntimeMoniker.NativeAot90:
+                    return CreateAotJob(baseJob, options, runtimeMoniker, "", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json");
 
                 case RuntimeMoniker.Wasm:
                     return MakeWasmJob(baseJob, options, RuntimeInformation.IsNetCore ? CoreRuntime.GetCurrentVersion().MsBuildMoniker : "net5.0", runtimeMoniker);
@@ -578,6 +582,9 @@ namespace BenchmarkDotNet.ConsoleArguments
                 case RuntimeMoniker.MonoAOTLLVMNet80:
                     return MakeMonoAOTLLVMJob(baseJob, options, "net8.0");
 
+                case RuntimeMoniker.MonoAOTLLVMNet90:
+                    return MakeMonoAOTLLVMJob(baseJob, options, "net9.0");
+
                 case RuntimeMoniker.Mono60:
                     return MakeMonoJob(baseJob, options, MonoRuntime.Mono60);
 
@@ -586,6 +593,9 @@ namespace BenchmarkDotNet.ConsoleArguments
 
                 case RuntimeMoniker.Mono80:
                     return MakeMonoJob(baseJob, options, MonoRuntime.Mono80);
+
+                case RuntimeMoniker.Mono90:
+                    return MakeMonoJob(baseJob, options, MonoRuntime.Mono90);
 
                 default:
                     throw new NotSupportedException($"Runtime {runtimeId} is not supported");

--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
@@ -20,8 +20,9 @@ namespace BenchmarkDotNet.Environments
         public static readonly CoreRuntime Core60 = new (RuntimeMoniker.Net60, "net6.0", ".NET 6.0");
         public static readonly CoreRuntime Core70 = new (RuntimeMoniker.Net70, "net7.0", ".NET 7.0");
         public static readonly CoreRuntime Core80 = new (RuntimeMoniker.Net80, "net8.0", ".NET 8.0");
+        public static readonly CoreRuntime Core90 = new (RuntimeMoniker.Net90, "net9.0", ".NET 9.0");
 
-        public static CoreRuntime Latest => Core80; // when dotnet/runtime branches for 9.0, this will need to get updated
+        public static CoreRuntime Latest => Core90; // when dotnet/runtime branches for 10.0, this will need to get updated
 
         private CoreRuntime(RuntimeMoniker runtimeMoniker, string msBuildMoniker, string displayName)
             : base(runtimeMoniker, msBuildMoniker, displayName)
@@ -72,6 +73,7 @@ namespace BenchmarkDotNet.Environments
                 case Version v when v.Major == 6 && v.Minor == 0: return GetPlatformSpecific(Core60);
                 case Version v when v.Major == 7 && v.Minor == 0: return GetPlatformSpecific(Core70);
                 case Version v when v.Major == 8 && v.Minor == 0: return GetPlatformSpecific(Core80);
+                case Version v when v.Major == 9 && v.Minor == 0: return GetPlatformSpecific(Core90);
                 default:
                     return CreateForNewVersion($"net{version.Major}.{version.Minor}", $".NET {version.Major}.{version.Minor}");
             }

--- a/src/BenchmarkDotNet/Environments/Runtimes/MonoRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/MonoRuntime.cs
@@ -9,6 +9,7 @@ namespace BenchmarkDotNet.Environments
         public static readonly MonoRuntime Mono60 = new ("Mono with .NET 6.0", RuntimeMoniker.Mono60, "net6.0", isDotNetBuiltIn: true);
         public static readonly MonoRuntime Mono70 = new ("Mono with .NET 7.0", RuntimeMoniker.Mono70, "net7.0", isDotNetBuiltIn: true);
         public static readonly MonoRuntime Mono80 = new ("Mono with .NET 8.0", RuntimeMoniker.Mono80, "net8.0", isDotNetBuiltIn: true);
+        public static readonly MonoRuntime Mono90 = new ("Mono with .NET 9.0", RuntimeMoniker.Mono90, "net9.0", isDotNetBuiltIn: true);
 
         public string CustomPath { get; }
 

--- a/src/BenchmarkDotNet/Environments/Runtimes/NativeAotRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/NativeAotRuntime.cs
@@ -18,6 +18,10 @@ namespace BenchmarkDotNet.Environments
         /// NativeAOT compiled as net8.0
         /// </summary>
         public static readonly NativeAotRuntime Net80 = new NativeAotRuntime(RuntimeMoniker.NativeAot80, "net8.0", "NativeAOT 8.0");
+        /// <summary>
+        /// NativeAOT compiled as net9.0
+        /// </summary>
+        public static readonly NativeAotRuntime Net90 = new NativeAotRuntime(RuntimeMoniker.NativeAot90, "net9.0", "NativeAOT 9.0");
 
         public override bool IsAOT => true;
 
@@ -42,6 +46,8 @@ namespace BenchmarkDotNet.Environments
             {
                 case Version v when v.Major == 6 && v.Minor == 0: return Net60;
                 case Version v when v.Major == 7 && v.Minor == 0: return Net70;
+                case Version v when v.Major == 8 && v.Minor == 0: return Net80;
+                case Version v when v.Major == 9 && v.Minor == 0: return Net90;
                 default:
                     return new NativeAotRuntime(RuntimeMoniker.NotRecognized, $"net{version.Major}.{version.Minor}", $"NativeAOT {version.Major}.{version.Minor}");
             }

--- a/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
@@ -45,6 +45,8 @@ namespace BenchmarkDotNet.Extensions
                     return CoreRuntime.Core70;
                 case RuntimeMoniker.Net80:
                     return CoreRuntime.Core80;
+                case RuntimeMoniker.Net90:
+                    return CoreRuntime.Core90;
                 case RuntimeMoniker.Mono:
                     return MonoRuntime.Default;
                 case RuntimeMoniker.NativeAot60:
@@ -53,10 +55,16 @@ namespace BenchmarkDotNet.Extensions
                     return NativeAotRuntime.Net70;
                 case RuntimeMoniker.NativeAot80:
                     return NativeAotRuntime.Net80;
+                case RuntimeMoniker.NativeAot90:
+                    return NativeAotRuntime.Net90;
                 case RuntimeMoniker.Mono60:
                     return MonoRuntime.Mono60;
                 case RuntimeMoniker.Mono70:
                     return MonoRuntime.Mono70;
+                case RuntimeMoniker.Mono80:
+                    return MonoRuntime.Mono80;
+                case RuntimeMoniker.Mono90:
+                    return MonoRuntime.Mono90;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(runtimeMoniker), runtimeMoniker, "Runtime Moniker not supported");
             }

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
@@ -24,6 +24,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         [PublicAPI] public static readonly IToolchain NetCoreApp60 = From(NetCoreAppSettings.NetCoreApp60);
         [PublicAPI] public static readonly IToolchain NetCoreApp70 = From(NetCoreAppSettings.NetCoreApp70);
         [PublicAPI] public static readonly IToolchain NetCoreApp80 = From(NetCoreAppSettings.NetCoreApp80);
+        [PublicAPI] public static readonly IToolchain NetCoreApp90 = From(NetCoreAppSettings.NetCoreApp90);
 
         internal CsProjCoreToolchain(string name, IGenerator generator, IBuilder builder, IExecutor executor, string customDotNetCliPath)
             : base(name, generator, builder, executor)

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
@@ -18,6 +18,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp60 = new ("net6.0", null, ".NET 6.0");
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp70 = new ("net7.0", null, ".NET 7.0");
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp80 = new ("net8.0", null, ".NET 8.0");
+        [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp90 = new ("net9.0", null, ".NET 9.0");
 
         /// <summary>
         /// <param name="targetFrameworkMoniker">

--- a/src/BenchmarkDotNet/Toolchains/Mono/MonoToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/Mono/MonoToolchain.cs
@@ -11,6 +11,7 @@ namespace BenchmarkDotNet.Toolchains.Mono
         [PublicAPI] public static readonly IToolchain Mono60 = From(new NetCoreAppSettings("net6.0", null, "mono60"));
         [PublicAPI] public static readonly IToolchain Mono70 = From(new NetCoreAppSettings("net7.0", null, "mono70"));
         [PublicAPI] public static readonly IToolchain Mono80 = From(new NetCoreAppSettings("net8.0", null, "mono80"));
+        [PublicAPI] public static readonly IToolchain Mono90 = From(new NetCoreAppSettings("net9.0", null, "mono90"));
 
         private MonoToolchain(string name, IGenerator generator, IBuilder builder, IExecutor executor, string customDotNetCliPath)
             : base(name, generator, builder, executor, customDotNetCliPath)

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
@@ -29,6 +29,14 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             .TargetFrameworkMoniker("net8.0")
             .ToToolchain();
 
+        /// <summary>
+        /// compiled as net9.0, targets latest NativeAOT build from the .NET 9 feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json
+        /// </summary>
+        public static readonly IToolchain Net90 = CreateBuilder()
+            .UseNuGet("", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json")
+            .TargetFrameworkMoniker("net9.0")
+            .ToToolchain();
+
         internal NativeAotToolchain(string displayName,
             string ilCompilerVersion,
             string runtimeFrameworkVersion, string targetFrameworkMoniker, string runtimeIdentifier,

--- a/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
@@ -66,6 +66,7 @@ namespace BenchmarkDotNet.Toolchains
                                 RuntimeMoniker.Mono60 => GetToolchain(RuntimeMoniker.Net60),
                                 RuntimeMoniker.Mono70 => GetToolchain(RuntimeMoniker.Net70),
                                 RuntimeMoniker.Mono80 => GetToolchain(RuntimeMoniker.Net80),
+                                RuntimeMoniker.Mono90 => GetToolchain(RuntimeMoniker.Net90),
                                 _ => CsProjCoreToolchain.From(new NetCoreAppSettings(mono.MsBuildMoniker, null, mono.Name))
                             };
                         }
@@ -152,6 +153,9 @@ namespace BenchmarkDotNet.Toolchains
                 case RuntimeMoniker.Net80:
                     return CsProjCoreToolchain.NetCoreApp80;
 
+                case RuntimeMoniker.Net90:
+                    return CsProjCoreToolchain.NetCoreApp90;
+
                 case RuntimeMoniker.NativeAot60:
                     return NativeAotToolchain.Net60;
 
@@ -161,6 +165,9 @@ namespace BenchmarkDotNet.Toolchains
                 case RuntimeMoniker.NativeAot80:
                     return NativeAotToolchain.Net80;
 
+                case RuntimeMoniker.NativeAot90:
+                    return NativeAotToolchain.Net90;
+
                 case RuntimeMoniker.Mono60:
                     return MonoToolchain.Mono60;
 
@@ -169,6 +176,9 @@ namespace BenchmarkDotNet.Toolchains
 
                 case RuntimeMoniker.Mono80:
                     return MonoToolchain.Mono80;
+
+                case RuntimeMoniker.Mono90:
+                    return MonoToolchain.Mono90;
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(runtimeMoniker), runtimeMoniker, "RuntimeMoniker not supported");

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -386,6 +386,7 @@ namespace BenchmarkDotNet.Tests
         [InlineData("net60")]
         [InlineData("net70")]
         [InlineData("net80")]
+        [InlineData("net90")]
         public void NetMonikersAreRecognizedAsNetCoreMonikers(string tfm)
         {
             var config = ConfigParser.Parse(new[] { "-r", tfm }, new OutputLogger(Output)).config;


### PR DESCRIPTION
fixes #2455

```cmd
dotnet run -c Release -f net8.0 --filter *IntroBasic* --job dry --runtimes net8.0 net9.0 nativeaot8.0 nativeaot9.0 mono8.0 mono9.0
```

I've verified that all new monikers work and do what is expected (build as net9.0):

![image](https://github.com/dotnet/BenchmarkDotNet/assets/6011991/375811da-b467-44ed-bdf4-cd9aba438a12)


And that CoreRun Toolchain works as expected too:

![image](https://github.com/dotnet/BenchmarkDotNet/assets/6011991/2c3f65a8-738a-454c-bc3a-9bab6a8241d7)
