### PR TITLE
docs: Add docs for breaking changes of disassembler native dependencies

### DIFF
--- a/docs/articles/features/disassembler.md
+++ b/docs/articles/features/disassembler.md
@@ -41,6 +41,8 @@ To compare different platforms the project which defines benchmarks has to targe
 > <BenchmarkDotNetTargetPlatform>all</BenchmarkDotNetTargetPlatform>
 > ```
 
+Or specify `<RuntimeIdentifier>` for the platform that it will be run on. 
+
 ### Disassembly Diagnoser for Mono on Windows
 
 If you want to get a disassembly listing for Mono on Windows, you need `as` and `x86_64-w64-mingw32-objdump.exe` tools.


### PR DESCRIPTION
This PR add docs about breaking change that introduced by PR #2737.

After PR  #2737 is merged. 
It need to explicitly specify following settings to preserve old behaviors.

```xml
<BenchmarkDotNetTargetPlatform>all</BenchmarkDotNetTargetPlatform>
```
