### PR TITLE
Add MsBuildArgument constructor supporting multiple values

### DIFF
--- a/src/BenchmarkDotNet/Jobs/Argument.cs
+++ b/src/BenchmarkDotNet/Jobs/Argument.cs
@@ -48,5 +48,18 @@ namespace BenchmarkDotNet.Jobs
     public class MsBuildArgument : Argument
     {
         public MsBuildArgument(string value) : base(value) { }
+
+        public MsBuildArgument(string key, params string[] values)
+            : base($"/p:{key}={EscapeAndJoin(values)}") { }
+
+        private static string EscapeAndJoin(string[] values)
+        {
+            return string.Join("%3b", values.Select(EscapeSpecialChars));
+        }
+
+        private static string EscapeSpecialChars(string input)
+        {
+            return input.Replace(";", "%3B");
+        }
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/MsBuildArgumentTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/MsBuildArgumentTests.cs
@@ -25,6 +25,13 @@ namespace BenchmarkDotNet.IntegrationTests.ManualRunning
         }
 
         [Fact]
+
+        public void Constructor_WithKeyAndMultipleValues_ShouldEscapeSemicolons()
+        {
+            var arg = new MsBuildArgument("DefineConstants", "FOO", "BAR");
+            Assert.Equal("/p:DefineConstants=FOO%3BBAR", arg.TextRepresentation);
+        }
+        
         public void MultipleProcessesAreBuiltWithCorrectProperties()
         {
             var config = ManualConfig.CreateEmpty()


### PR DESCRIPTION
Added MsBuildArgument(string key, params string[] values) constructor.
Implemented escaping of semicolons in argument values.
