### PR TITLE
Prevent premature end of the Benchmark process at Ctrl-C, fixes #2483

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.Windows/EtwProfiler.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/EtwProfiler.cs
@@ -120,21 +120,10 @@ namespace BenchmarkDotNet.Diagnostics.Windows
         private void Stop(DiagnoserActionParameters parameters)
         {
             WaitForDelayedEvents();
-            string userSessionFile;
-            try
-            {
-                kernelSession.Stop();
-                heapSession?.Stop();
-                userSession.Stop();
-
-                userSessionFile = userSession.FilePath;
-            }
-            finally
-            {
-                kernelSession.Dispose();
-                heapSession?.Dispose();
-                userSession.Dispose();
-            }
+            string userSessionFile = userSession.FilePath;
+            kernelSession.Dispose();
+            heapSession?.Dispose();
+            userSession.Dispose();
 
             // Merge the 'primary' etl file X.etl (userSession) with any files that match .clr*.etl .user*.etl. and .kernel.etl.
             TraceEventSession.MergeInPlace(userSessionFile, TextWriter.Null);

--- a/src/BenchmarkDotNet/Helpers/DisposeAtProcessTermination.cs
+++ b/src/BenchmarkDotNet/Helpers/DisposeAtProcessTermination.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace BenchmarkDotNet.Helpers
+{
+    /// <summary>
+    /// Ensures that Dispose is called at termination of the Process.
+    /// </summary>
+    public class DisposeAtProcessTermination : IDisposable
+    {
+        public DisposeAtProcessTermination()
+        {
+            Console.CancelKeyPress += OnCancelKeyPress;
+            AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+            // It does not make sense to include a finalizer. As we are subscribed to static events,
+            // it will never be called.
+        }
+
+        /// <summary>
+        /// Called when the user presses Ctrl-C or Ctrl-Break.
+        /// </summary>
+        private void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs e)
+        {
+            if (!e.Cancel) { Dispose(); }
+        }
+
+        /// <summary>
+        /// Called when the user clicks on the X in the upper right corner to close the Benchmark's Window.
+        /// </summary>
+        private void OnProcessExit(object? sender, EventArgs e) => Dispose();
+
+        public virtual void Dispose()
+        {
+            Console.CancelKeyPress -= OnCancelKeyPress;
+            AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
+        }
+    }
+}

--- a/src/BenchmarkDotNet/Helpers/DisposeAtProcessTermination.cs
+++ b/src/BenchmarkDotNet/Helpers/DisposeAtProcessTermination.cs
@@ -1,18 +1,38 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 
 namespace BenchmarkDotNet.Helpers
 {
     /// <summary>
-    /// Ensures that Dispose is called at termination of the Process.
+    /// Ensures that explicit Dispose is called at termination of the Process.
     /// </summary>
-    public class DisposeAtProcessTermination : IDisposable
+    /// <remarks>
+    /// <para>
+    /// This class exists to help in reverting system state where C#'s using statement does not
+    /// suffice. I.e. when Benchmark's process is aborted via Ctrl-C, Ctrl-Break or via click on the
+    /// X in the upper right of Window.
+    /// </para>
+    /// <para>
+    /// Usage: Derive your clas that changes system state of this class. Revert system state in
+    /// override of <see cref="Dispose"/> implementation.
+    /// Use your class in C#'s using statement, to ensure system state is reverted in normal situations.
+    /// This class ensures your override is also called at process 'abort'.
+    /// </para>
+    /// <para>
+    /// Note: This class is explicitly not responsible for cleanup of Native resources. Of course,
+    /// derived classes can cleanup their Native resources (usually managed via
+    /// <see cref="SafeHandle"/> derived classes), by delegating explicit Disposal to their
+    /// <see cref="IDisposable"/> fields.
+    /// </para>
+    /// </remarks>
+    public abstract class DisposeAtProcessTermination : IDisposable
     {
         public DisposeAtProcessTermination()
         {
             Console.CancelKeyPress += OnCancelKeyPress;
             AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
-            // It does not make sense to include a finalizer. As we are subscribed to static events,
-            // it will never be called.
+            // It does not make sense to include a Finalizer. We do not manage any native resource and:
+            // as we are subscribed to static events, it would never be called.
         }
 
         /// <summary>

--- a/src/BenchmarkDotNet/Running/ConsoleTitler.cs
+++ b/src/BenchmarkDotNet/Running/ConsoleTitler.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using BenchmarkDotNet.Detectors;
-using BenchmarkDotNet.Portability;
+using BenchmarkDotNet.Helpers;
 
 namespace BenchmarkDotNet.Running
 {
@@ -9,7 +9,7 @@ namespace BenchmarkDotNet.Running
     /// Updates Console.Title, subject to platform capabilities and Console availability.
     /// Restores the original (or fallback) title upon disposal.
     /// </summary>
-    internal class ConsoleTitler : IDisposable
+    internal class ConsoleTitler : DisposeAtProcessTermination
     {
         /// <summary>
         /// Whether this instance has any effect. This will be false if the platform doesn't support Console retitling,
@@ -76,13 +76,14 @@ namespace BenchmarkDotNet.Running
             }
         }
 
-        public void Dispose()
+        public override void Dispose()
         {
             if (IsEnabled)
             {
                 Console.Title = oldConsoleTitle;
                 IsEnabled = false;
             }
+            base.Dispose();
         }
     }
 }

--- a/src/BenchmarkDotNet/Running/PowerManagementApplier.cs
+++ b/src/BenchmarkDotNet/Running/PowerManagementApplier.cs
@@ -4,11 +4,10 @@ using BenchmarkDotNet.Detectors;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Helpers;
 using BenchmarkDotNet.Loggers;
-using BenchmarkDotNet.Portability;
 
 namespace BenchmarkDotNet.Running
 {
-    internal class PowerManagementApplier : IDisposable
+    internal class PowerManagementApplier : DisposeAtProcessTermination
     {
         private static readonly Guid UserPowerPlan = new Guid("67b4a053-3646-4532-affd-0535c9ea82a7");
 
@@ -28,7 +27,11 @@ namespace BenchmarkDotNet.Running
 
         internal PowerManagementApplier(ILogger logger) => this.logger = logger;
 
-        public void Dispose() => ApplyUserPowerPlan();
+        public override void Dispose()
+        {
+            ApplyUserPowerPlan();
+            base.Dispose();
+        }
 
         internal static Guid Map(PowerPlan value) => PowerPlansDict[value];
 


### PR DESCRIPTION
Set ConsoleCancelEventArgs.Cancel to true so that Benchmark process continues and PowerPlan is reverted at end of aborted Benchmark.

Note that at Ctrl-C (or Ctrl-Break) press, current benchmark fails (as all its processes are killed). The [main run loop](../blob/f8e0a5c23883fa6ea4a975cd08a0071c4648472c/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs#L161) continues running remaining benchmarks.

As it would (imho) require some complicated code to set `stop` to true at Ctrl-C press, I decided to document current behavior.

(If you do like to have all benchmarks aborted at Ctrl-C press, let me know and I'll implement such behavior)