### PR TITLE
update SDK to .NET 8

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -20,12 +20,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run task 'build'
         shell: cmd
-        run: |
-          ./build.cmd build
+        run: ./build.cmd build
       - name: Run task 'in-tests-core'
         shell: cmd
-        run: |
-          ./build.cmd in-tests-core -e
+        run: ./build.cmd in-tests-core -e
       - name: Upload test results
         uses: actions/upload-artifact@v3
         if: always()
@@ -42,12 +40,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run task 'build'
         shell: cmd
-        run: |
-          ./build.cmd build
+        run: ./build.cmd build
       - name: Run task 'in-tests-full'
         shell: cmd
-        run: |
-          ./build.cmd in-tests-full -e
+        run: ./build.cmd in-tests-full -e
       - name: Upload test results
         uses: actions/upload-artifact@v3
         if: always()

--- a/build/BenchmarkDotNet.Build/BenchmarkDotNet.Build.csproj
+++ b/build/BenchmarkDotNet.Build/BenchmarkDotNet.Build.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/build/BenchmarkDotNet.Build/BenchmarkDotNet.Build.csproj
+++ b/build/BenchmarkDotNet.Build/BenchmarkDotNet.Build.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="3.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="3.2.0" />
     <PackageReference Include="Cake.FileHelpers" Version="6.1.3" />
     <PackageReference Include="Cake.Git" Version="3.0.0" />
     <PackageReference Include="Docfx.App" Version="2.71.1" />

--- a/build/BenchmarkDotNet.Build/BuildContext.cs
+++ b/build/BenchmarkDotNet.Build/BuildContext.cs
@@ -59,6 +59,9 @@ public class BuildContext : FrostingContext
         BuildDirectory = RootDirectory.Combine("build");
         ArtifactsDirectory = RootDirectory.Combine("artifacts");
 
+        var toolFileName = context.IsRunningOnWindows() ? "dotnet.exe" : "dotnet";
+        var toolFilePath = RootDirectory.Combine(".dotnet").CombineWithFilePath(toolFileName);
+        context.Tools.RegisterFile(toolFilePath);
 
         SolutionFile = RootDirectory.CombineWithFilePath("BenchmarkDotNet.sln");
 

--- a/build/BenchmarkDotNet.Build/Program.cs
+++ b/build/BenchmarkDotNet.Build/Program.cs
@@ -98,7 +98,7 @@ public class InTestsFullTask : FrostingTask<BuildContext>, IHelpProvider
 public class InTestsCoreTask : FrostingTask<BuildContext>, IHelpProvider
 {
     private const string Name = "in-tests-core";
-    public override void Run(BuildContext context) => context.UnitTestRunner.RunInTests("net7.0");
+    public override void Run(BuildContext context) => context.UnitTestRunner.RunInTests("net8.0");
     public HelpInfo GetHelp() => new();
 }
 

--- a/build/BenchmarkDotNet.Build/Runners/BuildRunner.cs
+++ b/build/BenchmarkDotNet.Build/Runners/BuildRunner.cs
@@ -24,7 +24,8 @@ public class BuildRunner
         context.DotNetRestore(context.SolutionFile.FullPath,
             new DotNetRestoreSettings
             {
-                MSBuildSettings = context.MsBuildSettingsRestore
+                MSBuildSettings = context.MsBuildSettingsRestore,
+                Verbosity = DotNetVerbosity.Normal
             });
     }
 

--- a/build/BenchmarkDotNet.Build/Runners/UnitTestRunner.cs
+++ b/build/BenchmarkDotNet.Build/Runners/UnitTestRunner.cs
@@ -63,8 +63,8 @@ public class UnitTestRunner
     public void RunUnitTests()
     {
         var targetFrameworks = context.IsRunningOnWindows()
-            ? new[] { "net462", "net7.0" }
-            : new[] { "net7.0" };
+            ? new[] { "net462", "net8.0" }
+            : new[] { "net8.0" };
 
         foreach (var targetFramework in targetFrameworks)
             RunUnitTests(targetFramework);

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -58,11 +58,10 @@ if (!(Test-Path $InstallPath)) {
     $ScriptPath = Join-Path $InstallPath 'dotnet-install.ps1'
     (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, $ScriptPath);
     & $ScriptPath -JSonFile $GlobalJsonPath -InstallDir $InstallPath;
-
-    Remove-PathVariable "$InstallPath"
-    $env:PATH = "$InstallPath;$env:PATH"
 }
 
+Remove-PathVariable "$InstallPath"
+$env:PATH = "$InstallPath;$env:PATH"
 $env:DOTNET_ROOT=$InstallPath
 
 ###########################################################################

--- a/build/sdk/global.json
+++ b/build/sdk/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.401",
+    "version": "8.0.100",
     "rollForward": "disable"
   }
 }

--- a/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
+++ b/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />

--- a/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.Samples</AssemblyTitle>
-    <TargetFrameworks>net7.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.Samples</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/tests/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests.ConfigPerAssembly</AssemblyTitle>
-    <TargetFrameworks>net462;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.ConfigPerAssembly</AssemblyName>
     <PackageId>BenchmarkDotNet.IntegrationTests.ConfigPerAssembly</PackageId>

--- a/tests/BenchmarkDotNet.IntegrationTests.DisabledOptimizations/BenchmarkDotNet.IntegrationTests.DisabledOptimizations.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.DisabledOptimizations/BenchmarkDotNet.IntegrationTests.DisabledOptimizations.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests.DisabledOptimizations</AssemblyTitle>
-    <TargetFrameworks>net462;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.DisabledOptimizations</AssemblyName>
     <PackageId>BenchmarkDotNet.IntegrationTests.DisabledOptimizations</PackageId>

--- a/tests/BenchmarkDotNet.IntegrationTests.EnabledOptimizations/BenchmarkDotNet.IntegrationTests.EnabledOptimizations.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.EnabledOptimizations/BenchmarkDotNet.IntegrationTests.EnabledOptimizations.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests.EnabledOptimizations</AssemblyTitle>
-    <TargetFrameworks>net462;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.EnabledOptimizations</AssemblyName>
     <PackageId>BenchmarkDotNet.IntegrationTests.EnabledOptimizations</PackageId>

--- a/tests/BenchmarkDotNet.IntegrationTests.FSharp/BenchmarkDotNet.IntegrationTests.FSharp.fsproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.FSharp/BenchmarkDotNet.IntegrationTests.FSharp.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net462;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <PublicSign>false</PublicSign>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks</AssemblyTitle>
     <!-- We test the oldest frameworks supported by BDN (net461 and netcoreapp2.0), as well as newer versions of those frameworks. -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <TargetFrameworks>net461;net48;netcoreapp2.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net461;net48;netcoreapp2.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);NU1903</NoWarn> <!-- NU1903: Package 'Microsoft.NETCore.App' 2.0.0 has a known high severity vulnerability -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks</AssemblyName>

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/BenchmarkDotNet.IntegrationTests.ManualRunning.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/BenchmarkDotNet.IntegrationTests.ManualRunning.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests.ManualRunning</AssemblyTitle>
-    <TargetFrameworks>net462;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.ManualRunning</AssemblyName>
     <PackageId>BenchmarkDotNet.IntegrationTests.ManualRunning</PackageId>

--- a/tests/BenchmarkDotNet.IntegrationTests.Static/BenchmarkDotNet.IntegrationTests.Static.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.Static/BenchmarkDotNet.IntegrationTests.Static.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests.Static</AssemblyTitle>
-    <TargetFrameworks>net462;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.Static</AssemblyName>
     <PackageId>BenchmarkDotNet.IntegrationTests.Static</PackageId>

--- a/tests/BenchmarkDotNet.IntegrationTests.VisualBasic/BenchmarkDotNet.IntegrationTests.VisualBasic.vbproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.VisualBasic/BenchmarkDotNet.IntegrationTests.VisualBasic.vbproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net462;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
@@ -2,8 +2,8 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests</AssemblyTitle>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net462;net7.0</TargetFrameworks>
-    <TargetFramework Condition="'$(OS)' != 'Windows_NT'">net7.0</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net462;net8.0</TargetFrameworks>
+    <TargetFramework Condition="'$(OS)' != 'Windows_NT'">net8.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests</AssemblyName>
     <PackageId>BenchmarkDotNet.IntegrationTests</PackageId>

--- a/tests/BenchmarkDotNet.IntegrationTests/BuildTimeoutTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/BuildTimeoutTests.cs
@@ -31,8 +31,8 @@ namespace BenchmarkDotNet.IntegrationTests
                 .AddJob(Job.Dry
                     .WithRuntime(NativeAotRuntime.Net70)
                     .WithToolchain(NativeAotToolchain.CreateBuilder()
-                        .UseNuGet("7.0.0", "https://api.nuget.org/v3/index.json")
-                        .TargetFrameworkMoniker("net7.0")
+                        .UseNuGet("8.0.0", "https://api.nuget.org/v3/index.json")
+                        .TargetFrameworkMoniker("net8.0")
                         .ToToolchain()));
 
             var summary = CanExecute<NativeAotBenchmark>(config, fullValidation: false);

--- a/tests/BenchmarkDotNet.IntegrationTests/BuildTimeoutTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/BuildTimeoutTests.cs
@@ -29,7 +29,7 @@ namespace BenchmarkDotNet.IntegrationTests
             var config = ManualConfig.CreateEmpty()
                 .WithBuildTimeout(timeout)
                 .AddJob(Job.Dry
-                    .WithRuntime(NativeAotRuntime.Net70)
+                    .WithRuntime(NativeAotRuntime.Net80)
                     .WithToolchain(NativeAotToolchain.CreateBuilder()
                         .UseNuGet("8.0.0", "https://api.nuget.org/v3/index.json")
                         .TargetFrameworkMoniker("net8.0")

--- a/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
@@ -34,11 +34,11 @@ namespace BenchmarkDotNet.IntegrationTests
             {
                 if (RuntimeInformation.GetCurrentPlatform() is Platform.X86 or Platform.X64)
                 {
-                    yield return new object[] { Jit.RyuJit, Platform.X64, CoreRuntime.Core70 }; // .NET Core x64
+                    yield return new object[] { Jit.RyuJit, Platform.X64, CoreRuntime.Core80 }; // .NET Core x64
                 }
                 else if (RuntimeInformation.GetCurrentPlatform() is Platform.Arm64 && RuntimeInformation.IsLinux())
                 {
-                    yield return new object[] { Jit.RyuJit, Platform.Arm64, CoreRuntime.Core70 }; // .NET Core arm64
+                    yield return new object[] { Jit.RyuJit, Platform.Arm64, CoreRuntime.Core80 }; // .NET Core arm64
                 }
             }
             if (RuntimeInformation.IsMacOS())

--- a/tests/BenchmarkDotNet.IntegrationTests/JitRuntimeValidationTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/JitRuntimeValidationTest.cs
@@ -51,7 +51,7 @@ namespace BenchmarkDotNet.IntegrationTests
         [MemberData(nameof(CheckCore_Arguments))]
         public void CheckCore(Jit jit, Platform platform, string errorMessage)
         {
-            Verify(CoreRuntime.Core70, jit, platform, errorMessage);
+            Verify(CoreRuntime.Core80, jit, platform, errorMessage);
         }
 
         private void Verify(Runtime runtime, Jit jit, Platform platform, string errorMessage)

--- a/tests/BenchmarkDotNet.IntegrationTests/LargeAddressAwareTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/LargeAddressAwareTest.cs
@@ -47,7 +47,7 @@ namespace BenchmarkDotNet.IntegrationTests
                 .Any());
 
             Assert.Contains(".NET Framework", summary.AllRuntimes);
-            Assert.Contains(".NET 7.0", summary.AllRuntimes);
+            Assert.Contains(".NET 8.0", summary.AllRuntimes);
         }
     }
 

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -81,10 +81,10 @@ namespace BenchmarkDotNet.IntegrationTests
                     .ToToolchain());
         }
 
-        [FactEnvSpecific("We don't want to test MonoVM twice (for .NET Framework 4.6.2 and .NET 7.0)", EnvRequirement.DotNetCoreOnly)]
+        [FactEnvSpecific("We don't want to test MonoVM twice (for .NET Framework 4.6.2 and .NET 8.0)", EnvRequirement.DotNetCoreOnly)]
         public void MemoryDiagnoserSupportsModernMono()
         {
-            MemoryDiagnoserIsAccurate(MonoToolchain.Mono70);
+            MemoryDiagnoserIsAccurate(MonoToolchain.Mono80);
         }
 
         public class AllocatingGlobalSetupAndCleanup

--- a/tests/BenchmarkDotNet.IntegrationTests/MonoTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MonoTests.cs
@@ -4,16 +4,23 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Portability;
+using BenchmarkDotNet.Tests.Loggers;
 using BenchmarkDotNet.Tests.XUnit;
+using Xunit.Abstractions;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
     public class MonoTests : BenchmarkTestExecutor
     {
+        public MonoTests(ITestOutputHelper output) : base(output) { }
+
         [FactEnvSpecific("UseMonoRuntime option is available in .NET Core only starting from .NET 6", EnvRequirement.DotNetCoreOnly)]
-        public void Mono70IsSupported()
+        public void Mono80IsSupported()
         {
-            var config = ManualConfig.CreateEmpty().AddJob(Job.Dry.WithRuntime(MonoRuntime.Mono70));
+            var logger = new OutputLogger(Output);
+            var config = ManualConfig.CreateEmpty()
+                .AddLogger(logger)
+                .AddJob(Job.Dry.WithRuntime(MonoRuntime.Mono80));
             CanExecute<MonoBenchmark>(config);
         }
 
@@ -27,7 +34,7 @@ namespace BenchmarkDotNet.IntegrationTests
                     throw new Exception("This is not Mono runtime");
                 }
 
-                if (RuntimeInformation.GetCurrentRuntime() != MonoRuntime.Mono70)
+                if (RuntimeInformation.GetCurrentRuntime() != MonoRuntime.Mono80)
                 {
                     throw new Exception("Incorrect runtime detection");
                 }

--- a/tests/BenchmarkDotNet.IntegrationTests/MultipleRuntimesTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MultipleRuntimesTest.cs
@@ -51,7 +51,7 @@ namespace BenchmarkDotNet.IntegrationTests
                 .Any());
 
             Assert.Contains(".NET Framework", summary.AllRuntimes);
-            Assert.Contains(".NET 7.0", summary.AllRuntimes);
+            Assert.Contains(".NET 8.0", summary.AllRuntimes);
         }
     }
 

--- a/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
+++ b/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.Tests</AssemblyTitle>
-    <TargetFrameworks>net7.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>BenchmarkDotNet.Tests</AssemblyName>
     <PackageId>BenchmarkDotNet.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -168,7 +168,7 @@ namespace BenchmarkDotNet.Tests
         [FactEnvSpecific("It's impossible to determine TFM for CoreRunToolchain if host process is not .NET (Core) process", EnvRequirement.DotNetCoreOnly)]
         public void SpecifyingCoreRunAndRuntimeCreatesTwoJobs()
         {
-            const string runtime = "net7.0";
+            const string runtime = "net8.0";
             var fakeDotnetCliPath = typeof(object).Assembly.Location;
             var fakeCoreRunPath = typeof(ConfigParserTests).Assembly.Location;
             var fakeRestorePackages = Path.GetTempPath();


### PR DESCRIPTION
Currently it's just a draft. It would be nice to have for #2412, where we would not need to use reflection to figure out whether AVX512 is supported.