### PR TITLE
feat: TestAdapter BenchmarkCase constraints

### DIFF
--- a/src/BenchmarkDotNet.TestAdapter/Annotations/BenchmarkCaseConstraintAttribute.cs
+++ b/src/BenchmarkDotNet.TestAdapter/Annotations/BenchmarkCaseConstraintAttribute.cs
@@ -1,0 +1,18 @@
+﻿using BenchmarkDotNet.Reports;
+
+namespace BenchmarkDotNet.TestAdapter.Annotations
+{
+    /// <summary>
+    /// Base <see cref="System.Attribute"/> for TestAdapter <see cref="Running.BenchmarkCase"/> constraints
+    /// </summary>
+    [System.AttributeUsage(System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+    public abstract class BenchmarkCaseConstraintAttribute : System.Attribute
+    {
+        /// <summary>
+        /// Validate the <see cref="Running.BenchmarkCase"/> constraint
+        /// </summary>
+        /// <param name="report"></param>
+        /// <param name="builder"></param>
+        protected internal abstract void Validate(BenchmarkReport report, System.Text.StringBuilder builder);
+    }
+}

--- a/src/BenchmarkDotNet.TestAdapter/Annotations/ComparisonOperators.cs
+++ b/src/BenchmarkDotNet.TestAdapter/Annotations/ComparisonOperators.cs
@@ -1,0 +1,37 @@
+﻿namespace BenchmarkDotNet.TestAdapter.Annotations
+{
+    /// <summary>
+    /// Comparison Operators
+    /// </summary>
+    public enum ComparisonOperator
+    {
+        /// <summary>
+        /// Equal comparison operator
+        /// </summary>
+        Equal,
+        /// <summary>
+        /// Not Equal comparison operator
+        /// </summary>
+        NotEqual,
+        /// <summary>
+        ///  comparison operator
+        /// </summary>
+        Greater,
+        /// <summary>
+        ///  Greater than comparison operator
+        /// </summary>
+        GreaterOrEqual,
+        /// <summary>
+        ///  Greater or Equal than comparison operator
+        /// </summary>
+        Less,
+        /// <summary>
+        /// Less than comparison operator
+        /// </summary>
+        LessOrEqual,
+        /// <summary>
+        /// Less or equal than comparison operator
+        /// </summary>
+        Between
+    }
+}

--- a/src/BenchmarkDotNet.TestAdapter/Annotations/GCGenCollectionsConstraintAttribute.cs
+++ b/src/BenchmarkDotNet.TestAdapter/Annotations/GCGenCollectionsConstraintAttribute.cs
@@ -1,0 +1,95 @@
+﻿using BenchmarkDotNet.Reports;
+using System.Text;
+
+namespace BenchmarkDotNet.TestAdapter.Annotations
+{
+    /// <summary>
+    /// <see cref="Running.BenchmarkCase"/> GC Gen Collections constraints
+    /// </summary>
+    public sealed class GCGenCollectionsConstraintAttribute : BenchmarkCaseConstraintAttribute
+    {
+        /// <summary>
+        /// Instance new <see cref="GCGenCollectionsConstraintAttribute"/>
+        /// </summary>
+        /// <param name="generation"></param>
+        /// <param name="operator"></param>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        public GCGenCollectionsConstraintAttribute(GCGeneration generation, ComparisonOperator @operator, int from, int? to)
+        {
+            Operator = @operator;
+            From = from;
+            To = to;
+            Generation = generation;
+        }
+
+        /// <summary>
+        /// Instance new <see cref="GCGenCollectionsConstraintAttribute"/>
+        /// </summary>
+        /// <param name="generation"></param>
+        /// <param name="operator"></param>
+        /// <param name="from"></param>
+        public GCGenCollectionsConstraintAttribute(GCGeneration generation, ComparisonOperator @operator, int from)
+            : this(generation, @operator, from, null)
+        {
+        }
+
+        /// <summary>
+        /// GC Generation
+        /// </summary>
+        public GCGeneration Generation { get; }
+
+        /// <summary>
+        /// Comparison Operator
+        /// </summary>
+        public ComparisonOperator Operator { get; }
+        /// <summary>
+        /// From mean value
+        /// </summary>
+        public int From { get; }
+        /// <summary>
+        /// To mean value
+        /// </summary>
+        public int? To { get; }
+
+        /// inheritdoc
+        protected internal override void Validate(BenchmarkReport report, StringBuilder builder)
+        {
+            var resultRuns = report.GetResultRuns();
+            var gcStats = report.GcStats;
+            var genCollections = Generation switch
+            {
+                GCGeneration.Gen0 => gcStats.Gen0Collections,
+                GCGeneration.Gen1 => gcStats.Gen1Collections,
+                GCGeneration.Gen2 => gcStats.Gen2Collections,
+                _ => throw new System.NotSupportedException(),
+            };
+            switch (Operator)
+            {
+                case ComparisonOperator.Equal when genCollections != From:
+                    builder.AppendLine($"{Generation} is not equal to expected value {From}");
+                    break;
+                case ComparisonOperator.NotEqual when genCollections == From:
+                    builder.AppendLine($"{Generation} is equal to expected value {From}");
+                    break;
+                case ComparisonOperator.Less when genCollections >= From:
+                    builder.AppendLine($"{Generation} is greater or equal that expected value {From}");
+                    break;
+                case ComparisonOperator.LessOrEqual when genCollections > From:
+                    builder.AppendLine($"{Generation} is greater  that expected value {From}");
+                    break;
+                case ComparisonOperator.Greater when genCollections <= From:
+                    builder.AppendLine($"{Generation} is less or equal that expected value {From}");
+                    break;
+                case ComparisonOperator.GreaterOrEqual when genCollections < From:
+                    builder.AppendLine($"{Generation} is lest that expected value {From}");
+                    break;
+                case ComparisonOperator.Between when genCollections < From && genCollections > To:
+                    builder.AppendLine($"{Generation} is not betwenn  expected value [{From}-{To}]");
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/src/BenchmarkDotNet.TestAdapter/Annotations/GCGeneration.cs
+++ b/src/BenchmarkDotNet.TestAdapter/Annotations/GCGeneration.cs
@@ -1,0 +1,21 @@
+﻿namespace BenchmarkDotNet.TestAdapter.Annotations
+{
+    /// <summary>
+    /// GC Generation
+    /// </summary>
+    public enum GCGeneration: int
+    {
+        /// <summary>
+        /// GC Generation 0
+        /// </summary>
+        Gen0,
+        /// <summary>
+        /// GC Generation 1
+        /// </summary>
+        Gen1,
+        /// <summary>
+        /// GC Generation 2
+        /// </summary>
+        Gen2
+    }
+}

--- a/src/BenchmarkDotNet.TestAdapter/Annotations/MeanConstraintAttribute.cs
+++ b/src/BenchmarkDotNet.TestAdapter/Annotations/MeanConstraintAttribute.cs
@@ -1,0 +1,83 @@
+﻿using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Reports;
+using System.Text;
+
+namespace BenchmarkDotNet.TestAdapter.Annotations
+{
+    /// <summary>
+    /// /// <see cref="Running.BenchmarkCase"/> mean constraints
+    /// </summary>
+    [System.AttributeUsage(System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+    public sealed class MeanConstraintAttribute : BenchmarkCaseConstraintAttribute
+    {
+        /// <summary>
+        /// Instance new <see cref="MeanConstraintAttribute"/>
+        /// </summary>
+        /// <param name="operator"></param>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        public MeanConstraintAttribute(ComparisonOperator @operator, double from, double? to)
+        {
+            Operator = @operator;
+            From = from;
+            To = to;
+        }
+
+        /// <summary>
+        /// Instance new <see cref="MeanConstraintAttribute"/>
+        /// </summary>
+        /// <param name="operator"></param>
+        /// <param name="from"></param>
+        public MeanConstraintAttribute(ComparisonOperator @operator, double from) :
+            this(@operator, from, null)
+        {
+        }
+
+        /// <summary>
+        /// Comparison Operator
+        /// </summary>
+        public ComparisonOperator Operator { get; }
+        /// <summary>
+        /// From mean value
+        /// </summary>
+        public double From { get; }
+        /// <summary>
+        /// To mean value
+        /// </summary>
+        public double? To { get; }
+
+        /// inheritdoc
+        protected internal override void Validate(BenchmarkReport report, StringBuilder builder)
+        {
+            var resultRuns = report.GetResultRuns();
+            var statistics = resultRuns.GetStatistics();
+            switch (Operator)
+            {
+                case ComparisonOperator.Equal when statistics.Mean != From:
+                    builder.AppendLine($"{nameof(statistics.Mean)} is not equal to expected value {From}");
+                    break;
+                case ComparisonOperator.NotEqual when statistics.Mean == From:
+                    builder.AppendLine($"{nameof(statistics.Mean)} is equal to expected value {From}");
+                    break;
+                case ComparisonOperator.Less when statistics.Mean >= From:
+                    builder.AppendLine($"{nameof(statistics.Mean)} is greater or equal that expected value {From}");
+                    break;
+                case ComparisonOperator.LessOrEqual when statistics.Mean > From:
+                    builder.AppendLine($"{nameof(statistics.Mean)} is greater  that expected value {From}");
+                    break;
+                case ComparisonOperator.Greater when statistics.Mean <= From:
+                    builder.AppendLine($"{nameof(statistics.Mean)} is less or equal that expected value {From}");
+                    break;
+                case ComparisonOperator.GreaterOrEqual when statistics.Mean < From:
+                    builder.AppendLine($"{nameof(statistics.Mean)} is lest that expected value {From}");
+                    break;
+                case ComparisonOperator.Between when statistics.Mean < From && statistics.Mean > To:
+                    builder.AppendLine($"{nameof(statistics.Mean)} is not between expected value [{From}-{To}]");
+                    break;
+                default:
+                    break;
+            }
+
+        }
+    }
+}

--- a/src/BenchmarkDotNet.TestAdapter/Annotations/StdDevConstraintAttribute.cs
+++ b/src/BenchmarkDotNet.TestAdapter/Annotations/StdDevConstraintAttribute.cs
@@ -1,0 +1,82 @@
+﻿using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Reports;
+using System.Text;
+
+namespace BenchmarkDotNet.TestAdapter.Annotations
+{
+    /// <summary>
+    /// <see cref="Running.BenchmarkCase"/> standard deviation constraints
+    /// </summary>
+    public sealed class StdDevConstraintAttribute : BenchmarkCaseConstraintAttribute
+    {
+        /// <summary>
+        /// Instance new <see cref="StdDevConstraintAttribute"/>
+        /// </summary>
+        /// <param name="operator"></param>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        public StdDevConstraintAttribute(ComparisonOperator @operator, double from, double? to)
+        {
+            Operator = @operator;
+            From = from;
+            To = to;
+        }
+
+        /// <summary>
+        /// Instance new <see cref="StdDevConstraintAttribute"/>
+        /// </summary>
+        /// <param name="operator"></param>
+        /// <param name="from"></param>
+        public StdDevConstraintAttribute(ComparisonOperator @operator, double from) :
+            this(@operator, from, null)
+        {
+        }
+
+        /// <summary>
+        /// Comparison Operator
+        /// </summary>
+        public ComparisonOperator Operator { get; }
+        /// <summary>
+        /// From mean value
+        /// </summary>
+        public double From { get; }
+        /// <summary>
+        /// To mean value
+        /// </summary>
+        public double? To { get; }
+
+        /// inheritdoc
+        protected internal override void Validate(BenchmarkReport report, StringBuilder builder)
+        {
+            var resultRuns = report.GetResultRuns();
+            var statistics = resultRuns.GetStatistics();
+            var stdDev = statistics.StandardDeviation;
+            switch (Operator)
+            {
+                case ComparisonOperator.Equal when stdDev != From:
+                    builder.AppendLine($"{nameof(statistics.StandardDeviation)} is not equal to expected value {From}");
+                    break;
+                case ComparisonOperator.NotEqual when stdDev == From:
+                    builder.AppendLine($"{nameof(statistics.StandardDeviation)} is equal to expected value {From}");
+                    break;
+                case ComparisonOperator.Less when stdDev >= From:
+                    builder.AppendLine($"{nameof(statistics.StandardDeviation)} is greater or equal that expected value {From}");
+                    break;
+                case ComparisonOperator.LessOrEqual when stdDev > From:
+                    builder.AppendLine($"{nameof(statistics.StandardDeviation)} is greater  that expected value {From}");
+                    break;
+                case ComparisonOperator.Greater when stdDev <= From:
+                    builder.AppendLine($"{nameof(statistics.StandardDeviation)} is less or equal that expected value {From}");
+                    break;
+                case ComparisonOperator.GreaterOrEqual when stdDev < From:
+                    builder.AppendLine($"{nameof(statistics.StandardDeviation)} is lest that expected value {From}");
+                    break;
+                case ComparisonOperator.Between when stdDev < From && stdDev > To:
+                    builder.AppendLine($"{nameof(statistics.StandardDeviation)} is not between expected value [{From}-{To}]");
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/src/BenchmarkDotNet.TestAdapter/Annotations/StdErrConstraintAttribute.cs
+++ b/src/BenchmarkDotNet.TestAdapter/Annotations/StdErrConstraintAttribute.cs
@@ -1,0 +1,85 @@
+﻿using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Reports;
+using System.Text;
+
+namespace BenchmarkDotNet.TestAdapter.Annotations
+{
+    /// <summary>
+    /// <see cref="Running.BenchmarkCase"/> standard error constraints
+    /// </summary>
+    [System.AttributeUsage(System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+    public sealed class StdErrConstraintAttribute : BenchmarkCaseConstraintAttribute
+    {
+        /// <summary>
+        /// Instance new <see cref="StdErrConstraintAttribute"/>
+        /// </summary>
+        /// <param name="operator"></param>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        public StdErrConstraintAttribute(ComparisonOperator @operator, double from, double? to)
+        {
+            Operator = @operator;
+            From = from;
+            To = to;
+        }
+
+        /// <summary>
+        /// Instance new <see cref="StdErrConstraintAttribute"/>
+        /// </summary>
+        /// <param name="operator"></param>
+        /// <param name="from"></param>
+        public StdErrConstraintAttribute(ComparisonOperator @operator, double from) :
+            this(@operator, from, null)
+        {
+        }
+
+        /// <summary>
+        /// Comparison Operator
+        /// </summary>
+        public ComparisonOperator Operator { get; }
+        /// <summary>
+        /// From mean value
+        /// </summary>
+        public double From { get; }
+        /// <summary>
+        /// To mean value
+        /// </summary>
+        public double? To { get; }
+
+
+        /// inheritdoc
+        protected internal override void Validate(BenchmarkReport report, StringBuilder builder)
+        {
+            var resultRuns = report.GetResultRuns();
+            var statistics = resultRuns.GetStatistics();
+            var stdErr = statistics.StandardError;
+            switch (Operator)
+            {
+                case ComparisonOperator.Equal when stdErr != From:
+                    builder.AppendLine($"{nameof(statistics.StandardError)} is not equal to expected value {From}");
+                    break;
+                case ComparisonOperator.NotEqual when stdErr == From:
+                    builder.AppendLine($"{nameof(statistics.StandardError)} is equal to expected value {From}");
+                    break;
+                case ComparisonOperator.Less when stdErr >= From:
+                    builder.AppendLine($"{nameof(statistics.StandardError)} is greater or equal that expected value {From}");
+                    break;
+                case ComparisonOperator.LessOrEqual when stdErr > From:
+                    builder.AppendLine($"{nameof(statistics.StandardError)} is greater  that expected value {From}");
+                    break;
+                case ComparisonOperator.Greater when stdErr <= From:
+                    builder.AppendLine($"{nameof(statistics.StandardError)} is less or equal that expected value {From}");
+                    break;
+                case ComparisonOperator.GreaterOrEqual when stdErr < From:
+                    builder.AppendLine($"{nameof(statistics.StandardError)} is lest that expected value {From}");
+                    break;
+                case ComparisonOperator.Between when stdErr < From && stdErr > To:
+                    builder.AppendLine($"{nameof(statistics.StandardError)} is not between expected value [{From}-{To}]");
+                    break;
+                default:
+                    break;
+            }
+
+        }
+    }
+}

--- a/src/BenchmarkDotNet.TestAdapter/Annotations/TotalAllocatedBytesConstraintAttribute.cs
+++ b/src/BenchmarkDotNet.TestAdapter/Annotations/TotalAllocatedBytesConstraintAttribute.cs
@@ -1,0 +1,90 @@
+﻿using BenchmarkDotNet.Reports;
+using System.Text;
+
+namespace BenchmarkDotNet.TestAdapter.Annotations
+{
+    /// <summary>
+    /// <see cref="Running.BenchmarkCase"/> GC Total Allocated bytes constraints
+    /// </summary>
+    public sealed class TotalAllocatedBytesConstraintAttribute : BenchmarkCaseConstraintAttribute
+    {
+        private readonly bool excludeAllocationQuantumSideEffects;
+
+        /// <summary>
+        /// Instance new <see cref="TotalAllocatedBytesConstraintAttribute"/>
+        /// </summary>
+        /// <param name="operator"></param>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="excludeAllocationQuantumSideEffects">Allocation quantum can affecting some of our nano-benchmarks in non-deterministic way.
+        /// when this parameter is set to true and the number of all allocated bytes is less or equal AQ, we ignore AQ and put 0 to the results</param>
+        public TotalAllocatedBytesConstraintAttribute(ComparisonOperator @operator,
+            long from,
+            long? to,
+            bool excludeAllocationQuantumSideEffects = false
+            )
+        {
+            Operator = @operator;
+            From = from;
+            To = to;
+            this.excludeAllocationQuantumSideEffects = excludeAllocationQuantumSideEffects;
+        }
+
+        /// <summary>
+        /// Instance new <see cref="TotalAllocatedBytesConstraintAttribute"/>
+        /// </summary>
+        /// <param name="operator"></param>
+        /// <param name="from"></param>
+        /// <param name="excludeAllocationQuantumSideEffects">Allocation quantum can affecting some of our nano-benchmarks in non-deterministic way.
+        /// when this parameter is set to true and the number of all allocated bytes is less or equal AQ, we ignore AQ and put 0 to the results</param>
+        public TotalAllocatedBytesConstraintAttribute(ComparisonOperator @operator, long from, bool excludeAllocationQuantumSideEffects = false) :
+            this(@operator, from, null)
+        {
+        }
+
+        /// <summary>
+        /// Comparison Operator
+        /// </summary>
+        public ComparisonOperator Operator { get; }
+        /// <summary>
+        /// From mean value
+        /// </summary>
+        public long From { get; }
+        /// <summary>
+        /// To mean value
+        /// </summary>
+        public long? To { get; }
+
+        /// inheritdoc
+        protected internal override void Validate(BenchmarkReport report, StringBuilder builder)
+        {
+            var totalAllocatedBytes = report.GcStats.GetTotalAllocatedBytes(excludeAllocationQuantumSideEffects);
+            switch (Operator)
+            {
+                case ComparisonOperator.Equal when totalAllocatedBytes != From:
+                    builder.AppendLine($"GC total allocated bytes is not equal to expected value {From}");
+                    break;
+                case ComparisonOperator.NotEqual when totalAllocatedBytes == From:
+                    builder.AppendLine($"GC total allocated bytes is equal to expected value {From}");
+                    break;
+                case ComparisonOperator.Less when totalAllocatedBytes >= From:
+                    builder.AppendLine($"GC total allocated bytes is greater or equal that expected value {From}");
+                    break;
+                case ComparisonOperator.LessOrEqual when totalAllocatedBytes > From:
+                    builder.AppendLine($"GC total allocated bytes is greater  that expected value {From}");
+                    break;
+                case ComparisonOperator.Greater when totalAllocatedBytes <= From:
+                    builder.AppendLine($"GC total allocated bytes is less or equal that expected value {From}");
+                    break;
+                case ComparisonOperator.GreaterOrEqual when totalAllocatedBytes < From:
+                    builder.AppendLine($"GC total allocated bytes is lest that expected value {From}");
+                    break;
+                case ComparisonOperator.Between when totalAllocatedBytes < From && totalAllocatedBytes > To:
+                    builder.AppendLine($"GC total allocated bytes is not between  expected value [{From}-{To}]");
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add TestAdapter `BenchmarkCase` constraints

## Use Case

Ensure that the performance of a method remains within specification throughout versions.

## How works

Adding attributes that specify the constraints to apply to BenchmarkCase. You can add a custom constraint by adding a class that inherits from `BenchmarkCaseConstraintAttribute`.

### Example of use

```c#
using BenchmarkDotNet.Attributes;
using System.Threading;

namespace BenchmarkDotNet.Samples
{
    // It is very easy to use BenchmarkDotNet. You should just create a class
    public class IntroBasic
    {
        // And define a method with the Benchmark attribute
        [Benchmark]
        [TestAdapter.Annotations.MeanConstraint(TestAdapter.Annotations.ComparisonOperator.Less, 14)]
        public void Sleep() => Thread.Sleep(10);

        // You can write a description for your method.
        [Benchmark(Description = "Thread.Sleep(10)")]
        public void SleepWithDescription() => Thread.Sleep(10);
    }
}
``` 

### Example of output

![immagine](https://github.com/user-attachments/assets/fd5b92f1-addf-408c-a0e3-fdb1902a0188)

```
BenchmarkDotNet.Samples (net8.0)
  Tests in group: 1
   Total Duration: 23,2 sec

Outcomes
   1 Failed

 BenchmarkDotNet.Samples.IntroBasic.Sleep
   Source: IntroBasic.cs line 10
   Duration: 23,2 sec

  Message: 
// Constraint Errors: Mean is greater or equal that expected value 14


  Standard Output: 
IntroBasic.Sleep: DefaultJob
Runtime = .NET 8.0.6 (8.0.624.26715), X64 RyuJIT AVX2; GC = Concurrent Workstation
-------------------- Histogram --------------------
[15.459 ms ; 15.651 ms) | @@@@@@@@@@@@@@@
---------------------------------------------------
Mean = 15.531 ms, StdErr = 0.010 ms (0.07%), N = 15, StdDev = 0.040 ms
Min = 15.480 ms, Q1 = 15.493 ms, Median = 15.542 ms, Q3 = 15.550 ms, Max = 15.630 ms
IQR = 0.057 ms, LowerFence = 15.407 ms, UpperFence = 15.636 ms
ConfidenceInterval = [15.488 ms; 15.573 ms] (CI 99.9%), Margin = 0.043 ms (0.27% of Mean)
Skewness = 0.68, Kurtosis = 3.05, MValue = 2


``` 