### PR TITLE
Update Microsoft.Diagnostics.Tracing.TraceEvent

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.Windows/BenchmarkDotNet.Diagnostics.Windows.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/BenchmarkDotNet.Diagnostics.Windows.csproj
@@ -12,6 +12,6 @@
     <ProjectReference Include="..\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.2" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.8" PrivateAssets="contentfiles;analyzers" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Iced" Version="1.17.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.2.332302" />
     <PackageReference Include="Perfolizer" Version="[0.2.1]" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.2" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.8" PrivateAssets="contentfiles;analyzers" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <!-- Do not update these packages, or else netcoreapp3.0 and older will no longer work -->
     <PackageReference Include="System.Management" Version="5.0.0" />


### PR DESCRIPTION
Version 3.0.2 has logic which [adds](https://github.com/microsoft/perfview/blob/20ddf582bae8d024f37d27f1b4628dd23815213d/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props#L90-L94) a netstandard1.6 dll to the output. The package contains both netstandard1.6 and netstandard2.0 versions of this dll.

This runs into what I believe is an SDK [bug](https://github.com/dotnet/sdk/issues/39107) and results in neither dll being passed as input to the trimmer when publishing with `<PublishTrimmed>true</PublishTrimmed>`.

Recent versions of this package don't have the same problem since they include the netstandard2.0 version: https://github.com/microsoft/perfview/blob/c1c726690e138302c79fac1c1d20bf9d65426ce6/src/TraceEvent/Microsoft.Diagnostics.Tracing.TraceEvent.props#L46-L50.