### PR TITLE
chore: Update project dependencies of BenchmarkDotNet.Build

### DIFF
--- a/build/BenchmarkDotNet.Build/BenchmarkDotNet.Build.csproj
+++ b/build/BenchmarkDotNet.Build/BenchmarkDotNet.Build.csproj
@@ -6,10 +6,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="5.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="6.0.0" />
     <PackageReference Include="Cake.FileHelpers" Version="7.0.0" />
     <PackageReference Include="Cake.Git" Version="5.0.1" />
-    <PackageReference Include="Docfx.App" Version="2.78.3" />
+    <PackageReference Include="Docfx.App" Version="2.78.4" />
     <PackageReference Include="Octokit" Version="14.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR update `BenchmarkDotNet.Build` package dependencies.

**Background**
When build project with .NET SDK 10 SDK. 
Transitive NuGetAudit feature is automatically enabled. and raise following warnings.   (It's transitively referenced by `Docfx.App` package)

> D:\a\BenchmarkDotNet\BenchmarkDotNet\build\BenchmarkDotNet.Build\BenchmarkDotNet.Build.csproj : warning NU1903: Package 'Microsoft.Build.Tasks.Core' 17.7.2 has a known high severity vulnerability, https://github.com/advisories/GHSA-h4j7-5rxr-p4wc
