### PR TITLE
chore: Add setting to skip test reports when run-tests workflow is cancelled

### DIFF
--- a/.github/workflows/report-test-results.yaml
+++ b/.github/workflows/report-test-results.yaml
@@ -11,6 +11,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     permissions: write-all
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
     steps:
       # Cleanup Old Files
       - name: Cleanup Old Files


### PR DESCRIPTION
This PR add setting to skip `report-test-results` workflow when `run-tests` workflow cancelled.

**Background**
Currently when `run-tests` workflow is cancelled.
`report-test-results` workflow is also failed because artifacts is not exists.
