### PR TITLE
Fix density plot error by using correct bandwidth string in BuildPlots.R

### DIFF
--- a/src/BenchmarkDotNet/Templates/BuildPlots.R
+++ b/src/BenchmarkDotNet/Templates/BuildPlots.R
@@ -105,7 +105,7 @@ for (file in files) {
     densityPlot <- ggplot(df, aes(x=Measurement_Value, fill=Job_Id)) +
       ggtitle(paste(title, "/", target)) +
       xlab(paste("Time,", timeUnit)) +
-      geom_density(alpha=.5, bw="SJ")
+      geom_density(alpha=.5, bw="sj")
     printNice(densityPlot)
     ggsaveNice(gsub("-measurements.csv", paste0("-", target, "-density.png"), file), densityPlot)
 
@@ -118,7 +118,7 @@ for (file in files) {
       paramsDensityPlot <- ggplot(paramsDf, aes(x=Measurement_Value, fill=Job_Id)) +
         ggtitle(paste(title, "/", target, "/", params)) +
         xlab(paste("Time,", timeUnit)) +
-        geom_density(alpha=.5, bw="SJ")
+        geom_density(alpha=.5, bw="sj")
       printNice(paramsDensityPlot)
       prefix <- createPrefix(c(target,params))
       ggsaveNice(gsub("-measurements.csv", paste0(prefix, "-density.png"), file), paramsDensityPlot)
@@ -155,7 +155,7 @@ for (file in files) {
       densityPlotJob <- ggplot(jobDf, aes(x=Measurement_Value, fill="red")) +
         ggtitle(paste(title, "/", target, "/", job)) +
         xlab(paste("Time,", timeUnit)) +
-        geom_density(alpha=.5, bw="SJ")
+        geom_density(alpha=.5, bw="sj")
       printNice(densityPlotJob)
       ggsaveNice(gsub("-measurements.csv", paste0("-", target, "-", job, "-density.png"), file), densityPlotJob)
     }


### PR DESCRIPTION
### Summary

This PR fixes a bug in `BuildPlots.R` where the use of an incorrect bandwidth string in `geom_density()` caused runtime errors when generating density plots.

### Changes

- Replaced `bw = "SJ"` with `bw = "sj"` in all `geom_density()` calls:
  - Line 108
  - Line 121
  - Line 158

### Problem

The original code used `bw = "SJ"` (uppercase), which is not a valid option for the `bw` parameter in `geom_density()`. This caused the following error:

```
2: Computation failed in `stat_density()`.
Caused by error in `precompute_bw()`:
! `bw` must be one of "nrd0", "nrd", "ucv", "bcv", "sj", "sj-ste", or
  "sj-dpi", not "SJ".
Γä╣ Did you mean "sj"? 
3: Computation failed in `stat_density()`.
Caused by error in `precompute_bw()`:
! `bw` must be one of "nrd0", "nrd", "ucv", "bcv", "sj", "sj-ste", or
  "sj-dpi", not "SJ".
Γä╣ Did you mean "sj"? 
4: Computation failed in `stat_density()`.
Caused by error in `precompute_bw()`:
! `bw` must be one of "nrd0", "nrd", "ucv", "bcv", "sj", "sj-ste", or
  "sj-dpi", not "SJ".
Γä╣ Did you mean "sj"? 
5: Computation failed in `stat_density()`.
Caused by error in `precompute_bw()`:
! `bw` must be one of "nrd0", "nrd", "ucv", "bcv", "sj", "sj-ste", or
  "sj-dpi", not "SJ".
Γä╣ Did you mean "sj"? 
6: Computation failed in `stat_density()`.
Caused by error in `precompute_bw()`:
! `bw` must be one of "nrd0", "nrd", "ucv", "bcv", "sj", "sj-ste", or
  "sj-dpi", not "SJ".
Γä╣ Did you mean "sj"? 
```
### Fix

Changed the bandwidth method to lowercase `"sj"`, which is a valid and robust choice for density estimation.

### Impact

This fix ensures that density plots are generated correctly without runtime errors, improving the reliability of the plotting templates.
