### PR TITLE
chore: Add code to hide `global::` prefix on TestExplorer

### DIFF
--- a/src/BenchmarkDotNet.TestAdapter/BenchmarkCaseExtensions.cs
+++ b/src/BenchmarkDotNet.TestAdapter/BenchmarkCaseExtensions.cs
@@ -24,7 +24,7 @@ namespace BenchmarkDotNet.TestAdapter
         internal static TestCase ToVsTestCase(this BenchmarkCase benchmarkCase, string assemblyPath, bool includeJobInName = false)
         {
             var benchmarkMethod = benchmarkCase.Descriptor.WorkloadMethod;
-            var fullClassName = benchmarkCase.Descriptor.Type.GetCorrectCSharpTypeName();
+            var fullClassName = benchmarkCase.Descriptor.Type.GetCorrectCSharpTypeName(prefixWithGlobal:false);
             var parametrizedMethodName = FullNameProvider.GetMethodName(benchmarkCase);
 
             var displayJobInfo = benchmarkCase.GetUnrandomizedJobDisplayInfo();


### PR DESCRIPTION
This PR intended to hide `global::` prefix that shown on TestExplorer (It's added by #2897)

<img width="287" height="121" alt="image" src="https://github.com/user-attachments/assets/7d80151e-5cff-4eb7-aaec-d7f2754d8aa7" />
