### PR TITLE
feat: Add disassembler support for macos

### DIFF
--- a/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
+++ b/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
@@ -142,9 +142,8 @@ namespace BenchmarkDotNet.Diagnosers
         private static bool ShouldUseMonoDisassembler(BenchmarkCase benchmarkCase)
             => benchmarkCase.Job.Environment.Runtime is MonoRuntime || RuntimeInformation.IsMono;
 
-        // when we add  macOS support, RuntimeInformation.IsMacOS() needs to be added here
         private static bool ShouldUseClrMdDisassembler(BenchmarkCase benchmarkCase)
-            => !ShouldUseMonoDisassembler(benchmarkCase) && (OsDetector.IsWindows() || OsDetector.IsLinux());
+            => !ShouldUseMonoDisassembler(benchmarkCase) && (OsDetector.IsWindows() || OsDetector.IsLinux() || OsDetector.IsMacOS());
 
         private static bool ShouldUseSameArchitectureDisassembler(BenchmarkCase benchmarkCase, DiagnoserActionParameters parameters)
         {

--- a/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
@@ -37,18 +37,10 @@ namespace BenchmarkDotNet.IntegrationTests
                 {
                     yield return new object[] { Jit.RyuJit, Platform.X64, CoreRuntime.Core80 }; // .NET Core x64
                 }
-                else if (RuntimeInformation.GetCurrentPlatform() is Platform.Arm64 && OsDetector.IsLinux())
+                else if (RuntimeInformation.GetCurrentPlatform() is Platform.Arm64)
                 {
                     yield return new object[] { Jit.RyuJit, Platform.Arm64, CoreRuntime.Core80 }; // .NET Core arm64
                 }
-            }
-            if (OsDetector.IsMacOS())
-            {
-                // This scope of tests is not supported on macOS
-                // However, when the MemberData method provides no data, xUnit throws an "No data found" InvalidOperationException
-                // In order to fix the problem, we should provide at least one input data set
-                // All the tests check the OS on the first line and stop the test if it's macOS
-                yield return new object[] { Jit.Default, Platform.AnyCpu, CoreRuntime.Latest };
             }
 
             // we could add new object[] { Jit.Llvm, Platform.X64, new MonoRuntime() } here but our CI would need to have Mono installed..
@@ -92,8 +84,6 @@ namespace BenchmarkDotNet.IntegrationTests
         [Trait(Constants.Category, Constants.BackwardCompatibilityCategory)]
         public void CanDisassembleAllMethodCalls(Jit jit, Platform platform, Runtime runtime)
         {
-            if (OsDetector.IsMacOS()) return; // currently not supported
-
             var disassemblyDiagnoser = new DisassemblyDiagnoser(
                 new DisassemblyDiagnoserConfig(printSource: true, maxDepth: 3));
 
@@ -111,8 +101,6 @@ namespace BenchmarkDotNet.IntegrationTests
         [Trait(Constants.Category, Constants.BackwardCompatibilityCategory)]
         public void CanDisassembleAllMethodCallsUsingFilters(Jit jit, Platform platform, Runtime runtime)
         {
-            if (OsDetector.IsMacOS()) return; // currently not supported
-
             var disassemblyDiagnoser = new DisassemblyDiagnoser(
                 new DisassemblyDiagnoserConfig(printSource: true, maxDepth: 1, filters: new[] { "*WithCalls*" }));
 
@@ -136,8 +124,6 @@ namespace BenchmarkDotNet.IntegrationTests
         [Trait(Constants.Category, Constants.BackwardCompatibilityCategory)]
         public void CanDisassembleGenericTypes(Jit jit, Platform platform, Runtime runtime)
         {
-            if (OsDetector.IsMacOS()) return; // currently not supported
-
             var disassemblyDiagnoser = new DisassemblyDiagnoser(
                 new DisassemblyDiagnoserConfig(printSource: true, maxDepth: 3));
 
@@ -158,8 +144,6 @@ namespace BenchmarkDotNet.IntegrationTests
         [Trait(Constants.Category, Constants.BackwardCompatibilityCategory)]
         public void CanDisassembleInlinableBenchmarks(Jit jit, Platform platform, Runtime runtime)
         {
-            if (OsDetector.IsMacOS()) return; // currently not supported
-
             var disassemblyDiagnoser = new DisassemblyDiagnoser(
                 new DisassemblyDiagnoserConfig(printSource: true, maxDepth: 3));
 


### PR DESCRIPTION
This PR intended to add DisassemblyDiagnoser supports for macos.

Currently DisassemblyDiagnoser is not supported on macos.
This limitation appears to be coming from the ClrMD library.
And It seems to be resolved in the latest version.
