### PR TITLE
Do not use Taskbar on Containers.

### DIFF
--- a/src/BenchmarkDotNet/Helpers/Taskbar/TaskbarProgress.cs
+++ b/src/BenchmarkDotNet/Helpers/Taskbar/TaskbarProgress.cs
@@ -7,7 +7,9 @@ namespace BenchmarkDotNet.Helpers
     {
         private static readonly bool OsVersionIsSupported = Portability.RuntimeInformation.IsWindows()
             // Must be windows 7 or greater
-            && Environment.OSVersion.Version >= new Version(6, 1);
+            && Environment.OSVersion.Version >= new Version(6, 1)
+            // Taskbar COM Object not avilable
+            && !Portability.RuntimeInformation.IsRunningInContainer;
 
         private IntPtr consoleWindowHandle = IntPtr.Zero;
         private IntPtr consoleHandle = IntPtr.Zero;


### PR DESCRIPTION
Experienced the following when running Benchmarks on Windows Containers with BenchmarkDotNet 0.13.8.
```
System.Runtime.InteropServices.COMException (0x80040154): Retrieving the COM class factory for component with CLSID {56FDF344-FD6D-11D0-958A-006097C9A090} failed due to the following error: 80040154 Class not registered (0x80040154 (REGDB_E_CLASSNOTREG)).
at BenchmarkDotNet.Helpers.TaskbarProgressCom..cctor()
--- End of inner exception stack trace ---
at BenchmarkDotNet.Helpers.TaskbarProgressCom.SetState(IntPtr consoleWindowHandle, IntPtr consoleHandle, TaskbarProgressState taskbarState)
at BenchmarkDotNet.Helpers.TaskbarProgress.Dispose()
at BenchmarkDotNet.Running.BenchmarkRunnerClean.Run(BenchmarkRunInfo[] benchmarkRunInfos)
at BenchmarkDotNet.Running.BenchmarkRunner.RunWithDirtyAssemblyResolveHelper(BenchmarkRunInfo[] benchmarkRunInfos)
at BenchmarkDotNet.Running.BenchmarkRunner.<>c__DisplayClass5_0.<Run>b__0()
at BenchmarkDotNet.Running.BenchmarkRunner.RunWithExceptionHandling(Func`1 run)
at BenchmarkDotNet.Running.BenchmarkRunner.Run(BenchmarkRunInfo benchmarkRunInfo)
```

Setting the ENV-Variable should fix that issue.