### PR TITLE
Bump .NET SDK: 8.0.401->8.0.410

### DIFF
--- a/build/sdk/global.json
+++ b/build/sdk/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "8.0.410",
     "rollForward": "disable"
   }
 }


### PR DESCRIPTION
This PR update .NET SDK 8 dependency to [latest released version](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).

