### PR TITLE
Fix known high severity vulnerabilities

### DIFF
--- a/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
+++ b/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
@@ -24,6 +24,5 @@
     <PackageReference Update="FSharp.Core" Version="4.6.0" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
+++ b/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />
-    <ProjectReference Include="..\..\src\BenchmarkDotNet.TestAdapter\BenchmarkDotNet.TestAdapter.csproj"/>
+    <ProjectReference Include="..\..\src\BenchmarkDotNet.TestAdapter\BenchmarkDotNet.TestAdapter.csproj" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
@@ -24,5 +24,6 @@
     <PackageReference Update="FSharp.Core" Version="4.6.0" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarkDotNet.Annotations/BenchmarkDotNet.Annotations.csproj
+++ b/src/BenchmarkDotNet.Annotations/BenchmarkDotNet.Annotations.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>Basic BenchmarkDotNet attributes that can be used to annotate your benchmarks</AssemblyTitle>
-    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1701;1702;1705;1591;3005;NU1702;CA1825</NoWarn>
     <AssemblyName>BenchmarkDotNet.Annotations</AssemblyName>
     <PackageId>BenchmarkDotNet.Annotations</PackageId>
@@ -13,9 +13,5 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\BenchmarkDotNet\Helpers\CodeAnnotations.cs" Link="Attributes\CodeAnnotations.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarkDotNet.Annotations/BenchmarkDotNet.Annotations.csproj
+++ b/src/BenchmarkDotNet.Annotations/BenchmarkDotNet.Annotations.csproj
@@ -14,4 +14,8 @@
   <ItemGroup>
     <Compile Include="..\BenchmarkDotNet\Helpers\CodeAnnotations.cs" Link="Attributes\CodeAnnotations.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+  </ItemGroup>
 </Project>

--- a/src/BenchmarkDotNet.Diagnostics.dotMemory/BenchmarkDotNet.Diagnostics.dotMemory.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.dotMemory/BenchmarkDotNet.Diagnostics.dotMemory.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.9" />
+        <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.11" />
     </ItemGroup>
 
 </Project>

--- a/src/BenchmarkDotNet.Diagnostics.dotTrace/BenchmarkDotNet.Diagnostics.dotTrace.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.dotTrace/BenchmarkDotNet.Diagnostics.dotTrace.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.9" />
+        <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.11" />
     </ItemGroup>
 
 </Project>

--- a/tests/BenchmarkDotNet.Exporters.Plotting.Tests/BenchmarkDotNet.Exporters.Plotting.Tests.csproj
+++ b/tests/BenchmarkDotNet.Exporters.Plotting.Tests/BenchmarkDotNet.Exporters.Plotting.Tests.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit" Version="2.9.2" />
     <!-- We use older version 2.4.1 for combatibility with netcoreapp3.1. -->
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/BenchmarkDotNet.IntegrationTests.ManualRunning.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/BenchmarkDotNet.IntegrationTests.ManualRunning.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests.ManualRunning</AssemblyTitle>
@@ -35,8 +35,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
@@ -35,8 +35,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <!-- We implicitly need v13.0.1 of Newtonsoft.Json for BenchmarkDotNet.IntegrationTests.NuGetReferenceTests -->
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.1]" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
+++ b/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\build\common.props"/>
+  <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.Tests</AssemblyTitle>
     <TargetFrameworks>net8.0;net462</TargetFrameworks>
@@ -17,9 +17,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
     <!-- We use Verify.Xunit v20.8.2 because it's the latest version with net461 support -->
-    <PackageReference Include="Verify.Xunit" Version="[20.8.2]"/>
-    <PackageReference Include="xunit" Version="2.6.2"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="Verify.Xunit" Version="[20.8.2]" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -40,10 +40,10 @@
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}"/>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Detectors\Cpu\TestFiles\*.txt"/>
+    <EmbeddedResource Include="Detectors\Cpu\TestFiles\*.txt" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Detectors\Cpu\VerifiedFiles\CpuInfoFormatterTests.FormatTest.verified.txt">

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -233,8 +233,8 @@ namespace BenchmarkDotNet.Tests
 
             var jobs = config.GetJobs().ToArray();
             Assert.Equal(2, jobs.Length);
-            Assert.Single(jobs.Where(job => job.GetToolchain() is CoreRunToolchain toolchain && toolchain.SourceCoreRun.FullName == fakeCoreRunPath_1));
-            Assert.Single(jobs.Where(job => job.GetToolchain() is CoreRunToolchain toolchain && toolchain.SourceCoreRun.FullName == fakeCoreRunPath_2));
+            Assert.Single(jobs, job => job.GetToolchain() is CoreRunToolchain toolchain && toolchain.SourceCoreRun.FullName == fakeCoreRunPath_1);
+            Assert.Single(jobs, job => job.GetToolchain() is CoreRunToolchain toolchain && toolchain.SourceCoreRun.FullName == fakeCoreRunPath_2);
         }
 
         [Fact]
@@ -244,7 +244,7 @@ namespace BenchmarkDotNet.Tests
             var config = ConfigParser.Parse(new[] { "-r", "mono", "--monoPath", fakeMonoPath }, new OutputLogger(Output)).config;
 
             Assert.Single(config.GetJobs());
-            Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is MonoRuntime mono && mono.CustomPath == fakeMonoPath));
+            Assert.Single(config.GetJobs(), job => job.Environment.Runtime is MonoRuntime mono && mono.CustomPath == fakeMonoPath);
         }
 
         [FactEnvSpecific("Testing local builds of Full .NET Framework is supported only on Windows", EnvRequirement.WindowsOnly)]
@@ -254,7 +254,7 @@ namespace BenchmarkDotNet.Tests
             var config = ConfigParser.Parse(new[] { "--clrVersion", clrVersion }, new OutputLogger(Output)).config;
 
             Assert.Single(config.GetJobs());
-            Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is ClrRuntime clr && clr.Version == clrVersion));
+            Assert.Single(config.GetJobs(), job => job.Environment.Runtime is ClrRuntime clr && clr.Version == clrVersion);
         }
 
         [Fact]
@@ -418,20 +418,20 @@ namespace BenchmarkDotNet.Tests
                 new OutputLogger(Output)).config;
 
             Assert.True(config.GetJobs().First().Meta.Baseline); // when the user provides multiple runtimes the first one should be marked as baseline
-            Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is ClrRuntime clrRuntime && clrRuntime.MsBuildMoniker == "net462"));
-            Assert.Single(config.GetJobs().Where(job => job.Environment.Runtime is MonoRuntime));
-            Assert.Single(config.GetJobs().Where(job =>
+            Assert.Single(config.GetJobs(), job => job.Environment.Runtime is ClrRuntime clrRuntime && clrRuntime.MsBuildMoniker == "net462");
+            Assert.Single(config.GetJobs(), job => job.Environment.Runtime is MonoRuntime);
+            Assert.Single(config.GetJobs(), job =>
                 job.Environment.Runtime is CoreRuntime coreRuntime && coreRuntime.MsBuildMoniker == "netcoreapp3.1" &&
-                coreRuntime.RuntimeMoniker == RuntimeMoniker.NetCoreApp31));
-            Assert.Single(config.GetJobs().Where(job =>
+                coreRuntime.RuntimeMoniker == RuntimeMoniker.NetCoreApp31);
+            Assert.Single(config.GetJobs(), job =>
                 job.Environment.Runtime is NativeAotRuntime nativeAot && nativeAot.MsBuildMoniker == "net6.0" &&
-                nativeAot.RuntimeMoniker == RuntimeMoniker.NativeAot60));
-            Assert.Single(config.GetJobs().Where(job =>
+                nativeAot.RuntimeMoniker == RuntimeMoniker.NativeAot60);
+            Assert.Single(config.GetJobs(), job =>
                 job.Environment.Runtime is NativeAotRuntime nativeAot && nativeAot.MsBuildMoniker == "net7.0" &&
-                nativeAot.RuntimeMoniker == RuntimeMoniker.NativeAot70));
-            Assert.Single(config.GetJobs().Where(job =>
+                nativeAot.RuntimeMoniker == RuntimeMoniker.NativeAot70);
+            Assert.Single(config.GetJobs(), job =>
                 job.Environment.Runtime is NativeAotRuntime nativeAot && nativeAot.MsBuildMoniker == "net8.0" &&
-                nativeAot.RuntimeMoniker == RuntimeMoniker.NativeAot80));
+                nativeAot.RuntimeMoniker == RuntimeMoniker.NativeAot80);
         }
 
         [Theory]
@@ -469,8 +469,8 @@ namespace BenchmarkDotNet.Tests
                 new OutputLogger(Output)).config;
 
             Assert.Equal(2, config.GetHardwareCounters().Count());
-            Assert.Single(config.GetHardwareCounters().Where(counter => counter == HardwareCounter.CacheMisses));
-            Assert.Single(config.GetHardwareCounters().Where(counter => counter == HardwareCounter.InstructionRetired));
+            Assert.Single(config.GetHardwareCounters(), counter => counter == HardwareCounter.CacheMisses);
+            Assert.Single(config.GetHardwareCounters(), counter => counter == HardwareCounter.InstructionRetired);
         }
 
         [Fact]


### PR DESCRIPTION
I've tried to build and run our samples today and got following errors:

```log
PS D:\projects\BenchmarkDotNet\samples\BenchmarkDotNet.Samples> dotnet run -c Release -f net8.0 --filter *Counters* --list flat
C:\Program Files\dotnet\sdk\9.0.100-preview.7.24402.8\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(187,5): warning NETSDK1215: Targeting .NET Standard prior to 2.0 is no longer recommended. See https://aka.ms/dotnet/dotnet-standard-guidance for more details.
D:\projects\BenchmarkDotNet\src\BenchmarkDotNet.Annotations\BenchmarkDotNet.Annotations.csproj : error NU1903: Warning As Error: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
D:\projects\BenchmarkDotNet\samples\BenchmarkDotNet.Samples\BenchmarkDotNet.Samples.csproj : error NU1903: Warning As Error: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
D:\projects\BenchmarkDotNet\samples\BenchmarkDotNet.Samples\BenchmarkDotNet.Samples.csproj : error NU1903: Warning As Error: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
D:\projects\BenchmarkDotNet\src\BenchmarkDotNet.Diagnostics.dotMemory\BenchmarkDotNet.Diagnostics.dotMemory.csproj : error NU1903: Warning As Error: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
D:\projects\BenchmarkDotNet\src\BenchmarkDotNet.Diagnostics.dotTrace\BenchmarkDotNet.Diagnostics.dotTrace.csproj : error NU1903: Warning As Error: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
D:\projects\BenchmarkDotNet\src\BenchmarkDotNet.Diagnostics.dotMemory\BenchmarkDotNet.Diagnostics.dotMemory.csproj : error NU1903: Warning As Error: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
D:\projects\BenchmarkDotNet\src\BenchmarkDotNet.Diagnostics.dotTrace\BenchmarkDotNet.Diagnostics.dotTrace.csproj : error NU1903: Warning As Error: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
```

My first thought was that the fix will be straightforward: just update `System.Text.RegularExpressions` and `System.Net.Http` to most recent versions. I've quickly realized that these are transitive dependencies.

In case of `BenchmarkDotNet.Annotations`, this project targets `netstandard1.0` (it's just a project with attributes, almost no logic at all and we wanted to target lowest tfm possible). This gives us a dependency to https://www.nuget.org/packages/NETStandard.Library/1.6.1. Can we just update it? No, because it has not been updated since 2018. The following warning suggests that it's on purpose:

> warning NETSDK1215: Targeting .NET Standard prior to 2.0 is no longer recommended.

I could just remove the `netstandard1.0` TFM from `BenchmarkDotNet.Annotations`, but `BenchmarkDotNet.Diagnostics.dotTrace` and `BenchmarkDotNet.Diagnostics.dotMemory` both depend on https://www.nuget.org/packages/JetBrains.Profiler.SelfApi/, which depends on https://www.nuget.org/packages/JetBrains.HabitatDetector/ which depends on https://www.nuget.org/packages/JetBrains.FormatRipper/ which has the same dependency:

![image](https://github.com/user-attachments/assets/3c560790-5f42-45ed-bc9d-80768bc661c1)

As a quick workaround I've decided to just add a dependency to these two packages (`System.Text.RegularExpressions` and `System.Net.Http`) to `BenchmarkDotNet.Annotations`, which all BDN packages depend on.

The alternatives I've considered:
- Open an issue and send a PR to https://www.nuget.org/packages/JetBrains.FormatRipper/ to add these explicit dependencies to `System.Text.RegularExpressions` and `System.Net.Http`.
- Open an issue and send a PR to https://www.nuget.org/packages/JetBrains.Profiler.SelfApi/ to change the supported monikers: from `net46` to `net462` (this would pick up the `netstandard2.0` dependency of `JetBrains.HabitatDetector` and solve the problem). But this would be a breaking change (cc @AndreyAkinshin).

cc @ericstj


