### PR TITLE
feat: Add option to disable parallel build

### DIFF
--- a/src/BenchmarkDotNet/Configs/ConfigOptions.cs
+++ b/src/BenchmarkDotNet/Configs/ConfigOptions.cs
@@ -48,7 +48,11 @@ namespace BenchmarkDotNet.Configs
         /// <summary>
         /// Continue the execution if the last run was stopped.
         /// </summary>
-        Resume = 1 << 9
+        Resume = 1 << 9,
+        /// <summary>
+        /// Determines whether parallel build of benchmark projects should be disabled.
+        /// </summary>
+        DisableParallelBuild = 1 << 10,
     }
 
     internal static class ConfigOptionsExtensions

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -412,23 +412,18 @@ namespace BenchmarkDotNet.Running
             logger.WriteLineHeader($"// ***** Done, took {GetFormattedDifference(afterParallelBuild, afterSequentialBuild)}   *****");
 
             return buildResults;
-
-            static string GetFormattedDifference(ClockSpan before, ClockSpan after)
-                => (after.GetTimeSpan() - before.GetTimeSpan()).ToFormattedTotalTime(DefaultCultureInfo.Instance);
         }
 
         private static Dictionary<BuildPartition, BuildResult> BuildSequential(ILogger logger, string rootArtifactsFolderPath, BuildPartition[] buildPartitions, in StartedClock globalChronometer, EventProcessor eventProcessor)
         {
             logger.WriteLineHeader($"// ***** Building {buildPartitions.Length} exe(s): Start   *****");
 
-            var buildLogger = buildPartitions.Length == 1 ? logger : NullLogger.Instance; // when we have just one partition we can print to std out
-
             var beforeBuild = globalChronometer.GetElapsed();
 
             var buildResults = new Dictionary<BuildPartition, BuildResult>();
             foreach (var buildPartition in buildPartitions)
             {
-                buildResults[buildPartition] = Build(buildPartition, rootArtifactsFolderPath, buildLogger);
+                buildResults[buildPartition] = Build(buildPartition, rootArtifactsFolderPath, logger);
                 eventProcessor.OnBuildComplete(buildPartition, buildResults[buildPartition]);
             }
 
@@ -437,10 +432,10 @@ namespace BenchmarkDotNet.Running
             logger.WriteLineHeader($"// ***** Done, took {GetFormattedDifference(beforeBuild, afterBuild)}   *****");
 
             return buildResults;
-
-            static string GetFormattedDifference(ClockSpan before, ClockSpan after)
-                => (after.GetTimeSpan() - before.GetTimeSpan()).ToFormattedTotalTime(DefaultCultureInfo.Instance);
         }
+
+        private static string GetFormattedDifference(ClockSpan before, ClockSpan after)
+                => (after.GetTimeSpan() - before.GetTimeSpan()).ToFormattedTotalTime(DefaultCultureInfo.Instance);
 
         private static BuildResult Build(BuildPartition buildPartition, string rootArtifactsFolderPath, ILogger buildLogger)
         {


### PR DESCRIPTION
This PR intended to fix #2721

**What's changed in this PR**
1. Add `DisableParallelBuild` flag to `ConfigOptions`.
2. Modify `BenchmarkRunnerClean::Run`.
2.1. Add `BuildSequential` method that build project in sequentially.
2.2. Add logics to check `DisableParallelBuild` option.  If any of benchmarks contains `DisableParallelBuild` flag. Use sequential build path instead of parallel build path.

**Test** 
I've manually confirmed that `sequential build` path is called when specifying `WithOptions(ConfigOptions.DisableParallelBuild);` on benchmark config.

