### PR TITLE
fix: DotNetSdkValidator failed when using CsProjClassicNetToolchain

### DIFF
--- a/src/BenchmarkDotNet/Validators/DotNetSdkValidator.cs
+++ b/src/BenchmarkDotNet/Validators/DotNetSdkValidator.cs
@@ -32,7 +32,11 @@ namespace BenchmarkDotNet.Validators
 
         public static IEnumerable<ValidationError> ValidateFrameworkSdks(BenchmarkCase benchmark)
         {
-            var requiredSdkVersion = benchmark.GetRuntime().RuntimeMoniker.GetRuntimeVersion();
+            var targetRuntime = benchmark.Job.Environment.HasValue(EnvironmentMode.RuntimeCharacteristic)
+                ? benchmark.Job.Environment.Runtime
+                : ClrRuntime.GetTargetOrCurrentVersion(benchmark.Descriptor.WorkloadMethod.DeclaringType.Assembly);
+            var requiredSdkVersion = targetRuntime.RuntimeMoniker.GetRuntimeVersion();
+
             var installedVersionString = cachedFrameworkSdks.Value.FirstOrDefault();
             if (installedVersionString == null || Version.TryParse(installedVersionString, out var installedVersion) && installedVersion < requiredSdkVersion)
             {


### PR DESCRIPTION
This PR intended to fix issue #2896

When using `CsProjClassicNetToolchain` and running benchmarks on `.NET 8` host.

Following code isn't works as expected and fallback to `GetCurrentRuntime()` (It returns .NET 8)
https://github.com/dotnet/BenchmarkDotNet/blob/a62d90ad9e444fde6bbfd99df21db9ea21b2d052/src/BenchmarkDotNet/Portability/RuntimeInformation.cs#L173-L176


#### What's changed in this PR
Modify `ValidateFrameworkSdks` code with following logics.
1. When RuntimeCharacteristic is specified `WithRuntime(runtime)`. Use specified runtime. (It's existing behavior)
2. Otherwise, resolve runtime with `ClrRuntime.GetTargetOrCurrentVersion`
