### PR TITLE
chore: Modify macos runner image for CI

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -91,7 +91,13 @@ jobs:
           path: "**/*.trx"
 
   test-macos:
-    runs-on: macos-15
+    runs-on: ${{ matrix.os.runs-on }}
+    strategy:
+      matrix:
+        os: [
+          { runs-on: 'macos-latest', jsvu-os: 'mac64arm' },
+          { runs-on: 'macos-13',     jsvu-os: 'mac64' },
+        ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up node
@@ -99,7 +105,7 @@ jobs:
         with:
           node-version: "22"
       - name: Set up v8
-        run: npm install jsvu -g && jsvu --os=mac64 --engines=v8 && echo "$HOME/.jsvu/bin" >> $GITHUB_PATH
+        run: npm install jsvu -g && jsvu --os=${{ matrix.os.jsvu-os }} --engines=v8 && echo "$HOME/.jsvu/bin" >> $GITHUB_PATH
       - name: Install wasm-tools workload
         run: ./build.cmd install-wasm-tools
       # Build and Test
@@ -114,7 +120,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-macos-trx-${{ github.run_id }}
+          name: test-macos(${{ runner.arch }})-trx-${{ github.run_id }}
           path: "**/*.trx"
 
   test-pack:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -91,13 +91,17 @@ jobs:
           path: "**/*.trx"
 
   test-macos:
+    name: test-macos(${{ matrix.os.runs-on }})
     runs-on: ${{ matrix.os.runs-on }}
     strategy:
       matrix:
-        os: [
-          { runs-on: 'macos-latest', jsvu-os: 'mac64arm' },
-          { runs-on: 'macos-13',     jsvu-os: 'mac64' },
-        ]
+        os:
+          - runs-on: 'macos-latest'
+            jsvu-os: 'mac64arm'
+            arch: 'arm64'
+          - runs-on: 'macos-13'
+            jsvu-os: 'mac64'
+            arch: 'x64'
     steps:
       - uses: actions/checkout@v4
       - name: Set up node
@@ -120,7 +124,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-macos(${{ runner.arch }})-trx-${{ github.run_id }}
+          name: test-macos(${{ matrix.os.arch }})-trx-${{ github.run_id }}
           path: "**/*.trx"
 
   test-pack:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -91,7 +91,7 @@ jobs:
           path: "**/*.trx"
 
   test-macos:
-    name: test-macos(${{ matrix.os.runs-on }})
+    name: test-macos (${{ matrix.os.arch }})
     runs-on: ${{ matrix.os.runs-on }}
     strategy:
       matrix:

--- a/build/BenchmarkDotNet.Build/Runners/UnitTestRunner.cs
+++ b/build/BenchmarkDotNet.Build/Runners/UnitTestRunner.cs
@@ -4,6 +4,7 @@ using Cake.Common.Diagnostics;
 using Cake.Common.Tools.DotNet;
 using Cake.Common.Tools.DotNet.Test;
 using Cake.Core.IO;
+using System.Runtime.InteropServices;
 
 namespace BenchmarkDotNet.Build.Runners;
 
@@ -47,7 +48,8 @@ public class UnitTestRunner(BuildContext context)
     private void RunTests(FilePath projectFile, string alias, string tfm)
     {
         var os = Utils.GetOs();
-        var trxFileName = $"{os}-{alias}-{tfm}.trx";
+        var arch = RuntimeInformation.OSArchitecture.ToString().ToLower();
+        var trxFileName = $"{os}({arch})-{alias}-{tfm}.trx";
         var trxFile = TestOutputDirectory.CombineWithFilePath(trxFileName);
         var settings = GetTestSettingsParameters(trxFile, tfm);
 


### PR DESCRIPTION
This PR fix macos runner image issue that unintentionally changed image from x64 to ARM64. (#2738)
`macos15` using ARM64 architecture. It need to use `macos13` image to tests on x64. 
https://github.com/actions/runner-images?tab=readme-ov-file#available-images

**What's changed in this PR**
1. Modify `test-macos` job to use both ARM64/x64 images with matrix.
2. Modify `BenchmarkDotNet.Build.csproj` to output trx log with unit file name.

~~Note:~~ 
~~Artifact zip archive name is outputted as following.~~
~~(It's because GitHub Action don't have build-in functions for toLowerCase)~~  
~~- `test-macos(ARM64)-trx-15629555566`~~
~~- `test-macos(X64)-trx-15629555566`~~