### PR TITLE
chore: Modify IntroNuGet sample and remove `System.Collections.Immutable` dependency

### DIFF
--- a/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -20,11 +20,11 @@
     <Reference Include="System.Reflection" />
   </ItemGroup>
   <PropertyGroup>
-    <!-- Use 9.0.0 as baseline package for IntroNuGet -->
-    <SciVersion Condition="'$(SciVersion)' == ''">9.0.0</SciVersion>
+    <!-- Use 8.0.0 as baseline package for IntroNuGet -->
+    <SihVersion Condition="'$(SihVersion)' == ''">8.0.0</SihVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="$(SciVersion)" />
+    <PackageReference Include="System.IO.Hashing" Version="$(SihVersion)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="9.0.5" />

--- a/samples/BenchmarkDotNet.Samples/IntroNuGet.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroNuGet.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Immutable;
+using System.IO.Hashing;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
@@ -19,11 +19,11 @@ namespace BenchmarkDotNet.Samples
         // Setup your csproj like this:
         /*
         <PropertyGroup>
-          <!-- Use 9.0.0 as default package version if not specified -->
-          <SciVersion Condition="'$(SciVersion)' == ''">9.0.0</SciVersion>
+          <!-- Use 8.0.0 as default package version if not specified -->
+          <SihVersion Condition="'$(SihVersion)' == ''">8.0.0</SciVersion>
         </PropertyGroup>
         <ItemGroup>
-          <PackageReference Include="System.Collections.Immutable" Version="$(SciVersion)" />
+          <PackageReference Include="System.IO.Hashing" Version="$(SihVersion)" />
         </ItemGroup>
         */
         // All versions of the package must be source-compatible with your benchmark code.
@@ -32,28 +32,34 @@ namespace BenchmarkDotNet.Samples
             public Config()
             {
                 string[] targetVersions = [
+                    "8.0.0",
                     "9.0.0",
-                    "9.0.3",
-                    "9.0.5",
+                    "10.0.0",
                 ];
 
                 foreach (var version in targetVersions)
                 {
                     AddJob(Job.MediumRun
-                        .WithMsBuildArguments($"/p:SciVersion={version}")
+                        .WithMsBuildArguments($"/p:SihVersion={version}")
                         .WithId($"v{version}")
                     );
                 }
             }
         }
 
-        private static readonly Random rand = new Random(Seed: 0);
-        private static readonly double[] values = Enumerable.Range(1, 10_000).Select(x => rand.NextDouble()).ToArray();
+        private static readonly byte[] values;
+
+        static IntroNuGet()
+        {
+            var rand = new Random(Seed: 0);
+            values = new byte[10_000];
+            rand.NextBytes(values);
+        }
 
         [Benchmark]
-        public void ToImmutableArrayBenchmark()
+        public void XxHash3Benchmark()
         {
-            var results = values.ToImmutableArray();
+            var results = XxHash3.Hash(values);
         }
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
@@ -6,8 +6,6 @@
     <TargetFrameworks>net461;net48;netcoreapp2.0;net8.0</TargetFrameworks>
     <!-- Deprecated runtime and vulnerabilities from old runtime, just in case any are found in the future. -->
     <NoWarn>$(NoWarn);NETSDK1138;NU1903</NoWarn>
-    <!-- Suppress warning NU1510: PackageReference Microsoft.NETCore.App will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.-->
-    <NoWarn>$(NoWarn);NU1510</NoWarn>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks</AssemblyName>


### PR DESCRIPTION
This PR modify IntroNuGet samples.
By removing `System.Collections.Immutable` dependency and Replace to use `System.IO.Hashing` package instead.

It's required because when build with .NET 10 SDK.
`System.Collections.Immutable` package can be pruned to SDK included version. and cause warnings.

Additionally, remove unused setting of `BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj`.
 