### PR TITLE
chore: Increase vstest timeout value

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,7 +6,7 @@ on:
   push:
   
 env:
-  VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: "10000" # Increase timeout to 10 seconds(Default: 1000). See: https://github.com/microsoft/vstest/issues/2952
+  VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: "500"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
@@ -91,7 +91,7 @@ jobs:
         if: always()
         with:
           name: test-linux-trx-${{ github.run_id }}
-          path: "**/*.trx"
+          path: "**/*.diag.log"
 
   test-macos:
     runs-on: macos-15

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <VSTestDiag>$(MSBuildProjectName).diag.log</VSTestDiag>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This PR intended to fix **random** CI test failure.
By increasing VSTest shutdown timeout. (1sec ->10 sec)

**CI error details**
Currently CI error happens on `test-linux` job.
And following logs are recorded on finish test timing.

>The active test run was aborted. Reason: Test host process crashed.

So, It is assumed to be related to the following vstest issue.
https://github.com/microsoft/vstest/issues/2952

**Related CI error logs.**
- https://github.com/dotnet/BenchmarkDotNet/actions/runs/15458327190
- https://github.com/dotnet/BenchmarkDotNet/actions/runs/15117387191

