### PR TITLE
chore: Add GitHub Actions workflow that run selected tests

### DIFF
--- a/.github/workflows/run-tests-selected.yaml
+++ b/.github/workflows/run-tests-selected.yaml
@@ -1,0 +1,89 @@
+name: run-tests-selected
+run-name: Run selected tests (${{ inputs.runs_on }} --framework ${{ inputs.framework}} --filter ${{ inputs.filter }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs_on:
+        type: choice
+        description: GitHub Actions runner image name
+        required: true
+        default: ubuntu-latest
+        options:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+          - windows-11-arm          
+          - ubuntu-24.04-arm
+          - macos-13
+      project:
+        type: string
+        description: Specify test project path
+        required: true
+        default: tests/BenchmarkDotNet.IntegrationTests
+        options:
+          - tests/BenchmarkDotNet.Tests
+          - tests/BenchmarkDotNet.IntegrationTests
+          - tests/BenchmarkDotNet.IntegrationTests.ManualRunning
+      framework:
+        type: choice
+        description: Specify target framework
+        required: true
+        options:
+          - net8.0
+          - net462
+      filter:
+        type: string
+        description: Test filter text (It's used for `dotnet test --filter`) Use default value when running all tests
+        required: true
+        default: "BenchmarkDotNet"
+      iteration_count:
+        type: number
+        description: Count of test loop (It's expected to be used for flaky tests)
+        required: true
+        default: 1
+
+jobs:
+  test:
+    name: test (${{ inputs.runs_on }} --framework ${{ inputs.framework}} --filter ${{ inputs.filter }})
+    runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: 60 # Explicitly set timeout. When wrong input parameter is passed. It may continue to run until it times out (Default:360 minutes))
+    steps:
+      - uses: actions/checkout@v4
+      
+      # Setup
+      - name: Setup
+        run: |
+          mkdir artifacts
+
+      # Build
+      - name: Run build
+        working-directory: ${{ github.event.inputs.project }}
+        run: |
+          dotnet build -c Release --framework ${{ inputs.framework }} -tl:off
+
+      # Test
+      - name: Run tests
+        shell: pwsh
+        working-directory: ${{ github.event.inputs.project }}
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $true
+          $iterationCount = ${{ inputs.iteration_count }}
+
+          foreach($i in 1..$iterationCount) {
+            Write-Output ('##[group]Executing Iteration: {0}/${{ inputs.iteration_count }}' -f $i)
+
+            dotnet test -c Release --framework ${{ inputs.framework }} --filter ${{ inputs.filter }} -tl:off --no-build --logger "console;verbosity=normal"
+
+            Write-Output '##[endgroup]'
+          }
+
+      # Upload artifact files that are located at `$(GITHUB_WORKSPACE)/artifacts` directory
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: results
+          if-no-files-found: ignore
+          path: |
+            artifacts/**/*


### PR DESCRIPTION
This PR add workflow file (`run-tests-selected.yaml`) that run selected tests on specific project/OS/framework.

**Expected workflow usage**
1. Run only selected tests on specific OS/framework (to reduce CI test workaround time)
2. Run flaky tests that need multiple iterations to reproduce problems.
3. Run `BenchmarkDotNet.IntegrationTests.ManualRunning` tests on CI (#2751)
4. To collect custom tests artifacts (e.g. `dotnet-gcdume` results)

**How to run this workflow**

1. Run workflow from GitHub Action's Web UI
2. Run workflow with `gh` command
    ```
    # Run  CanDisassembleAllMethodCalls tests with net462 on `windows-latest` image.
    gh workflow run run-tests-selected.yaml --repo dotnet/BenchmarkDotNet --ref master -f runs_on=windows-latest -f project=tests/BenchmarkDotNet.IntegrationTests -f filter=CanDisassembleAllMethodCalls -f framework=net462
    ```

> [!NOTE]
> To invoke workflow that use `workflow_dispach` trigger.  
> It need to to be committed to default branch (`master`) to use.