### PR TITLE
Native AOT projects should also copy SettingsWeWantToCopy

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml;
 using BenchmarkDotNet.ConsoleArguments;
 using BenchmarkDotNet.Detectors;
 using BenchmarkDotNet.Detectors.Cpu;
@@ -155,7 +156,19 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
   <ItemGroup>
     {string.Join(Environment.NewLine, GetRdXmlFiles(buildPartition.RepresentativeBenchmarkCase.Descriptor.Type, logger).Select(file => $"<RdXmlFile Include=\"{file}\" />"))}
   </ItemGroup>
+{GetCustomProperties(buildPartition, logger)}
 </Project>";
+
+        private string GetCustomProperties(BuildPartition buildPartition, ILogger logger)
+        {
+            var projectFile = GetProjectFilePath(buildPartition.RepresentativeBenchmarkCase.Descriptor.Type, logger);
+            var xmlDoc = new XmlDocument();
+            xmlDoc.Load(projectFile.FullName);
+
+            (string customProperties, _) = GetSettingsThatNeedToBeCopied(xmlDoc, projectFile);
+            return customProperties;
+        }
+
 
         private string GetILCompilerPackageReference()
             => string.IsNullOrEmpty(ilCompilerVersion) ? "" : $@"<PackageReference Include=""Microsoft.DotNet.ILCompiler"" Version=""{ilCompilerVersion}"" />";


### PR DESCRIPTION
See: https://github.com/dotnet/BenchmarkDotNet/issues/2428#issuecomment-2477793449

I'm happy to add tests here, but I didn't see any good examples of similar tests currently present. I ran some of the integration tests and checked the outputs and those matched expectations.

relates to #2428 