### PR TITLE
chore: Skip null runtime validation for InProcessToolchain

### DIFF
--- a/src/BenchmarkDotNet/Validators/RuntimeValidator.cs
+++ b/src/BenchmarkDotNet/Validators/RuntimeValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Characteristics;
+using BenchmarkDotNet.Toolchains;
 
 namespace BenchmarkDotNet.Validators;
 
@@ -28,7 +29,7 @@ public class RuntimeValidator : IValidator
         }
 
         var errors = new List<ValidationError>();
-        foreach (var benchmark in nullRuntimeBenchmarks)
+        foreach (var benchmark in nullRuntimeBenchmarks.Where(x=> !x.GetToolchain().IsInProcess))
         {
             var job = benchmark.Job;
             var jobText = job.HasValue(CharacteristicObject.IdCharacteristic)


### PR DESCRIPTION
This PR fix review comment (https://github.com/dotnet/BenchmarkDotNet/pull/2771#issuecomment-2973529256)

When using InProcessToolchain `Runtime` shows correct value.
So there is no need to show runtime validation error for InProcessToolchain.
