### PR TITLE
chore: Enable assembly signing for debug build

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -31,9 +31,12 @@
     <None Include="$(MSBuildThisFileDirectory)package-icon.png" Pack="True" PackagePath=""/>
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+  <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)strongNameKey.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/BenchmarkDotNet.Diagnostics.Windows/Properties/AssemblyInfo.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/Properties/AssemblyInfo.cs
@@ -7,8 +7,4 @@ using BenchmarkDotNet.Properties;
 
 [assembly: CLSCompliant(true)]
 
-#if RELEASE
 [assembly: InternalsVisibleTo("BenchmarkDotNet.IntegrationTests,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]
-#else
-[assembly: InternalsVisibleTo("BenchmarkDotNet.IntegrationTests")]
-#endif

--- a/src/BenchmarkDotNet.Diagnostics.dotMemory/Properties/AssemblyInfo.cs
+++ b/src/BenchmarkDotNet.Diagnostics.dotMemory/Properties/AssemblyInfo.cs
@@ -4,8 +4,4 @@ using BenchmarkDotNet.Properties;
 
 [assembly: CLSCompliant(true)]
 
-#if RELEASE
 [assembly: InternalsVisibleTo("BenchmarkDotNet.Tests,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]
-#else
-[assembly: InternalsVisibleTo("BenchmarkDotNet.Tests")]
-#endif

--- a/src/BenchmarkDotNet.Diagnostics.dotTrace/Properties/AssemblyInfo.cs
+++ b/src/BenchmarkDotNet.Diagnostics.dotTrace/Properties/AssemblyInfo.cs
@@ -4,8 +4,4 @@ using BenchmarkDotNet.Properties;
 
 [assembly: CLSCompliant(true)]
 
-#if RELEASE
 [assembly: InternalsVisibleTo("BenchmarkDotNet.Tests,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]
-#else
-[assembly: InternalsVisibleTo("BenchmarkDotNet.Tests")]
-#endif

--- a/src/BenchmarkDotNet/Properties/AssemblyInfo.cs
+++ b/src/BenchmarkDotNet/Properties/AssemblyInfo.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if RELEASE
 using BenchmarkDotNet.Properties;
-#endif
 
 [assembly: Guid("cbba82d3-e650-407f-a0f0-767891d4f04c")]
 
 [assembly: CLSCompliant(true)]
 
-#if RELEASE
 [assembly: InternalsVisibleTo("BenchmarkDotNet.Tests,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]
 [assembly: InternalsVisibleTo("BenchmarkDotNet.IntegrationTests,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]
 [assembly: InternalsVisibleTo("BenchmarkDotNet.Diagnostics.Windows,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]
@@ -18,13 +15,3 @@ using BenchmarkDotNet.Properties;
 [assembly: InternalsVisibleTo("BenchmarkDotNet.IntegrationTests.ManualRunning,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]
 [assembly: InternalsVisibleTo("BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]
 [assembly: InternalsVisibleTo("BenchmarkDotNet.TestAdapter,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]
-#else
-[assembly: InternalsVisibleTo("BenchmarkDotNet.Tests")]
-[assembly: InternalsVisibleTo("BenchmarkDotNet.IntegrationTests")]
-[assembly: InternalsVisibleTo("BenchmarkDotNet.Diagnostics.Windows")]
-[assembly: InternalsVisibleTo("BenchmarkDotNet.Diagnostics.dotTrace")]
-[assembly: InternalsVisibleTo("BenchmarkDotNet.Diagnostics.dotMemory")]
-[assembly: InternalsVisibleTo("BenchmarkDotNet.IntegrationTests.ManualRunning")]
-[assembly: InternalsVisibleTo("BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks")]
-[assembly: InternalsVisibleTo("BenchmarkDotNet.TestAdapter")]
-#endif


### PR DESCRIPTION
This PR enable assembly signing for `Debug` build also.

**Background**
When using `BenchmarkDotNet.TestAdapter` and project contains `net462` target.
`net462` benchmarks are not shown on TestExplorer with `Debug` configuration.
And following error log is recorded on VS output window's `Tests` pane.

> System.IO.FileLoadException: A strongly-named assembly is required. (Exception from HRESULT: 0x80131044)'

Currently BenchmarkDotNet sign assembly on `Release` build only.
This PR change this behavior to sign `Debug` build assembly also.

**What's Tested**
- `BenchmarkDotNet.Samples (net462)` benchmarks are shown on TestExplorer 
- It can display benchmarks on TestExplorer when benchmark project don't use assembly-signing.
