### PR TITLE
chore: modify ExporterBase::GetArtifactFullName accessibility

### DIFF
--- a/src/BenchmarkDotNet/Exporters/ExporterBase.cs
+++ b/src/BenchmarkDotNet/Exporters/ExporterBase.cs
@@ -48,7 +48,7 @@ namespace BenchmarkDotNet.Exporters
             return new[] { filePath };
         }
 
-        internal string GetArtifactFullName(Summary summary)
+        public string GetArtifactFullName(Summary summary)
         {
             string fileName = GetFileName(summary);
             return $"{Path.Combine(summary.ResultsDirectoryPath, fileName)}-{FileCaption}{FileNameSuffix}.{FileExtension}";


### PR DESCRIPTION
This PR intended to fix #2619 
By changing `ExporterBase::GetArtifactFullName` from `internal` to `public`.

**Expected use case**
Print benchmark results as **clickable links** when benchmark completed.

**Example Code to output benchmark result summaries**

```csharp
    public class Program
    {
        public static void Main(string[] args)
        {
            var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)
                                             .Run(args)
                                             .ToArray();

            summaries.PrintBenchmarkResults();
        }
    }

    internal static class SummariesExtensions
    {
        public static void PrintBenchmarkResults(this Summary[] summaries)
        {
            if (summaries.Length == 0)
            {
                return; // Benchmark is not executed (Invalid filter is specified or print infomation only(e.g. `--help`)
            }

            // LogFilePath/ResultsDirectoryPath is shared between summaries.
            var firstSummary = summaries[0];

            var logger = ConsoleLogger.Default;

            // Print log file path.
            var logFilePath = firstSummary.LogFilePath;
            logger.WriteLine();
            logger.WriteLine("Benchmark LogFile:");
            WriteLineAsClickableLink(logger, logFilePath);

            // Print results directory path.
            var resultsDirectoryPath = firstSummary.ResultsDirectoryPath;
            logger.WriteLine();
            logger.WriteLine("Benchmark Results Directory:");
            WriteLineAsClickableLink(logger, resultsDirectoryPath);

            // Print exported file links.
            logger.WriteLine();
            logger.WriteLine("Exported Files:");
            foreach (var summary in summaries)
            {
                var exportedFiles = ExtractExportedFiles(summary);
                foreach (var path in exportedFiles)
                {
                    var relativePath = path.Substring(resultsDirectoryPath.Length + 1); // Path.GetRelativePath(resultsDirectoryPath, path);
                    WriteLineAsClickableLink(logger, path, caption: relativePath);
                }
            }
            logger.WriteLine();
        }

        private static string[] ExtractExportedFiles(Summary summary)
        {
            var config = summary.BenchmarksCases[0].Config;
            var exporters = config.GetExporters().OfType<ExporterBase>();

            return config.GetExporters()
                         .OfType<ExporterBase>()
                         .Select(x => x.GetArtifactFullName(summary))
                         .ToArray();
        }

        private static void WriteLineAsClickableLink(ILogger logger, string link, string? caption = null, string prefixIndent = "  ")
        {
            logger.Write($"{prefixIndent}");
            if (!Console.IsOutputRedirected)
            {
                logger.WriteLine(ToClickableLink(link, caption));
            }
            else
            {
                logger.WriteLine(link);
            }
        }

        private static string ToClickableLink(string url, string? caption = null)
        {
            const char ESC = '\u001B'; // `\e`
            caption ??= url;
            return $"{ESC}]8;;{url}{ESC}\\{caption}{ESC}]8;;{ESC}\\";
        }
    }
```

**Example of output messages**
```
Benchmark LogFile:
  C:\Projects\BenchmarkDotNet\samples\BenchmarkDotNet.Samples\bin\Release\net8.0\BenchmarkDotNet.Artifacts\BenchmarkDotNet.Samples.IntroBasic-20250608-191326.log

Benchmark Results Directory:
  C:\Projects\BenchmarkDotNet\samples\BenchmarkDotNet.Samples\bin\Release\net8.0\BenchmarkDotNet.Artifacts\results

Exported Files:
  BenchmarkDotNet.Samples.IntroBasic-report.csv
  BenchmarkDotNet.Samples.IntroBasic-report-github.md
  BenchmarkDotNet.Samples.IntroBasic-report.html
```





