### PR TITLE
feat: Add custom MsBuild targets to remove unnecessary files from bin directory

### DIFF
--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -15,6 +15,9 @@
     <EmbeddedResource Include="Templates\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="BenchmarkDotNet.targets" Pack="true" PackagePath="buildTransitive" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Gee.External.Capstone" Version="2.3.0" />
     <PackageReference Include="Iced" Version="1.17.0" />

--- a/src/BenchmarkDotNet/BenchmarkDotNet.targets
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.targets
@@ -1,0 +1,31 @@
+﻿<Project>
+  <PropertyGroup>
+    <!-- If the RuntimeIdentifier is explicitly specified, use the specified target platform. -->
+    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == ''">$(RuntimeIdentifier)</BenchmarkDotNetTargetPlatform>
+
+    <!-- Otherwise, try to use current build platform -->
+    <!-- See: List of runtimes supported by Gee.External.Capstone: https://github.com/9ee1/Capstone.NET/tree/master/Gee.External.Capstone/runtimes -->
+    <!-- linux-x86 is excluded. Because .NET SDK don't support x86. -->
+    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))   AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">linux-x64</BenchmarkDotNetTargetPlatform>
+    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))   AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">linux-arm64</BenchmarkDotNetTargetPlatform>
+    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X86'">win-x86</BenchmarkDotNetTargetPlatform>
+    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">win-x64</BenchmarkDotNetTargetPlatform>
+    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">win-arm64</BenchmarkDotNetTargetPlatform>
+    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))     AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">osx-x64</BenchmarkDotNetTargetPlatform>
+    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))     AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">osx-arm64</BenchmarkDotNetTargetPlatform>
+  </PropertyGroup>
+
+  <Target Name="FilterBenchmarkDotNetPackageAssets" AfterTargets="ResolvePackageAssets">
+    <!-- Remove `runtimes/{RuntimeIdentifier}` files that is not matched to target platform. -->
+    <ItemGroup Condition="'$(BenchmarkDotNetTargetPlatform)' != '' AND $(BenchmarkDotNetTargetPlatform) != 'all'">
+      <RuntimeTargetsCopyLocalItems Remove="@(RuntimeTargetsCopyLocalItems)"
+                                    Condition="'%(RuntimeTargetsCopyLocalItems.NuGetPackageId)' == 'Gee.External.Capstone' AND '%(RuntimeTargetsCopyLocalItems.RuntimeIdentifier)' != '$(BenchmarkDotNetTargetPlatform)'" />
+    </ItemGroup>
+
+    <!-- Remove unnecessary satellite assemblies. -->
+    <ItemGroup>
+      <ResourceCopyLocalItems Remove="@(ResourceCopyLocalItems)"
+                              Condition="'%(ResourceCopyLocalItems.NuGetPackageId)' == 'Microsoft.CodeAnalysis.Common' OR '%(ResourceCopyLocalItems.NuGetPackageId)' == 'Microsoft.CodeAnalysis.CSharp'"/>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/BenchmarkDotNet/BenchmarkDotNet.targets
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.targets
@@ -1,18 +1,18 @@
 ﻿<Project>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(BenchmarkDotNetTargetPlatform)' == ''">
     <!-- If the RuntimeIdentifier is explicitly specified, use the specified target platform. -->
-    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == ''">$(RuntimeIdentifier)</BenchmarkDotNetTargetPlatform>
+    <BenchmarkDotNetTargetPlatform>$(RuntimeIdentifier)</BenchmarkDotNetTargetPlatform>
 
     <!-- Otherwise, try to use current build platform -->
-    <!-- See: List of runtimes supported by Gee.External.Capstone: https://github.com/9ee1/Capstone.NET/tree/master/Gee.External.Capstone/runtimes -->
-    <!-- linux-x86 is excluded. Because .NET SDK don't support x86. -->
-    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))   AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">linux-x64</BenchmarkDotNetTargetPlatform>
-    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))   AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">linux-arm64</BenchmarkDotNetTargetPlatform>
-    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X86'">win-x86</BenchmarkDotNetTargetPlatform>
-    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">win-x64</BenchmarkDotNetTargetPlatform>
-    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">win-arm64</BenchmarkDotNetTargetPlatform>
-    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))     AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">osx-x64</BenchmarkDotNetTargetPlatform>
-    <BenchmarkDotNetTargetPlatform Condition="'$(BenchmarkDotNetTargetPlatform)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))     AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">osx-arm64</BenchmarkDotNetTargetPlatform>
+    <!-- List of runtimes supported by Gee.External.Capstone: https://github.com/9ee1/Capstone.NET/tree/master/Gee.External.Capstone/runtimes -->
+    <BenchmarkDotNetTargetPlatform Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux</BenchmarkDotNetTargetPlatform>
+    <BenchmarkDotNetTargetPlatform Condition="$([MSBuild]::IsOSPlatform('Windows'))">win</BenchmarkDotNetTargetPlatform>
+    <BenchmarkDotNetTargetPlatform Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx</BenchmarkDotNetTargetPlatform>
+
+    <BenchmarkDotNetTargetPlatform Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">$(BenchmarkDotNetTargetPlatform)-x64</BenchmarkDotNetTargetPlatform>
+    <BenchmarkDotNetTargetPlatform Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X86'">$(BenchmarkDotNetTargetPlatform)-x86</BenchmarkDotNetTargetPlatform>
+    <BenchmarkDotNetTargetPlatform Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm'">$(BenchmarkDotNetTargetPlatform)-arm</BenchmarkDotNetTargetPlatform>
+    <BenchmarkDotNetTargetPlatform Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">$(BenchmarkDotNetTargetPlatform)-arm64</BenchmarkDotNetTargetPlatform>
   </PropertyGroup>
 
   <Target Name="FilterBenchmarkDotNetPackageAssets" AfterTargets="ResolvePackageAssets">

--- a/src/BenchmarkDotNet/BenchmarkDotNet.targets
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.targets
@@ -1,9 +1,12 @@
 ﻿<Project>
-  <PropertyGroup Condition="'$(BenchmarkDotNetTargetPlatform)' == ''">
-    <!-- If the RuntimeIdentifier is explicitly specified, use the specified target platform. -->
-    <BenchmarkDotNetTargetPlatform>$(RuntimeIdentifier)</BenchmarkDotNetTargetPlatform>
 
-    <!-- Otherwise, try to use current build platform -->
+  <PropertyGroup>
+    <!-- If the RuntimeIdentifier is explicitly specified. Use the specified target platform. -->
+    <BenchmarkDotNetTargetPlatform>$(RuntimeIdentifier)</BenchmarkDotNetTargetPlatform>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(BenchmarkDotNetTargetPlatform)' == ''">
+    <!-- If RuntimeIdentifier is not specified Use current build platform -->
     <!-- List of runtimes supported by Gee.External.Capstone: https://github.com/9ee1/Capstone.NET/tree/master/Gee.External.Capstone/runtimes -->
     <BenchmarkDotNetTargetPlatform Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux</BenchmarkDotNetTargetPlatform>
     <BenchmarkDotNetTargetPlatform Condition="$([MSBuild]::IsOSPlatform('Windows'))">win</BenchmarkDotNetTargetPlatform>


### PR DESCRIPTION
This PR intended to resolve https://github.com/dotnet/BenchmarkDotNet/issues/2736

### What's changed in this PR

**1. Add custom MSBuild targets file to nupkg.**
This custom target is packed as `buildTransitive/BenchmarkDotNet.targets` file.
And it'sused by .NET SDK-Style projects. (It's ignored when referenced from .NET Framework non-SDK style project)

**2. Details of custom MSBuild target process.**
It try to set `BenchmarkDotNetTargetPlatform` property.
If target `runtime` is explicitly specified (e.g. `--runtime`) just use specified runtime.
Otherwise. try to use  **current build environment** platform.

Then `FilterBenchmarkDotNetPackageAssets` custom target try to remove following files.
1. `runtime/*` files that are copied from `Gee.External.Capstone` package
2. Satellite assemblies that are copied from `Microsoft.CodeAnalysis.*` package

**Breaking changes**
This PR contains following breaking changes.

1. `runtimes\*` files that not matched to **current build environment** are not copied to bin by default.  
  When it need to use old behaviors.  It need to set following MSBuild property on benchmark project. 
    > `<BenchmarkDotNetTargetPlatform>all</BenchmarkDotNetTargetPlatform> 
2. Roslyn's satellite assemblies are not copied to bin directory.

### What's tested on my environment.
I've confirmed PR behaviors with following steps (On Windows/Ubuntu on WSL)
1. Run following command to create nupkg for tests. (It need unique suffix to avoid caching issue)
    > dotnet pack BenchmarkDotNet.sln --version-suffix develop-1 -o ./packages
2. Create benchmark project that use `packages` directory as package source.
3. Build benchmark project. And confirms followings. 
3.1. `runtimes/*` directory contains only current build environment's runtime only
3.2. Satellite assembly directory is not copied to bin directory.
4. Run benchmark with `--keepFiles` options. and confirm temporary project outputs.

Additionally, I've confirmed following behaviors. 
- non-SDK style .NET Framework project is not affected by this PR.
- `dotnet publish -r {runtimeIdentifier}` command works as expected. (Satellite assembly is not copied)
 