### PR TITLE
Fix benchmarks with same class but different namespace having same ID

### DIFF
--- a/src/BenchmarkDotNet.TestAdapter/BenchmarkCaseExtensions.cs
+++ b/src/BenchmarkDotNet.TestAdapter/BenchmarkCaseExtensions.cs
@@ -86,6 +86,7 @@ namespace BenchmarkDotNet.TestAdapter
         {
             var testIdProvider = new TestIdProvider();
             testIdProvider.AppendString(VsTestAdapter.ExecutorUriString);
+            testIdProvider.AppendString(benchmarkCase.Descriptor.Type.Namespace ?? string.Empty);
             testIdProvider.AppendString(benchmarkCase.Descriptor.DisplayInfo);
             testIdProvider.AppendString(benchmarkCase.GetUnrandomizedJobDisplayInfo());
             testIdProvider.AppendString(benchmarkCase.Parameters.DisplayInfo);


### PR DESCRIPTION
This bug is causing the test adapter to fail to load on the dotnet/performance repository as we have some benchmarks where the test and class name are identical but live in different namespaces. Adding the namespace to the test ID resolves the issue.