### PR TITLE
chore: Skip setting `process priority` when running on non windows environment

### DIFF
--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -27,6 +27,10 @@ namespace BenchmarkDotNet.Extensions
 
         public static void EnsureHighPriority(this Process process, ILogger logger)
         {
+            // Process.set_PriorityClass requires root on Unix
+            if (!OsDetector.IsWindows())
+                return;
+
             try
             {
                 process.PriorityClass = ProcessPriorityClass.High;
@@ -62,6 +66,10 @@ namespace BenchmarkDotNet.Extensions
                 throw new ArgumentNullException(nameof(process));
             if (logger == null)
                 throw new ArgumentNullException(nameof(logger));
+
+            // Process.set_PriorityClass requires root on Unix
+            if (!OsDetector.IsWindows())
+                return false;
 
             try
             {


### PR DESCRIPTION
Setting process priority seems failed with following error on GitHub Actions CI.
And produce about 1135 lines outputs (on ubuntu-latest) 

> Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.

This PR add code to skip setting process priority on non-Windows environment. 