### PR TITLE
fix: Modify logging behavior when explicitly adding NullLogger with custom config

### DIFF
--- a/src/BenchmarkDotNet/Configs/ConfigExtensions.cs
+++ b/src/BenchmarkDotNet/Configs/ConfigExtensions.cs
@@ -122,7 +122,7 @@ namespace BenchmarkDotNet.Configs
         internal static ILogger GetNonNullCompositeLogger(this IConfig config)
         {
             // if user did not provide any loggers, we use the ConsoleLogger to somehow show the errors to the user
-            if (config == null || !config.GetLoggers().Any())
+            if (config == null || !config.GetLoggers().Any() || config.GetLoggers().All(x => x is NullLogger))
                 return new CompositeLogger(ImmutableHashSet.Create(ConsoleLogger.Default));
 
             return new CompositeLogger(config.GetLoggers().ToImmutableHashSet());


### PR DESCRIPTION
This PR intended to fix problem no console log is outputted when following conditions met.
- Using custom config that adding `NullLogger` explicitly
- Using custom config as `Global Config` (passing config as `BenchmarkSwitcher::Run` parameters)..

Currently BenchmarkDotNet use `ConsoleLogger` to print errors and list of benchmarks if logger is not enabled.
But when explicitly set `NullLogger` it's not works and no console logs are outputted.

**Background**

I'm trying to write custom progress logger that resolve #190 issue.
And it'll be implemented by using custom `EventProcessor` that is added from v0.13.9.

So It need to suppress default `ConsoleLogger` by adding `NullLogger`. 
Because when no logger specified following error is recorded.
> No loggers defined, you will not see any progress!

It works almost as intended.
But when passing custom config to `BenchmarkSwitcher::Run` argument. console log is not outputted.
