### PR TITLE
Clean up unsupported native AOT flags

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -134,9 +134,10 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <RunAnalyzers>false</RunAnalyzers>
     <PublishAot Condition="" '$(TargetFramework)' != 'net6.0' "">true</PublishAot>
     <IlcOptimizationPreference>{ilcOptimizationPreference}</IlcOptimizationPreference>
+    <OptimizationPreference>{ilcOptimizationPreference}</OptimizationPreference>
     {GetTrimmingSettings()}
-    <IlcGenerateCompleteTypeMetadata>{ilcGenerateCompleteTypeMetadata}</IlcGenerateCompleteTypeMetadata>
     <IlcGenerateStackTraceData>{ilcGenerateStackTraceData}</IlcGenerateStackTraceData>
+    <StackTraceSupport>{ilcGenerateStackTraceData}</StackTraceSupport>
     <EnsureNETCoreAppRuntime>false</EnsureNETCoreAppRuntime> <!-- workaround for 'This runtime may not be supported by.NET Core.' error -->
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles> <!-- workaround for 'Found multiple publish output files with the same relative path.' error -->
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -132,7 +132,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <UseSharedCompilation>false</UseSharedCompilation>
     <Deterministic>true</Deterministic>
     <RunAnalyzers>false</RunAnalyzers>
-    <PublishAot Condition="" '$(TargetFramework)' != 'net6.0' "">true</PublishAot>
+    <PublishAot Condition=""$([MSBuild]::VersionGreaterThan('$(NETCoreSdkVersion)', '6.0'))"">true</PublishAot>
     <IlcOptimizationPreference>{ilcOptimizationPreference}</IlcOptimizationPreference>
     <OptimizationPreference>{ilcOptimizationPreference}</OptimizationPreference>
     {GetTrimmingSettings()}


### PR DESCRIPTION
* `llcOptimizationPreference` was renamed to `OptimizationPreference` and became supported in .NET 8 (or maybe .NET 7, it doesn't matter)
* `IlcGenerateStackTraceData` is now `StackTraceSupport` and supported. (Also got renamed in .NET 8 or maybe in 7 already.)

I'm leaving the old names of properties for backcompat. We could also delete them. I don't know how much BDN cares about .NET versions that are out of support.

The last one, `IlcGenerateCompleteTypeMetadata` is unsupported, we don't test it, it's a mode for troubleshooting trimming issues for people who ignore trimming warnings. I don't think BDN should be setting this. You'll only find bugs (https://github.com/dotnet/runtime/issues/106439). So deleting that. Not deleting the API because it looks to be a public API.