### PR TITLE
Adds a custom exporter option on command line args

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -31,9 +31,6 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option('e', "exporters", Required = false, HelpText = "GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML")]
         public IEnumerable<string> Exporters { get; set; }
 
-        [Option( "customExporter", Required = false, HelpText = "The assembly-qualified name of the Custom Exporter type")]
-        public string CustomExporter { get; set; }
-
         [Option('m', "memory", Required = false, Default = false, HelpText = "Prints memory statistics")]
         public bool UseMemoryDiagnoser { get; set; }
 

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -31,6 +31,9 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option('e', "exporters", Required = false, HelpText = "GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML")]
         public IEnumerable<string> Exporters { get; set; }
 
+        [Option( "customExporter", Required = false, HelpText = "The assembly-qualified name of the Custom Exporter type")]
+        public string CustomExporter { get; set; }
+
         [Option('m', "memory", Required = false, Default = false, HelpText = "Prints memory statistics")]
         public bool UseMemoryDiagnoser { get; set; }
 

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -26,6 +26,7 @@ using Perfolizer.Horology;
 using Perfolizer.Mathematics.SignificanceTesting;
 using Perfolizer.Mathematics.Thresholds;
 using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Exporters.Xml;
 
 namespace BenchmarkDotNet.Tests
 {
@@ -37,13 +38,18 @@ namespace BenchmarkDotNet.Tests
         public ConfigParserTests(ITestOutputHelper output) => Output = output;
 
         [Theory]
-        [InlineData("--customExporter", "BenchmarkDotNet.Tests.CustomExporterTestClass, BenchmarkDotNet.Tests")]
+        [InlineData("--exporters", "BenchmarkDotNet.Tests.CustomExporterTestClass, BenchmarkDotNet.Tests", "html", "xml")]
+        [InlineData("--exporters", "html", "BenchmarkDotNet.Tests.CustomExporterTestClass, BenchmarkDotNet.Tests", "xml")]
+        [InlineData("--exporters", "html", "xml", "BenchmarkDotNet.Tests.CustomExporterTestClass, BenchmarkDotNet.Tests")]
         public void CustomExporterConfigParsedCorrectly(params string[] args)
         {
             var config = ConfigParser.Parse(args, new OutputLogger(Output)).config;
 
-            var customExporter = config.GetExporters().ToList();
-            Assert.Equal("CustomExporterTestClass", customExporter[0].Name);
+            Assert.Equal(3, config.GetExporters().Count());
+            Assert.Contains(typeof(CustomExporterTestClass).Name, config.GetExporters().Select(e => e.Name));
+            Assert.Contains(HtmlExporter.Default, config.GetExporters());
+            Assert.Contains(XmlExporter.Default, config.GetExporters());
+
             Assert.Empty(config.GetColumnProviders());
             Assert.Empty(config.GetDiagnosers());
             Assert.Empty(config.GetAnalysers());

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -25,14 +25,30 @@ using BenchmarkDotNet.Portability;
 using Perfolizer.Horology;
 using Perfolizer.Mathematics.SignificanceTesting;
 using Perfolizer.Mathematics.Thresholds;
+using BenchmarkDotNet.Exporters.Json;
 
 namespace BenchmarkDotNet.Tests
 {
+    public class CustomExporterTestClass : JsonExporterBase { }
     public class ConfigParserTests
     {
         public ITestOutputHelper Output { get; }
 
         public ConfigParserTests(ITestOutputHelper output) => Output = output;
+
+        [Theory]
+        [InlineData("--customExporter", "BenchmarkDotNet.Tests.CustomExporterTestClass, BenchmarkDotNet.Tests")]
+        public void CustomExporterConfigParsedCorrectly(params string[] args)
+        {
+            var config = ConfigParser.Parse(args, new OutputLogger(Output)).config;
+
+            var customExporter = config.GetExporters().ToList();
+            Assert.Equal("CustomExporterTestClass", customExporter[0].Name);
+            Assert.Empty(config.GetColumnProviders());
+            Assert.Empty(config.GetDiagnosers());
+            Assert.Empty(config.GetAnalysers());
+            Assert.Empty(config.GetLoggers());
+        }
 
         [Theory]
         [InlineData("--job=dry", "--exporters", "html", "rplot")]


### PR DESCRIPTION
Fix #1967

This code adds the ability to include a custom exporter from command line arguments.

The user can use the option --customExporter "{assembly-qualified name of exporter}" and it will load the exporter into the config. 

Please let me know your thoughts on this approach.

Thank you. 