### PR TITLE
Allow override method/property for ParamsSource

### DIFF
--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -308,7 +308,7 @@ namespace BenchmarkDotNet.Running
 
         private static (MemberInfo source, object[] values) GetValidValuesForParamsSource(Type sourceType, string sourceName)
         {
-            var paramsSourceMethod = sourceType.GetAllMethods().SingleOrDefault(method => method.Name == sourceName && method.IsPublic);
+            var paramsSourceMethod = sourceType.GetAllMethods().FirstOrDefault(method => method.Name == sourceName && method.IsPublic);
 
             if (paramsSourceMethod != default)
                 return (paramsSourceMethod, ToArray(
@@ -316,7 +316,7 @@ namespace BenchmarkDotNet.Running
                     paramsSourceMethod,
                     sourceType));
 
-            var paramsSourceProperty = sourceType.GetAllProperties().SingleOrDefault(property => property.Name == sourceName && property.GetMethod.IsPublic);
+            var paramsSourceProperty = sourceType.GetAllProperties().FirstOrDefault(property => property.Name == sourceName && property.GetMethod.IsPublic);
 
             if (paramsSourceProperty != default)
                 return (paramsSourceProperty, ToArray(

--- a/tests/BenchmarkDotNet.IntegrationTests/ParamSourceTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ParamSourceTests.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
-    public class ParamSourceTests: BenchmarkTestExecutor
+    public class ParamSourceTests : BenchmarkTestExecutor
     {
         public ParamSourceTests(ITestOutputHelper output) : base(output) { }
 
@@ -204,5 +204,43 @@ namespace BenchmarkDotNet.IntegrationTests
             //   public void SourceWithExplicitCastToTarget_Succeeds(IToolchain toolchain) => CanExecuteWithExtraInfo(typeof(SourceWithExplicitCastToTarget), toolchain);
             Assert.ThrowsAny<Exception>(() => CanExecuteWithExtraInfo(typeof(SourceWithExplicitCastToTarget), InProcessEmitToolchain.Instance));
         }
+
+        public abstract class OverridePropertyBase
+        {
+            public abstract int[] GetSourceProperty { get; }
+
+            [ParamsSource(nameof(GetSourceProperty))]
+            public int ParamsTarget { get; set; }
+        }
+
+        public class OverrideProperty : OverridePropertyBase
+        {
+            public override int[] GetSourceProperty => new int[] { 1, 2, 3 };
+
+            [Benchmark]
+            public int Benchmark() => ParamsTarget;
+        }
+
+        [Theory, MemberData(nameof(GetToolchains), DisableDiscoveryEnumeration = true)]
+        public void OverrideProperty_Succeeds(IToolchain toolchain) => CanExecuteWithExtraInfo(typeof(OverrideProperty), toolchain);
+
+        public abstract class OverrideMethodBase
+        {
+            public abstract int[] GetSourceMethod();
+
+            [ParamsSource(nameof(GetSourceMethod))]
+            public int ParamsTarget { get; set; }
+        }
+
+        public class OverrideMethod : OverrideMethodBase
+        {
+            public override int[] GetSourceMethod() => new int[] { 1, 2, 3 };
+
+            [Benchmark]
+            public int Benchmark() => ParamsTarget;
+        }
+
+        [Theory, MemberData(nameof(GetToolchains), DisableDiscoveryEnumeration = true)]
+        public void OverrideMethod_Succeeds(IToolchain toolchain) => CanExecuteWithExtraInfo(typeof(OverrideMethod), toolchain);
     }
 }


### PR DESCRIPTION
Currently, when specifying abstract properties or methods with ParamsSource, an exception occurs with SingleOrDefault:
`System.InvalidOperationException: Sequence contains more than one matching element`

```csharp
BenchmarkRunner.Run<Bench>();

public abstract class BenchBase
{
    public abstract int[] Levels { get; }

    [ParamsSource(nameof(Levels))]
    public int Level { get; set; }

    [Benchmark]
    public void Foo()
    {
    }
}

public class Bench : BenchBase
{
    public override int[] Levels => [1, 2, 3];

    [Benchmark]
    public void Bar()
    {
    }
}
```

This is because `sourceType.GetAllMethods()` and `sourceType.GetAllProperties()` traverse up the parent class hierarchy, enumerating both the overridden property and abstract property with the same name.
And since `GetValidValuesForParamsSource` processes with `SingleOrDefault`, the exception occurs.

Since the enumeration starts from sourceType in order, this should be safe to change to `FirstOrDefault` as the best match.