### PR TITLE
chore: Add temporary setting to skip flaky test (AllocationQuantumIsNotAnIssueForNetCore21Plus) on macos

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -242,6 +242,10 @@ namespace BenchmarkDotNet.IntegrationTests
         [Trait(Constants.Category, Constants.BackwardCompatibilityCategory)]
         public void AllocationQuantumIsNotAnIssueForNetCore21Plus(IToolchain toolchain)
         {
+            // TODO: Skip test on macos. Temporary workaround for https://github.com/dotnet/BenchmarkDotNet/issues/2779
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
+                return;
+
             long objectAllocationOverhead = IntPtr.Size * 2; // pointer to method table + object header word
             long arraySizeOverhead = IntPtr.Size; // array length
             int warmupCount = OsDetector.IsMacOS()


### PR DESCRIPTION
This PR skip `AllocationQuantumIsNotAnIssueForNetCore21Plus` on macos (x64/arm64)  
(Note: It's reported as successful on test report because it return without assertion)

This test is flaky. and It seems to be happening more frequently lately.
(When running `run-tests-selected.yaml` on macos(arm64) it's reproduce with 10-20 times retry)

Please merge this PR and reopen issue #2779