### PR TITLE
fix: Deadlock issue when invoked external command write a lot of output 

### DIFF
--- a/src/BenchmarkDotNet/Helpers/ProcessHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/ProcessHelper.cs
@@ -23,7 +23,6 @@ namespace BenchmarkDotNet.Helpers
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,
-                RedirectStandardError = true
             };
             if (environmentVariables != null)
                 foreach (var variable in environmentVariables)

--- a/src/BenchmarkDotNet/Validators/DotNetSdkValidator.cs
+++ b/src/BenchmarkDotNet/Validators/DotNetSdkValidator.cs
@@ -84,11 +84,11 @@ namespace BenchmarkDotNet.Validators
                         return Enumerable.Empty<Version>();
                     }
 
+                    var output = process.StandardOutput.ReadToEnd();
                     process.WaitForExit();
 
                     if (process.ExitCode == 0)
                     {
-                        var output = process.StandardOutput.ReadToEnd();
                         var lines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
                         var versions = new List<Version>(lines.Count());


### PR DESCRIPTION
This PR intended to fix #2873 

#### 1. `DotNetSdkValidator.cs`
Modify code to call ReadToEnd before WaitForExit.

#### 2. `ProcessHelper.cs`
Remove `RedirectStandardError = true` setting because stderror is not consumed.

#### 3. `ProcessExtensions.cs`
Modify code to asynchronously  read StandardOutput to support timeout. (ReadToEnd don't support timeout)
And change code to use [KillTree](https://github.com/dotnet/BenchmarkDotNet/blob/d2be797a77daf561630f24b235008533edb13253/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs#L163-L181) when timeout happens. (It might wait 30 seconds if kill signal is not property handled though)