### PR TITLE
chore: Fix flaky AllocationQuantumIsNotAnIssueForNetCore21Plus tests on macos

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -244,11 +244,14 @@ namespace BenchmarkDotNet.IntegrationTests
         {
             long objectAllocationOverhead = IntPtr.Size * 2; // pointer to method table + object header word
             long arraySizeOverhead = IntPtr.Size; // array length
+            int warmupCount = OsDetector.IsMacOS()
+                ? 5  // Workaround setting for macos. https://github.com/dotnet/BenchmarkDotNet/issues/2779
+                : 0; // Other OS don't need warmup
 
             AssertAllocations(toolchain, typeof(TimeConsuming), new Dictionary<string, long>
             {
                 { nameof(TimeConsuming.SixtyFourBytesArray), 64 + objectAllocationOverhead + arraySizeOverhead }
-            }, warmupCount: 2);
+            }, warmupCount: warmupCount);
         }
 
         public class MultiThreadedAllocation


### PR DESCRIPTION
This PR intended to fix flaky test issue (#2779) that happens when running AllocationQuantumIsNotAnIssueForNetCore21Plus` on macos.

On previous PR (#2782)
I've setting `warmupCount: 2` and it reduced failed CI.

But it seems error still continues with low frequency.
So I've changed workupCount setting from `2` to `5`.

And this issue is not confirmed on OS other than macos (x64/arm64).
So I've revert setting to use `warmupcount:0` on other OS.
