### PR TITLE
chore: Move EmptyBenchmarkTests to integration tests

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/RunningEmptyBenchmarkTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/RunningEmptyBenchmarkTests.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Filters;
 
-namespace BenchmarkDotNet.Tests.Running
+namespace BenchmarkDotNet.IntegrationTests
 {
     public class RunningEmptyBenchmarkTests
     {


### PR DESCRIPTION
This PR fixes #2861

By this changes. 
Following unit test execution time is expected to be reduced. 
https://github.com/dotnet/BenchmarkDotNet/runs/57222777975#r3
