### PR TITLE
Exporters.Plotting: ScottPlot histogram export

### DIFF
--- a/src/BenchmarkDotNet.Exporters.Plotting/ScottPlotExporter.cs
+++ b/src/BenchmarkDotNet.Exporters.Plotting/ScottPlotExporter.cs
@@ -415,9 +415,6 @@ namespace BenchmarkDotNet.Exporters.Plotting
                 }
             }
 
-            // Tell the plot to autoscale with a small padding below the boxes.
-            plt.Axes.Margins(bottom: 0.05, right: .2);
-
             plt.PlottableList.AddRange(annotations);
 
             plt.SavePng(fileName, this.Width, this.Height);

--- a/tests/BenchmarkDotNet.Exporters.Plotting.Tests/ScottPlotExporterTests.cs
+++ b/tests/BenchmarkDotNet.Exporters.Plotting.Tests/ScottPlotExporterTests.cs
@@ -35,6 +35,7 @@ namespace BenchmarkDotNet.Exporters.Plotting.Tests
             {
                 IncludeBarPlot = true,
                 IncludeBoxPlot = false,
+                IncludeHistogramPlot = false,
             };
             var summary = MockFactory.CreateSummary(benchmarkType);
             var filePaths = exporter.ExportToFiles(summary, logger).ToList();
@@ -57,6 +58,7 @@ namespace BenchmarkDotNet.Exporters.Plotting.Tests
             {
                 IncludeBarPlot = false,
                 IncludeBoxPlot = true,
+                IncludeHistogramPlot = false,
             };
             var summary = MockFactory.CreateSummaryWithBiasedDistribution(benchmarkType, 1, 4, 10, 9);
             var filePaths = exporter.ExportToFiles(summary, logger).ToList();
@@ -79,8 +81,32 @@ namespace BenchmarkDotNet.Exporters.Plotting.Tests
             {
                 IncludeBarPlot = false,
                 IncludeBoxPlot = true,
+                IncludeHistogramPlot = false,
             };
             var summary = MockFactory.CreateSummaryWithBiasedDistribution(benchmarkType, 1, 4, 10, 1);
+            var filePaths = exporter.ExportToFiles(summary, logger).ToList();
+            Assert.NotEmpty(filePaths);
+            Assert.All(filePaths, f => File.Exists(f));
+
+            foreach (string filePath in filePaths)
+                logger.WriteLine($"* {filePath}");
+            output.WriteLine(logger.GetLog());
+        }
+
+        [Theory]
+        [MemberData(nameof(GetGroupBenchmarkTypes))]
+        public void HistogramPlots(Type benchmarkType)
+        {
+            var logger = new AccumulationLogger();
+            logger.WriteLine("=== " + benchmarkType.Name + " ===");
+
+            var exporter = new ScottPlotExporter()
+            {
+                IncludeBarPlot = false,
+                IncludeBoxPlot = false,
+                IncludeHistogramPlot = true,
+            };
+            var summary = MockFactory.CreateSummaryWithBiasedDistribution(benchmarkType, 1, 4, 10, 9);
             var filePaths = exporter.ExportToFiles(summary, logger).ToList();
             Assert.NotEmpty(filePaths);
             Assert.All(filePaths, f => File.Exists(f));


### PR DESCRIPTION
It's my understanding that the existing R plot exporters includes a density plot, but I don't know what kind of smoothing that goes through. ScottPlot does support calculating this from a histogram but it doesn't support the necessary kernel density estimation. So your options are to either compute the discrete PDF (unlikely to be appropriate unless there's hundreds of bins) or assume a normal distribution (almost certainly not appropriate). And then you can potentially add smoothing on top of that (e.g. turn it into a bezier or compute a moving average).

I figure that a histogram is at least part of the way there, and I might look at adding a KDE implementation into ScottPlot, since it would unlock a few plot types that we've never supported before.

On real data it looks something like this: 
![ScottPlotBench Benchmarks DataLogger-20250323-182101-DataLogger-histogramplot](https://github.com/user-attachments/assets/9e8afce4-a99b-46e3-aeed-8627c761a45b)

On test data it looks more like this:
![MockSummary-N9-JobBaseline_MethodsJobs-histogramplot](https://github.com/user-attachments/assets/b768538a-10c3-4e8a-966c-6fbb86359101)

I'm noticing that the chart is fairly messy, since there are multiple histograms in the same colour (as they're in the same job). Unless I did something wrong while grouping the data, this suggests that either histograms may not be a great option to have enabled by default (if this is typical of real-world usage) or that there might need to be separate test cases which are less busy (if this isn't typical of real-world usage).

This may be unrelated, but I noticed that the R exporter shows multiple plots in one image. This is supported in ScottPlot, so if you want to go that route that is an option. Here's a couple of examples: https://scottplot.net/cookbook/5.0/MultiplotRecipes/