### PR TITLE
Fix #2740: Use CpuInfo.Unknown if CpuDetector.Detect() does not find supported OS

### DIFF
--- a/src/BenchmarkDotNet/Environments/HostEnvironmentInfo.cs
+++ b/src/BenchmarkDotNet/Environments/HostEnvironmentInfo.cs
@@ -78,7 +78,7 @@ namespace BenchmarkDotNet.Environments
             AntivirusProducts = new Lazy<ICollection<Antivirus>>(RuntimeInformation.GetAntivirusProducts);
             VirtualMachineHypervisor = new Lazy<VirtualMachineHypervisor>(RuntimeInformation.GetVirtualMachineHypervisor);
             Os = new Lazy<OsInfo>(OsDetector.GetOs);
-            Cpu = new Lazy<CpuInfo>(CpuDetector.CrossPlatform.Detect);
+            Cpu = new Lazy<CpuInfo>(() => CpuDetector.CrossPlatform.Detect() ?? CpuInfo.Unknown);
         }
 
         public new static HostEnvironmentInfo GetCurrent() => current ??= new HostEnvironmentInfo();


### PR DESCRIPTION
The nullability of HostEnvironmentInfo's Cpu property was mistakenly going unnoticed. This caused a null reference exception in the `ZeroMeasurementAnalyser`. I corrected this by making it nullable and checking for it in the analyser. Preventing it from breaking for all not-yet supported OS `CpuDetectors`