### PR TITLE
Enable MemoryDiagnoser on Legacy Mono

### DIFF
--- a/docs/articles/configs/diagnosers.md
+++ b/docs/articles/configs/diagnosers.md
@@ -86,7 +86,6 @@ In BenchmarkDotNet, 1kB = 1024B, 1MB = 1024kB, and so on. The column Gen X means
 
 * In order to not affect main results we perform a separate run if any diagnoser is used. That's why it might take more time to execute benchmarks.
 * MemoryDiagnoser:
-	* Mono currently [does not](https://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-in-mono) expose any api to get the number of allocated bytes. That's why our Mono users will get `?` in Allocated column.
 	* In order to get the number of allocated bytes in cross platform way we are using `GC.GetAllocatedBytesForCurrentThread` which recently got [exposed](https://github.com/dotnet/corefx/pull/12489) for netcoreapp1.1. That's why BenchmarkDotNet does not support netcoreapp1.0 from version 0.10.1.
 	* MemoryDiagnoser is `99.5%` accurate about allocated memory when using default settings or Job.ShortRun (or any longer job than it).
 * Threading Diagnoser:

--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -150,14 +150,14 @@ namespace BenchmarkDotNet.Engines
 #if NET6_0_OR_GREATER
             return GC.GetTotalAllocatedBytes(precise: true);
 #else
-            if (ReflectionHelper.GetTotalAllocatedBytesDelegate != null) // it's .NET Core 3.0 with the new API available
-                return ReflectionHelper.GetTotalAllocatedBytesDelegate.Invoke(true); // true for the "precise" argument
+            if (GcHelpers.GetTotalAllocatedBytesDelegate != null) // it's .NET Core 3.0 with the new API available
+                return GcHelpers.GetTotalAllocatedBytesDelegate.Invoke(true); // true for the "precise" argument
 
-            if (ReflectionHelper.CanUseMonitoringTotalAllocatedMemorySize) // Monitoring is not available in Mono, see http://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-
+            if (GcHelpers.CanUseMonitoringTotalAllocatedMemorySize) // Monitoring is not available in Mono, see http://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-
                 return AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize;
 
-            if (ReflectionHelper.GetAllocatedBytesForCurrentThreadDelegate != null)
-                return ReflectionHelper.GetAllocatedBytesForCurrentThreadDelegate.Invoke();
+            if (GcHelpers.GetAllocatedBytesForCurrentThreadDelegate != null)
+                return GcHelpers.GetAllocatedBytesForCurrentThreadDelegate.Invoke();
 
             return null;
 #endif
@@ -238,7 +238,7 @@ namespace BenchmarkDotNet.Engines
         public override int GetHashCode() => HashCode.Combine(Gen0Collections, Gen1Collections, Gen2Collections, AllocatedBytes, TotalOperations);
 
 #if !NET6_0_OR_GREATER
-        private static class ReflectionHelper
+        private static class GcHelpers
         {
             // do not reorder these, CheckMonitoringTotalAllocatedMemorySize relies on GetTotalAllocatedBytesDelegate being initialized first
             public static readonly Func<bool, long> GetTotalAllocatedBytesDelegate = CreateGetTotalAllocatedBytesDelegate();

--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -15,8 +15,10 @@ namespace BenchmarkDotNet.Engines
         public static readonly long AllocationQuantum = CalculateAllocationQuantumSize();
 
 #if !NET6_0_OR_GREATER
-        private static readonly Func<long> GetAllocatedBytesForCurrentThreadDelegate = CreateGetAllocatedBytesForCurrentThreadDelegate();
+        // do not reorder these, CheckMonitoringTotalAllocatedMemorySize relies on GetTotalAllocatedBytesDelegate being initialized first
         private static readonly Func<bool, long> GetTotalAllocatedBytesDelegate = CreateGetTotalAllocatedBytesDelegate();
+        private static readonly Func<long> GetAllocatedBytesForCurrentThreadDelegate = CreateGetAllocatedBytesForCurrentThreadDelegate();
+        private static readonly bool CanUseMonitoringTotalAllocatedMemorySize = CheckMonitoringTotalAllocatedMemorySize();
 #endif
 
         public static readonly GcStats Empty = default;
@@ -143,9 +145,6 @@ namespace BenchmarkDotNet.Engines
 
         private static long? GetAllocatedBytes()
         {
-            if (RuntimeInformation.IsOldMono) // Monitoring is not available in Mono, see http://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-
-                return null;
-
             // we have no tests for WASM and don't want to risk introducing a new bug (https://github.com/dotnet/BenchmarkDotNet/issues/2226)
             if (RuntimeInformation.IsWasm)
                 return null;
@@ -155,37 +154,88 @@ namespace BenchmarkDotNet.Engines
             // so we enforce GC.Collect here just to make sure we get accurate results
             GC.Collect();
 
-            if (RuntimeInformation.IsFullFramework) // it can be a .NET app consuming our .NET Standard package
-                return AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize;
-
 #if NET6_0_OR_GREATER
             return GC.GetTotalAllocatedBytes(precise: true);
 #else
             if (GetTotalAllocatedBytesDelegate != null) // it's .NET Core 3.0 with the new API available
                 return GetTotalAllocatedBytesDelegate.Invoke(true); // true for the "precise" argument
 
-            // https://apisof.net/catalog/System.GC.GetAllocatedBytesForCurrentThread() is not part of the .NET Standard, so we use reflection to call it..
-            return GetAllocatedBytesForCurrentThreadDelegate.Invoke();
+            if (CanUseMonitoringTotalAllocatedMemorySize) // Monitoring is not available in Mono, see http://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-
+                return AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize;
+
+            if (GetAllocatedBytesForCurrentThreadDelegate != null)
+                return GetAllocatedBytesForCurrentThreadDelegate.Invoke();
+
+            return null;
 #endif
+        }
+
+#if !NET6_0_OR_GREATER
+        private static Func<bool, long> CreateGetTotalAllocatedBytesDelegate()
+        {
+            try
+            {
+                // this method is not a part of .NET Standard so we need to use reflection
+                var method = typeof(GC).GetTypeInfo().GetMethod("GetTotalAllocatedBytes", BindingFlags.Public | BindingFlags.Static);
+
+                if (method == null)
+                    return null;
+
+                // we create delegate to avoid boxing, IMPORTANT!
+                var del = (Func<bool, long>)method.CreateDelegate(typeof(Func<bool, long>));
+
+                // verify the api works
+                return del(true) >= 0 ? del : null;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         private static Func<long> CreateGetAllocatedBytesForCurrentThreadDelegate()
         {
-            // this method is not a part of .NET Standard so we need to use reflection
-            var method = typeof(GC).GetTypeInfo().GetMethod("GetAllocatedBytesForCurrentThread", BindingFlags.Public | BindingFlags.Static);
+            try
+            {
+                // this method is not a part of .NET Standard so we need to use reflection
+                var method = typeof(GC).GetTypeInfo().GetMethod("GetAllocatedBytesForCurrentThread", BindingFlags.Public | BindingFlags.Static);
 
-            // we create delegate to avoid boxing, IMPORTANT!
-            return method != null ? (Func<long>)method.CreateDelegate(typeof(Func<long>)) : null;
+                if (method == null)
+                    return null;
+
+                // we create delegate to avoid boxing, IMPORTANT!
+                var del = (Func<long>)method.CreateDelegate(typeof(Func<long>));
+
+                // verify the api works
+                return del() >= 0 ? del : null;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
-        private static Func<bool, long> CreateGetTotalAllocatedBytesDelegate()
+        private static bool CheckMonitoringTotalAllocatedMemorySize()
         {
-            // this method is not a part of .NET Standard so we need to use reflection
-            var method = typeof(GC).GetTypeInfo().GetMethod("GetTotalAllocatedBytes", BindingFlags.Public | BindingFlags.Static);
+            try
+            {
+                // we potentially don't want to enable monitoring if we don't need it
+                if (GetTotalAllocatedBytesDelegate != null)
+                    return false;
 
-            // we create delegate to avoid boxing, IMPORTANT!
-            return method != null ? (Func<bool, long>)method.CreateDelegate(typeof(Func<bool, long>)) : null;
+                // check if monitoring is enabled
+                if (!AppDomain.MonitoringIsEnabled)
+                    AppDomain.MonitoringIsEnabled = true;
+
+                // verify the api works
+                return AppDomain.MonitoringIsEnabled && AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize >= 0;
+            }
+            catch
+            {
+                return false;
+            }
         }
+#endif
 
         public string ToOutputLine()
             => $"{ResultsLinePrefix} {Gen0Collections} {Gen1Collections} {Gen2Collections} {AllocatedBytes?.ToString() ?? MetricColumn.UnknownRepresentation} {TotalOperations}";

--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -237,7 +237,7 @@ namespace BenchmarkDotNet.Engines
 
         public override int GetHashCode() => HashCode.Combine(Gen0Collections, Gen1Collections, Gen2Collections, AllocatedBytes, TotalOperations);
 
-        #if !NET6_0_OR_GREATER
+#if !NET6_0_OR_GREATER
         private static class ReflectionHelper
         {
             // do not reorder these, CheckMonitoringTotalAllocatedMemorySize relies on GetTotalAllocatedBytesDelegate being initialized first

--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -238,6 +238,7 @@ namespace BenchmarkDotNet.Engines
         public override int GetHashCode() => HashCode.Combine(Gen0Collections, Gen1Collections, Gen2Collections, AllocatedBytes, TotalOperations);
 
 #if !NET6_0_OR_GREATER
+        // separate class to have the cctor run lazily
         private static class GcHelpers
         {
             // do not reorder these, CheckMonitoringTotalAllocatedMemorySize relies on GetTotalAllocatedBytesDelegate being initialized first

--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -238,7 +238,7 @@ namespace BenchmarkDotNet.Engines
         public override int GetHashCode() => HashCode.Combine(Gen0Collections, Gen1Collections, Gen2Collections, AllocatedBytes, TotalOperations);
 
 #if !NET6_0_OR_GREATER
-        // separate class to have the cctor run lazily
+        // Separate class to have the cctor run lazily, to avoid enabling monitoring before the benchmarks are ran.
         private static class GcHelpers
         {
             // do not reorder these, CheckMonitoringTotalAllocatedMemorySize relies on GetTotalAllocatedBytesDelegate being initialized first

--- a/src/BenchmarkDotNet/Engines/GcStats.cs
+++ b/src/BenchmarkDotNet/Engines/GcStats.cs
@@ -14,13 +14,6 @@ namespace BenchmarkDotNet.Engines
 
         public static readonly long AllocationQuantum = CalculateAllocationQuantumSize();
 
-#if !NET6_0_OR_GREATER
-        // do not reorder these, CheckMonitoringTotalAllocatedMemorySize relies on GetTotalAllocatedBytesDelegate being initialized first
-        private static readonly Func<bool, long> GetTotalAllocatedBytesDelegate = CreateGetTotalAllocatedBytesDelegate();
-        private static readonly Func<long> GetAllocatedBytesForCurrentThreadDelegate = CreateGetAllocatedBytesForCurrentThreadDelegate();
-        private static readonly bool CanUseMonitoringTotalAllocatedMemorySize = CheckMonitoringTotalAllocatedMemorySize();
-#endif
-
         public static readonly GcStats Empty = default;
 
         private GcStats(int gen0Collections, int gen1Collections, int gen2Collections, long? allocatedBytes, long totalOperations)
@@ -157,85 +150,18 @@ namespace BenchmarkDotNet.Engines
 #if NET6_0_OR_GREATER
             return GC.GetTotalAllocatedBytes(precise: true);
 #else
-            if (GetTotalAllocatedBytesDelegate != null) // it's .NET Core 3.0 with the new API available
-                return GetTotalAllocatedBytesDelegate.Invoke(true); // true for the "precise" argument
+            if (ReflectionHelper.GetTotalAllocatedBytesDelegate != null) // it's .NET Core 3.0 with the new API available
+                return ReflectionHelper.GetTotalAllocatedBytesDelegate.Invoke(true); // true for the "precise" argument
 
-            if (CanUseMonitoringTotalAllocatedMemorySize) // Monitoring is not available in Mono, see http://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-
+            if (ReflectionHelper.CanUseMonitoringTotalAllocatedMemorySize) // Monitoring is not available in Mono, see http://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-
                 return AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize;
 
-            if (GetAllocatedBytesForCurrentThreadDelegate != null)
-                return GetAllocatedBytesForCurrentThreadDelegate.Invoke();
+            if (ReflectionHelper.GetAllocatedBytesForCurrentThreadDelegate != null)
+                return ReflectionHelper.GetAllocatedBytesForCurrentThreadDelegate.Invoke();
 
             return null;
 #endif
         }
-
-#if !NET6_0_OR_GREATER
-        private static Func<bool, long> CreateGetTotalAllocatedBytesDelegate()
-        {
-            try
-            {
-                // this method is not a part of .NET Standard so we need to use reflection
-                var method = typeof(GC).GetTypeInfo().GetMethod("GetTotalAllocatedBytes", BindingFlags.Public | BindingFlags.Static);
-
-                if (method == null)
-                    return null;
-
-                // we create delegate to avoid boxing, IMPORTANT!
-                var del = (Func<bool, long>)method.CreateDelegate(typeof(Func<bool, long>));
-
-                // verify the api works
-                return del(true) >= 0 ? del : null;
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        private static Func<long> CreateGetAllocatedBytesForCurrentThreadDelegate()
-        {
-            try
-            {
-                // this method is not a part of .NET Standard so we need to use reflection
-                var method = typeof(GC).GetTypeInfo().GetMethod("GetAllocatedBytesForCurrentThread", BindingFlags.Public | BindingFlags.Static);
-
-                if (method == null)
-                    return null;
-
-                // we create delegate to avoid boxing, IMPORTANT!
-                var del = (Func<long>)method.CreateDelegate(typeof(Func<long>));
-
-                // verify the api works
-                return del() >= 0 ? del : null;
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        private static bool CheckMonitoringTotalAllocatedMemorySize()
-        {
-            try
-            {
-                // we potentially don't want to enable monitoring if we don't need it
-                if (GetTotalAllocatedBytesDelegate != null)
-                    return false;
-
-                // check if monitoring is enabled
-                if (!AppDomain.MonitoringIsEnabled)
-                    AppDomain.MonitoringIsEnabled = true;
-
-                // verify the api works
-                return AppDomain.MonitoringIsEnabled && AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize >= 0;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-#endif
 
         public string ToOutputLine()
             => $"{ResultsLinePrefix} {Gen0Collections} {Gen1Collections} {Gen2Collections} {AllocatedBytes?.ToString() ?? MetricColumn.UnknownRepresentation} {TotalOperations}";
@@ -310,5 +236,80 @@ namespace BenchmarkDotNet.Engines
         public override bool Equals(object obj) => obj is GcStats other && Equals(other);
 
         public override int GetHashCode() => HashCode.Combine(Gen0Collections, Gen1Collections, Gen2Collections, AllocatedBytes, TotalOperations);
+
+        #if !NET6_0_OR_GREATER
+        private static class ReflectionHelper
+        {
+            // do not reorder these, CheckMonitoringTotalAllocatedMemorySize relies on GetTotalAllocatedBytesDelegate being initialized first
+            public static readonly Func<bool, long> GetTotalAllocatedBytesDelegate = CreateGetTotalAllocatedBytesDelegate();
+            public static readonly Func<long> GetAllocatedBytesForCurrentThreadDelegate = CreateGetAllocatedBytesForCurrentThreadDelegate();
+            public static readonly bool CanUseMonitoringTotalAllocatedMemorySize = CheckMonitoringTotalAllocatedMemorySize();
+
+            private static Func<bool, long> CreateGetTotalAllocatedBytesDelegate()
+            {
+                try
+                {
+                    // this method is not a part of .NET Standard so we need to use reflection
+                    var method = typeof(GC).GetTypeInfo().GetMethod("GetTotalAllocatedBytes", BindingFlags.Public | BindingFlags.Static);
+
+                    if (method == null)
+                        return null;
+
+                    // we create delegate to avoid boxing, IMPORTANT!
+                    var del = (Func<bool, long>)method.CreateDelegate(typeof(Func<bool, long>));
+
+                    // verify the api works
+                    return del.Invoke(true) >= 0 ? del : null;
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+
+            private static Func<long> CreateGetAllocatedBytesForCurrentThreadDelegate()
+            {
+                try
+                {
+                    // this method is not a part of .NET Standard so we need to use reflection
+                    var method = typeof(GC).GetTypeInfo().GetMethod("GetAllocatedBytesForCurrentThread", BindingFlags.Public | BindingFlags.Static);
+
+                    if (method == null)
+                        return null;
+
+                    // we create delegate to avoid boxing, IMPORTANT!
+                    var del = (Func<long>)method.CreateDelegate(typeof(Func<long>));
+
+                    // verify the api works
+                    return del.Invoke() >= 0 ? del : null;
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+
+            private static bool CheckMonitoringTotalAllocatedMemorySize()
+            {
+                try
+                {
+                    // we potentially don't want to enable monitoring if we don't need it
+                    if (GetTotalAllocatedBytesDelegate != null)
+                        return false;
+
+                    // check if monitoring is enabled
+                    if (!AppDomain.MonitoringIsEnabled)
+                        AppDomain.MonitoringIsEnabled = true;
+
+                    // verify the api works
+                    return AppDomain.MonitoringIsEnabled && AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize >= 0;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+#endif
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -34,9 +34,6 @@ namespace BenchmarkDotNet.IntegrationTests
 
         public static IEnumerable<object[]> GetToolchains()
         {
-            if (RuntimeInformation.IsOldMono) // https://github.com/mono/mono/issues/8397
-                yield break;
-
             yield return new object[] { Job.Default.GetToolchain() };
             yield return new object[] { InProcessEmitToolchain.Instance };
         }


### PR DESCRIPTION
This enables MemoryDiagnoser on Legacy Mono (since it provides `GetAllocatedBytesForCurrentThread`) and makes it more resilient to errors.