### PR TITLE
Basic support of `InProcessNoEmitRunner` for NativeAOT.

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitRunner.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitRunner.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Environments;

--- a/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitRunner.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitRunner.cs
@@ -15,7 +15,9 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
     /// </summary>
     internal class InProcessNoEmitRunner
     {
+#if NET6_0_OR_GREATER
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Runnable))]
+#endif
         public static int Run(IHost host, BenchmarkCase benchmarkCase)
         {
             // the first thing to do is to let diagnosers hook in before anything happens

--- a/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitRunner.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitRunner.cs
@@ -15,6 +15,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
     /// </summary>
     internal class InProcessNoEmitRunner
     {
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Runnable))]
         public static int Run(IHost host, BenchmarkCase benchmarkCase)
         {
             // the first thing to do is to let diagnosers hook in before anything happens


### PR DESCRIPTION
Supports benchmark methods with `void` or `Task` as return type.