### PR TITLE
improve BaselineCustomAnalyzer warning message, fixes #2591

### DIFF
--- a/src/BenchmarkDotNet/Analysers/BaselineCustomAnalyzer.cs
+++ b/src/BenchmarkDotNet/Analysers/BaselineCustomAnalyzer.cs
@@ -31,7 +31,8 @@ namespace BenchmarkDotNet.Analysers
                     continue;
 
                 var message = "A question mark '?' symbol indicates that it was not possible to compute the " +
-                                $"({columnNames}) column(s) because the baseline value is too close to zero.";
+                                $"({columnNames}) column(s) because the baseline or benchmark could not be found, or " +
+                                $"the baseline value is too close to zero.";
 
                 yield return Conclusion.CreateWarning(Id, message);
             }


### PR DESCRIPTION
Went through #2591 and tried to improve the warning message here - taking a look at what code paths can cause this warning, I see that in `BaseLineCustomColumn.ResultsAreInvalid` it checks for whether the baseline / benchmark (or the results of) was null, and a check for `!CanBeInverted` on the baseline which checks if it's too close to zero. 
```c#
internal static bool ResultsAreInvalid(Summary summary, BenchmarkCase benchmarkCase, BenchmarkCase? baseline)
{
    return baseline == null ||
           summary[baseline] == null ||
           summary[baseline].ResultStatistics == null ||
           !summary[baseline].ResultStatistics.CanBeInverted() ||
           summary[benchmarkCase] == null ||
           summary[benchmarkCase].ResultStatistics == null;
}
```
```c#
 public bool CanBeInverted() => Min > 1e-9;
```

First issue here, let me know if this analysis is right / what other changes I need to make before this can be merged. Thanks! :)