### PR TITLE
chore: Add .editorfile setting file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,42 @@
-﻿[*.cs]
+root = true
+
+# All files
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = unset
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# XML files
+[*.{xml,resx,ruleset,props,targets,runsettings}]
+indent_size = 2
+
+# .NET solution/project files
+[*.{slnx,csproj,vbproj]
+indent_size = 2
+
+# Shell scripts
+[*.{cmd, bat}]
+end_of_line = crlf
+
+# Markdown files
+[*.md]
+trim_trailing_whitespace = false
+
+# C# files
+[*.cs]
+# IDE0160: Use block-scoped namespace
+csharp_style_namespace_declarations=file_scoped:suggestion
 
 # CS1998: Async method lacks 'await' operators and will run synchronously
 dotnet_diagnostic.CS1998.severity = suggestion
+
 # CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = warning
+


### PR DESCRIPTION
This PR add `.editorconfig` setting file at solution root level.

#### Background
Currently BenchmakDotNet source code don't enforce linter and following files are mixed.
- Files that using UTF-8 (with BOM) and UTF-8 (without BOM)
- Files that using `CRLF` and `LF`
- Files that ends with LF and without LF
- Other minor code format difference that can be fixed by `dotnet format`

#### What's changed this PR
Add `.editorconfig` file that enforce following settings.
- Use UTF-8 (without BOM)
- Use `LF`
- Indent settings
- Enable `suggestion` for file scoped namespace.
- Insert `LF` at end of file. (This setting cause error on CI. it's not included in this PR)

#### Task after this PR is merged
This PR cause a lot of file changes by `dotnet format` command and it's hard to review.
So diffs are not included in this PR.

Please run following steps by BenchmarkDotNet maintainer side. 

1. Apply `dotnet format` command to enforce `.editorconfig` settings with following command.
    ```
    dotnet format BenchmarkDotNet.slnx -v diagnostic
    dotnet format BenchmarkDotNet.Maui.slnx -v diagnostic
    dotnet format build/BenchmarkDotNet.Build -v diagnostic
    ```
2. Review changes and commit code changes
3. Edit `.editorconfig` and set `insert_final_newline = true`. then execute 1-2 steps. 
4. Push changes.

Note:
- `dotnet format` command don't support F# project. so these files are skipped  (Warnings are raised when running `dotnet format`)

