### PR TITLE
deps: Update package dependencies

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -58,7 +58,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
+++ b/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
@@ -21,8 +21,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.0" />
-    <PackageReference Update="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Update="FSharp.Core" Version="9.0.300" />
+    <PackageReference Update="System.ValueTuple" Version="4.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
   </ItemGroup>
 </Project>

--- a/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -16,15 +16,15 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <Reference Include="System.Reflection" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="[13.0.1]" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.5" />
     <!-- The Test SDK is required only for the VSTest Adapter to work -->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
     <!-- This package enables the Visual Studio Profiler integration IntroVisualStudioProfiler.cs -->
-    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="17.13.35606.1" />
+    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36127.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.dotTrace\BenchmarkDotNet.Diagnostics.dotTrace.csproj" />

--- a/samples/BenchmarkDotNet.Samples/IntroNativeMemory.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroNativeMemory.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnostics.Windows.Configs;
+using BenchmarkDotNet.Filters;
 
 namespace BenchmarkDotNet.Samples
 {
@@ -11,7 +12,8 @@ namespace BenchmarkDotNet.Samples
     [MemoryDiagnoser]
     public class IntroNativeMemory
     {
-        [Benchmark]
+#pragma warning disable CA1416
+        [Benchmark, WindowsOnly]
         public void BitmapWithLeaks()
         {
             var flag = new Bitmap(200, 100);
@@ -20,7 +22,7 @@ namespace BenchmarkDotNet.Samples
             graphics.DrawLine(blackPen, 100, 100, 500, 100);
         }
 
-        [Benchmark]
+        [Benchmark, WindowsOnly]
         public void Bitmap()
         {
             using (var flag = new Bitmap(200, 100))
@@ -34,6 +36,7 @@ namespace BenchmarkDotNet.Samples
                 }
             }
         }
+#pragma warning restore CA1416
 
         private const int Size = 20; // Greater value could cause System.OutOfMemoryException for test with memory leaks.
         private int ArraySize = Size * Marshal.SizeOf(typeof(int));
@@ -51,6 +54,14 @@ namespace BenchmarkDotNet.Samples
         {
             IntPtr unmanagedHandle = Marshal.AllocHGlobal(ArraySize);
             Span<byte> unmanaged = new Span<byte>(unmanagedHandle.ToPointer(), ArraySize);
+        }
+
+        private class WindowsOnlyAttribute : FilterConfigBaseAttribute
+        {
+            public WindowsOnlyAttribute()
+                : base(new SimpleFilter(_ => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
+            {
+            }
         }
     }
 }

--- a/samples/BenchmarkDotNet.Samples/IntroNuGet.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroNuGet.cs
@@ -18,7 +18,7 @@ namespace BenchmarkDotNet.Samples
         // Specify jobs with different versions of the same NuGet package to benchmark.
         // The NuGet versions referenced on these jobs must be greater or equal to the
         // same NuGet version referenced in this benchmark project.
-        // Example: This benchmark project references Newtonsoft.Json 9.0.1
+        // Example: This benchmark project references Newtonsoft.Json 13.0.1
         private class Config : ManualConfig
         {
             public Config()
@@ -34,7 +34,6 @@ namespace BenchmarkDotNet.Samples
                 foreach (var version in targetVersions)
                 {
                     AddJob(baseJob.WithNuGet("Newtonsoft.Json", version)
-                                  .WithCustomBuildConfiguration(version)
                                   .WithId(version));
                 }
             }

--- a/samples/BenchmarkDotNet.Samples/IntroNuGet.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroNuGet.cs
@@ -25,12 +25,18 @@ namespace BenchmarkDotNet.Samples
             {
                 var baseJob = Job.MediumRun;
 
-                AddJob(baseJob.WithNuGet("Newtonsoft.Json", "11.0.2").WithId("11.0.2"));
-                AddJob(baseJob.WithNuGet("Newtonsoft.Json", "11.0.1").WithId("11.0.1"));
-                AddJob(baseJob.WithNuGet("Newtonsoft.Json", "10.0.3").WithId("10.0.3"));
-                AddJob(baseJob.WithNuGet("Newtonsoft.Json", "10.0.2").WithId("10.0.2"));
-                AddJob(baseJob.WithNuGet("Newtonsoft.Json", "10.0.1").WithId("10.0.1"));
-                AddJob(baseJob.WithNuGet("Newtonsoft.Json", "9.0.1").WithId("9.0.1"));
+                string[] targetVersions = [
+                    "13.0.3",
+                    "13.0.2",
+                    "13.0.1"
+                ];
+
+                foreach (var version in targetVersions)
+                {
+                    AddJob(baseJob.WithNuGet("Newtonsoft.Json", version)
+                                  .WithCustomBuildConfiguration(version)
+                                  .WithId(version));
+                }
             }
         }
 

--- a/src/BenchmarkDotNet.Diagnostics.Windows/BenchmarkDotNet.Diagnostics.Windows.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/BenchmarkDotNet.Diagnostics.Windows.csproj
@@ -12,6 +12,6 @@
     <ProjectReference Include="..\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.8" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" PrivateAssets="contentfiles;analyzers" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarkDotNet.Diagnostics.dotMemory/BenchmarkDotNet.Diagnostics.dotMemory.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.dotMemory/BenchmarkDotNet.Diagnostics.dotMemory.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.11" />
+        <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.13" />
     </ItemGroup>
 
 </Project>

--- a/src/BenchmarkDotNet.Diagnostics.dotTrace/BenchmarkDotNet.Diagnostics.dotTrace.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.dotTrace/BenchmarkDotNet.Diagnostics.dotTrace.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.11" />
+        <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.13" />
     </ItemGroup>
 
 </Project>

--- a/src/BenchmarkDotNet.Disassembler.x64/BenchmarkDotNet.Disassembler.x64.csproj
+++ b/src/BenchmarkDotNet.Disassembler.x64/BenchmarkDotNet.Disassembler.x64.csproj
@@ -15,7 +15,7 @@
     <RootNamespace>BenchmarkDotNet.Disassembler</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Iced" Version="1.17.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.126102" />
+    <PackageReference Include="Iced" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="[1.1.142101]" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarkDotNet.Disassembler.x86/BenchmarkDotNet.Disassembler.x86.csproj
+++ b/src/BenchmarkDotNet.Disassembler.x86/BenchmarkDotNet.Disassembler.x86.csproj
@@ -21,7 +21,7 @@
     <Compile Include="..\BenchmarkDotNet.Disassembler.x64\Program.cs" Link="Program.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Iced" Version="1.17.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.126102" />
+    <PackageReference Include="Iced" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="[1.1.142101]" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarkDotNet.Exporters.Plotting/BenchmarkDotNet.Exporters.Plotting.csproj
+++ b/src/BenchmarkDotNet.Exporters.Plotting/BenchmarkDotNet.Exporters.Plotting.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ScottPlot" Version="5.0.54" />
+    <PackageReference Include="ScottPlot" Version="5.0.55" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarkDotNet.TestAdapter/BenchmarkDotNet.TestAdapter.csproj
+++ b/src/BenchmarkDotNet.TestAdapter/BenchmarkDotNet.TestAdapter.csproj
@@ -9,10 +9,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <!-- Use minimum supported LTSC version of Visual Studio 2022 -->
+  <!-- https://learn.microsoft.com/en-us/lifecycle/products/visual-studio-2022 -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestPlatform.AdapterUtilities" Version="17.7.2" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.7.2" />
-    <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="17.7.2" />
+    <PackageReference Include="Microsoft.TestPlatform.AdapterUtilities" Version="17.8.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.8.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="17.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -17,20 +17,21 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Gee.External.Capstone" Version="2.3.0" />
-    <PackageReference Include="Iced" Version="1.17.0" />
+    <PackageReference Include="Iced" Version="1.21.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="3.1.512801" />
     <PackageReference Include="Perfolizer" Version="[0.5.3]" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.8" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" PrivateAssets="contentfiles;analyzers" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-    <PackageReference Include="System.Management" Version="6.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageReference Include="System.Management" Version="9.0.5" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <!-- Reference System.Numerics.Vectors 4.5.0 (that support net461) as minimum version to avoid MSB3277 warning -->
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT' AND '$(UseMonoRuntime)' != 'true' ">
     <ProjectReference Include="..\BenchmarkDotNet.Disassembler.x64\BenchmarkDotNet.Disassembler.x64.csproj">

--- a/tests/BenchmarkDotNet.Exporters.Plotting.Tests/BenchmarkDotNet.Exporters.Plotting.Tests.csproj
+++ b/tests/BenchmarkDotNet.Exporters.Plotting.Tests/BenchmarkDotNet.Exporters.Plotting.Tests.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BenchmarkDotNet.Exporters.Plotting\BenchmarkDotNet.Exporters.Plotting.csproj" />
@@ -16,9 +16,9 @@
     <ProjectReference Include="..\BenchmarkDotNet.Tests\BenchmarkDotNet.Tests.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <Reference Include="System.Runtime" />
   </ItemGroup>
 </Project>

--- a/tests/BenchmarkDotNet.IntegrationTests.CustomPaths/BenchmarkDotNet.IntegrationTests.CustomPaths.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.CustomPaths/BenchmarkDotNet.IntegrationTests.CustomPaths.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <Reference Include="System.Runtime" />
   </ItemGroup>
 

--- a/tests/BenchmarkDotNet.IntegrationTests.DisabledOptimizations/BenchmarkDotNet.IntegrationTests.DisabledOptimizations.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.DisabledOptimizations/BenchmarkDotNet.IntegrationTests.DisabledOptimizations.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <Reference Include="System.Runtime" />
   </ItemGroup>
 </Project>

--- a/tests/BenchmarkDotNet.IntegrationTests.EnabledOptimizations/BenchmarkDotNet.IntegrationTests.EnabledOptimizations.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.EnabledOptimizations/BenchmarkDotNet.IntegrationTests.EnabledOptimizations.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <Reference Include="System.Runtime" />
   </ItemGroup>
 </Project>

--- a/tests/BenchmarkDotNet.IntegrationTests.FSharp/BenchmarkDotNet.IntegrationTests.FSharp.fsproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.FSharp/BenchmarkDotNet.IntegrationTests.FSharp.fsproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.0" />
-    <PackageReference Update="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Update="FSharp.Core" Version="9.0.300" />
+    <PackageReference Update="System.ValueTuple" Version="4.6.1" />
   </ItemGroup>
 </Project>

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
@@ -5,7 +5,9 @@
     <!-- We test the oldest frameworks supported by BDN (net461 and netcoreapp2.0), as well as newer versions of those frameworks. -->
     <TargetFrameworks>net461;net48;netcoreapp2.0;net8.0</TargetFrameworks>
     <!-- Deprecated runtime and vulnerabilities from old runtime, just in case any are found in the future. -->
-    <NoWarn>$(NoWarn);NETSDK1138;NU1901;NU1902;NU1903;NU1904</NoWarn>
+    <NoWarn>$(NoWarn);NETSDK1138;NU1903</NoWarn>
+    <!-- Suppress warning NU1510: PackageReference Microsoft.NETCore.App will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.-->
+    <NoWarn>$(NoWarn);NU1510</NoWarn>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks</AssemblyName>
@@ -25,8 +27,8 @@
     <Compile Include="..\BenchmarkDotNet.Tests\XUnit\SmartAssert.cs" Link="SmartAssert.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.0" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
+    <PackageReference Include="System.Memory" Version="[4.5.5]" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\BenchmarkDotNet.IntegrationTests.ManualRunning\xunit.runner.json">
@@ -39,10 +41,10 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Microsoft.NET.Test.Sdk breaks netcoreapp2.0 -->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" Condition=" '$(TargetFramework)' != 'netcoreapp2.0' " />
-    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" Condition=" '$(TargetFramework)' != 'netcoreapp2.0' " />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <!-- We use older version 2.4.1 for combatibility with netcoreapp2.0. -->
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.4.1]">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/BenchmarkDotNet.IntegrationTests.ManualRunning.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/BenchmarkDotNet.IntegrationTests.ManualRunning.csproj
@@ -34,9 +34,9 @@
     <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.Windows\BenchmarkDotNet.Diagnostics.Windows.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/BenchmarkDotNet.IntegrationTests.Static/BenchmarkDotNet.IntegrationTests.Static.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.Static/BenchmarkDotNet.IntegrationTests.Static.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <Reference Include="System.Runtime" />
   </ItemGroup>
 </Project>

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
@@ -32,24 +32,26 @@
     <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.dotMemory\BenchmarkDotNet.Diagnostics.dotMemory.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
+  </ItemGroup>
+  <ItemGroup>    
     <!-- We implicitly need v13.0.1 of Newtonsoft.Json for BenchmarkDotNet.IntegrationTests.NuGetReferenceTests -->
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.1]" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Mono.Cecil" Version="0.11.1" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.5" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.Windows\BenchmarkDotNet.Diagnostics.Windows.csproj" />
     <ProjectReference Include="..\BenchmarkDotNet.IntegrationTests.CustomPaths\BenchmarkDotNet.IntegrationTests.CustomPaths.csproj" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Threading.Tasks" />

--- a/tests/BenchmarkDotNet.Tests/Attributes/ParamsAllValuesVerifyTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Attributes/ParamsAllValuesVerifyTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 namespace BenchmarkDotNet.Tests.Attributes
 {
     [Collection("VerifyTests")]
-    [UsesVerify]
     public class ParamsAllValuesVerifyTests : IDisposable
     {
         private readonly CultureInfo initCulture;

--- a/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
+++ b/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
@@ -15,20 +15,19 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-    <!-- We use Verify.Xunit v20.8.2 because it's the latest version with net461 support -->
-    <PackageReference Include="Verify.Xunit" Version="[20.8.2]" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]"/>
+    <PackageReference Include="Verify.Xunit" Version="30.3.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.Windows\BenchmarkDotNet.Diagnostics.Windows.csproj" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.0" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System" />

--- a/tests/BenchmarkDotNet.Tests/Detectors/Cpu/CpuInfoFormatterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Detectors/Cpu/CpuInfoFormatterTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 namespace BenchmarkDotNet.Tests.Detectors.Cpu;
 
 [Collection("VerifyTests")]
-[UsesVerify]
 public class CpuInfoFormatterTests
 {
     [Fact]

--- a/tests/BenchmarkDotNet.Tests/Exporters/CommonExporterVerifyTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Exporters/CommonExporterVerifyTests.cs
@@ -22,7 +22,6 @@ using Xunit;
 namespace BenchmarkDotNet.Tests.Exporters
 {
     [Collection("VerifyTests")]
-    [UsesVerify]
     public class CommonExporterVerifyTests : IDisposable
     {
         private readonly CultureInfo initCulture;

--- a/tests/BenchmarkDotNet.Tests/Exporters/MarkdownExporterVerifyTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Exporters/MarkdownExporterVerifyTests.cs
@@ -19,7 +19,6 @@ using Xunit;
 namespace BenchmarkDotNet.Tests.Exporters
 {
     [Collection("VerifyTests")]
-    [UsesVerify]
     public class MarkdownExporterVerifyTests : IDisposable
     {
         private readonly CultureInfo initCulture = Thread.CurrentThread.CurrentCulture;

--- a/tests/BenchmarkDotNet.Tests/Perfonar/PerfonarTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Perfonar/PerfonarTests.cs
@@ -18,7 +18,6 @@ using Xunit.Abstractions;
 
 namespace BenchmarkDotNet.Tests.Perfonar;
 
-[UsesVerify]
 public class PerfonarTests(ITestOutputHelper output)
 {
     [Theory]


### PR DESCRIPTION
This PR update package dependencies to latest versions.

## How to confirms outdated packages
Run following command.
> dotnet package list --outdated --project BenchmarkDotNet.sln

## List of updated packages

| Name                                                             | From            | To              | Description |
|------------------------------------------------------------------|-----------------|-----------------|-------------|
|`FSharp.Core`                                                     | `4.6.0`         | `9.0.300`       |             |
|`Iced`                                                            | `1.17.0`        | `1.21.0`        |             |
|`JetBrains.Profiler.SelfApi`                                      | `2.5.11`        | `2.5.13`        |             |
|`Microsoft.CodeAnalysis.CSharp`                                   | `4.12.0`        | `4.14.0`        |             |
|`Microsoft.Diagnostics.Runtime`                                   | `1.1.126102`    | `3.1.512801`    |             |
|`Microsoft.Diagnostics.Tracing.TraceEvent`                        | `3.1.8`         | `3.1.21`        |             |
|`Microsoft.NETCore.Platforms`                                     | `6.0.0`         | `7.0.4`         |             |
|`Microsoft.NETFramework.ReferenceAssemblies`                      | `1.0.2`         | `1.0.3`         |             |
|`Microsoft.NET.Test.Sdk`                                          | `17.7.2`        | `[17.13.0]`     |             |
|`Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers` | `17.13.35606.1` | `18.0.36127.1`  |             |
|`Newtonsoft.Json`                                                 | `13.0.1`        | `[13.0.1]`      | Use 13.0.1 as baseline package |
|`ScottPlot`                                                       | `5.0.54`        | `5.0.55`        |             |
|`System.Configuration.ConfigurationManager`                       | `4.5.0`         | `9.0.5`         |             |
|`System.Drawing.Common`                                           | `4.7.2`         | `9.0.5`         |             |
|`System.Management`                                               | `6.0.0`         | `9.0.5`         |             |
|`System.Memory`                                                   | `4.5.5`         | `4.6.3`         |             |
|`System.Runtime.CompilerServices.Unsafe`                          | `6.0.0`         | `6.1.2`         |             |
|`System.Threading.Tasks.Extensions`                               | `4.5.4`         | `4.6.3`         |             |
|`System.ValueType`                                                | `4.5.0`         | `4.6.1`         |             |
|`Verify.Xunit`                                                    | `20.8.2`        | `30.3.1`        |             |
|`xunit`                                                           | `2.9.2`         | `2.9.3`         | Latest version that support .NET Framework 4.6.2 |
|`xunit.runner.visualstudio`                                       | `2.4.1`         | `[2.8.2]`       | Latest version that support .NET Framework 4.6.2 |

> [!Note]
> - `BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks` project  contains legacy targets (`.NET461` and `netcoreapp2.0`) So it need to use `xunit.runner.visualstudio` v2.4.1 that compatible these frameworks.
> - `Microsoft.NET.Test.Sdk` 14.0.0 or later depends on NewtonsoftJson `13.0.3`. So it can't update versions
> - `System.Numerics.Vectors` for `netstandard2.0` build need to reference `4.5.0` version (that support net461).
 
## Other changes

### 1. `BenchmarkDotNet.Samples.csproj`

**`IntroNativeMemory.cs`**
Add custom benchmark filter (`WindowsOnlyAttribute`) to exclude benchmarks that not works on non-Windows OS.
(Because [`System.Drawing.Common` is not supported .NET 6.0 or later](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only))

**`IntroNuGet.cs`**
Modify benchmarks to use Newtonsoft.Json `13.0.1` as baseline package.
And add `WithCustomBuildConfiguration` settings. (It's required when targeting multiple NuGet versions)

### 2. `BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj`

1. Remove unused warning suppression for `NU1901`/`NU1902`/ `NU1904` .
2. Add settings to suppress  following NU1510 warnings. (It's occurred when build with .NET 10 SDK)
    > NU1510: PackageReference Microsoft.NETCore.App will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.

### 3. Remove `[UsesVerify]` attributes
This attribute is removed on latest `xUnit.Verify` package.

## Additional manual tests
- [x] Confirm `IntroNuGet`/`IntroVisualStudioProfiler` benchmark behaviors
- [ ] Confirm `BenchmarkDotNet.IntegrationTests.ManualRunning`  tests behaviors. (Blocked by #2751)
- [x] Confirm `BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks` tests behaviors.
