### PR TITLE
Fix comment in package props about GenerateProgramFile

### DIFF
--- a/src/BenchmarkDotNet.TestAdapter/build/BenchmarkDotNet.TestAdapter.props
+++ b/src/BenchmarkDotNet.TestAdapter/build/BenchmarkDotNet.TestAdapter.props
@@ -14,7 +14,7 @@
       <Compile Include="$(EntryPointSourceDirectory)EntryPoint.vb" Condition="'$(Language)' == 'VB'" Visible="false"/>
     </ItemGroup>
     <PropertyGroup>
-      <!-- Disables generation of MSTest entrypoint -->
+      <!-- Disables generation of VSTest entrypoint -->
       <GenerateProgramFile>false</GenerateProgramFile>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
GenerateProgramFile is used by VSTest, not MSTest.