### PR TITLE
Missing dotnet 9.0 support.

### DIFF
--- a/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
@@ -57,6 +57,8 @@ namespace BenchmarkDotNet.Extensions
                     return NativeAotRuntime.Net70;
                 case RuntimeMoniker.NativeAot80:
                     return NativeAotRuntime.Net80;
+                case RuntimeMoniker.NativeAot90:
+                    return NativeAotRuntime.Net90;
                 case RuntimeMoniker.NativeAot10_0:
                     return NativeAotRuntime.Net10_0;
                 case RuntimeMoniker.Mono60:

--- a/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
@@ -67,6 +67,8 @@ namespace BenchmarkDotNet.Extensions
                     return MonoRuntime.Mono70;
                 case RuntimeMoniker.Mono80:
                     return MonoRuntime.Mono80;
+                case RuntimeMoniker.Mono90:
+                    return MonoRuntime.Mono90;
                 case RuntimeMoniker.Mono10_0:
                     return MonoRuntime.Mono10_0;
                 default:


### PR DESCRIPTION
Added support for `RuntimeMoniker.NativeAot90` in the `RuntimeMonikerExtensions.cs` file, which returns `NativeAotRuntime.Net90`.