### PR TITLE
chore: Rollback `Microsoft.Diagnostics.Tracing.TraceEvent` package version to 3.1.20

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.Windows/BenchmarkDotNet.Diagnostics.Windows.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/BenchmarkDotNet.Diagnostics.Windows.csproj
@@ -12,6 +12,6 @@
     <ProjectReference Include="..\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="[3.1.20]" PrivateAssets="contentfiles;analyzers" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Iced" Version="1.21.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="3.1.512801" />
     <PackageReference Include="Perfolizer" Version="[0.6.1]" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="[3.1.20]" PrivateAssets="contentfiles;analyzers" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageReference Include="System.Management" Version="9.0.5" />


### PR DESCRIPTION
This PR is intended to workaround of #2871

`Microsoft.Diagnostics.Tracing.TraceEvent` v3.1.21 or later has additional `System.Text.Json` dependency.
So temporary rollback version `v3.1.20`.

If it need to use latest version of `TraceEvent` package.
It need to accept dependencies to `System.Text.Json`.
or need to introduce separate package approach.

**Release notes of TraceEvent**
https://github.com/microsoft/perfview/releases