### PR TITLE
Create empty Directory.Build.props to ignore other prop files

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -87,6 +87,22 @@ namespace BenchmarkDotNet.Toolchains.CsProj
                 .ToString();
 
             File.WriteAllText(artifactsPaths.ProjectFilePath, content);
+
+            // We create an empty Directory.Build.props file next to the project file to ignore other prop files
+            // https://github.com/dotnet/BenchmarkDotNet/issues/2371#issuecomment-1814709479
+            string propsFilePath = Path.Combine(Path.GetDirectoryName(artifactsPaths.ProjectFilePath), "Directory.Build.props");
+            if (!File.Exists(propsFilePath))
+            {
+                File.WriteAllText(propsFilePath, @"
+<Project>
+  <!-- This is an empty Directory.Build.props file to prevent projects which reside
+       under this directory to use any of the repository local settings. -->
+  <PropertyGroup>
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  </PropertyGroup>
+</Project>");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
It should not affect the WASM benchmarks (cc @radical), as they have their own generator:

https://github.com/dotnet/BenchmarkDotNet/blob/630622b6df3192f766ffa03ff07b5086e70cb264/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs#L52

https://github.com/dotnet/BenchmarkDotNet/blob/630622b6df3192f766ffa03ff07b5086e70cb264/src/BenchmarkDotNet/Templates/WasmCsProj.txt#L3-L5

which links a dedicated props file: https://github.com/dotnet/performance/blob/main/src/benchmarks/micro/MicroBenchmarks.Wasm.props

But I am not sure about dotnet/performance in general, as IIRC the props file there alters some settings like build output path. This is going to require a detailed testing (@cincuranet  @LoopedBard3 @DrewScoggins @caaavik-msft @sblom)

fixes #2371