### PR TITLE
chore: Ensure `EventProcessor::OnEndValidationStage` is called when critical validation error contained

### DIFF
--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -71,10 +71,10 @@ namespace BenchmarkDotNet.Running
 
                 PrintValidationErrors(compositeLogger, validationErrors);
 
+                eventProcessor.OnEndValidationStage(); // Ensure that OnEndValidationStage() is called when a critical validation error exists.
+
                 if (validationErrors.Any(validationError => validationError.IsCritical))
                     return new[] { Summary.ValidationFailed(title, resultsFolderPath, logFilePath, validationErrors.ToImmutableArray()) };
-
-                eventProcessor.OnEndValidationStage();
 
                 int totalBenchmarkCount = supportedBenchmarks.Sum(benchmarkInfo => benchmarkInfo.BenchmarksCases.Length);
                 int benchmarksToRunCount = totalBenchmarkCount - (idToResume + 1); // ids are indexed from 0

--- a/tests/BenchmarkDotNet.IntegrationTests/EventProcessorTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/EventProcessorTests.cs
@@ -23,9 +23,10 @@ namespace BenchmarkDotNet.IntegrationTests
         public void WhenUsingEventProcessorAndNoBenchmarks()
         {
             var events = RunBenchmarksAndRecordEvents(new[] { typeof(ClassEmpty) });
-            Assert.Equal(2, events.Count);
+            Assert.Equal(3, events.Count);
             Assert.Equal(nameof(EventProcessor.OnStartValidationStage), events[0].EventType);
             Assert.Equal(nameof(EventProcessor.OnValidationError), events[1].EventType);
+            Assert.Equal(nameof(EventProcessor.OnEndValidationStage), events[2].EventType);
         }
 
         [Fact]
@@ -135,12 +136,13 @@ namespace BenchmarkDotNet.IntegrationTests
             var toolchain = new AllUnsupportedToolchain();
             var events = RunBenchmarksAndRecordEvents(new[] { typeof(ClassA) }, toolchain: toolchain);
 
-            Assert.Equal(3, events.Count);
+            Assert.Equal(4, events.Count);
             Assert.Equal(nameof(EventProcessor.OnStartValidationStage), events[0].EventType);
             Assert.Equal(nameof(EventProcessor.OnValidationError), events[1].EventType);
             Assert.Equal(typeof(ClassA).GetMethod(nameof(ClassA.Method1)), (events[1].Args[0] as ValidationError).BenchmarkCase.Descriptor.WorkloadMethod);
             Assert.Equal(nameof(EventProcessor.OnValidationError), events[2].EventType);
             Assert.Equal(typeof(ClassA).GetMethod(nameof(ClassA.Method2)), (events[2].Args[0] as ValidationError).BenchmarkCase.Descriptor.WorkloadMethod);
+            Assert.Equal(nameof(EventProcessor.OnEndValidationStage), events[3].EventType);
         }
 
         [Fact]


### PR DESCRIPTION
This PR modify `EventProcessor::OnEndValidationStage` invoke timing to ensure `OnEndValidationStage` is called when validation failed.

**Background**
I want to handle validation errors on `EventProcessor::OnEndValidationStage` event to grouping errors per `BenchmarkCase`.

But on current implementation.
`EventProcessor::OnEndValidationStage` is not called when ValidationErrors contains **critical** error.
