### PR TITLE
Some minor fixes before new version release

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -23,6 +23,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <Nullable>annotations</Nullable>
+    <!-- Lets supress the  "System.Collections.Immutable 8.0.0 doesn't support netcoreapp3.1" warning -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -22,9 +22,9 @@
     <PackageReference Include="Perfolizer" Version="[0.4.0]" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.8" PrivateAssets="contentfiles;analyzers" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <!-- Do not update these packages, or else netcoreapp3.1 may no longer work -->
     <PackageReference Include="System.Management" Version="6.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -774,10 +774,17 @@ namespace BenchmarkDotNet.ConsoleArguments
         internal static bool TryParse(string runtime, out RuntimeMoniker runtimeMoniker)
         {
             int index = runtime.IndexOf('-');
+            if (index >= 0)
+            {
+                runtime = runtime.Substring(0, index);
+            }
 
-            return index < 0
-                ? Enum.TryParse<RuntimeMoniker>(runtime.Replace(".", string.Empty), ignoreCase: true, out runtimeMoniker)
-                : Enum.TryParse<RuntimeMoniker>(runtime.Substring(0, index).Replace(".", string.Empty), ignoreCase: true, out runtimeMoniker);
+            // Monikers older than Net 10 don't use any version delimiter, newer monikers use _ delimiter.
+            if (Enum.TryParse(runtime.Replace(".", string.Empty), ignoreCase: true, out runtimeMoniker))
+            {
+                return true;
+            }
+            return Enum.TryParse(runtime.Replace('.', '_'), ignoreCase: true, out runtimeMoniker);
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -383,12 +383,12 @@ namespace BenchmarkDotNet.Tests
         }
 
         [Theory]
-        [InlineData("net50")]
-        [InlineData("net60")]
-        [InlineData("net70")]
-        [InlineData("net80")]
-        [InlineData("net90")]
-        [InlineData("net10_0")]
+        [InlineData("net5.0")]
+        [InlineData("net6.0")]
+        [InlineData("net7.0")]
+        [InlineData("net8.0")]
+        [InlineData("net9.0")]
+        [InlineData("net10.0")]
         public void NetMonikersAreRecognizedAsNetCoreMonikers(string tfm)
         {
             var config = ConfigParser.Parse(new[] { "-r", tfm }, new OutputLogger(Output)).config;

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -383,11 +383,17 @@ namespace BenchmarkDotNet.Tests
         }
 
         [Theory]
+        [InlineData("net50")]
         [InlineData("net5.0")]
+        [InlineData("net60")]
         [InlineData("net6.0")]
+        [InlineData("net70")]
         [InlineData("net7.0")]
+        [InlineData("net80")]
         [InlineData("net8.0")]
+        [InlineData("net90")]
         [InlineData("net9.0")]
+        [InlineData("net10_0")]
         [InlineData("net10.0")]
         public void NetMonikersAreRecognizedAsNetCoreMonikers(string tfm)
         {


### PR DESCRIPTION
This PR consists of:

- https://github.com/am11/BenchmarkDotNet/pull/1 by @LoopedBard3 
- update Microsoft.CodeAnalysis.CSharp to 4.12.0 to stop referencing an old version of System.Collections.Immutable, fixes #2678
- minor test improvements (we need to add new test cases, not replace existing ones)

@timcassell I saw your comment here:

https://github.com/dotnet/BenchmarkDotNet/blob/3337a0936c7f44503aa740a9c53e7594fe264967/src/BenchmarkDotNet/BenchmarkDotNet.csproj#L25-L27

And tested the netcoreapp3.1 support with my changes:

```cmd
dotnet run -c Release -f net8.0 --filter *IntroBasic.Sleep --project .\samples\BenchmarkDotNet.Samples\BenchmarkDotNet.Samples.csproj -- --runtimes netcoreapp3.1 --job dry
```

It works:

![image](https://github.com/user-attachments/assets/7d054c11-561e-46e6-bd73-4da565981345)

