### PR TITLE
Allow to set ParamsAttribute's values from derived class

### DIFF
--- a/src/BenchmarkDotNet.Annotations/Attributes/ParamsAttribute.cs
+++ b/src/BenchmarkDotNet.Annotations/Attributes/ParamsAttribute.cs
@@ -5,7 +5,7 @@ namespace BenchmarkDotNet.Attributes
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
     public class ParamsAttribute : PriorityAttribute
     {
-        public object?[] Values { get; }
+        public object?[] Values { get; protected set; }
 
         // CLS-Compliant Code requires a constructor without an array in the argument list
         public ParamsAttribute() => Values = new object[0];


### PR DESCRIPTION
This PR change `ParamsAttribute::Values` setter accessibility to `protected`.
There is similar request about 5 years ago (#1415)

**Background**
I want to adjust benchmark parameters per benchmarks by using attribute that inherit `ParamsAttribute`.

But currently `ParamsAttribute` derived class can't set `Values` property.
And It can't set dynamic parameters via `base()` constructor parameter.

As a workaround, It can use [ParamsSourceAttribute] instead.
But in this case, it need to define source per benchmark class.