### PR TITLE
feat: Add validator for benchmarks that contains null runtime

### DIFF
--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -72,6 +72,7 @@ namespace BenchmarkDotNet.Configs
             yield return DeferredExecutionValidator.FailOnError;
             yield return ParamsAllValuesValidator.FailOnError;
             yield return ParamsValidator.FailOnError;
+            yield return RuntimeValidator.DontFailOnError;
         }
 
         public IOrderer Orderer => null;

--- a/src/BenchmarkDotNet/Validators/RuntimeValidator.cs
+++ b/src/BenchmarkDotNet/Validators/RuntimeValidator.cs
@@ -35,7 +35,7 @@ public class RuntimeValidator : IValidator
                 ? job.Id
                 : CharacteristicSetPresenter.Display.ToPresentation(job); // Use job text representation instead for auto generated JobId.
 
-            var message = $"Job({jobText}) don't have a Runtime characteristic. It's recommended to specify runtime by using WithRuntime explicitly.";
+            var message = $"Job({jobText}) doesn't have a Runtime characteristic. It's recommended to specify runtime by using WithRuntime explicitly.";
             errors.Add(new ValidationError(false, message));
         }
         return errors;

--- a/src/BenchmarkDotNet/Validators/RuntimeValidator.cs
+++ b/src/BenchmarkDotNet/Validators/RuntimeValidator.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using BenchmarkDotNet.Jobs;
+
+namespace BenchmarkDotNet.Validators;
+
+/// <summary>
+/// Validator for runtime characteristic.
+/// <see href="https://github.com/dotnet/BenchmarkDotNet/issues/2609" />
+/// </summary>
+public class RuntimeValidator : IValidator
+{
+    public static readonly IValidator DontFailOnError = new RuntimeValidator();
+
+    private RuntimeValidator() { }
+
+    public bool TreatsWarningsAsErrors => false;
+
+    public IEnumerable<ValidationError> Validate(ValidationParameters input)
+    {
+        var allBenchmarks = input.Benchmarks.ToArray();
+
+        var runtimes = allBenchmarks.Select(x => x.Job.Environment.Runtime)
+                                    .Distinct()
+                                    .ToArray();
+
+        if (runtimes.Length > 1 && runtimes.Contains(null))
+        {
+            // GetRuntime() method returns current environment's runtime if RuntimeCharacteristic is not set.
+            var message = "There are benchmarks that job don't have a Runtime characteristic. It's recommended explicitly specify runtime by `WithRuntime`.";
+            yield return new ValidationError(false, message);
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.Tests/Validators/RuntimeValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/RuntimeValidatorTests.cs
@@ -39,8 +39,14 @@ public class RuntimeValidatorTests
         var errors = RuntimeValidator.DontFailOnError.Validate(parameters).Select(e => e.Message).ToArray();
 
         // Assert
-        var expectedMessage = "There are benchmarks that job don't have a Runtime characteristic. It's recommended explicitly specify runtime by `WithRuntime`.";
-        Assert.Contains(errors, s => s.Equals(expectedMessage));
+        {
+            var expectedMessage = "Job(Dry) don't have a Runtime characteristic. It's recommended to specify runtime by using WithRuntime explicitly.";
+            Assert.Contains(expectedMessage, errors);
+        }
+        {
+            var expectedMessage = "Job(Toolchain=.NET 10.0) don't have a Runtime characteristic. It's recommended to specify runtime by using WithRuntime explicitly.";
+            Assert.Contains(expectedMessage, errors);
+        }
     }
 
     [Fact]
@@ -94,6 +100,9 @@ public class RuntimeValidatorTests
             AddJob(baseJob.WithToolchain(CsProjCoreToolchain.NetCoreApp80));
             AddJob(baseJob.WithToolchain(CsProjCoreToolchain.NetCoreApp90)
                           .WithRuntime(CoreRuntime.Core90));
+
+            // Validate error message for auto generated jobid.
+            AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp10_0));
         }
     }
 

--- a/tests/BenchmarkDotNet.Tests/Validators/RuntimeValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/RuntimeValidatorTests.cs
@@ -40,11 +40,11 @@ public class RuntimeValidatorTests
 
         // Assert
         {
-            var expectedMessage = "Job(Dry) don't have a Runtime characteristic. It's recommended to specify runtime by using WithRuntime explicitly.";
+            var expectedMessage = "Job(Dry) doesn't have a Runtime characteristic. It's recommended to specify runtime by using WithRuntime explicitly.";
             Assert.Contains(expectedMessage, errors);
         }
         {
-            var expectedMessage = "Job(Toolchain=.NET 10.0) don't have a Runtime characteristic. It's recommended to specify runtime by using WithRuntime explicitly.";
+            var expectedMessage = "Job(Toolchain=.NET 10.0) doesn't have a Runtime characteristic. It's recommended to specify runtime by using WithRuntime explicitly.";
             Assert.Contains(expectedMessage, errors);
         }
     }

--- a/tests/BenchmarkDotNet.Tests/Validators/RuntimeValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/RuntimeValidatorTests.cs
@@ -1,0 +1,116 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.CsProj;
+using BenchmarkDotNet.Validators;
+using System.Linq;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.Validators;
+
+public class RuntimeValidatorTests
+{
+    [Fact]
+    public void SameRuntime_Should_Success()
+    {
+        // Arrange
+        var config = new TestConfig1().CreateImmutableConfig();
+        var runInfo = BenchmarkConverter.TypeToBenchmarks(typeof(DummyBenchmark), config);
+        var parameters = new ValidationParameters(runInfo.BenchmarksCases, config);
+
+        // Act
+        var errors = RuntimeValidator.DontFailOnError.Validate(parameters).Select(e => e.Message).ToArray();
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void NullRuntimeMixed_Should_Failed()
+    {
+        // Arrange
+        var config = new TestConfig2().CreateImmutableConfig();
+        var runInfo = BenchmarkConverter.TypeToBenchmarks(typeof(DummyBenchmark), config);
+        var parameters = new ValidationParameters(runInfo.BenchmarksCases, config);
+
+        // Act
+        var errors = RuntimeValidator.DontFailOnError.Validate(parameters).Select(e => e.Message).ToArray();
+
+        // Assert
+        var expectedMessage = "There are benchmarks that job don't have a Runtime characteristic. It's recommended explicitly specify runtime by `WithRuntime`.";
+        Assert.Contains(errors, s => s.Equals(expectedMessage));
+    }
+
+    [Fact]
+    public void NotNullRuntimeOnly_Should_Success()
+    {
+        // Arrange
+        var config = new TestConfig3().CreateImmutableConfig();
+        var runInfo = BenchmarkConverter.TypeToBenchmarks(typeof(DummyBenchmark), config);
+        var parameters = new ValidationParameters(runInfo.BenchmarksCases, config);
+
+        // Act
+        var errors = RuntimeValidator.DontFailOnError.Validate(parameters).Select(e => e.Message).ToArray();
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    public class DummyBenchmark
+    {
+        [Benchmark]
+        public void Benchmark()
+        {
+        }
+    }
+
+    // TestConfig that expicitly specify runtime.
+    private class TestConfig1 : ManualConfig
+    {
+        public TestConfig1()
+        {
+            var baseJob = Job.Dry;
+
+            WithOption(ConfigOptions.DisableOptimizationsValidator, true);
+            AddColumnProvider(DefaultConfig.Instance.GetColumnProviders().ToArray());
+
+            AddJob(baseJob.WithToolchain(CsProjCoreToolchain.NetCoreApp80));
+            AddJob(baseJob.WithToolchain(CsProjCoreToolchain.NetCoreApp90));
+        }
+    }
+
+    // TestConfig that contains job that don't specify runtime.
+    private class TestConfig2 : ManualConfig
+    {
+        public TestConfig2()
+        {
+            var baseJob = Job.Dry;
+
+            WithOption(ConfigOptions.DisableOptimizationsValidator, true);
+            AddColumnProvider(DefaultConfig.Instance.GetColumnProviders().ToArray());
+
+            AddJob(baseJob.WithToolchain(CsProjCoreToolchain.NetCoreApp80));
+            AddJob(baseJob.WithToolchain(CsProjCoreToolchain.NetCoreApp90)
+                          .WithRuntime(CoreRuntime.Core90));
+        }
+    }
+
+    // TestConfig that expicitly specify runtime.
+    private class TestConfig3 : ManualConfig
+    {
+        public TestConfig3()
+        {
+            var baseJob = Job.Dry;
+
+            WithOption(ConfigOptions.DisableOptimizationsValidator, true);
+            AddColumnProvider(DefaultConfig.Instance.GetColumnProviders().ToArray());
+
+            AddJob(baseJob.WithToolchain(CsProjCoreToolchain.NetCoreApp80)
+                          .WithRuntime(CoreRuntime.Core80)); ;
+            AddJob(baseJob.WithToolchain(CsProjCoreToolchain.NetCoreApp90)
+                          .WithRuntime(CoreRuntime.Core90));
+        }
+    }
+}


### PR DESCRIPTION
This PR add validator to handle issue that is reported #2609.

**What's changed in this PR**

1. Add `RuntimeValidator.cs` for benchmarks that have multiple runtimes and contains null.
2. Add RuntimeValidator to DefaultConfig's validator
3. Add unit tests.

**Background**
When benchmark don't contains `Runtime` characteristic. (e.g. When specify `WithToolChain() only`)
[BenchmarkCase::GetRuntime](https://github.com/dotnet/BenchmarkDotNet/blob/c84de9a0d4af419309743c5f86e765de8d490a90/src/BenchmarkDotNet/Running/BenchmarkCase.cs#L31-L33) returns current runtime instead of actual runtime that used by benchmark.

Normally, `Runtime` column is hidden on table because all benchmarks have same runtime value.
So it's not a problem. But when mixed `WithRuntime` settings. it display wrong runtime.

So it need to add validator to check benchmarks that contains multiple runtimes and contains null.

**RuntimeValidator's error message**
> //    * There are benchmarks that job don't have a Runtime characteristic. It's recommended explicitly specify runtime by `WithRuntime`