### PR TITLE
Test for both .sln and .slnx when searching for solution file

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliGenerator.cs
@@ -12,6 +12,8 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
     {
         private static readonly string[] ProjectExtensions = { ".csproj", ".fsproj", ".vbroj" };
 
+        private static readonly string[] SolutionExtensions = { ".sln", ".slnx" };
+
         [PublicAPI] public string TargetFrameworkMoniker { get; }
 
         [PublicAPI] public string CliPath { get; }
@@ -111,7 +113,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         private static bool IsRootSolutionFolder(DirectoryInfo directoryInfo)
             => directoryInfo
                 .GetFileSystemInfos()
-                .Any(fileInfo => fileInfo.Extension == ".sln" || fileInfo.Name == "global.json");
+                .Any(fileInfo => SolutionExtensions.Contains(fileInfo.Extension) || fileInfo.Name == "global.json");
 
         private static bool IsRootProjectFolder(DirectoryInfo directoryInfo)
             => directoryInfo


### PR DESCRIPTION
This pull request introduces enhancements to the `DotNetCliGenerator` class to improve support for solution file extensions. The changes primarily focus on making the code more extensible and maintainable by centralizing the handling of solution extensions.

Enhancements to solution file handling:

* [`src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliGenerator.cs`](diffhunk://#diff-97c0704ac349c26af0a61aaa9bbea631b13b7bbf0446141c76810cb01c4a9e6cR15-R16): Added a new static array `SolutionExtensions` to define supported solution file extensions (`.sln` and `.slnx`).
* [`src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliGenerator.cs`](diffhunk://#diff-97c0704ac349c26af0a61aaa9bbea631b13b7bbf0446141c76810cb01c4a9e6cL114-R116): Updated the `IsRootSolutionFolder` method to use the new `SolutionExtensions` array for checking solution file extensions, replacing the hardcoded values.

Fixes #2763 