### PR TITLE
Fix parallel builds

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -40,8 +40,8 @@ namespace BenchmarkDotNet.Toolchains.CsProj
 
         public string RuntimeFrameworkVersion { get; }
 
-        public CsProjGenerator(string targetFrameworkMoniker, string cliPath, string packagesPath, string runtimeFrameworkVersion, bool isNetCore = true)
-            : base(targetFrameworkMoniker, cliPath, packagesPath, isNetCore)
+        public CsProjGenerator(string targetFrameworkMoniker, string cliPath, string packagesPath, string runtimeFrameworkVersion, bool isNetCore = true, bool useArtifactsPathIfSupported = true)
+            : base(targetFrameworkMoniker, cliPath, packagesPath, isNetCore, useArtifactsPathIfSupported)
         {
             RuntimeFrameworkVersion = runtimeFrameworkVersion;
         }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
@@ -7,23 +7,25 @@ using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Toolchains.DotNetCli
 {
-    [PublicAPI]
-    public class DotNetCliBuilder : IBuilder
+    public abstract class DotNetCliBuilderBase : IBuilder
     {
-        private string TargetFrameworkMoniker { get; }
+        public string? CustomDotNetCliPath { get; protected set; }
+        public abstract BuildResult Build(GenerateResult generateResult, BuildPartition buildPartition, ILogger logger);
+    }
 
-        private string CustomDotNetCliPath { get; }
+    [PublicAPI]
+    public class DotNetCliBuilder : DotNetCliBuilderBase
+    {
         private bool LogOutput { get; }
 
         [PublicAPI]
         public DotNetCliBuilder(string targetFrameworkMoniker, string? customDotNetCliPath = null, bool logOutput = false)
         {
-            TargetFrameworkMoniker = targetFrameworkMoniker;
             CustomDotNetCliPath = customDotNetCliPath;
             LogOutput = logOutput;
         }
 
-        public BuildResult Build(GenerateResult generateResult, BuildPartition buildPartition, ILogger logger)
+        public override BuildResult Build(GenerateResult generateResult, BuildPartition buildPartition, ILogger logger)
         {
             BuildResult buildResult = new DotNetCliCommand(
                     CustomDotNetCliPath,

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
@@ -10,6 +10,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
     public abstract class DotNetCliBuilderBase : IBuilder
     {
         public string? CustomDotNetCliPath { get; protected set; }
+        internal bool UseArtifactsPathIfSupported { get; private protected set; } = true;
         public abstract BuildResult Build(GenerateResult generateResult, BuildPartition buildPartition, ILogger logger);
     }
 
@@ -25,6 +26,13 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             LogOutput = logOutput;
         }
 
+        internal DotNetCliBuilder(string? customDotNetCliPath, bool logOutput, bool useArtifactsPathIfSupported)
+        {
+            CustomDotNetCliPath = customDotNetCliPath;
+            LogOutput = logOutput;
+            UseArtifactsPathIfSupported = useArtifactsPathIfSupported;
+        }
+
         public override BuildResult Build(GenerateResult generateResult, BuildPartition buildPartition, ILogger logger)
         {
             BuildResult buildResult = new DotNetCliCommand(
@@ -36,7 +44,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                     Array.Empty<EnvironmentVariable>(),
                     buildPartition.Timeout,
                     logOutput: LogOutput)
-                .RestoreThenBuild();
+                .RestoreThenBuild(UseArtifactsPathIfSupported);
             if (buildResult.IsBuildSuccess &&
                 buildPartition.RepresentativeBenchmarkCase.Job.Environment.LargeAddressAware)
             {

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommandExecutor.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using BenchmarkDotNet.Detectors;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Helpers;
 using BenchmarkDotNet.Jobs;
@@ -55,9 +56,19 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             }
         }
 
-        internal static string? GetDotNetSdkVersion()
+        internal static bool DotNetSdkSupportsArtifactsPath(string? customDotNetCliPath)
         {
-            using (var process = new Process { StartInfo = BuildStartInfo(customDotNetCliPath: null, workingDirectory: string.Empty, arguments: "--version", redirectStandardError: false) })
+            var version = string.IsNullOrEmpty(customDotNetCliPath)
+                ? HostEnvironmentInfo.GetCurrent().DotNetSdkVersion.Value
+                : GetDotNetSdkVersion(customDotNetCliPath);
+            return Version.TryParse(version, out var semVer) && semVer.Major >= 8;
+        }
+
+        internal static string? GetDotNetSdkVersion() => GetDotNetSdkVersion(null);
+
+        internal static string? GetDotNetSdkVersion(string? customDotNetCliPath)
+        {
+            using (var process = new Process { StartInfo = BuildStartInfo(customDotNetCliPath, workingDirectory: string.Empty, arguments: "--version", redirectStandardError: false) })
             using (new ConsoleExitHandler(process, NullLogger.Instance))
             {
                 try

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliGenerator.cs
@@ -101,8 +101,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         protected override void GenerateBuildScript(BuildPartition buildPartition, ArtifactsPaths artifactsPaths)
         {
             var content = new StringBuilder(300)
-                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetRestoreCommand(artifactsPaths, buildPartition)}")
-                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetBuildCommand(artifactsPaths, buildPartition)}")
+                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetRestoreCommand(artifactsPaths, buildPartition, DotNetCliCommandExecutor.DotNetSdkSupportsArtifactsPath(CliPath))}")
+                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetBuildCommand(artifactsPaths, buildPartition, DotNetCliCommandExecutor.DotNetSdkSupportsArtifactsPath(CliPath))}")
                 .ToString();
 
             File.WriteAllText(artifactsPaths.BuildScriptFilePath, content);

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliPublisher.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliPublisher.cs
@@ -6,7 +6,7 @@ using BenchmarkDotNet.Toolchains.Results;
 
 namespace BenchmarkDotNet.Toolchains.DotNetCli
 {
-    public class DotNetCliPublisher : IBuilder
+    public class DotNetCliPublisher : DotNetCliBuilderBase
     {
         public DotNetCliPublisher(
             string? customDotNetCliPath = null,
@@ -18,13 +18,11 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             EnvironmentVariables = environmentVariables;
         }
 
-        private string? CustomDotNetCliPath { get; }
-
         private string? ExtraArguments { get; }
 
         private IReadOnlyList<EnvironmentVariable>? EnvironmentVariables { get; }
 
-        public BuildResult Build(GenerateResult generateResult, BuildPartition buildPartition, ILogger logger)
+        public override BuildResult Build(GenerateResult generateResult, BuildPartition buildPartition, ILogger logger)
             => new DotNetCliCommand(
                     CustomDotNetCliPath,
                     ExtraArguments,

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliPublisher.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliPublisher.cs
@@ -31,6 +31,6 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                     buildPartition,
                     EnvironmentVariables,
                     buildPartition.Timeout)
-                .RestoreThenBuildThenPublish();
+                .RestoreThenBuildThenPublish(UseArtifactsPathIfSupported);
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/Mono/MonoPublisher.cs
+++ b/src/BenchmarkDotNet/Toolchains/Mono/MonoPublisher.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Toolchains.Results;
 
 namespace BenchmarkDotNet.Toolchains.Mono
 {
-    public class MonoPublisher : IBuilder
+    public class MonoPublisher : DotNetCliBuilderBase
     {
         public MonoPublisher(string customDotNetCliPath)
         {
@@ -18,13 +18,11 @@ namespace BenchmarkDotNet.Toolchains.Mono
             ExtraArguments = $"--self-contained -r {runtimeIdentifier} /p:UseMonoRuntime=true /p:RuntimeIdentifiers={runtimeIdentifier}";
         }
 
-        private string CustomDotNetCliPath { get; }
-
         private string ExtraArguments { get; }
 
         private IReadOnlyList<EnvironmentVariable> EnvironmentVariables { get; }
 
-        public BuildResult Build(GenerateResult generateResult, BuildPartition buildPartition, ILogger logger)
+        public override BuildResult Build(GenerateResult generateResult, BuildPartition buildPartition, ILogger logger)
             => new DotNetCliCommand(
                     CustomDotNetCliPath,
                     ExtraArguments,
@@ -33,6 +31,6 @@ namespace BenchmarkDotNet.Toolchains.Mono
                     buildPartition,
                     EnvironmentVariables,
                     buildPartition.Timeout)
-                .Publish().ToBuildResult(generateResult);
+                .Publish(UseArtifactsPathIfSupported).ToBuildResult(generateResult);
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/MonoAotLLVM/MonoAotLLVMGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoAotLLVM/MonoAotLLVMGenerator.cs
@@ -18,7 +18,8 @@ namespace BenchmarkDotNet.Toolchains.MonoAotLLVM
         private readonly MonoAotCompilerMode AotCompilerMode;
 
         public MonoAotLLVMGenerator(string targetFrameworkMoniker, string cliPath, string packagesPath, string customRuntimePack, string aotCompilerPath, MonoAotCompilerMode aotCompilerMode)
-            : base(targetFrameworkMoniker, cliPath, packagesPath, runtimeFrameworkVersion: null)
+            // We have no tests for this toolchain, so not including ArtifactsPath in case it fails the same as wasm.
+            : base(targetFrameworkMoniker, cliPath, packagesPath, runtimeFrameworkVersion: null, useArtifactsPathIfSupported: false)
         {
             CustomRuntimePack = customRuntimePack;
             AotCompilerPath = aotCompilerPath;

--- a/src/BenchmarkDotNet/Toolchains/MonoAotLLVM/MonoAotLLVMToolChain.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoAotLLVM/MonoAotLLVMToolChain.cs
@@ -24,8 +24,8 @@ namespace BenchmarkDotNet.Toolchains.MonoAotLLVM
                     netCoreAppSettings.CustomRuntimePack,
                     netCoreAppSettings.AOTCompilerPath,
                     netCoreAppSettings.AOTCompilerMode),
-                new DotNetCliBuilder(netCoreAppSettings.TargetFrameworkMoniker,
-                    netCoreAppSettings.CustomDotNetCliPath),
+                // We have no tests for this toolchain, so not including ArtifactsPath in case it fails the same as wasm.
+                new DotNetCliBuilder(netCoreAppSettings.CustomDotNetCliPath, logOutput: false, useArtifactsPathIfSupported: false),
                 new Executor(),
                 netCoreAppSettings.CustomDotNetCliPath);
 

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -17,7 +17,8 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
         private readonly string MainJS;
 
         public WasmGenerator(string targetFrameworkMoniker, string cliPath, string packagesPath, string customRuntimePack, bool aot)
-            : base(targetFrameworkMoniker, cliPath, packagesPath, runtimeFrameworkVersion: null)
+            // Building wasm with ArtifactsPath set fails for some reason (haven't figured out why yet).
+            : base(targetFrameworkMoniker, cliPath, packagesPath, runtimeFrameworkVersion: null, useArtifactsPathIfSupported: false)
         {
             Aot = aot;
             CustomRuntimePack = customRuntimePack;

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmToolchain.cs
@@ -48,10 +48,11 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
                         netCoreAppSettings.PackagesPath,
                         netCoreAppSettings.CustomRuntimePack,
                         netCoreAppSettings.AOTCompilerMode == MonoAotLLVM.MonoAotCompilerMode.wasm),
-                    new DotNetCliBuilder(netCoreAppSettings.TargetFrameworkMoniker,
-                        netCoreAppSettings.CustomDotNetCliPath,
+                    new DotNetCliBuilder(netCoreAppSettings.CustomDotNetCliPath,
                         // aot builds can be very slow
-                        logOutput: netCoreAppSettings.AOTCompilerMode == MonoAotLLVM.MonoAotCompilerMode.wasm),
+                        logOutput: netCoreAppSettings.AOTCompilerMode == MonoAotLLVM.MonoAotCompilerMode.wasm,
+                        // Building wasm with ArtifactsPath set fails for some reason (haven't figured out why yet).
+                        useArtifactsPathIfSupported: false),
                     new WasmExecutor(),
                     netCoreAppSettings.CustomDotNetCliPath);
     }

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -73,8 +73,8 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             string extraArguments = NativeAotToolchain.GetExtraArguments(runtimeIdentifier);
 
             var content = new StringBuilder(300)
-                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetRestoreCommand(artifactsPaths, buildPartition, extraArguments)}")
-                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetPublishCommand(artifactsPaths, buildPartition, extraArguments)}")
+                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetRestoreCommand(artifactsPaths, buildPartition, DotNetCliCommandExecutor.DotNetSdkSupportsArtifactsPath(CliPath), extraArguments)}")
+                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetPublishCommand(artifactsPaths, buildPartition, DotNetCliCommandExecutor.DotNetSdkSupportsArtifactsPath(CliPath), extraArguments)}")
                 .ToString();
 
             File.WriteAllText(artifactsPaths.BuildScriptFilePath, content);

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -70,11 +70,12 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
 
         protected override void GenerateBuildScript(BuildPartition buildPartition, ArtifactsPaths artifactsPaths)
         {
+            bool useArtifactsPath = UseArtifactsPathIfSupported && DotNetCliCommandExecutor.DotNetSdkSupportsArtifactsPath(CliPath);
             string extraArguments = NativeAotToolchain.GetExtraArguments(runtimeIdentifier);
 
             var content = new StringBuilder(300)
-                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetRestoreCommand(artifactsPaths, buildPartition, DotNetCliCommandExecutor.DotNetSdkSupportsArtifactsPath(CliPath), extraArguments)}")
-                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetPublishCommand(artifactsPaths, buildPartition, DotNetCliCommandExecutor.DotNetSdkSupportsArtifactsPath(CliPath), extraArguments)}")
+                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetRestoreCommand(artifactsPaths, buildPartition, useArtifactsPath, extraArguments)}")
+                .AppendLine($"call {CliPath ?? "dotnet"} {DotNetCliCommand.GetPublishCommand(artifactsPaths, buildPartition, useArtifactsPath, extraArguments)}")
                 .ToString();
 
             File.WriteAllText(artifactsPaths.BuildScriptFilePath, content);


### PR DESCRIPTION
Fixes #2425 

Builds using dotnet sdk 8 or newer use `ArtifactsPath` to enable safe parallel builds. Builds using older dotnet sdks and wasm and monoaotllvm build sequentially.

It would be nice to enable parallel builds also for wasm and monoaotllvm, but I can't test them on my machine, so I'm not sure why it doesn't work with those toolchains. cc @LoopedBard3 @caaavik-msft 