### PR TITLE
[ios/catalyst] fix for "sandboxed" platforms

### DIFF
--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -94,9 +94,17 @@ namespace BenchmarkDotNet.Configs
         {
             get
             {
-                var root = OsDetector.IsAndroid() ?
-                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) :
-                    Directory.GetCurrentDirectory();
+                string root;
+                if (OsDetector.IsAndroid() || OsDetector.IsIOS())
+                {
+                    // On mobile platforms (Android, iOS, and Mac Catalyst), use a writable location
+                    // because the app bundle and current directory are read-only due to sandboxing
+                    root = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                }
+                else
+                {
+                    root = Directory.GetCurrentDirectory();
+                }
                 return Path.Combine(root, "BenchmarkDotNet.Artifacts");
             }
         }


### PR DESCRIPTION
Context: https://github.com/dotnet/BenchmarkDotNet/pull/2929

Without this fix, I was getting the exception on `net10.0-ios` and `net10.0-maccatalyst` projects:

    Access to the path '~/src/dotnet/BenchmarkDotNet/samples/BenchmarkDotNet.Samples.Maui/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/BenchmarkDotNet.Samples.Maui.app/BenchmarkDotNet.Artifacts' is denied.

This change was already here for Android, but it feels like it should have been here for iOS as well.

`net10.0-maccatalyst` will also respond to this fix, as it is basically iOS "emulated" on macOS.