### PR TITLE
Improve memory diagnoser accuracy

### DIFF
--- a/src/BenchmarkDotNet/Engines/Engine.cs
+++ b/src/BenchmarkDotNet/Engines/Engine.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
@@ -220,31 +221,56 @@ namespace BenchmarkDotNet.Engines
 
         private (GcStats, ThreadingStats, double) GetExtraStats(IterationData data)
         {
-            // we enable monitoring after main target run, for this single iteration which is executed at the end
-            // so even if we enable AppDomain monitoring in separate process
-            // it does not matter, because we have already obtained the results!
-            EnableMonitoring();
+            // Warm up the measurement functions before starting the actual measurement.
+            DeadCodeEliminationHelper.KeepAliveWithoutBoxing(GcStats.ReadInitial());
+            DeadCodeEliminationHelper.KeepAliveWithoutBoxing(GcStats.ReadFinal());
 
             IterationSetupAction(); // we run iteration setup first, so even if it allocates, it is not included in the results
 
             var initialThreadingStats = ThreadingStats.ReadInitial(); // this method might allocate
             var exceptionsStats = new ExceptionsStats(); // allocates
             exceptionsStats.StartListening(); // this method might allocate
-            var initialGcStats = GcStats.ReadInitial();
 
-            WorkloadAction(data.InvokeCount / data.UnrollFactor);
+#if !NET7_0_OR_GREATER
+            if (RuntimeInformation.IsNetCore && Environment.Version.Major is >= 3 and <= 6 && RuntimeInformation.IsTieredJitEnabled)
+            {
+                // #1542
+                // We put the current thread to sleep so tiered jit can kick in, compile its stuff,
+                // and NOT allocate anything on the background thread when we are measuring allocations.
+                // This is only an issue on netcoreapp3.0 to net6.0. Tiered jit allocations were "fixed" in net7.0
+                // (maybe not completely eliminated forever, but at least reduced to a point where measurements are much more stable),
+                // and netcoreapp2.X uses only GetAllocatedBytesForCurrentThread which doesn't capture the tiered jit allocations.
+                Thread.Sleep(TimeSpan.FromMilliseconds(500));
+            }
+#endif
 
-            exceptionsStats.Stop();
-            var finalGcStats = GcStats.ReadFinal();
+            // GC collect before measuring allocations.
+            ForceGcCollect();
+            GcStats gcStats;
+            using (FinalizerBlocker.MaybeStart())
+            {
+                gcStats = MeasureWithGc(data.InvokeCount / data.UnrollFactor);
+            }
+
+            exceptionsStats.Stop(); // this method might (de)allocate
             var finalThreadingStats = ThreadingStats.ReadFinal();
 
             IterationCleanupAction(); // we run iteration cleanup after collecting GC stats
 
             var totalOperationsCount = data.InvokeCount * OperationsPerInvoke;
-            GcStats gcStats = (finalGcStats - initialGcStats).WithTotalOperations(totalOperationsCount);
-            ThreadingStats threadingStats = (finalThreadingStats - initialThreadingStats).WithTotalOperations(data.InvokeCount * OperationsPerInvoke);
+            return (gcStats.WithTotalOperations(totalOperationsCount),
+                (finalThreadingStats - initialThreadingStats).WithTotalOperations(totalOperationsCount),
+                exceptionsStats.ExceptionsCount / (double)totalOperationsCount);
+        }
 
-            return (gcStats, threadingStats, exceptionsStats.ExceptionsCount / (double)totalOperationsCount);
+        // Isolate the allocation measurement and skip tier0 jit to make sure we don't get any unexpected allocations.
+        [MethodImpl(MethodImplOptions.NoInlining | CodeGenHelper.AggressiveOptimizationOption)]
+        private GcStats MeasureWithGc(long invokeCount)
+        {
+            var initialGcStats = GcStats.ReadInitial();
+            WorkloadAction(invokeCount);
+            var finalGcStats = GcStats.ReadFinal();
+            return finalGcStats - initialGcStats;
         }
 
         private void RandomizeManagedHeapMemory()
@@ -273,7 +299,7 @@ namespace BenchmarkDotNet.Engines
             ForceGcCollect();
         }
 
-        private static void ForceGcCollect()
+        internal static void ForceGcCollect()
         {
             GC.Collect();
             GC.WaitForPendingFinalizers();
@@ -283,15 +309,6 @@ namespace BenchmarkDotNet.Engines
         public void WriteLine(string text) => Host.WriteLine(text);
 
         public void WriteLine() => Host.WriteLine();
-
-        private static void EnableMonitoring()
-        {
-            if (RuntimeInformation.IsOldMono) // Monitoring is not available in Mono, see http://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-in-mono
-                return;
-
-            if (RuntimeInformation.IsFullFramework)
-                AppDomain.MonitoringIsEnabled = true;
-        }
 
         [UsedImplicitly]
         public static class Signals
@@ -314,6 +331,57 @@ namespace BenchmarkDotNet.Engines
 
             public static bool TryGetSignal(string message, out HostSignal signal)
                 => MessagesToSignals.TryGetValue(message, out signal);
+        }
+
+        // Very long key and value so this shouldn't be used outside of unit tests.
+        internal const string UnitTestBlockFinalizerEnvKey = "BENCHMARKDOTNET_UNITTEST_BLOCK_FINALIZER_FOR_MEMORYDIAGNOSER";
+        internal const string UnitTestBlockFinalizerEnvValue = UnitTestBlockFinalizerEnvKey + "_ACTIVE";
+
+        // To prevent finalizers interfering with allocation measurements for unit tests,
+        // we block the finalizer thread until we've completed the measurement.
+        // https://github.com/dotnet/runtime/issues/101536#issuecomment-2077647417
+        private readonly struct FinalizerBlocker : IDisposable
+        {
+            private readonly ManualResetEventSlim hangEvent;
+
+            private FinalizerBlocker(ManualResetEventSlim hangEvent) => this.hangEvent = hangEvent;
+
+            private sealed class Impl
+            {
+                private readonly ManualResetEventSlim hangEvent = new (false);
+                private readonly ManualResetEventSlim enteredFinalizerEvent = new (false);
+
+                ~Impl()
+                {
+                    enteredFinalizerEvent.Set();
+                    hangEvent.Wait();
+                }
+
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                internal static (ManualResetEventSlim hangEvent, ManualResetEventSlim enteredFinalizerEvent) CreateWeakly()
+                {
+                    var impl = new Impl();
+                    return (impl.hangEvent, impl.enteredFinalizerEvent);
+                }
+            }
+
+            internal static FinalizerBlocker MaybeStart()
+            {
+                if (Environment.GetEnvironmentVariable(UnitTestBlockFinalizerEnvKey) != UnitTestBlockFinalizerEnvValue)
+                {
+                    return default;
+                }
+                var (hangEvent, enteredFinalizerEvent) = Impl.CreateWeakly();
+                do
+                {
+                    GC.Collect();
+                    // Do NOT call GC.WaitForPendingFinalizers.
+                }
+                while (!enteredFinalizerEvent.IsSet);
+                return new FinalizerBlocker(hangEvent);
+            }
+
+            public void Dispose() => hangEvent?.Set();
         }
     }
 }

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -54,17 +54,17 @@ namespace BenchmarkDotNet.Portability
             ((Environment.Version.Major >= 5) || FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase))
                 && !string.IsNullOrEmpty(typeof(object).Assembly.Location);
 
-        public static readonly bool IsNativeAOT =
-            Environment.Version.Major >= 5
-                && string.IsNullOrEmpty(typeof(object).Assembly.Location) // it's merged to a single .exe and .Location returns null
-                && !IsWasm; // Wasm also returns "" for assembly locations
-
 #if NET6_0_OR_GREATER
         [System.Runtime.Versioning.SupportedOSPlatformGuard("browser")]
         public static readonly bool IsWasm = OperatingSystem.IsBrowser();
 #else
         public static readonly bool IsWasm = IsOSPlatform(OSPlatform.Create("BROWSER"));
 #endif
+
+        public static readonly bool IsNativeAOT =
+            Environment.Version.Major >= 5
+                && string.IsNullOrEmpty(typeof(object).Assembly.Location) // it's merged to a single .exe and .Location returns null
+                && !IsWasm; // Wasm also returns "" for assembly locations
 
 #if NETSTANDARD2_0
         public static readonly bool IsAot = IsAotMethod();

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -27,47 +27,47 @@ namespace BenchmarkDotNet.Portability
         internal const string ReleaseConfigurationName = "RELEASE";
         internal const string Unknown = "?";
 
+        // Many of these checks allocate and/or are expensive to compute. We store the results in static readonly fields to keep Engine non-allocating.
+        // Static readonly fields are used instead of properties to avoid an extra getter method call that might not be tier1 jitted.
+        // This class is internal, so we don't need to expose these as properties.
+
         /// <summary>
         /// returns true for both the old (implementation of .NET Framework) and new Mono (.NET 6+ flavour)
         /// </summary>
-        public static bool IsMono { get; } =
-            Type.GetType("Mono.RuntimeStructs") != null; // it allocates a lot of memory, we need to check it once in order to keep Engine non-allocating!
+        public static readonly bool IsMono = Type.GetType("Mono.RuntimeStructs") != null;
 
-        public static bool IsOldMono { get; } = Type.GetType("Mono.Runtime") != null;
+        public static readonly bool IsOldMono = Type.GetType("Mono.Runtime") != null;
 
-        public static bool IsNewMono { get; } = IsMono && !IsOldMono;
+        public static readonly bool IsNewMono = IsMono && !IsOldMono;
 
-        public static bool IsFullFramework =>
+        public static readonly bool IsFullFramework =
 #if NET6_0_OR_GREATER
+            // This could be const, but we want to avoid unreachable code warnings.
             false;
 #else
             FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 #endif
 
-        [PublicAPI]
-        public static bool IsNetNative => FrameworkDescription.StartsWith(".NET Native", StringComparison.OrdinalIgnoreCase);
+        public static readonly bool IsNetNative = FrameworkDescription.StartsWith(".NET Native", StringComparison.OrdinalIgnoreCase);
 
-        public static bool IsNetCore
-            => ((Environment.Version.Major >= 5) || FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase))
-               && !string.IsNullOrEmpty(typeof(object).Assembly.Location);
+        public static readonly bool IsNetCore =
+            ((Environment.Version.Major >= 5) || FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase))
+                && !string.IsNullOrEmpty(typeof(object).Assembly.Location);
 
-        public static bool IsNativeAOT
-            => Environment.Version.Major >= 5
-               && string.IsNullOrEmpty(typeof(object).Assembly.Location) // it's merged to a single .exe and .Location returns null
-               && !IsWasm; // Wasm also returns "" for assembly locations
+        public static readonly bool IsNativeAOT =
+            Environment.Version.Major >= 5
+                && string.IsNullOrEmpty(typeof(object).Assembly.Location) // it's merged to a single .exe and .Location returns null
+                && !IsWasm; // Wasm also returns "" for assembly locations
 
 #if NET6_0_OR_GREATER
         [System.Runtime.Versioning.SupportedOSPlatformGuard("browser")]
-#endif
-        public static bool IsWasm =>
-#if NET6_0_OR_GREATER
-            OperatingSystem.IsBrowser();
+        public static readonly bool IsWasm = OperatingSystem.IsBrowser();
 #else
-            IsOSPlatform(OSPlatform.Create("BROWSER"));
+        public static readonly bool IsWasm = IsOSPlatform(OSPlatform.Create("BROWSER"));
 #endif
 
 #if NETSTANDARD2_0
-        public static bool IsAot { get; } = IsAotMethod(); // This allocates, so we only want to call it once statically.
+        public static readonly bool IsAot = IsAotMethod();
 
         private static bool IsAotMethod()
         {
@@ -85,11 +85,22 @@ namespace BenchmarkDotNet.Portability
             return false;
         }
 #else
-        public static bool IsAot => !System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeCompiled;
+        public static readonly bool IsAot = !System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeCompiled;
 #endif
 
-        public static bool IsRunningInContainer => string.Equals(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), "true");
+        public static readonly bool IsTieredJitEnabled =
+            IsNetCore
+            && (Environment.Version.Major < 3
+                // Disabled by default in netcoreapp2.X, check if it's enabled.
+                ? Environment.GetEnvironmentVariable("COMPlus_TieredCompilation") == "1"
+                || Environment.GetEnvironmentVariable("DOTNET_TieredCompilation") == "1"
+                || (AppContext.TryGetSwitch("System.Runtime.TieredCompilation", out bool isEnabled) && isEnabled)
+                // Enabled by default in netcoreapp3.0+, check if it's disabled.
+                : Environment.GetEnvironmentVariable("COMPlus_TieredCompilation") != "0"
+                && Environment.GetEnvironmentVariable("DOTNET_TieredCompilation") != "0"
+                && (!AppContext.TryGetSwitch("System.Runtime.TieredCompilation", out isEnabled) || isEnabled));
 
+        public static readonly bool IsRunningInContainer = string.Equals(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), "true");
 
         internal static string GetArchitecture() => GetCurrentPlatform().ToString();
 

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
@@ -18,6 +18,8 @@
     <Content Include="xunit.runner.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <!-- Disable EventSource to stabilize MemoryDiagnoserTests. https://github.com/dotnet/BenchmarkDotNet/pull/2562#issuecomment-2081317379 -->
+    <RuntimeHostConfigurationOption Include="System.Diagnostics.Tracing.EventSource.IsSupported" Value="false" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BenchmarkDotNet.IntegrationTests.ConfigPerAssembly\BenchmarkDotNet.IntegrationTests.ConfigPerAssembly.csproj" />

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -234,9 +234,8 @@ namespace BenchmarkDotNet.IntegrationTests
             }
         }
 
-        [TheoryEnvSpecific("Full Framework cannot measure precisely enough for low invocation counts.", EnvRequirement.DotNetCoreOnly), MemberData(nameof(GetToolchains),
-            Skip = "Some random background allocations are occurring that we haven't been able to figure out, causing this test in particular to be flaky." +
-            " Other tests likely also suffer from it, but their high invocation counts successfully drown it out. #2562")]
+        [TheoryEnvSpecific("Full Framework cannot measure precisely enough for low invocation counts.", EnvRequirement.DotNetCoreOnly)]
+        [MemberData(nameof(GetToolchains))]
         [Trait(Constants.Category, Constants.BackwardCompatibilityCategory)]
         public void AllocationQuantumIsNotAnIssueForNetCore21Plus(IToolchain toolchain)
         {

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -36,7 +36,11 @@ namespace BenchmarkDotNet.IntegrationTests
         public static IEnumerable<object[]> GetToolchains()
         {
             yield return new object[] { Job.Default.GetToolchain() };
-            yield return new object[] { InProcessEmitToolchain.Instance };
+            // InProcessEmit reports flaky allocations in current .Net 8.
+            if (!RuntimeInformation.IsNetCore)
+            {
+                yield return new object[] { InProcessEmitToolchain.Instance };
+            }
         }
 
         public class AccurateAllocations
@@ -67,7 +71,7 @@ namespace BenchmarkDotNet.IntegrationTests
             });
         }
 
-        [FactEnvSpecific("We don't want to test NativeAOT twice (for .NET Framework 4.6.2 and .NET 7.0)", EnvRequirement.DotNetCoreOnly)]
+        [FactEnvSpecific("We don't want to test NativeAOT twice (for .NET Framework 4.6.2 and .NET 8.0)", EnvRequirement.DotNetCoreOnly)]
         public void MemoryDiagnoserSupportsNativeAOT()
         {
             if (OsDetector.IsMacOS())
@@ -105,7 +109,7 @@ namespace BenchmarkDotNet.IntegrationTests
             }
         }
 
-        [Theory(Skip = "#1542 Tiered JIT Thread allocates memory in the background"), MemberData(nameof(GetToolchains))]
+        [Theory, MemberData(nameof(GetToolchains))]
         [Trait(Constants.Category, Constants.BackwardCompatibilityCategory)]
         public void MemoryDiagnoserDoesNotIncludeAllocationsFromSetupAndCleanup(IToolchain toolchain)
         {
@@ -118,21 +122,39 @@ namespace BenchmarkDotNet.IntegrationTests
         public class NoAllocationsAtAll
         {
             [Benchmark] public void EmptyMethod() { }
+
+            [Benchmark]
+            public ulong TimeConsuming()
+            {
+                var r = 1ul;
+                for (var i = 0; i < 50_000_000; i++)
+                {
+                    r /= 1;
+                }
+                return r;
+            }
         }
 
         [Theory, MemberData(nameof(GetToolchains))]
         [Trait(Constants.Category, Constants.BackwardCompatibilityCategory)]
         public void EngineShouldNotInterfereAllocationResults(IToolchain toolchain)
         {
-            if (RuntimeInformation.IsFullFramework && toolchain.IsInProcess)
-            {
-                return; // this test is flaky on Full Framework
-            }
-
             AssertAllocations(toolchain, typeof(NoAllocationsAtAll), new Dictionary<string, long>
             {
                 { nameof(NoAllocationsAtAll.EmptyMethod), 0 }
             });
+        }
+
+        // #1542
+        [Theory, MemberData(nameof(GetToolchains))]
+        [Trait(Constants.Category, Constants.BackwardCompatibilityCategory)]
+        public void TieredJitShouldNotInterfereAllocationResults(IToolchain toolchain)
+        {
+            AssertAllocations(toolchain, typeof(NoAllocationsAtAll), new Dictionary<string, long>
+            {
+                { nameof(NoAllocationsAtAll.TimeConsuming), 0 }
+            },
+            disableTieredJit: false, iterationCount: 10); // 1 iteration is not enough to repro the problem
         }
 
         public class NoBoxing
@@ -165,11 +187,6 @@ namespace BenchmarkDotNet.IntegrationTests
         [Trait(Constants.Category, Constants.BackwardCompatibilityCategory)]
         public void AwaitingTasksShouldNotInterfereAllocationResults(IToolchain toolchain)
         {
-            if (toolchain.IsInProcess)
-            {
-                return; // it's flaky: https://github.com/dotnet/BenchmarkDotNet/issues/1925
-            }
-
             AssertAllocations(toolchain, typeof(NonAllocatingAsynchronousBenchmarks), new Dictionary<string, long>
             {
                 { nameof(NonAllocatingAsynchronousBenchmarks.CompletedTask), 0 },
@@ -217,8 +234,9 @@ namespace BenchmarkDotNet.IntegrationTests
             }
         }
 
-        [Theory(Skip = "#1542 Tiered JIT Thread allocates memory in the background"), MemberData(nameof(GetToolchains))]
-        //[TheoryNetCoreOnly("Only .NET Core 2.0+ API is bug free for this case"), MemberData(nameof(GetToolchains))]
+        [TheoryEnvSpecific("Full Framework cannot measure precisely enough for low invocation counts.", EnvRequirement.DotNetCoreOnly), MemberData(nameof(GetToolchains),
+            Skip = "Some random background allocations are occurring that we haven't been able to figure out, causing this test in particular to be flaky." +
+            " Other tests likely also suffer from it, but their high invocation counts successfully drown it out. #2562")]
         [Trait(Constants.Category, Constants.BackwardCompatibilityCategory)]
         public void AllocationQuantumIsNotAnIssueForNetCore21Plus(IToolchain toolchain)
         {
@@ -233,31 +251,57 @@ namespace BenchmarkDotNet.IntegrationTests
 
         public class MultiThreadedAllocation
         {
-            public const int Size = 1_000_000;
+            public const int Size = 1024;
             public const int ThreadsCount = 10;
 
+            // We cache the threads in GlobalSetup and reuse them for each benchmark invocation
+            // to avoid measuring the cost of thread start and join, which varies across different runtimes.
             private Thread[] threads;
+            private volatile bool keepRunning = true;
+            private readonly Barrier barrier = new (ThreadsCount + 1);
+            private readonly CountdownEvent countdownEvent = new (ThreadsCount);
 
-            [IterationSetup]
-            public void SetupIteration()
+            [GlobalSetup]
+            public void Setup()
             {
                 threads = Enumerable.Range(0, ThreadsCount)
-                    .Select(_ => new Thread(() => GC.KeepAlive(new byte[Size])))
+                    .Select(_ => new Thread(() =>
+                    {
+                        while (keepRunning)
+                        {
+                            barrier.SignalAndWait();
+                            GC.KeepAlive(new byte[Size]);
+                            countdownEvent.Signal();
+                        }
+                    }))
                     .ToArray();
+                foreach (var thread in threads)
+                {
+                    thread.Start();
+                }
+            }
+
+            [GlobalCleanup]
+            public void Cleanup()
+            {
+                keepRunning = false;
+                barrier.SignalAndWait();
+                foreach (var thread in threads)
+                {
+                    thread.Join();
+                }
             }
 
             [Benchmark]
             public void Allocate()
             {
-                foreach (var thread in threads)
-                {
-                    thread.Start();
-                    thread.Join();
-                }
+                countdownEvent.Reset(ThreadsCount);
+                barrier.SignalAndWait();
+                countdownEvent.Wait();
             }
         }
 
-        [Theory(Skip = "Test is flaky even in latest .Net")]
+        [TheoryEnvSpecific("Full Framework cannot measure precisely enough", EnvRequirement.DotNetCoreOnly)]
         [MemberData(nameof(GetToolchains))]
         [Trait(Constants.Category, Constants.BackwardCompatibilityCategory)]
         public void MemoryDiagnoserIsAccurateForMultiThreadedBenchmarks(IToolchain toolchain)
@@ -265,18 +309,16 @@ namespace BenchmarkDotNet.IntegrationTests
             long objectAllocationOverhead = IntPtr.Size * 2; // pointer to method table + object header word
             long arraySizeOverhead = IntPtr.Size; // array length
             long memoryAllocatedPerArray = (MultiThreadedAllocation.Size + objectAllocationOverhead + arraySizeOverhead);
-            long threadStartAndJoinOverhead = 112; // this is more or less a magic number taken from memory profiler
-            long allocatedMemoryPerThread = memoryAllocatedPerArray + threadStartAndJoinOverhead;
 
             AssertAllocations(toolchain, typeof(MultiThreadedAllocation), new Dictionary<string, long>
             {
-                { nameof(MultiThreadedAllocation.Allocate), allocatedMemoryPerThread * MultiThreadedAllocation.ThreadsCount }
+                { nameof(MultiThreadedAllocation.Allocate), memoryAllocatedPerArray * MultiThreadedAllocation.ThreadsCount }
             });
         }
 
-        private void AssertAllocations(IToolchain toolchain, Type benchmarkType, Dictionary<string, long> benchmarksAllocationsValidators)
+        private void AssertAllocations(IToolchain toolchain, Type benchmarkType, Dictionary<string, long> benchmarksAllocationsValidators, bool disableTieredJit = true, int iterationCount = 1)
         {
-            var config = CreateConfig(toolchain);
+            var config = CreateConfig(toolchain, disableTieredJit, iterationCount);
             var benchmarks = BenchmarkConverter.TypeToBenchmarks(benchmarkType, config);
 
             var summary = BenchmarkRunner.Run(benchmarks);
@@ -312,24 +354,35 @@ namespace BenchmarkDotNet.IntegrationTests
             }
         }
 
-        private IConfig CreateConfig(IToolchain toolchain)
-            => ManualConfig.CreateEmpty()
-                .AddJob(Job.ShortRun
-                    .WithEvaluateOverhead(false) // no need to run idle for this test
-                    .WithWarmupCount(0) // don't run warmup to save some time for our CI runs
-                    .WithIterationCount(1) // single iteration is enough for us
-                    .WithGcForce(false)
-                    .WithGcServer(false)
-                    .WithGcConcurrent(false)
-                    .WithEnvironmentVariables([
-                        // Tiered JIT can allocate some memory on a background thread, let's disable it to make our tests less flaky (#1542)
+        private IConfig CreateConfig(IToolchain toolchain,
+            // Tiered JIT can allocate some memory on a background thread, let's disable it by default to make our tests less flaky (#1542).
+            // This was mostly fixed in net7.0, but tiered jit thread is not guaranteed to not allocate, so we disable it just in case.
+            bool disableTieredJit = true,
+            // Single iteration is enough for most of the tests.
+            int iterationCount = 1)
+        {
+            var job = Job.ShortRun
+                .WithEvaluateOverhead(false) // no need to run idle for this test
+                .WithWarmupCount(0) // don't run warmup to save some time for our CI runs
+                .WithIterationCount(iterationCount)
+                .WithGcForce(false)
+                .WithGcServer(false)
+                .WithGcConcurrent(false)
+                // To prevent finalizers allocating out of our control, we hang the finalizer thread.
+                // https://github.com/dotnet/runtime/issues/101536#issuecomment-2077647417
+                .WithEnvironmentVariable(Engines.Engine.UnitTestBlockFinalizerEnvKey, Engines.Engine.UnitTestBlockFinalizerEnvValue)
+                .WithToolchain(toolchain);
+            return ManualConfig.CreateEmpty()
+                .AddJob(disableTieredJit
+                    ? job.WithEnvironmentVariables(
                         new EnvironmentVariable("DOTNET_TieredCompilation", "0"),
                         new EnvironmentVariable("COMPlus_TieredCompilation", "0")
-                    ])
-                    .WithToolchain(toolchain))
+                    )
+                    : job)
                 .AddColumnProvider(DefaultColumnProviders.Instance)
                 .AddDiagnoser(MemoryDiagnoser.Default)
                 .AddLogger(toolchain.IsInProcess ? ConsoleLogger.Default : new OutputLogger(output)); // we can't use OutputLogger for the InProcess toolchains because it allocates memory on the same thread
+        }
 
         // note: don't copy, never use in production systems (it should work but I am not 100% sure)
         private int CalculateRequiredSpace<T>()


### PR DESCRIPTION
<s>This doesn't fix the zero-alloc measurement, but it does fix a bug from the threading diagnoser interfering with the results. The other changes give us the highest confidence that any errant measurements are not our fault. The rest is up to the runtime.</s>

Fixes #1542