### PR TITLE
chore: Fix benchmark TestAdapter related issues

### DIFF
--- a/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -16,11 +16,10 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <Reference Include="System.Reflection" />
-    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
   <ItemGroup>
-    <!-- Use v9.0.3 as baseline package for WithNuGet tests -->
-    <PackageReference Include="System.Collections.Immutable" Version="9.0.3" />
+    <!-- Use v9.0.0 as baseline package for WithNuGet tests -->
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="9.0.5" />

--- a/samples/BenchmarkDotNet.Samples/IntroNuGet.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroNuGet.cs
@@ -27,15 +27,15 @@ namespace BenchmarkDotNet.Samples
                 var baseJob = Job.MediumRun;
 
                 string[] targetVersions = [
+                    "9.0.0",
                     "9.0.3",
-                    "9.0.4",
                     "9.0.5",
                 ];
 
                 foreach (var version in targetVersions)
                 {
                     AddJob(baseJob.WithNuGet("System.Collections.Immutable", version)
-                                  .WithId("v"+version));
+                                  .WithId($"v{version}"));
                 }
             }
         }

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
@@ -30,7 +30,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
-    <PackageReference Include="System.Memory" Version="[4.5.5]" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\BenchmarkDotNet.IntegrationTests.ManualRunning\xunit.runner.json">

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
@@ -35,8 +35,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
   <ItemGroup>
-    <!-- Use v9.0.3 as baseline package for WithNuGet tests -->
-    <PackageReference Include="System.Collections.Immutable" Version="[9.0.3]" />
+    <!-- Use v9.0.0 as baseline package for WithNuGet tests -->
+    <PackageReference Include="System.Collections.Immutable" Version="[9.0.0]" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
+++ b/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
@@ -26,7 +26,6 @@
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.Windows\BenchmarkDotNet.Diagnostics.Windows.csproj" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
-    <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Threading.Tasks" />


### PR DESCRIPTION
This PR intended to fix `BenchmarkDotNet.TestAdapter` related issues.

**What's changed in this PR**
1. Modify `System.Collections.Immutable` baseline version from `9.0.3` -> `9.0.0` and modify related benchmark.
2. Add `AppDomain.CurrentDomain.AssemblyResolver` for .NET 4.6.2 on TestAdapter project to fix assembly loading issue.
3. Remove explicit PackageReference to `System.Memory`  (Use transitively referenced package version instead)

**Background**
`System.Collections.Immutable` is transitively referenced by other packages.
And it cause version conflicts when using TestAdapter. So it need to adjust minimum version to other packages.
(Normally it's not cause issue Because newer version is loaded first. But when running with TestAdapter. It seems `9.0.0` version is loaded and cause conflicts)

And when using TestAdapter on .NET 4.6.2.
It failed to load `BenchmarkDotNet.dll`.
So I've added custom  AssemblyResolve for net462.

I've confirmed this issue on following condigitons.
```
1. Run BenchmarkDotNet.Samples project with following command.
    > dotnet test -c Release --list-tests --framework net462 -tl:off
2. When using `BenchmarkDotNet.TestAdapter` package and targeting .NET Framework.
```