### PR TITLE
chore: add NO_COLOR environment variable support

### DIFF
--- a/src/BenchmarkDotNet/Loggers/ConsoleLogger.cs
+++ b/src/BenchmarkDotNet/Loggers/ConsoleLogger.cs
@@ -15,8 +15,13 @@ namespace BenchmarkDotNet.Loggers
         public static readonly ILogger Default = new ConsoleLogger();
         public static readonly ILogger Ascii = new ConsoleLogger(false);
         public static readonly ILogger Unicode = new ConsoleLogger(true);
-        private static readonly bool ConsoleSupportsColors
-            = !(OsDetector.IsAndroid() || OsDetector.IsIOS() || RuntimeInformation.IsWasm || OsDetector.IsTvOS());
+        private static readonly Lazy<bool> ConsoleSupportsColors = new(() =>
+        {
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NO_COLOR")))
+                return false;
+
+            return !(OsDetector.IsAndroid() || OsDetector.IsIOS() || RuntimeInformation.IsWasm || OsDetector.IsTvOS());
+        });
 
         private readonly bool unicodeSupport;
         private readonly Dictionary<LogKind, ConsoleColor> colorScheme;
@@ -45,7 +50,7 @@ namespace BenchmarkDotNet.Loggers
             if (!unicodeSupport)
                 text = text.ToAscii();
 
-            if (!ConsoleSupportsColors)
+            if (!ConsoleSupportsColors.Value)
             {
                 write(text);
                 return;


### PR DESCRIPTION
This PR add support for `NO_COLOR` environment variable.

**What's changed in this PR**

- Add logic to check `NO_COLOR` environment variable and suppress color if **non-empty** value is set.
- Modify existing code to use Lazy initialization.

Related links
- https://no-color.org
- [CLI Guidelines for the dotnet CLI and related commands](https://github.com/dotnet/sdk/blob/eb34dc964be0f2ce90df9146ad48f4b41c7fe712/documentation/project-docs/cli-guidelines.md?plain=1#L206)
