### PR TITLE
fix isnativeaot definition

### DIFF
--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -50,7 +50,7 @@ namespace BenchmarkDotNet.Portability
 
         public static bool IsNativeAOT
             => Environment.Version.Major >= 5
-                && string.IsNullOrEmpty(typeof(object).Assembly.Location) // it's merged to a single .exe and .Location returns null
+                && !RuntimeFeature.IsDynamicCodeSupported // is false on NativeAOT
                 && !IsWasm; // Wasm also returns "" for assembly locations
 
 #if NET6_0_OR_GREATER


### PR DESCRIPTION
current detection fails to differentiate between PublishSingleFile and PublishAot because they both return null from Assembly.Location.

@adamsitnik @jkotas is there any existing app model API available to make this detection less fragile?