### PR TITLE
Add DOTNET_ environment vars

### DIFF
--- a/samples/BenchmarkDotNet.Samples/IntroEnvVars.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroEnvVars.cs
@@ -10,13 +10,14 @@ namespace BenchmarkDotNet.Samples
     {
         private class ConfigWithCustomEnvVars : ManualConfig
         {
-            private const string JitNoInline = "COMPlus_JitNoInline";
-
             public ConfigWithCustomEnvVars()
             {
                 AddJob(Job.Default.WithRuntime(CoreRuntime.Core80).WithId("Inlining enabled"));
                 AddJob(Job.Default.WithRuntime(CoreRuntime.Core80)
-                    .WithEnvironmentVariables(new EnvironmentVariable(JitNoInline, "1"))
+                    .WithEnvironmentVariables([
+                        new EnvironmentVariable("DOTNET_JitNoInline", "1"),
+                        new EnvironmentVariable("COMPlus_JitNoInline", "1")
+                    ])
                     .WithId("Inlining disabled"));
             }
         }

--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -125,7 +125,7 @@ namespace BenchmarkDotNet.Extensions
         internal static void SetEnvironmentVariables(this ProcessStartInfo start, BenchmarkCase benchmarkCase, IResolver resolver)
         {
             if (benchmarkCase.Job.Environment.Runtime is ClrRuntime clrRuntime && !string.IsNullOrEmpty(clrRuntime.Version))
-                start.EnvironmentVariables["COMPLUS_Version"] = clrRuntime.Version;
+                SetClrEnvironmentVariables(start, "Version", clrRuntime.Version);
 
             if (benchmarkCase.Job.Environment.Runtime is MonoRuntime monoRuntime && !string.IsNullOrEmpty(monoRuntime.MonoBclPath))
                 start.EnvironmentVariables["MONO_PATH"] = monoRuntime.MonoBclPath;
@@ -133,10 +133,10 @@ namespace BenchmarkDotNet.Extensions
             if (benchmarkCase.Config.HasPerfCollectProfiler())
             {
                 // enable tracing configuration inside of CoreCLR (https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/linux-performance-tracing.md#collecting-a-trace)
-                start.EnvironmentVariables["COMPlus_PerfMapEnabled"] = "1";
-                start.EnvironmentVariables["COMPlus_EnableEventLog"] = "1";
+                SetClrEnvironmentVariables(start, "PerfMapEnabled", "1");
+                SetClrEnvironmentVariables(start, "EnableEventLog", "1");
                 // enable BDN Event Source (https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/linux-performance-tracing.md#filtering)
-                start.EnvironmentVariables["COMPlus_EventSourceFilter"] = EngineEventSource.SourceName;
+                SetClrEnvironmentVariables(start, "EventSourceFilter", EngineEventSource.SourceName);
                 // workaround for https://github.com/dotnet/runtime/issues/71786, will be solved by next perf version
                 start.EnvironmentVariables["DOTNET_EnableWriteXorExecute"] = "0";
             }
@@ -258,21 +258,27 @@ namespace BenchmarkDotNet.Extensions
         {
             var gcMode = benchmarkCase.Job.Environment.Gc;
 
-            start.EnvironmentVariables["COMPlus_gcServer"] = gcMode.ResolveValue(GcMode.ServerCharacteristic, resolver) ? "1" : "0";
-            start.EnvironmentVariables["COMPlus_gcConcurrent"] = gcMode.ResolveValue(GcMode.ConcurrentCharacteristic, resolver) ? "1" : "0";
+            SetClrEnvironmentVariables(start, "gcServer", gcMode.ResolveValue(GcMode.ServerCharacteristic, resolver) ? "1" : "0");
+            SetClrEnvironmentVariables(start, "gcConcurrent", gcMode.ResolveValue(GcMode.ConcurrentCharacteristic, resolver) ? "1" : "0");
 
             if (gcMode.HasValue(GcMode.CpuGroupsCharacteristic))
-                start.EnvironmentVariables["COMPlus_GCCpuGroup"] = gcMode.ResolveValue(GcMode.CpuGroupsCharacteristic, resolver) ? "1" : "0";
+                SetClrEnvironmentVariables(start, "GCCpuGroup", gcMode.ResolveValue(GcMode.CpuGroupsCharacteristic, resolver) ? "1" : "0");
             if (gcMode.HasValue(GcMode.AllowVeryLargeObjectsCharacteristic))
-                start.EnvironmentVariables["COMPlus_gcAllowVeryLargeObjects"] = gcMode.ResolveValue(GcMode.AllowVeryLargeObjectsCharacteristic, resolver) ? "1" : "0";
+                SetClrEnvironmentVariables(start, "gcAllowVeryLargeObjects", gcMode.ResolveValue(GcMode.AllowVeryLargeObjectsCharacteristic, resolver) ? "1" : "0");
             if (gcMode.HasValue(GcMode.RetainVmCharacteristic))
-                start.EnvironmentVariables["COMPlus_GCRetainVM"] = gcMode.ResolveValue(GcMode.RetainVmCharacteristic, resolver) ? "1" : "0";
+                SetClrEnvironmentVariables(start, "GCRetainVM", gcMode.ResolveValue(GcMode.RetainVmCharacteristic, resolver) ? "1" : "0");
             if (gcMode.HasValue(GcMode.NoAffinitizeCharacteristic))
-                start.EnvironmentVariables["COMPlus_GCNoAffinitize"] = gcMode.ResolveValue(GcMode.NoAffinitizeCharacteristic, resolver) ? "1" : "0";
+                SetClrEnvironmentVariables(start, "GCNoAffinitize", gcMode.ResolveValue(GcMode.NoAffinitizeCharacteristic, resolver) ? "1" : "0");
             if (gcMode.HasValue(GcMode.HeapAffinitizeMaskCharacteristic))
-                start.EnvironmentVariables["COMPlus_GCHeapAffinitizeMask"] = gcMode.HeapAffinitizeMask.ToString("X");
+                SetClrEnvironmentVariables(start, "GCHeapAffinitizeMask", gcMode.HeapAffinitizeMask.ToString("X"));
             if (gcMode.HasValue(GcMode.HeapCountCharacteristic))
-                start.EnvironmentVariables["COMPlus_GCHeapCount"] = gcMode.HeapCount.ToString("X");
+                SetClrEnvironmentVariables(start, "GCHeapCount", gcMode.HeapCount.ToString("X"));
+        }
+
+        private static void SetClrEnvironmentVariables(ProcessStartInfo start, string suffix, string value)
+        {
+            start.EnvironmentVariables[$"DOTNET_{suffix}"] = value;
+            start.EnvironmentVariables[$"COMPlus_{suffix}"] = value;
         }
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -321,7 +321,11 @@ namespace BenchmarkDotNet.IntegrationTests
                     .WithGcForce(false)
                     .WithGcServer(false)
                     .WithGcConcurrent(false)
-                    .WithEnvironmentVariable("COMPlus_TieredCompilation", "0") // Tiered JIT can allocate some memory on a background thread, let's disable it to make our tests less flaky (#1542)
+                    .WithEnvironmentVariables([
+                        // Tiered JIT can allocate some memory on a background thread, let's disable it to make our tests less flaky (#1542)
+                        new EnvironmentVariable("DOTNET_JitNoInline", "0"),
+                        new EnvironmentVariable("COMPlus_JitNoInline", "0")
+                    ])
                     .WithToolchain(toolchain))
                 .AddColumnProvider(DefaultColumnProviders.Instance)
                 .AddDiagnoser(MemoryDiagnoser.Default)

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -323,8 +323,8 @@ namespace BenchmarkDotNet.IntegrationTests
                     .WithGcConcurrent(false)
                     .WithEnvironmentVariables([
                         // Tiered JIT can allocate some memory on a background thread, let's disable it to make our tests less flaky (#1542)
-                        new EnvironmentVariable("DOTNET_JitNoInline", "0"),
-                        new EnvironmentVariable("COMPlus_JitNoInline", "0")
+                        new EnvironmentVariable("DOTNET_TieredCompilation", "0"),
+                        new EnvironmentVariable("COMPlus_TieredCompilation", "0")
                     ])
                     .WithToolchain(toolchain))
                 .AddColumnProvider(DefaultColumnProviders.Instance)


### PR DESCRIPTION
The configuration system in coreclr and mono started supporting `DOTNET_` prefix in net6.0. Using `DOTNET_` is preferred because [it has precedence](https://github.com/dotnet/runtime/blob/a3d1e1cdb61a65b64246dee45998f2701c8987b8/src/coreclr/inc/clrconfignocache.h#L81) over `COMPlus_`.