### PR TITLE
chore: Update BenchmarkDotNet.Samples project

### DIFF
--- a/samples/BenchmarkDotNet.Samples/Properties/launchSettings.json
+++ b/samples/BenchmarkDotNet.Samples/Properties/launchSettings.json
@@ -3,15 +3,18 @@
     "Default": {
       "commandName": "Project",
       "commandLineArgs": "",
-      "workingDirectory": ".",
       "environmentVariables": {
       }
     },
     "Run IntroBasic Benchmarks": {
       "commandName": "Project",
       "commandLineArgs": "--filter *IntroBasic*",
-      // "commandLineArgs": "--filter *IntroBasic* --inProcess --strategy Monitoring", // Use this setting for in-process debug
-      "workingDirectory": ".",
+      "environmentVariables": {
+      }
+    },
+    "Run IntroBasic Benchmarks with --inProcess": {
+      "commandName": "Project",
+      "commandLineArgs": "--filter *IntroBasic* --inProcess",
       "environmentVariables": {
       }
     },

--- a/src/BenchmarkDotNet/Extensions/ReportExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ReportExtensions.cs
@@ -34,5 +34,20 @@ namespace BenchmarkDotNet.Extensions
 
         public static Statistics GetStatistics(this IEnumerable<Measurement> runs) =>
             GetStatistics(runs.ToList());
+
+        public static bool HasError(this IEnumerable<Summary> summaries)
+        {
+            if (summaries.Count() == 0)
+            {
+                // When following argument specified. BenchmarkDotNet show information only.
+                var knownArguments = new HashSet<string>(["--help", "--list", "--info", "--version"]);
+                return !Environment.GetCommandLineArgs().Any(knownArguments.Contains);
+            }
+
+            if (summaries.Any(x => x.HasCriticalValidationErrors))
+                return true;
+
+            return summaries.Any(x => x.Reports.Any(r => !r.Success));
+        }
     }
 }


### PR DESCRIPTION
This PR contains following changes.

#### 1. Add code to return exit code
Currently `void Main` is used, and it return ExitCode: `0` regardless validation/build/benchmark failure exists.
This PR add code to return error code when failed. (Except for non-critical validation error)

#### 2. Add `Properties/launchSettings.json`
Add profiles to switch settings (VisualStudio or Use `--launch-profile` argument).
By default, `Default` profile is loaded. (It can be suppressed when pass `--no-launch-profile`)

~~`"workingDirectory": ".",` setting is added to output logs based on current directory.~~   
~~(It's `project directory` when running on VS)~~
~~Previous behavior output logs to `bin/$(Configuration)/$(TargetFramework)`.~~

#### 3. Add code for debugging
Add dedicated config that is used when build with `Debug` configuration.
It's expected to be used for Debugging with "Run IntroBasic Benchmarks" profile.

Note:  
When target benchmark define local config with `[Config(typeof(Config))]`.   
Job is merged with `ConfigUnionRule.Union` rule. And it's not works as expected.  
(Because both Job is executed that included GlobalConfig/LocalConfig)
