### PR TITLE
Use "native" for .NET 8, don't use "serialize" for .NET 7

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -763,7 +763,7 @@ namespace BenchmarkDotNet.ConsoleArguments
             return coreRunPath.FullName.Substring(lastCommonDirectorySeparatorIndex);
         }
 
-        private static bool TryParse(string runtime, out RuntimeMoniker runtimeMoniker)
+        internal static bool TryParse(string runtime, out RuntimeMoniker runtimeMoniker)
         {
             int index = runtime.IndexOf('-');
 

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -223,8 +223,12 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
         // based on https://github.com/dotnet/runtime/blob/ce61c09a5f6fc71d8f717d3fc4562f42171869a0/src/coreclr/tools/Common/JitInterface/CorInfoInstructionSet.cs#L727
         private IEnumerable<string> GetCurrentProcessInstructionSets(Platform platform)
         {
+            if (!ConfigParser.TryParse(TargetFrameworkMoniker, out RuntimeMoniker runtimeMoniker))
+            {
+                throw new NotSupportedException($"Invalid TFM: '{TargetFrameworkMoniker}'");
+            }
+
             if (platform == RuntimeInformation.GetCurrentPlatform() // "native" does not support cross-compilation (so does BDN for now)
-                && ConfigParser.TryParse(TargetFrameworkMoniker, out RuntimeMoniker runtimeMoniker)
                 && runtimeMoniker >= RuntimeMoniker.NativeAot80)
             {
                 yield return "native"; // added in .NET 8 https://github.com/dotnet/runtime/pull/87865
@@ -252,7 +256,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                     if (HardwareIntrinsics.IsX86PclmulqdqSupported) yield return "pclmul";
                     if (HardwareIntrinsics.IsX86PopcntSupported) yield return "popcnt";
                     if (HardwareIntrinsics.IsX86AvxVnniSupported) yield return "avxvnni";
-                    if (HardwareIntrinsics.IsX86SerializeSupported) yield return "serialize";
+                    if (HardwareIntrinsics.IsX86SerializeSupported && runtimeMoniker > RuntimeMoniker.NativeAot70) yield return "serialize"; // https://github.com/dotnet/BenchmarkDotNet/issues/2463#issuecomment-1809625008
                     break;
                 case Platform.Arm64:
                     if (HardwareIntrinsics.IsArmBaseSupported) yield return "base";


### PR DESCRIPTION
Use "native" for .NET 8, don't use "serialize" for .NET 7.

fixes #2060
fixes #2463

cc @MichalStrehovsky 