### PR TITLE
Add support for wasm and Mono AOT LLVM monikers to SDK Validator

### DIFF
--- a/src/BenchmarkDotNet/Validators/DotNetSdkVersionValidator.cs
+++ b/src/BenchmarkDotNet/Validators/DotNetSdkVersionValidator.cs
@@ -222,6 +222,15 @@ namespace BenchmarkDotNet.Validators
                 RuntimeMoniker.Mono70 => "7.0",
                 RuntimeMoniker.Mono80 => "8.0",
                 RuntimeMoniker.Mono90 => "9.0",
+                RuntimeMoniker.WasmNet50 => "5.0",
+                RuntimeMoniker.WasmNet60 => "6.0",
+                RuntimeMoniker.WasmNet70 => "7.0",
+                RuntimeMoniker.WasmNet80 => "8.0",
+                RuntimeMoniker.WasmNet90 => "9.0",
+                RuntimeMoniker.MonoAOTLLVMNet60 => "6.0",
+                RuntimeMoniker.MonoAOTLLVMNet70 => "7.0",
+                RuntimeMoniker.MonoAOTLLVMNet80 => "8.0",
+                RuntimeMoniker.MonoAOTLLVMNet90 => "9.0",
                 _ => throw new NotImplementedException($"SDK version check not implemented for {runtimeMoniker}")
             };
         }


### PR DESCRIPTION
These monikers were missed in the recent SDK Validation feature.