### PR TITLE
add HostSignal.AfterProcessStart to allow the users to obtain ID of a process that was started suspended

### DIFF
--- a/src/BenchmarkDotNet/Engines/HostSignal.cs
+++ b/src/BenchmarkDotNet/Engines/HostSignal.cs
@@ -8,6 +8,11 @@
         BeforeProcessStart,
 
         /// <summary>
+        /// right after we start the benchmarking process
+        /// </summary>
+        AfterProcessStart,
+
+        /// <summary>
         /// before jitting, warmup
         /// </summary>
         BeforeAnythingElse,

--- a/src/BenchmarkDotNet/Loggers/Broker.cs
+++ b/src/BenchmarkDotNet/Loggers/Broker.cs
@@ -15,9 +15,7 @@ namespace BenchmarkDotNet.Loggers
     {
         private readonly ILogger logger;
         private readonly Process process;
-        private readonly IDiagnoser diagnoser;
         private readonly AnonymousPipeServerStream inputFromBenchmark, acknowledgments;
-        private readonly DiagnoserActionParameters diagnoserActionParameters;
         private readonly ManualResetEvent finished;
 
         public Broker(ILogger logger, Process process, IDiagnoser diagnoser,
@@ -25,10 +23,10 @@ namespace BenchmarkDotNet.Loggers
         {
             this.logger = logger;
             this.process = process;
-            this.diagnoser = diagnoser;
+            this.Diagnoser = diagnoser;
             this.inputFromBenchmark = inputFromBenchmark;
             this.acknowledgments = acknowledgments;
-            diagnoserActionParameters = new DiagnoserActionParameters(process, benchmarkCase, benchmarkId);
+            DiagnoserActionParameters = new DiagnoserActionParameters(process, benchmarkCase, benchmarkId);
             finished = new ManualResetEvent(false);
 
             Results = new List<string>();
@@ -37,6 +35,10 @@ namespace BenchmarkDotNet.Loggers
             process.EnableRaisingEvents = true;
             process.Exited += OnProcessExited;
         }
+
+        internal IDiagnoser Diagnoser { get; }
+
+        internal DiagnoserActionParameters DiagnoserActionParameters { get; }
 
         internal List<string> Results { get; }
 
@@ -90,7 +92,7 @@ namespace BenchmarkDotNet.Loggers
                 }
                 else if (Engine.Signals.TryGetSignal(line, out var signal))
                 {
-                    diagnoser?.Handle(signal, diagnoserActionParameters);
+                    Diagnoser?.Handle(signal, DiagnoserActionParameters);
 
                     writer.WriteLine(Engine.Signals.Acknowledgment);
 

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliExecutor.cs
@@ -83,9 +83,12 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
                 logger.WriteLineInfo($"// Execute: {process.StartInfo.FileName} {process.StartInfo.Arguments} in {process.StartInfo.WorkingDirectory}");
 
-                diagnoser?.Handle(HostSignal.BeforeProcessStart, new DiagnoserActionParameters(process, benchmarkCase, benchmarkId));
+                diagnoser?.Handle(HostSignal.BeforeProcessStart, broker.DiagnoserActionParameters);
 
                 process.Start();
+
+                diagnoser?.Handle(HostSignal.AfterProcessStart, broker.DiagnoserActionParameters);
+
                 processOutputReader.BeginRead();
 
                 process.EnsureHighPriority(logger);

--- a/src/BenchmarkDotNet/Toolchains/Executor.cs
+++ b/src/BenchmarkDotNet/Toolchains/Executor.cs
@@ -79,6 +79,8 @@ namespace BenchmarkDotNet.Toolchains
                 return new ExecuteResult(true, null, null, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), launchIndex);
             }
 
+            broker.Diagnoser?.Handle(HostSignal.AfterProcessStart, broker.DiagnoserActionParameters);
+
             processOutputReader.BeginRead();
 
             process.EnsureHighPriority(logger);


### PR DESCRIPTION
I got this feature request from the VS Profiler Team

The code sample I've used:

```csharp
using BenchmarkDotNet.Analysers;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Engines;
using BenchmarkDotNet.Environments;
using BenchmarkDotNet.Exporters;
using BenchmarkDotNet.Jobs;
using BenchmarkDotNet.Loggers;
using BenchmarkDotNet.Reports;
using BenchmarkDotNet.Running;
using BenchmarkDotNet.Validators;
using System;
using System.Collections.Generic;

namespace BenchmarkDotNet.Samples
{
    [Config(typeof(ConfigWithSuspendEnvVars))]
    public class IntroProcessResume
    {
        // DOTNET_DefaultDiagnosticPortSuspend=1
        private class ConfigWithSuspendEnvVars : ManualConfig
        {
            public ConfigWithSuspendEnvVars()
            {
                AddJob(Job.Dry.WithRuntime(CoreRuntime.Core80)
                    .WithEnvironmentVariables([
                        new EnvironmentVariable("DOTNET_DefaultDiagnosticPortSuspend", "1"),
                    ])
                    .WithId("Suspended"));
                AddDiagnoser(new DummyDiagnoser());
            }
        }

        private class DummyDiagnoser : IDiagnoser
        {
            public IEnumerable<string> Ids => [nameof(DummyDiagnoser)];

            public IEnumerable<IExporter> Exporters => [];

            public IEnumerable<IAnalyser> Analysers => [];

            public void DisplayResults(ILogger logger) { }

            public Diagnosers.RunMode GetRunMode(BenchmarkCase benchmarkCase)
                => Diagnosers.RunMode.NoOverhead;

            public void Handle(HostSignal signal, DiagnoserActionParameters parameters)
                => Console.WriteLine($"Signal: {signal}, PID: {(signal == HostSignal.BeforeProcessStart ? -1 : parameters.Process.Id)}");

            public IEnumerable<Metric> ProcessResults(DiagnoserResults results) => [];

            public IEnumerable<ValidationError> Validate(ValidationParameters validationParameters) => [];
        }

        [Benchmark]
        public void Foo()
        {
            // Benchmark body
        }
    }
}
```