### PR TITLE
fix: Issue that auto-generate JobId  is changed between benchmark runs

### DIFF
--- a/src/BenchmarkDotNet/Jobs/JobIdGenerator.cs
+++ b/src/BenchmarkDotNet/Jobs/JobIdGenerator.cs
@@ -10,12 +10,23 @@ namespace BenchmarkDotNet.Jobs
             string presentation = CharacteristicSetPresenter.Display.ToPresentation(job);
             if (presentation == "")
                 return "DefaultJob";
-            int seed = presentation.GetHashCode();
+            int seed = GetStableHashCode(presentation);
             var random = new Random(seed);
             string id = "";
             for (int i = 0; i < 6; i++)
-                id += (char) ('A' + random.Next(26));
+                id += (char)('A' + random.Next(26));
             return "Job-" + id;
+        }
+
+        // Compute string hash value with DJB2 algorithm.
+        private static int GetStableHashCode(string value)
+        {
+            uint hash = 5381;
+            foreach (char c in value)
+            {
+                hash = ((hash << 5) + hash) + c; // hash * 32 + hash + c
+            }
+            return unchecked((int)hash);
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/ImmutableConfigTests.cs
@@ -312,7 +312,7 @@ namespace BenchmarkDotNet.Tests.Configs
                 Assert.Equal(warmupCount, mergedJob.Run.WarmupCount);
                 Assert.False(mergedJob.Meta.IsDefault); // after the merge the "child" job becomes a standard job
                 Assert.False(mergedJob.Meta.IsMutator); // after the merge the "child" job becomes a standard job
-                Assert.Single(mergedJob.GetCharacteristicsWithValues(), changedCharacteristic => ReferenceEquals(changedCharacteristic, Jobs.RunMode.WarmupCountCharacteristic));
+                Assert.Single(mergedJob.GetCharacteristicsWithValues(), changedCharacteristic => ReferenceEquals(changedCharacteristic, BenchmarkDotNet.Jobs.RunMode.WarmupCountCharacteristic));
             }
         }
 

--- a/tests/BenchmarkDotNet.Tests/Jobs/JobIdGeneratorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Jobs/JobIdGeneratorTests.cs
@@ -1,0 +1,27 @@
+﻿using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.CsProj;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.Jobs;
+
+public class JobIdGeneratorTests
+{
+    [Theory]
+    [MemberData(nameof(GetTheoryData), DisableDiscoveryEnumeration = true)]
+    public void AutoGenerateJobId(string expectedId, Job job)
+    {
+        // Act
+        var result = job.ResolvedId;
+
+        // Assert
+        Assert.Equal(expectedId, result);
+    }
+
+    public static TheoryData<string, Job> GetTheoryData() => new TheoryData<string, Job>()
+    {
+        {"Job-OOTPKI", Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp80) },
+        {"Job-QAODSR", Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp90) },
+        {"Job-KHMDUZ", Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp80).WithRuntime(CoreRuntime.Core80) },
+    };
+}


### PR DESCRIPTION
This PR fix issue that auto-generated JobId is changed every time when launching benchmark process.

**Background**
Currently `object.GetHashCode()` returns different value between runs on .NET Core.
It's not seems to be intended behaviors. because generated hash value is used for seed of Random.
And cause diffs when comparing benchmark logs.

This PR modify `JobIdGenerator.cs` to return same ID between processes.