### PR TITLE
[msbuild] refactor `BenchmarkDotNet.Weaver.targets` to support mobile platforms

### DIFF
--- a/src/BenchmarkDotNet.Weaver/buildTransitive/netstandard2.0/BenchmarkDotNet.Weaver.targets
+++ b/src/BenchmarkDotNet.Weaver/buildTransitive/netstandard2.0/BenchmarkDotNet.Weaver.targets
@@ -3,26 +3,26 @@
   <UsingTask TaskName="BenchmarkDotNet.Weaver.WeaveAssemblyTask" AssemblyFile="$(MSBuildThisFileDirectory)..\..\tasks\netstandard2.0\BenchmarkDotNet.Weaver.dll" />
 
   <PropertyGroup>
-    <ShouldWeaveAssemblies Condition="'$(ShouldWeaveAssemblies)' == ''">true</ShouldWeaveAssemblies>
-    <WeaveAssembliesAfterTargets Condition="'$(WeaveAssembliesAfterTargets)' == ''">CoreCompile</WeaveAssembliesAfterTargets>
-    <WeaveAssembliesBeforeTargets Condition="'$(WeaveAssembliesBeforeTargets)' == ''">CopyFilesToOutputDirectory</WeaveAssembliesBeforeTargets>
-    <WeaveAssemblyPath Condition="'$(WeaveAssemblyPath)' == ''">$(IntermediateOutputPath)$(TargetName)$(TargetExt)</WeaveAssemblyPath>
-    <WeaveAssembliesStampFile Condition="'$(WeaveAssembliesStampFile)' == ''">$(IntermediateOutputPath)BenchmarkDotNetWeaver.stamp</WeaveAssembliesStampFile>
+    <BenchmarkDotNetShouldWeaveAssemblies Condition="'$(BenchmarkDotNetShouldWeaveAssemblies)' == ''">true</BenchmarkDotNetShouldWeaveAssemblies>
+    <BenchmarkDotNetWeaveAssembliesAfterTargets Condition="'$(BenchmarkDotNetWeaveAssembliesAfterTargets)' == ''">CoreCompile</BenchmarkDotNetWeaveAssembliesAfterTargets>
+    <BenchmarkDotNetWeaveAssembliesBeforeTargets Condition="'$(BenchmarkDotNetWeaveAssembliesBeforeTargets)' == ''">CopyFilesToOutputDirectory</BenchmarkDotNetWeaveAssembliesBeforeTargets>
+    <BenchmarkDotNetWeaveAssemblyPath Condition="'$(BenchmarkDotNetWeaveAssemblyPath)' == ''">$(IntermediateOutputPath)$(TargetName)$(TargetExt)</BenchmarkDotNetWeaveAssemblyPath>
+    <BenchmarkDotNetWeaveAssembliesStampFile Condition="'$(BenchmarkDotNetWeaveAssembliesStampFile)' == ''">$(IntermediateOutputPath)BenchmarkDotNetWeaver.stamp</BenchmarkDotNetWeaveAssembliesStampFile>
   </PropertyGroup>
   
-  <Target Name="WeaveAssemblies"
-      AfterTargets="$(WeaveAssembliesAfterTargets)"
-      BeforeTargets="$(WeaveAssembliesBeforeTargets)"
-      Condition="'$(ShouldWeaveAssemblies)' == 'true'"
-      Inputs="$(WeaveAssemblyPath)"
-      Outputs="$(WeaveAssembliesStampFile)">
+  <Target Name="BenchmarkDotNetWeaveAssemblies"
+      AfterTargets="$(BenchmarkDotNetWeaveAssembliesAfterTargets)"
+      BeforeTargets="$(BenchmarkDotNetWeaveAssembliesBeforeTargets)"
+      Condition="'$(BenchmarkDotNetShouldWeaveAssemblies)' == 'true'"
+      Inputs="$(BenchmarkDotNetWeaveAssemblyPath)"
+      Outputs="$(BenchmarkDotNetWeaveAssembliesStampFile)">
 
-    <WeaveAssemblyTask TargetAssembly="$(WeaveAssemblyPath)" />
+    <WeaveAssemblyTask TargetAssembly="$(BenchmarkDotNetWeaveAssemblyPath)" />
 
     <!-- Create stamp file for incrementality -->
-    <Touch Files="$(WeaveAssembliesStampFile)" AlwaysCreate="true" />
+    <Touch Files="$(BenchmarkDotNetWeaveAssembliesStampFile)" AlwaysCreate="true" />
     <ItemGroup>
-      <FileWrites Include="$(WeaveAssembliesStampFile)" />
+      <FileWrites Include="$(BenchmarkDotNetWeaveAssembliesStampFile)" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Context: https://github.com/dotnet/BenchmarkDotNet/pull/2929
Context: https://github.com/dotnet/android/blob/4aa9af89102af2e745a8507992187d3c5993d638/Documentation/guides/MSBuildBestPractices.md

In initially testing BenchmarkDotNet with .NET MAUI, I found that the weaver was not being executed because the `Publish` target is not called during the build process for Android and iOS projects. I think the target could actually run much sooner during builds and achieve better results.

To address this, I refactored the `BenchmarkDotNet.Weaver.targets` file to run after `CoreCompile` on the `@(IntermediateAssembly)` in the `obj` directory. This is similar to what other targets do, such as the XamlC compiler:

https://github.com/dotnet/maui/blob/8224becbb3a8a6bb1caaca4bbe70c56e88875506/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets#L213-L255

Other general MSBuild improvements:

* Defined an MSBuild property for everything that seems useful. This allows consuming projects to configure the behavior (or workarounds!) as needed.

* Made the MSBuild target incremental by using inputs and outputs. If the `.dll` file is an input, we can write a `.stamp` file as an output to indicate that the weaver has already been run for that assembly. If the `.dll` file changes, the weaver will run again.

I tested this change with a .NET MAUI on 4 platforms and also the existing `BenchmarkDotNet.Samples` console app.