### PR TITLE
Fix condition for TestTfmsInParallel property

### DIFF
--- a/src/BenchmarkDotNet.TestAdapter/build/BenchmarkDotNet.TestAdapter.props
+++ b/src/BenchmarkDotNet.TestAdapter/build/BenchmarkDotNet.TestAdapter.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <EntryPointSourceDirectory>$(MSBuildThisFileDirectory)..\entrypoints\</EntryPointSourceDirectory>
     <!-- Disable parallel tests between TargetFrameworks, if it's not explicitly specified. -->
-    <TestTfmsInParallel Condition="'$(TestTfmsInParallel)' = ''">false</TestTfmsInParallel>
+    <TestTfmsInParallel Condition="'$(TestTfmsInParallel)' == ''">false</TestTfmsInParallel>
   </PropertyGroup>
   <!-- 
     Microsoft.NET.Test.Sdk uses a property called "GenerateProgramFile" to determine whether it generates an entry 


### PR DESCRIPTION
Condition needs double equals to be a comparison. As it is, it won't load in Visual Studio right now.