### PR TITLE
fix: Console logs are outputted twice when using TestAdapter

### DIFF
--- a/src/BenchmarkDotNet.TestAdapter/BenchmarkExecutor.cs
+++ b/src/BenchmarkDotNet.TestAdapter/BenchmarkExecutor.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.TestAdapter.Remoting;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -67,7 +68,10 @@ namespace BenchmarkDotNet.TestAdapter
                 .Select(b => new BenchmarkRunInfo(
                     b.BenchmarksCases,
                     b.Type,
-                    b.Config.AddEventProcessor(eventProcessor).AddLogger(logger).CreateImmutableConfig()))
+                    b.Config.AddEventProcessor(eventProcessor)
+                            .AddLogger(logger)
+                            .RemoveLogger<ConsoleLogger>() // Console logs are also outputted by VSTestLogger.
+                            .CreateImmutableConfig()))
                 .ToArray();
 
             // Run all the benchmarks, and ensure that any tests that don't have a result yet are sent.

--- a/src/BenchmarkDotNet.TestAdapter/BenchmarkExecutor.cs
+++ b/src/BenchmarkDotNet.TestAdapter/BenchmarkExecutor.cs
@@ -70,7 +70,7 @@ namespace BenchmarkDotNet.TestAdapter
                     b.Type,
                     b.Config.AddEventProcessor(eventProcessor)
                             .AddLogger(logger)
-                            .RemoveLogger<ConsoleLogger>() // Console logs are also outputted by VSTestLogger.
+                            .RemoveLoggersOfType<ConsoleLogger>() // Console logs are also outputted by VSTestLogger.
                             .CreateImmutableConfig()))
                 .ToArray();
 

--- a/src/BenchmarkDotNet/Configs/ManualConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ManualConfig.cs
@@ -327,6 +327,14 @@ namespace BenchmarkDotNet.Configs
             return manualConfig;
         }
 
+        internal ManualConfig RemoveLogger<T>()
+        {
+            var filterdLoggers = loggers.Where(logger => logger is not T).ToArray();
+            loggers.Clear();
+            loggers.AddRange(filterdLoggers);
+            return this;
+        }
+
         internal void RemoveAllJobs() => jobs.Clear();
 
         internal void RemoveAllDiagnosers() => diagnosers.Clear();

--- a/src/BenchmarkDotNet/Configs/ManualConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ManualConfig.cs
@@ -327,11 +327,9 @@ namespace BenchmarkDotNet.Configs
             return manualConfig;
         }
 
-        internal ManualConfig RemoveLogger<T>()
+        internal ManualConfig RemoveLoggersOfType<T>()
         {
-            var filterdLoggers = loggers.Where(logger => logger is not T).ToArray();
-            loggers.Clear();
-            loggers.AddRange(filterdLoggers);
+            loggers.RemoveAll(logger => logger is T);
             return this;
         }
 


### PR DESCRIPTION
This PR intended to fix issue that console and VS Output Window logs are outputted twice when running benchmarks with TestAdapter/ `dotnet test` command.

**What's Tested**

1. When running benchmark from Visual Studio TestExplorer.  
    No duplicated logs outputted on Output Window's `Tests` pane. 
3. When running following command.   
   No duplicated logs outputted. 
    > dotnet test BenchmarkDotNet.sln -c Release --filter Category=Fast -tl:off --framework net8.0 --logger:"console;verbosity=normal"
