### PR TITLE
Add support for user-supplied project file detection

### DIFF
--- a/src/BenchmarkDotNet/Configs/DebugConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DebugConfig.cs
@@ -8,6 +8,7 @@ using BenchmarkDotNet.EventProcessors;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Locators;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Reports;
@@ -58,6 +59,7 @@ namespace BenchmarkDotNet.Configs
         public IEnumerable<IValidator> GetValidators() => Array.Empty<IValidator>();
         public IEnumerable<IColumnProvider> GetColumnProviders() => DefaultColumnProviders.Instance;
         public IEnumerable<IExporter> GetExporters() => Array.Empty<IExporter>();
+        public IEnumerable<ILocator> GetLocators() => new[] { ProjectLocator.Default };
         public IEnumerable<ILogger> GetLoggers() => new[] { ConsoleLogger.Default };
         public IEnumerable<IDiagnoser> GetDiagnosers() => Array.Empty<IDiagnoser>();
         public IEnumerable<IAnalyser> GetAnalysers() => Array.Empty<IAnalyser>();

--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -11,6 +11,7 @@ using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Exporters.Csv;
 using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Locators;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Portability;
@@ -38,6 +39,11 @@ namespace BenchmarkDotNet.Configs
             yield return CsvExporter.Default;
             yield return MarkdownExporter.GitHub;
             yield return HtmlExporter.Default;
+        }
+
+        public IEnumerable<ILocator> GetLocators()
+        {
+            yield return ProjectLocator.Default;
         }
 
         public IEnumerable<ILogger> GetLoggers()

--- a/src/BenchmarkDotNet/Configs/IConfig.cs
+++ b/src/BenchmarkDotNet/Configs/IConfig.cs
@@ -8,6 +8,7 @@ using BenchmarkDotNet.EventProcessors;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Locators;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Reports;
@@ -20,6 +21,7 @@ namespace BenchmarkDotNet.Configs
     {
         IEnumerable<IColumnProvider> GetColumnProviders();
         IEnumerable<IExporter> GetExporters();
+        IEnumerable<ILocator> GetLocators();
         IEnumerable<ILogger> GetLoggers();
         IEnumerable<IDiagnoser> GetDiagnosers();
         IEnumerable<IAnalyser> GetAnalysers();

--- a/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
@@ -10,6 +10,7 @@ using BenchmarkDotNet.EventProcessors;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Locators;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Reports;
@@ -24,6 +25,7 @@ namespace BenchmarkDotNet.Configs
         // if something is an array here instead of hashset it means it must have a guaranteed order of elements
         private readonly ImmutableArray<IColumnProvider> columnProviders;
         private readonly ImmutableArray<IExporter> exporters;
+        private readonly ImmutableArray<ILocator> locators;
         private readonly ImmutableHashSet<ILogger> loggers;
         private readonly ImmutableHashSet<IDiagnoser> diagnosers;
         private readonly ImmutableHashSet<IAnalyser> analysers;
@@ -41,6 +43,7 @@ namespace BenchmarkDotNet.Configs
             ImmutableHashSet<HardwareCounter> uniqueHardwareCounters,
             ImmutableHashSet<IDiagnoser> uniqueDiagnosers,
             ImmutableArray<IExporter> uniqueExporters,
+            ImmutableArray<ILocator> uniqueLocators,
             ImmutableHashSet<IAnalyser> uniqueAnalyzers,
             ImmutableHashSet<IValidator> uniqueValidators,
             ImmutableHashSet<IFilter> uniqueFilters,
@@ -63,6 +66,7 @@ namespace BenchmarkDotNet.Configs
             hardwareCounters = uniqueHardwareCounters;
             diagnosers = uniqueDiagnosers;
             exporters = uniqueExporters;
+            locators = uniqueLocators;
             analysers = uniqueAnalyzers;
             validators = uniqueValidators;
             filters = uniqueFilters;
@@ -92,6 +96,7 @@ namespace BenchmarkDotNet.Configs
 
         public IEnumerable<IColumnProvider> GetColumnProviders() => columnProviders;
         public IEnumerable<IExporter> GetExporters() => exporters;
+        public IEnumerable<ILocator> GetLocators() => locators;
         public IEnumerable<ILogger> GetLoggers() => loggers;
         public IEnumerable<IDiagnoser> GetDiagnosers() => diagnosers;
         public IEnumerable<IAnalyser> GetAnalysers() => analysers;

--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using BenchmarkDotNet.Analysers;
@@ -44,6 +44,7 @@ namespace BenchmarkDotNet.Configs
             var uniqueHardwareCounters = source.GetHardwareCounters().Where(counter => counter != HardwareCounter.NotSet).ToImmutableHashSet();
             var uniqueDiagnosers = GetDiagnosers(source.GetDiagnosers(), uniqueHardwareCounters);
             var uniqueExporters = GetExporters(source.GetExporters(), uniqueDiagnosers, configAnalyse);
+            var uniqueLocators = source.GetLocators().ToImmutableArray();
             var uniqueAnalyzers = GetAnalysers(source.GetAnalysers(), uniqueDiagnosers);
 
             var uniqueValidators = GetValidators(source.GetValidators(), MandatoryValidators, source.Options);
@@ -61,6 +62,7 @@ namespace BenchmarkDotNet.Configs
                 uniqueHardwareCounters,
                 uniqueDiagnosers,
                 uniqueExporters,
+                uniqueLocators,
                 uniqueAnalyzers,
                 uniqueValidators,
                 uniqueFilters,

--- a/src/BenchmarkDotNet/Configs/ManualConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ManualConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
@@ -11,6 +11,7 @@ using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Locators;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Reports;
@@ -26,6 +27,7 @@ namespace BenchmarkDotNet.Configs
 
         private readonly List<IColumnProvider> columnProviders = new List<IColumnProvider>();
         private readonly List<IExporter> exporters = new List<IExporter>();
+        private readonly List<ILocator> locators = new List<ILocator>();
         private readonly List<ILogger> loggers = new List<ILogger>();
         private readonly List<IDiagnoser> diagnosers = new List<IDiagnoser>();
         private readonly List<IAnalyser> analysers = new List<IAnalyser>();
@@ -39,6 +41,7 @@ namespace BenchmarkDotNet.Configs
 
         public IEnumerable<IColumnProvider> GetColumnProviders() => columnProviders;
         public IEnumerable<IExporter> GetExporters() => exporters;
+        public IEnumerable<ILocator> GetLocators() => locators;
         public IEnumerable<ILogger> GetLoggers() => loggers;
         public IEnumerable<IDiagnoser> GetDiagnosers() => diagnosers;
         public IEnumerable<IAnalyser> GetAnalysers() => analysers;
@@ -136,6 +139,12 @@ namespace BenchmarkDotNet.Configs
         public ManualConfig AddExporter(params IExporter[] newExporters)
         {
             exporters.AddRange(newExporters);
+            return this;
+        }
+
+        public ManualConfig AddLocator(params ILocator[] newLocators)
+        {
+            locators.AddRange(newLocators);
             return this;
         }
 
@@ -256,6 +265,7 @@ namespace BenchmarkDotNet.Configs
         {
             columnProviders.AddRange(config.GetColumnProviders());
             exporters.AddRange(config.GetExporters());
+            locators.AddRange(config.GetLocators());
             loggers.AddRange(config.GetLoggers());
             diagnosers.AddRange(config.GetDiagnosers());
             analysers.AddRange(config.GetAnalysers());
@@ -287,6 +297,7 @@ namespace BenchmarkDotNet.Configs
         public static ManualConfig CreateMinimumViable()
             => CreateEmpty()
                 .AddColumnProvider(DefaultColumnProviders.Instance)
+                .AddLocator(ProjectLocator.Default)
                 .AddLogger(ConsoleLogger.Default);
 
         public static ManualConfig Create(IConfig config)

--- a/src/BenchmarkDotNet/Locators/ILocator.cs
+++ b/src/BenchmarkDotNet/Locators/ILocator.cs
@@ -1,0 +1,10 @@
+using System;
+using System.IO;
+
+namespace BenchmarkDotNet.Locators;
+
+public interface ILocator
+{
+    LocatorType LocatorType { get; }
+    FileInfo Locate(DirectoryInfo rootDirectory, Type type);
+}

--- a/src/BenchmarkDotNet/Locators/LocatorType.cs
+++ b/src/BenchmarkDotNet/Locators/LocatorType.cs
@@ -1,0 +1,6 @@
+namespace BenchmarkDotNet.Locators;
+
+public enum LocatorType
+{
+    ProjectFile
+}

--- a/src/BenchmarkDotNet/Locators/ProjectLocator.cs
+++ b/src/BenchmarkDotNet/Locators/ProjectLocator.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using BenchmarkDotNet.Exporters;
+
+namespace BenchmarkDotNet.Locators;
+
+public class ProjectLocator : ILocator
+{
+    public static ProjectLocator Default { get; } = new ProjectLocator();
+
+    public LocatorType LocatorType => LocatorType.ProjectFile;
+
+    public FileInfo Locate(DirectoryInfo rootDirectory, Type type)
+    {
+        // important assumption! project's file name === output dll name
+        string projectName = type.GetTypeInfo().Assembly.GetName().Name;
+
+        var possibleNames = new HashSet<string> { $"{projectName}.csproj", $"{projectName}.fsproj", $"{projectName}.vbproj" };
+        var projectFiles = rootDirectory
+                           .EnumerateFiles("*proj", SearchOption.AllDirectories)
+                           .Where(file => possibleNames.Contains(file.Name))
+                           .ToArray();
+
+        if (projectFiles.Length == 0)
+        {
+            throw new NotSupportedException(
+                $"Unable to find {projectName} in {rootDirectory.FullName} and its subfolders. Most probably the name of output exe is different than the name of the .(c/f)sproj");
+        }
+        else if (projectFiles.Length > 1)
+        {
+            throw new NotSupportedException(
+                $"Found more than one matching project file for {projectName} in {rootDirectory.FullName} and its subfolders: {string.Join(",", projectFiles.Select(pf => $"'{pf.FullName}'"))}. Benchmark project names needs to be unique.");
+        }
+
+        return projectFiles[0];
+    }
+}

--- a/src/BenchmarkDotNet/Toolchains/MonoAotLLVM/MonoAotLLVMGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoAotLLVM/MonoAotLLVMGenerator.cs
@@ -28,7 +28,7 @@ namespace BenchmarkDotNet.Toolchains.MonoAotLLVM
         protected override void GenerateProject(BuildPartition buildPartition, ArtifactsPaths artifactsPaths, ILogger logger)
         {
             BenchmarkCase benchmark = buildPartition.RepresentativeBenchmarkCase;
-            var projectFile = GetProjectFilePath(benchmark.Descriptor.Type, logger);
+            var projectFile = GetProjectFilePath(benchmark, logger);
 
             string useLLVM = AotCompilerMode == MonoAotCompilerMode.llvm ? "true" : "false";
 

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -41,7 +41,7 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
         protected void GenerateProjectFile(BuildPartition buildPartition, ArtifactsPaths artifactsPaths, bool aot, ILogger logger)
         {
             BenchmarkCase benchmark = buildPartition.RepresentativeBenchmarkCase;
-            var projectFile = GetProjectFilePath(benchmark.Descriptor.Type, logger);
+            var projectFile = GetProjectFilePath(benchmark, logger);
 
             WasmRuntime runtime = (WasmRuntime) buildPartition.Runtime;
 

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -151,17 +151,17 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
   </ItemGroup>
   <ItemGroup>
     {GetILCompilerPackageReference()}
-    <ProjectReference Include=""{GetProjectFilePath(buildPartition.RepresentativeBenchmarkCase.Descriptor.Type, logger).FullName}"" />
+    <ProjectReference Include=""{GetProjectFilePath(buildPartition.RepresentativeBenchmarkCase, logger).FullName}"" />
   </ItemGroup>
   <ItemGroup>
-    {string.Join(Environment.NewLine, GetRdXmlFiles(buildPartition.RepresentativeBenchmarkCase.Descriptor.Type, logger).Select(file => $"<RdXmlFile Include=\"{file}\" />"))}
+    {string.Join(Environment.NewLine, GetRdXmlFiles(buildPartition.RepresentativeBenchmarkCase, logger).Select(file => $"<RdXmlFile Include=\"{file}\" />"))}
   </ItemGroup>
 {GetCustomProperties(buildPartition, logger)}
 </Project>";
 
         private string GetCustomProperties(BuildPartition buildPartition, ILogger logger)
         {
-            var projectFile = GetProjectFilePath(buildPartition.RepresentativeBenchmarkCase.Descriptor.Type, logger);
+            var projectFile = GetProjectFilePath(buildPartition.RepresentativeBenchmarkCase, logger);
             var xmlDoc = new XmlDocument();
             xmlDoc.Load(projectFile.FullName);
 
@@ -186,11 +186,11 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             return !string.IsNullOrEmpty(instructionSet) ? $"<IlcInstructionSet>{instructionSet}</IlcInstructionSet>" : "";
         }
 
-        public IEnumerable<string> GetRdXmlFiles(Type benchmarkTarget, ILogger logger)
+        public IEnumerable<string> GetRdXmlFiles(BenchmarkCase benchmark, ILogger logger)
         {
             yield return GeneratedRdXmlFileName;
 
-            var projectFile = GetProjectFilePath(benchmarkTarget, logger);
+            var projectFile = GetProjectFilePath(benchmark, logger);
             var projectFileFolder = projectFile.DirectoryName;
             var rdXml = Path.Combine(projectFileFolder, "rd.xml");
             if (File.Exists(rdXml))

--- a/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
@@ -8,6 +8,7 @@ using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Locators;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Reports;
@@ -451,6 +452,44 @@ namespace BenchmarkDotNet.Tests.Configs
 
             }
 
+        }
+
+        [Fact]
+        public void LocatorsAreAddedCorrectly()
+        {
+            var mutable = ManualConfig.CreateEmpty();
+
+            mutable.AddLocator(ProjectLocator.Default);
+
+            var final = ImmutableConfigBuilder.Create(mutable);
+
+            var locator = Assert.Single(final.GetLocators());
+            Assert.Same(ProjectLocator.Default, locator);
+        }
+
+        [Fact]
+        public void DuplicateLocatorsAreAllowed()
+        {
+            var mutable = ManualConfig.CreateEmpty();
+
+            mutable.AddLocator(ProjectLocator.Default);
+            mutable.AddLocator(ProjectLocator.Default);
+
+            var final = ImmutableConfigBuilder.Create(mutable);
+
+            Assert.Equal(2, final.GetLocators().Count());
+        }
+
+        [Fact]
+        public void VerifyConfigsHaveLocators()
+        {
+            var minVar = ManualConfig.CreateMinimumViable();
+            var build1 = ImmutableConfigBuilder.Create(minVar);
+            Assert.Single(build1.GetLocators());
+
+            var def = DefaultConfig.Instance;
+            var build2 = ImmutableConfigBuilder.Create(def);
+            Assert.Single(build2.GetLocators());
         }
     }
 }


### PR DESCRIPTION
This update adds support for "Locators" in the IConfig interface. A Locator is an extensibility point where users can define path-handling logic that differs from the built-in logic.

For example, if the user sets `AssemblyName` in their csproj, they are forced to use the InProcess job, or else BenchmarkDotnet gives an error with:
> Generate Exception: System.NotSupportedException: Unable to find <csproj> in <folder> and its subfolders. Most probably the name of output exe is different than the name of the .(c/f)sproj

The error is caused by the built-in logic trying to find a project file relative to the project root, which has the same name as the DLL. Unfortunately, [lots of projects](https://github.com/search?q=lang%3Axml+AssemblyName+&type=code) use AssemblyName to generate a short name, different from the project name (Like GNU utilities) or prepend the owners name (like GitHub/Nuget prefixes) to avoid assembly name collisions.

The issue has been repeatedly raised on the BenchmarkDotnet issue tracker and StackOverlow. For issues, see #1019, #498, #1178, #1785 and #1927.

### The code
ILocator is a new public interface where users can define their logic. The interface is implemented like this:

```csharp
private class CustomLocator : ILocator
{
    public LocatorType LocatorType => LocatorType.ProjectFile;

    public FileInfo Locate(DirectoryInfo rootDirectory, Type type)
    {
        return new FileInfo(Path.Combine(rootDirectory.FullName, @"Src\Benchmarks\MyBenchmarks.csproj"));
    }
}
```
The LocatorType is not strictly necessary, as the locator is only used in a single place right now. However, if there are other places where the user could benefit from the extensibility, it is necessary to have to distinguish between locators.

If that is not wanted, let me know, and I'll remove it and rename ILocator to IProjectLocator to specialize the code for its intended purpose.

Users can add their locator to a ManualConfig like so:

```csharp
// To use both ProjectLocator.Default and custom locator:
IConfig config = ManualConfig.CreateMinimumViable()
                           .AddLocator(new CustomLocator());

// To use only the custom locator:
IConfig config = ManualConfig.CreateEmpty()
                           .AddLocator(new CustomLocator());
```

### Notes
- ProjectLocator is a new class that contains the old logic to find the project file.
- DefaultConfig uses ProjectLocator.Default
- DebugConfig also uses ProjectLocator.Default
- ManualConfig defaults to no ILocator, but `CreateMinimumViable` includes ProjectLocator.Default
- I've added tests to ensure 1) duplicate locators are supported 2) that configs contains the correct locators


