### PR TITLE
chore: Increase warmupCount for flaky test

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -245,7 +245,7 @@ namespace BenchmarkDotNet.IntegrationTests
             long objectAllocationOverhead = IntPtr.Size * 2; // pointer to method table + object header word
             long arraySizeOverhead = IntPtr.Size; // array length
             int warmupCount = OsDetector.IsMacOS()
-                ? 5  // Workaround setting for macos. https://github.com/dotnet/BenchmarkDotNet/issues/2779
+                ? 10 // Workaround setting for macos. https://github.com/dotnet/BenchmarkDotNet/issues/2779
                 : 0; // Other OS don't need warmup
 
             AssertAllocations(toolchain, typeof(TimeConsuming), new Dictionary<string, long>


### PR DESCRIPTION
I've encountered flaky CI test issue of `AllocationQuantumIsNotAnIssueForNetCore21Plus` on recent PRs about 2-times.
And it need to re-run failed workflow.

To reduce failure rate.
This PR increase warmupCount from `5` to `10`.
