### PR TITLE
Add ConfigOption for disabling the .NET SDK Validator

### DIFF
--- a/src/BenchmarkDotNet/Configs/ConfigOptions.cs
+++ b/src/BenchmarkDotNet/Configs/ConfigOptions.cs
@@ -48,7 +48,11 @@ namespace BenchmarkDotNet.Configs
         /// <summary>
         /// Continue the execution if the last run was stopped.
         /// </summary>
-        Resume = 1 << 9
+        Resume = 1 << 9,
+        /// <summary>
+        /// Determines if the .NET SDK Version validator should be entirely turned off
+        /// </summary>
+        DisableDotnetSdkVersionValidator = 1 << 10,
     }
 
     internal static class ConfigOptionsExtensions

--- a/src/BenchmarkDotNet/Validators/DotNetSdkVersionValidator.cs
+++ b/src/BenchmarkDotNet/Validators/DotNetSdkVersionValidator.cs
@@ -1,4 +1,5 @@
-﻿using BenchmarkDotNet.Environments;
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using System;
@@ -17,6 +18,11 @@ namespace BenchmarkDotNet.Validators
 
         public static IEnumerable<ValidationError> ValidateCoreSdks(string? customDotNetCliPath, BenchmarkCase benchmark)
         {
+            if (benchmark.Config.Options.IsSet(ConfigOptions.DisableDotnetSdkVersionValidator))
+            {
+                yield break;
+            }
+
             if (IsCliPathInvalid(customDotNetCliPath, benchmark, out ValidationError? cliPathError))
             {
                 yield return cliPathError;
@@ -33,6 +39,11 @@ namespace BenchmarkDotNet.Validators
 
         public static IEnumerable<ValidationError> ValidateFrameworkSdks(BenchmarkCase benchmark)
         {
+            if (benchmark.Config.Options.IsSet(ConfigOptions.DisableDotnetSdkVersionValidator))
+            {
+                yield break;
+            }
+
             if (!TryGetSdkVersion(benchmark, out string requiredSdkVersionString))
             {
                 yield break;

--- a/src/BenchmarkDotNet/Validators/DotNetSdkVersionValidator.cs
+++ b/src/BenchmarkDotNet/Validators/DotNetSdkVersionValidator.cs
@@ -18,16 +18,11 @@ namespace BenchmarkDotNet.Validators
 
         public static IEnumerable<ValidationError> ValidateCoreSdks(string? customDotNetCliPath, BenchmarkCase benchmark)
         {
-            if (benchmark.Config.Options.IsSet(ConfigOptions.DisableDotnetSdkVersionValidator))
-            {
-                yield break;
-            }
-
             if (IsCliPathInvalid(customDotNetCliPath, benchmark, out ValidationError? cliPathError))
             {
                 yield return cliPathError;
             }
-            else if (TryGetSdkVersion(benchmark, out string requiredSdkVersion))
+            else if (!benchmark.Config.Options.IsSet(ConfigOptions.DisableDotnetSdkVersionValidator) && TryGetSdkVersion(benchmark, out string requiredSdkVersion))
             {
                 var installedSdks = GetInstalledDotNetSdks(customDotNetCliPath);
                 if (!installedSdks.Any(sdk => sdk.StartsWith(requiredSdkVersion)))


### PR DESCRIPTION
We are in the process of upgrading the .NET runtime repository to target the .NET 10 TFM, and so when this happens we have some benchmarks which are configured to target .NET 9, but the .NET 10 SDK will be installed. We wanted to add a config option that lets us disable the SDK validator so that we can do this without getting a validation error.