### PR TITLE
Fix Mono AOT LLVM

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -571,19 +571,19 @@ namespace BenchmarkDotNet.ConsoleArguments
                     return MakeWasmJob(baseJob, options, "net9.0", runtimeMoniker);
 
                 case RuntimeMoniker.MonoAOTLLVM:
-                    return MakeMonoAOTLLVMJob(baseJob, options, RuntimeInformation.IsNetCore ? CoreRuntime.GetCurrentVersion().MsBuildMoniker : "net6.0");
+                    return MakeMonoAOTLLVMJob(baseJob, options, RuntimeInformation.IsNetCore ? CoreRuntime.GetCurrentVersion().MsBuildMoniker : "net6.0", runtimeMoniker);
 
                 case RuntimeMoniker.MonoAOTLLVMNet60:
-                    return MakeMonoAOTLLVMJob(baseJob, options, "net6.0");
+                    return MakeMonoAOTLLVMJob(baseJob, options, "net6.0", runtimeMoniker);
 
                 case RuntimeMoniker.MonoAOTLLVMNet70:
-                    return MakeMonoAOTLLVMJob(baseJob, options, "net7.0");
+                    return MakeMonoAOTLLVMJob(baseJob, options, "net7.0", runtimeMoniker);
 
                 case RuntimeMoniker.MonoAOTLLVMNet80:
-                    return MakeMonoAOTLLVMJob(baseJob, options, "net8.0");
+                    return MakeMonoAOTLLVMJob(baseJob, options, "net8.0", runtimeMoniker);
 
                 case RuntimeMoniker.MonoAOTLLVMNet90:
-                    return MakeMonoAOTLLVMJob(baseJob, options, "net9.0");
+                    return MakeMonoAOTLLVMJob(baseJob, options, "net9.0", runtimeMoniker);
 
                 case RuntimeMoniker.Mono60:
                     return MakeMonoJob(baseJob, options, MonoRuntime.Mono60);
@@ -637,7 +637,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                         packagesPath: options.RestorePath?.FullName)));
         }
 
-        private static Job MakeMonoAOTLLVMJob(Job baseJob, CommandLineOptions options, string msBuildMoniker)
+        private static Job MakeMonoAOTLLVMJob(Job baseJob, CommandLineOptions options, string msBuildMoniker, RuntimeMoniker moniker)
         {
             var monoAotLLVMRuntime = new MonoAotLLVMRuntime(aotCompilerPath: options.AOTCompilerPath, aotCompilerMode: options.AOTCompilerMode, msBuildMoniker: msBuildMoniker);
 

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -639,7 +639,7 @@ namespace BenchmarkDotNet.ConsoleArguments
 
         private static Job MakeMonoAOTLLVMJob(Job baseJob, CommandLineOptions options, string msBuildMoniker, RuntimeMoniker moniker)
         {
-            var monoAotLLVMRuntime = new MonoAotLLVMRuntime(aotCompilerPath: options.AOTCompilerPath, aotCompilerMode: options.AOTCompilerMode, msBuildMoniker: msBuildMoniker);
+            var monoAotLLVMRuntime = new MonoAotLLVMRuntime(aotCompilerPath: options.AOTCompilerPath, aotCompilerMode: options.AOTCompilerMode, msBuildMoniker: msBuildMoniker, moniker: moniker);
 
             var toolChain = MonoAotLLVMToolChain.From(
             new NetCoreAppSettings(

--- a/src/BenchmarkDotNet/Environments/Runtimes/MonoAotLLVMRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/MonoAotLLVMRuntime.cs
@@ -20,7 +20,7 @@ namespace BenchmarkDotNet.Environments
         /// <summary>
         /// creates new instance of MonoAotLLVMRuntime
         /// </summary>
-        public MonoAotLLVMRuntime(FileInfo aotCompilerPath, MonoAotCompilerMode aotCompilerMode, string msBuildMoniker = "net6.0", string displayName = "MonoAOTLLVM") : base(RuntimeMoniker.MonoAOTLLVM, msBuildMoniker, displayName)
+        public MonoAotLLVMRuntime(FileInfo aotCompilerPath, MonoAotCompilerMode aotCompilerMode, string msBuildMoniker = "net6.0", string displayName = "MonoAOTLLVM", RuntimeMoniker moniker = RuntimeMoniker.MonoAOTLLVM) : base(moniker, msBuildMoniker, displayName)
         {
             if (aotCompilerPath == null)
                 throw new ArgumentNullException(paramName: nameof(aotCompilerPath));

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -146,7 +146,7 @@ namespace BenchmarkDotNet.Toolchains
                 case MonoAotLLVMRuntime _:
                     start.FileName = exePath;
                     start.Arguments = args;
-                    start.WorkingDirectory = artifactsPaths.BinariesDirectoryPath;
+                    start.WorkingDirectory = Path.Combine(artifactsPaths.BinariesDirectoryPath, "publish");
                     break;
                 case CustomRuntime _:
                     start.FileName = exePath;

--- a/src/BenchmarkDotNet/Toolchains/MonoAotLLVM/MonoAotLLVMGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoAotLLVM/MonoAotLLVMGenerator.cs
@@ -55,10 +55,10 @@ namespace BenchmarkDotNet.Toolchains.MonoAotLLVM
 
         protected override string GetExecutablePath(string binariesDirectoryPath, string programName)
             => Portability.RuntimeInformation.IsWindows()
-                ? Path.Combine(binariesDirectoryPath, $"{programName}.exe")
-                : Path.Combine(binariesDirectoryPath, programName);
+                ? Path.Combine(binariesDirectoryPath, "publish", $"{programName}.exe")
+                : Path.Combine(binariesDirectoryPath, "publish", programName);
 
         protected override string GetBinariesDirectoryPath(string buildArtifactsDirectoryPath, string configuration)
-            => Path.Combine(buildArtifactsDirectoryPath, "bin", configuration, TargetFrameworkMoniker, CustomDotNetCliToolchainBuilder.GetPortableRuntimeIdentifier(), "publish");
+            => Path.Combine(buildArtifactsDirectoryPath, "bin", configuration, TargetFrameworkMoniker, CustomDotNetCliToolchainBuilder.GetPortableRuntimeIdentifier());
     }
 }


### PR DESCRIPTION
Similar to what broke with the WASM runs, it seems that Mono AOT LLVM also will always append the `publish` directory onto the end of the `OutDir` and `OutputPath` that we pass in, so we need to remove it from the end of those paths and then append it the executable path and working directory.

~~We are doing some more testing on this first before it can be ready to merge however, but this seems like the likely fix.~~
Testing is done, this PR is ready for a merge.