### PR TITLE
Update the default framework on the templates to net8.0

### DIFF
--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.CSharp/.template.config/template.json
@@ -91,7 +91,7 @@
         "cases": [
           {
             "condition": "(consoleApp == true)",
-            "value": "net6.0"
+            "value": "net8.0"
           },
           {
             "condition": "(consoleApp == false)",

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.FSharp/.template.config/template.json
@@ -91,7 +91,7 @@
         "cases": [
           {
             "condition": "(consoleApp == true)",
-            "value": "net6.0"
+            "value": "net8.0"
           },
           {
             "condition": "(consoleApp == false)",

--- a/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json
+++ b/templates/templates/BenchmarkDotNet.BenchmarkProjectTemplate.VB/.template.config/template.json
@@ -91,7 +91,7 @@
         "cases": [
           {
             "condition": "(consoleApp == true)",
-            "value": "net6.0"
+            "value": "net8.0"
           },
           {
             "condition": "(consoleApp == false)",


### PR DESCRIPTION
This PR updates the default framework on the templates to net8.0 which is a LTS release (was net6.0).
Useful to bench newer C# features, like UTF-8 string literals.