### PR TITLE
feat: Add filter support for TestAdapter

### DIFF
--- a/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
+++ b/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
@@ -7,6 +7,8 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <!-- Disable parallel tests between TargetFrameworks -->
+    <TestTfmsInParallel>false</TestTfmsInParallel>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />

--- a/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -13,6 +13,8 @@
     <NoWarn>$(NoWarn);CA1018;CA5351;CA1825</NoWarn>
     <!-- Disable entry point generation as this project has it's own entry point -->
     <GenerateProgramFile>false</GenerateProgramFile>
+    <!-- Disable parallel tests between TargetFrameworks -->
+    <TestTfmsInParallel>false</TestTfmsInParallel>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <Reference Include="System.Reflection" />

--- a/src/BenchmarkDotNet.TestAdapter/Utility/LoggerHelper.cs
+++ b/src/BenchmarkDotNet.TestAdapter/Utility/LoggerHelper.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using System.Diagnostics;
+using System.IO;
+
+namespace BenchmarkDotNet.TestAdapter;
+
+internal class LoggerHelper
+{
+    public LoggerHelper(IMessageLogger logger, Stopwatch stopwatch)
+    {
+        InnerLogger = logger;
+        Stopwatch = stopwatch;
+    }
+
+    public IMessageLogger InnerLogger { get; private set; }
+
+    public Stopwatch Stopwatch { get; private set; }
+
+    public void Log(string format, params object[] args)
+    {
+        SendMessage(TestMessageLevel.Informational, null, string.Format(format, args));
+    }
+
+    public void LogWithSource(string source, string format, params object[] args)
+    {
+        SendMessage(TestMessageLevel.Informational, source, string.Format(format, args));
+    }
+
+    public void LogError(string format, params object[] args)
+    {
+        SendMessage(TestMessageLevel.Error, null, string.Format(format, args));
+    }
+
+    public void LogErrorWithSource(string source, string format, params object[] args)
+    {
+        SendMessage(TestMessageLevel.Error, source, string.Format(format, args));
+    }
+
+    public void LogWarning(string format, params object[] args)
+    {
+        SendMessage(TestMessageLevel.Warning, null, string.Format(format, args));
+    }
+
+    public void LogWarningWithSource(string source, string format, params object[] args)
+    {
+        SendMessage(TestMessageLevel.Warning, source, string.Format(format, args));
+    }
+
+    private void SendMessage(TestMessageLevel level, string? assemblyName, string message)
+    {
+        var assemblyText = assemblyName == null
+            ? "" :
+            $"{Path.GetFileNameWithoutExtension(assemblyName)}: ";
+
+        InnerLogger.SendMessage(level, $"[BenchmarkDotNet {Stopwatch.Elapsed:hh\\:mm\\:ss\\.ff}] {assemblyText}{message}");
+    }
+}

--- a/src/BenchmarkDotNet.TestAdapter/Utility/TestCaseFilter.cs
+++ b/src/BenchmarkDotNet.TestAdapter/Utility/TestCaseFilter.cs
@@ -1,0 +1,166 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace BenchmarkDotNet.TestAdapter;
+
+internal class TestCaseFilter
+{
+    private const string DisplayNameString = "DisplayName";
+    private const string FullyQualifiedNameString = "FullyQualifiedName";
+
+    private readonly HashSet<string> knownTraits;
+    private List<string> supportedPropertyNames;
+    private readonly ITestCaseFilterExpression? filterExpression;
+    private readonly bool successfullyGotFilter;
+    private readonly bool isDiscovery;
+
+    public TestCaseFilter(IDiscoveryContext discoveryContext, LoggerHelper logger)
+    {
+        // Traits are not known at discovery time because we load them from benchmarks
+        isDiscovery = true;
+        knownTraits = [];
+        supportedPropertyNames = GetSupportedPropertyNames();
+        successfullyGotFilter = GetTestCaseFilterExpressionFromDiscoveryContext(discoveryContext, logger, out filterExpression);
+    }
+
+    public TestCaseFilter(IRunContext runContext, LoggerHelper logger, string assemblyFileName, HashSet<string> knownTraits)
+    {
+        this.knownTraits = knownTraits;
+        supportedPropertyNames = GetSupportedPropertyNames();
+        successfullyGotFilter = GetTestCaseFilterExpression(runContext, logger, assemblyFileName, out filterExpression);
+    }
+
+    public string GetTestCaseFilterValue()
+    {
+        return successfullyGotFilter
+            ? filterExpression?.TestCaseFilterValue ?? ""
+            : "";
+    }
+
+    public bool MatchTestCase(TestCase testCase)
+    {
+        if (!successfullyGotFilter)
+        {
+            // Had an error while getting filter, match no testcase to ensure discovered test list is empty
+            return false;
+        }
+        else if (filterExpression == null)
+        {
+            // No filter specified, keep every testcase
+            return true;
+        }
+
+        return filterExpression.MatchTestCase(testCase, p => PropertyProvider(testCase, p));
+    }
+
+    public object? PropertyProvider(TestCase testCase, string name)
+    {
+        // Traits filtering
+        if (isDiscovery || knownTraits.Contains(name))
+        {
+            var result = new List<string>();
+
+            foreach (var trait in GetTraits(testCase))
+                if (string.Equals(trait.Key, name, StringComparison.OrdinalIgnoreCase))
+                    result.Add(trait.Value);
+
+            if (result.Count > 0)
+                return result.ToArray();
+        }
+
+        // Property filtering
+        switch (name.ToLowerInvariant())
+        {
+            // FullyQualifiedName
+            case "fullyqualifiedname":
+                return testCase.FullyQualifiedName;
+            // DisplayName
+            case "displayname":
+                return testCase.DisplayName;
+            default:
+                return null;
+        }
+    }
+
+    private bool GetTestCaseFilterExpression(IRunContext runContext, LoggerHelper logger, string assemblyFileName, out ITestCaseFilterExpression? filter)
+    {
+        filter = null;
+
+        try
+        {
+            filter = runContext.GetTestCaseFilter(supportedPropertyNames, null!);
+            return true;
+        }
+        catch (TestPlatformFormatException e)
+        {
+            logger.LogWarning("{0}: Exception filtering tests: {1}", Path.GetFileNameWithoutExtension(assemblyFileName), e.Message);
+            return false;
+        }
+    }
+
+    private bool GetTestCaseFilterExpressionFromDiscoveryContext(IDiscoveryContext discoveryContext, LoggerHelper logger, out ITestCaseFilterExpression? filter)
+    {
+        filter = null;
+
+        if (discoveryContext is IRunContext runContext)
+        {
+            try
+            {
+                filter = runContext.GetTestCaseFilter(supportedPropertyNames, null!);
+                return true;
+            }
+            catch (TestPlatformException e)
+            {
+                logger.LogWarning("Exception filtering tests: {0}", e.Message);
+                return false;
+            }
+        }
+        else
+        {
+            try
+            {
+                // GetTestCaseFilter is present on DiscoveryContext but not in IDiscoveryContext interface
+                var method = discoveryContext.GetType().GetRuntimeMethod("GetTestCaseFilter", [typeof(IEnumerable<string>), typeof(Func<string, TestProperty>)]);
+                filter = (ITestCaseFilterExpression)method?.Invoke(discoveryContext, [supportedPropertyNames, null])!;
+
+                return true;
+            }
+            catch (TargetInvocationException e)
+            {
+                if (e?.InnerException is TestPlatformException ex)
+                {
+                    logger.LogWarning("Exception filtering tests: {0}", ex.InnerException.Message ?? "");
+                    return false;
+                }
+
+                throw e!.InnerException;
+            }
+        }
+    }
+
+    private List<string> GetSupportedPropertyNames()
+    {
+        // Returns the set of well-known property names usually used with the Test Plugins (Used Test Traits + DisplayName + FullyQualifiedName)
+        if (supportedPropertyNames == null)
+        {
+            supportedPropertyNames = knownTraits.ToList();
+            supportedPropertyNames.Add(DisplayNameString);
+            supportedPropertyNames.Add(FullyQualifiedNameString);
+        }
+
+        return supportedPropertyNames;
+    }
+
+    private static IEnumerable<KeyValuePair<string, string>> GetTraits(TestCase testCase)
+    {
+        var traitProperty = TestProperty.Find("TestObject.Traits");
+        return traitProperty != null
+            ? testCase.GetPropertyValue(traitProperty, Array.Empty<KeyValuePair<string, string>>())
+            : [];
+    }
+}

--- a/src/BenchmarkDotNet.TestAdapter/build/BenchmarkDotNet.TestAdapter.props
+++ b/src/BenchmarkDotNet.TestAdapter/build/BenchmarkDotNet.TestAdapter.props
@@ -1,6 +1,8 @@
 ﻿<Project InitialTargets="GenerateBDNEntryPoint" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <EntryPointSourceDirectory>$(MSBuildThisFileDirectory)..\entrypoints\</EntryPointSourceDirectory>
+    <!-- Disable parallel tests between TargetFrameworks, if it's not explicitly specified. -->
+    <TestTfmsInParallel Condition="'$(TestTfmsInParallel)' = ''">false</TestTfmsInParallel>
   </PropertyGroup>
   <!-- 
     Microsoft.NET.Test.Sdk uses a property called "GenerateProgramFile" to determine whether it generates an entry 


### PR DESCRIPTION
This PR add `--filter` parameter support for `dotnet test`.
It intended to resolve #2767 issue (and some part of issue #2662)

### What's changed in this PR.

**1. Add benchmark filter logics**
Add following files to support benchmark filtering. 
- `TestCaseFilter.cs`
- `LoggerHelper.cs`

Note: These files are based on [xUnit v2 TestAdapter Code](https://github.com/xunit/visualstudio.xunit/blob/main/src/xunit.runner.visualstudio/Utility/TestCaseFilter.cs) (License: Apache 2.0)

**2. Modify `VSTestAdapter.cs`**
Add benchmark filter logics to `DiscoverTests` and `RunTests`

~~**3. BenchmarkEnumerator.cs**~~
~~Remove code for `Debug` configuration.~~
~~(By #2774 changes. It can load DLLs that are build with `Debug` configurations)~~

**4. Disable `TestTfmsInParallel` MSBuild property**
It's enabled by default on .NET 9 or later.
But it's not expected multiple benchmarks are executed in parallel. 

I've added code to disable this setting to following files.
- `BenchmarkDotNet.Samples.csproj`
- `BenchmarkDotNet.Samples.FSharp.csproj`
- `BenchmarkDotNet.TestAdapter/build/BenchmarkDotNet.TestAdapter.props`

~~**5. Temporary comment out `IntroVisualStudioProfiler` benchmark**~~
~~Because it cause errors when benchmarks are enumerated/evaluated twice. (#2758)~~

## Tasks that is not scope of this PR
- Benchmark progress is not shown when running benchmark with `dotnet test` by default  
  -> It need to specify `--logger:"console;verbosity=normal"` explicitly
- `DisplayName` filter is same as `FullyQualifiedName`  
  -> Currently there is no attribute that can be used for DisplayName

### What's Tested
Currently it's hard to write unit tests that use TestAdapter.
So it need to run tests manually.

#### TestExplorer
~~1. All benchmarks(net462/net80) are displayed when using `Release` configuration.~~
1. It can run single selected test and multiple selected tests.
2. When running multiple TFMs benchmarks. It's sequentially executed. (Not executed in parallel)

#### `dotnet test`

1. Verify default behavior is not changed when run command without `--filter` parameter
    > dotnet test -c Release -tl:off --no-build --framework net8.0 --logger:"console;verbosity=detailed" --list-tests
    > dotnet test -c Release -tl:off --no-build --framework net8.0 --logger:"console;verbosity=detailed"
2. Filter by `partial query` works as expected.
    > dotnet test -c Release --filter IntroBasic -tl:off --no-build --framework net8.0 --logger:"console;verbosity=detailed" --list-tests
    > dotnet test -c Release --filter IntroBasic -tl:off --no-build --framework net8.0 --logger:"console;verbosity=detailed"
3. Filter by `property value` works as expected.
    > dotnet test -c Release --filter FullyQualifiedName=BenchmarkDotNet.Samples.IntroBasic.Sleep -tl:off --no-build --framework net8.0 --logger:"console;verbosity=detailed" --list-tests
    > dotnet test -c Release --filter DisplayName=BenchmarkDotNet.Samples.IntroBasic.Sleep        -tl:off --no-build --framework net8.0 --logger:"console;verbosity=detailed" --list-tests
    >
    > dotnet test -c Release --filter FullyQualifiedName=BenchmarkDotNet.Samples.IntroBasic.Sleep -tl:off --no-build --framework net8.0 --logger:"console;verbosity=detailed"
    > dotnet test -c Release --filter DisplayName=BenchmarkDotNet.Samples.IntroBasic.Sleep        -tl:off --no-build --framework net8.0 --logger:"console;verbosity=detailed"
5. Filter by `Category` works as expected
    > dotnet test -c Release --filter Category=Fast -tl:off  --no-build --framework net8.0  --logger:"console;verbosity=normal" --list-tests
    > dotnet test -c Release --filter Category=Fast -tl:off  --no-build --framework net8.0  --logger:"console;verbosity=normal"
6. Verify it can run .NET462 benchmarks also
    > dotnet test -c Release --filter IntroBasic -tl:off --no-build --framework net462 --logger:"console;verbosity=detailed" --list-tests 
    > dotnet test -c Release --filter IntroBasic -tl:off --no-build --framework net462 --logger:"console;verbosity=detailed"
