### PR TITLE
chore: Enable DeterministicBuild on CI

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -11,6 +11,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dotnet/BenchmarkDotNet</RepositoryUrl>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
 
     <CLSCompliant>true</CLSCompliant>
     <ComVisible>false</ComVisible>


### PR DESCRIPTION
Currently BenchmarkDotNet published NuGet package don't using deterministic build setting.

So when opening pakage with NuGetPackageExplorer. It reporting health alert.
https://nuget.info/packages/BenchmarkDotNet/0.15.8

<img width="521" height="309" alt="image" src="https://github.com/user-attachments/assets/5ffed507-90e1-4f17-b158-dbf69393e494" />

---

This PR add setting to enable DeterministicBuild on GitHub Actions CI build.
After this PR is merged alert is expected to be resolved.