### PR TITLE
fix(wasm): prevent generated project from being trimmed out

### DIFF
--- a/src/BenchmarkDotNet/Templates/WasmLinkerDescription.xml
+++ b/src/BenchmarkDotNet/Templates/WasmLinkerDescription.xml
@@ -2,4 +2,5 @@
   <assembly fullname="System.Private.CoreLib">
     <type fullname="System.IntPtr" />
   </assembly>
+  <assembly fullname="$PROGRAMNAME$" preserve="all" />
 </linker>

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmGenerator.cs
@@ -29,10 +29,9 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
             if (((WasmRuntime)buildPartition.Runtime).Aot)
             {
                 GenerateProjectFile(buildPartition, artifactsPaths, aot: true, logger);
-
-                var linkDescriptionFileName = "WasmLinkerDescription.xml";
-                File.WriteAllText(Path.Combine(Path.GetDirectoryName(artifactsPaths.ProjectFilePath), linkDescriptionFileName), ResourceHelper.LoadTemplate(linkDescriptionFileName));
-            } else
+                GenerateLinkerDescriptionFile(artifactsPaths);
+            }
+            else
             {
                 GenerateProjectFile(buildPartition, artifactsPaths, aot: false, logger);
             }
@@ -63,6 +62,16 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
             .ToString();
 
             File.WriteAllText(artifactsPaths.ProjectFilePath, content);
+        }
+
+        protected void GenerateLinkerDescriptionFile(ArtifactsPaths artifactsPaths)
+        {
+            const string linkDescriptionFileName = "WasmLinkerDescription.xml";
+
+            var content = ResourceHelper.LoadTemplate(linkDescriptionFileName)
+                .Replace("$PROGRAMNAME$", artifactsPaths.ProgramName);
+
+            File.WriteAllText(Path.Combine(Path.GetDirectoryName(artifactsPaths.ProjectFilePath)!, linkDescriptionFileName), content);
         }
 
         protected override string GetExecutablePath(string binariesDirectoryPath, string programName) => Path.Combine(binariesDirectoryPath, "AppBundle", MainJS);


### PR DESCRIPTION
When running WASM benchmarks with AOT, the autogenerated classes `Runnable_x` are trimmed out.
This PR prevents this by adding the generated assembly to the already existing `TrimmerRootDescriptor` xml file.