### PR TITLE
Get full parsable version part in .NET SDK Validator

### DIFF
--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
@@ -194,7 +194,7 @@ namespace BenchmarkDotNet.Environments
         }
 
         // Version.TryParse does not handle thing like 3.0.0-WORD
-        private static string GetParsableVersionPart(string fullVersionName) => new string(fullVersionName.TakeWhile(c => char.IsDigit(c) || c == '.').ToArray());
+        internal static string GetParsableVersionPart(string fullVersionName) => new string(fullVersionName.TakeWhile(c => char.IsDigit(c) || c == '.').ToArray());
 
         private static CoreRuntime GetPlatformSpecific(CoreRuntime fallback)
         {

--- a/src/BenchmarkDotNet/Validators/DotNetSdkVersionValidator.cs
+++ b/src/BenchmarkDotNet/Validators/DotNetSdkVersionValidator.cs
@@ -111,18 +111,9 @@ namespace BenchmarkDotNet.Validators
                         var versions = new List<Version>(lines.Count());
                         foreach (var line in lines)
                         {
-                            // Each line will start with the SDK version followed by the SDK path. Since we only support
-                            // targeting SDK versions by the major version, we'll just look at extracting the major and
-                            // minor versions. This is done by looking for the first two dots in the line.
-                            var firstDot = line.IndexOf('.');
-                            if (firstDot < 0)
-                                continue;
-
-                            var secondDot = line.IndexOf('.', firstDot + 1);
-                            if (secondDot < 0)
-                                continue;
-
-                            if (Version.TryParse(line.Substring(0, secondDot), out var version))
+                            // Version.TryParse does not handle things like 3.0.0-WORD, so this will get just the 3.0.0 part
+                            var parsableVersionPart = CoreRuntime.GetParsableVersionPart(line);
+                            if (Version.TryParse(parsableVersionPart, out var version))
                             {
                                 versions.Add(version);
                             }


### PR DESCRIPTION
Unfortunately there was a bug introduced in https://github.com/dotnet/BenchmarkDotNet/pull/2645 that I missed which this PR will fix. Essentially if you use `--runtimes monoaotllvm` or `--runtimes wasm`, it would actually return `new Version(9, 0, 0)` because it defers to `CoreRuntime.TryGetVersion()` to get the version. The code that parsed the output of `dotnet --list-sdks` was only looking at the major and minor versions, and so the comparison of `new Version(9, 0, 0) <= new Version(9, 0)` was returning false. With this change we will read the full version string including the feature band/patch version.

In the dotnet/runtime performance tests we don't use `--runtimes wasm` but we do use `--runtimes monoaotllvm` to run the Mono AOT benchmarks, so this will fix that one. I'm doing some more testing locally but wanted to get the PR out now so it can get some reviews and get it merged quickly.