### PR TITLE
chore: Suppress MSB3277 warning messages

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
@@ -6,6 +6,8 @@
     <TargetFrameworks>net461;net48;netcoreapp2.0;net8.0</TargetFrameworks>
     <!-- Deprecated runtime and vulnerabilities from old runtime, just in case any are found in the future. -->
     <NoWarn>$(NoWarn);NETSDK1138;NU1903</NoWarn>
+    <!-- Suppress warning MSB3277: Found conflicts between different versions of "System.Buffers" that could not be resolved. -->
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3277</MSBuildWarningsAsMessages>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks</AssemblyName>


### PR DESCRIPTION
When building `BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj` project with `net461` tfm.
Following warnings are raised on recent build. 

```
D:\a\BenchmarkDotNet\BenchmarkDotNet\.dotnet\sdk\10.0.100\Microsoft.Common.CurrentVersion.targets(2437,5): warning MSB3277: Found conflicts between different versions of "System.Buffers" that could not be resolved. [D:\a\BenchmarkDotNet\BenchmarkDotNet\tests\BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks\BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj::TargetFramework=net461]
D:\a\BenchmarkDotNet\BenchmarkDotNet\.dotnet\sdk\10.0.100\Microsoft.Common.CurrentVersion.targets(2437,5): warning MSB3277: There was a conflict between "System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" and "System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51". [D:\a\BenchmarkDotNet\BenchmarkDotNet\tests\BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks\BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj::TargetFramework=net461]
```

It's seems be occurred when `System.Buffers` package is restored as `netstandard2.0` target.
And it can't resolved by explicitly specifing `System.Buffers` package.
(Because Roslyn 5.0.0 requires `System.Buffers` package 4.6.0 or later)

So I've added settings to suppress MSB3277 warnings.
