### PR TITLE
InProcess toolchains updates

### DIFF
--- a/samples/BenchmarkDotNet.Samples/IntroInProcess.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroInProcess.cs
@@ -22,7 +22,7 @@ namespace BenchmarkDotNet.Samples
 
                 AddJob(Job.MediumRun
                     .WithLaunchCount(1)
-                    .WithToolchain(InProcessEmitToolchain.Instance)
+                    .WithToolchain(InProcessEmitToolchain.Default)
                     .WithId("InProcess"));
             }
         }

--- a/samples/BenchmarkDotNet.Samples/IntroInProcessWrongEnv.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroInProcessWrongEnv.cs
@@ -26,7 +26,7 @@ namespace BenchmarkDotNet.Samples
                 AddJob(Job.MediumRun
                     .WithLaunchCount(1)
                     .WithPlatform(wrongPlatform)
-                    .WithToolchain(InProcessEmitToolchain.Instance)
+                    .WithToolchain(InProcessEmitToolchain.Default)
                     .WithId("InProcess"));
 
                 AddValidator(InProcessValidator.DontFailOnError);

--- a/src/BenchmarkDotNet/Attributes/Jobs/InProcessAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/Jobs/InProcessAttribute.cs
@@ -1,13 +1,34 @@
 using System;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Portability;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 
-namespace BenchmarkDotNet.Attributes
+namespace BenchmarkDotNet.Attributes;
+
+public enum InProcessToolchainType
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
-    public class InProcessAttribute : JobConfigBaseAttribute
+    Auto,
+    Emit,
+    NoEmit,
+}
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
+public class InProcessAttribute(
+    InProcessToolchainType toolchainType = InProcessToolchainType.Auto,
+    bool executeOnSeparateThread = true)
+    : JobConfigBaseAttribute(GetJob(toolchainType, executeOnSeparateThread))
+{
+    internal static Job GetJob(InProcessToolchainType toolchainType, bool executeOnSeparateThread)
     {
-        public InProcessAttribute(bool dontLogOutput = false) : base(dontLogOutput ? Job.InProcessDontLogOutput : Job.InProcess)
+        if (toolchainType == InProcessToolchainType.Auto)
         {
+            toolchainType = RuntimeInformation.IsAot
+                ? InProcessToolchainType.NoEmit
+                : InProcessToolchainType.Emit;
         }
+        return toolchainType == InProcessToolchainType.Emit
+            ? Job.Default.WithToolchain(new InProcessEmitToolchain(new() { ExecuteOnSeparateThread = executeOnSeparateThread }))
+            : Job.Default.WithToolchain(new InProcessNoEmitToolchain(new() { ExecuteOnSeparateThread = executeOnSeparateThread }));
     }
 }

--- a/src/BenchmarkDotNet/Configs/DebugConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DebugConfig.cs
@@ -25,15 +25,11 @@ namespace BenchmarkDotNet.Configs
     [PublicAPI]
     public class DebugInProcessConfig : DebugConfig
     {
-        public override IEnumerable<Job> GetJobs()
-            => new[]
-            {
-                Job.Default
-                    .WithToolchain(
-                        new InProcessEmitToolchain(
-                            TimeSpan.FromHours(1), // 1h should be enough to debug the benchmark
-                            true))
-            };
+        public override IEnumerable<Job> GetJobs() =>
+        [
+            Job.Default
+                .WithToolchain(InProcessEmitToolchain.Default)
+        ];
     }
 
     /// <summary>
@@ -42,29 +38,28 @@ namespace BenchmarkDotNet.Configs
     [PublicAPI]
     public class DebugBuildConfig : DebugConfig
     {
-        public override IEnumerable<Job> GetJobs()
-            => new[]
-            {
-                Job.Default
-                    .WithCustomBuildConfiguration("Debug") // will do `-c Debug everywhere`
-            };
+        public override IEnumerable<Job> GetJobs() =>
+        [
+            Job.Default
+                .WithCustomBuildConfiguration("Debug") // will do `-c Debug everywhere`
+        ];
     }
 
     public abstract class DebugConfig : IConfig
     {
-        private readonly static Conclusion[] emptyConclusion = Array.Empty<Conclusion>();
+        private readonly static Conclusion[] emptyConclusion = [];
         public abstract IEnumerable<Job> GetJobs();
 
-        public IEnumerable<IValidator> GetValidators() => Array.Empty<IValidator>();
+        public IEnumerable<IValidator> GetValidators() => [];
         public IEnumerable<IColumnProvider> GetColumnProviders() => DefaultColumnProviders.Instance;
-        public IEnumerable<IExporter> GetExporters() => Array.Empty<IExporter>();
-        public IEnumerable<ILogger> GetLoggers() => new[] { ConsoleLogger.Default };
-        public IEnumerable<IDiagnoser> GetDiagnosers() => Array.Empty<IDiagnoser>();
-        public IEnumerable<IAnalyser> GetAnalysers() => Array.Empty<IAnalyser>();
-        public IEnumerable<HardwareCounter> GetHardwareCounters() => Array.Empty<HardwareCounter>();
-        public IEnumerable<EventProcessor> GetEventProcessors() => Array.Empty<EventProcessor>();
-        public IEnumerable<IFilter> GetFilters() => Array.Empty<IFilter>();
-        public IEnumerable<IColumnHidingRule> GetColumnHidingRules() => Array.Empty<IColumnHidingRule>();
+        public IEnumerable<IExporter> GetExporters() => [];
+        public IEnumerable<ILogger> GetLoggers() => [ConsoleLogger.Default];
+        public IEnumerable<IDiagnoser> GetDiagnosers() => [];
+        public IEnumerable<IAnalyser> GetAnalysers() => [];
+        public IEnumerable<HardwareCounter> GetHardwareCounters() => [];
+        public IEnumerable<EventProcessor> GetEventProcessors() => [];
+        public IEnumerable<IFilter> GetFilters() => [];
+        public IEnumerable<IColumnHidingRule> GetColumnHidingRules() => [];
 
         public IOrderer Orderer => DefaultOrderer.Instance;
         public ICategoryDiscoverer? CategoryDiscoverer => DefaultCategoryDiscoverer.Instance;
@@ -76,7 +71,7 @@ namespace BenchmarkDotNet.Configs
         public string ArtifactsPath => null; // DefaultConfig.ArtifactsPath will be used if the user does not specify it in explicit way
 
         public CultureInfo CultureInfo => null;
-        public IEnumerable<BenchmarkLogicalGroupRule> GetLogicalGroupRules() => Array.Empty<BenchmarkLogicalGroupRule>();
+        public IEnumerable<BenchmarkLogicalGroupRule> GetLogicalGroupRules() => [];
 
         public ConfigOptions Options => ConfigOptions.KeepBenchmarkFiles | ConfigOptions.DisableOptimizationsValidator;
 

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -464,7 +464,7 @@ namespace BenchmarkDotNet.ConsoleArguments
         {
             if (options.RunInProcess)
             {
-                yield return baseJob.WithToolchain(InProcessEmitToolchain.Instance);
+                yield return Attributes.InProcessAttribute.GetJob(Attributes.InProcessToolchainType.Auto, true);
             }
             else if (options.ClrVersion.IsNotBlank())
             {

--- a/src/BenchmarkDotNet/Jobs/InfrastructureMode.cs
+++ b/src/BenchmarkDotNet/Jobs/InfrastructureMode.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Engines;
@@ -23,8 +21,7 @@ namespace BenchmarkDotNet.Jobs
         public static readonly Characteristic<string> BuildConfigurationCharacteristic = CreateCharacteristic<string>(nameof(BuildConfiguration));
         public static readonly Characteristic<IReadOnlyList<Argument>> ArgumentsCharacteristic = CreateCharacteristic<IReadOnlyList<Argument>>(nameof(Arguments));
 
-        public static readonly InfrastructureMode InProcess = new InfrastructureMode(InProcessEmitToolchain.Instance);
-        public static readonly InfrastructureMode InProcessDontLogOutput = new InfrastructureMode(InProcessEmitToolchain.DontLogOutput);
+        public static readonly InfrastructureMode InProcess = new InfrastructureMode(InProcessEmitToolchain.Default);
 
         public InfrastructureMode() { }
 

--- a/src/BenchmarkDotNet/Jobs/Job.cs
+++ b/src/BenchmarkDotNet/Jobs/Job.cs
@@ -28,7 +28,6 @@ namespace BenchmarkDotNet.Jobs
 
         // Infrastructure
         public static readonly Job InProcess = new Job(nameof(InProcess), InfrastructureMode.InProcess);
-        public static readonly Job InProcessDontLogOutput = new Job(nameof(InProcessDontLogOutput), InfrastructureMode.InProcessDontLogOutput);
 
         public Job() : this("") { }
 

--- a/src/BenchmarkDotNet/Toolchains/InProcess/Emit/InProcessEmitExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/Emit/InProcessEmitExecutor.cs
@@ -4,9 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using BenchmarkDotNet.Detectors;
-using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Engines;
-using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
@@ -16,78 +14,35 @@ using BenchmarkDotNet.Toolchains.Results;
 
 namespace BenchmarkDotNet.Toolchains.InProcess.Emit
 {
-    /// <summary>
-    /// Implementation of <see cref="IExecutor" /> for in-process benchmarks.
-    /// </summary>
-    public class InProcessEmitExecutor : IExecutor
+    internal class InProcessEmitExecutor(bool executeOnSeparateThread) : IExecutor
     {
-        private static readonly TimeSpan UnderDebuggerTimeout = TimeSpan.FromDays(1);
-        private static readonly TimeSpan UnderProfilerTimeout = TimeSpan.FromDays(1);
-
-        /// <summary> Default timeout for in-process benchmarks. </summary>
-        public static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
-
-        /// <summary>Initializes a new instance of the <see cref="InProcessEmitExecutor" /> class.</summary>
-        /// <param name="timeout">Timeout for the run.</param>
-        /// <param name="logOutput"><c>true</c> if the output should be logged.</param>
-        public InProcessEmitExecutor(TimeSpan timeout, bool logOutput)
-        {
-            if (timeout == TimeSpan.Zero)
-                timeout = DefaultTimeout;
-
-            ExecutionTimeout = timeout;
-            LogOutput = logOutput;
-        }
-
-        /// <summary>Timeout for the run.</summary>
-        /// <value>The timeout for the run.</value>
-        public TimeSpan ExecutionTimeout { get; }
-
-        /// <summary>Gets a value indicating whether the output should be logged.</summary>
-        /// <value><c>true</c> if the output should be logged; otherwise, <c>false</c>.</value>
-        public bool LogOutput { get; }
-
-        /// <summary>Executes the specified benchmark.</summary>
         public ExecuteResult Execute(ExecuteParameters executeParameters)
         {
-            // TODO: preallocate buffer for output (no direct logging)?
-            var hostLogger = LogOutput ? executeParameters.Logger : NullLogger.Instance;
-            var host = new InProcessHost(executeParameters.BenchmarkCase, hostLogger, executeParameters.Diagnoser);
+            var host = new InProcessHost(executeParameters.BenchmarkCase, executeParameters.Logger, executeParameters.Diagnoser);
 
             int exitCode = -1;
-            var runThread = new Thread(() => exitCode = ExecuteCore(host, executeParameters));
-
-            if (executeParameters.BenchmarkCase.Descriptor.WorkloadMethod
-                .GetCustomAttributes<STAThreadAttribute>(false)
-                .Any() &&
-                OsDetector.IsWindows())
+            if (executeOnSeparateThread)
             {
-                runThread.SetApartmentState(ApartmentState.STA);
+                var runThread = new Thread(() => exitCode = ExecuteCore(host, executeParameters));
+
+                if (executeParameters.BenchmarkCase.Descriptor.WorkloadMethod.GetCustomAttributes<STAThreadAttribute>(false).Any()
+                    && OsDetector.IsWindows())
+                {
+                    runThread.SetApartmentState(ApartmentState.STA);
+                }
+
+                runThread.IsBackground = true;
+
+                runThread.Start();
+                runThread.Join();
             }
-
-            runThread.IsBackground = true;
-
-            var timeout = GetTimeout(executeParameters);
-
-            runThread.Start();
-
-            if (!runThread.Join((int)timeout.TotalMilliseconds))
-                throw new InvalidOperationException(
-                    $"Benchmark {executeParameters.BenchmarkCase.DisplayInfo} takes too long to run. " +
-                    "Prefer to use out-of-process toolchains for long-running benchmarks.");
-
+            else
+            {
+                exitCode = ExecuteCore(host, executeParameters);
+            }
             host.HandleInProcessDiagnoserResults(executeParameters.BenchmarkCase, executeParameters.CompositeInProcessDiagnoser);
 
             return ExecuteResult.FromRunResults(host.RunResults, exitCode);
-        }
-
-        private TimeSpan GetTimeout(ExecuteParameters executeParameters)
-        {
-            if (HostEnvironmentInfo.GetCurrent().HasAttachedDebugger)
-                return UnderDebuggerTimeout;
-            if (executeParameters.Diagnoser is IProfiler)
-                return UnderProfilerTimeout;
-            return ExecutionTimeout;
         }
 
         private int ExecuteCore(IHost host, ExecuteParameters parameters)

--- a/src/BenchmarkDotNet/Toolchains/InProcess/Emit/InProcessEmitSettings.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/Emit/InProcessEmitSettings.cs
@@ -1,0 +1,5 @@
+﻿namespace BenchmarkDotNet.Toolchains.InProcess.Emit;
+
+public class InProcessEmitSettings : InProcessSettings
+{
+}

--- a/src/BenchmarkDotNet/Toolchains/InProcess/Emit/InProcessEmitToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/Emit/InProcessEmitToolchain.cs
@@ -1,32 +1,23 @@
-﻿using System;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Toolchains.InProcess.Emit
 {
+    /// <summary>
+    /// An <see cref="IToolchain"/> to run the benchmarks in-process by emitting IL.
+    /// </summary>
     [PublicAPI]
     public class InProcessEmitToolchain : Toolchain
     {
-        /// <summary>The default toolchain instance.</summary>
-        public static readonly IToolchain Instance = new InProcessEmitToolchain(true);
-
-        /// <summary>The toolchain instance without output logging.</summary>
-        public static readonly IToolchain DontLogOutput = new InProcessEmitToolchain(false);
+        /// <summary>A toolchain instance with default settings.</summary>
+        public static readonly IToolchain Default = new InProcessEmitToolchain(new() { ExecuteOnSeparateThread = true });
 
         /// <summary>Initializes a new instance of the <see cref="InProcessEmitToolchain" /> class.</summary>
-        /// <param name="logOutput"><c>true</c> if the output should be logged.</param>
-        public InProcessEmitToolchain(bool logOutput) :
-            this(TimeSpan.Zero, logOutput)
-        { }
-
-        /// <summary>Initializes a new instance of the <see cref="InProcessEmitToolchain" /> class.</summary>
-        /// <param name="timeout">Timeout for the run.</param>
-        /// <param name="logOutput"><c>true</c> if the output should be logged.</param>
-        public InProcessEmitToolchain(TimeSpan timeout, bool logOutput) :
-            base(
-                nameof(InProcessEmitToolchain),
-                new InProcessEmitGenerator(),
-                new InProcessEmitBuilder(),
-                new InProcessEmitExecutor(timeout, logOutput))
+        /// <param name="settings">The settings to use for the toolchain.</param>
+        public InProcessEmitToolchain(InProcessEmitSettings settings) : base(
+            nameof(InProcessEmitToolchain),
+            new InProcessEmitGenerator(),
+            new InProcessEmitBuilder(),
+            new InProcessEmitExecutor(settings.ExecuteOnSeparateThread))
         {
         }
 

--- a/src/BenchmarkDotNet/Toolchains/InProcess/InProcessSettings.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/InProcessSettings.cs
@@ -1,0 +1,6 @@
+﻿namespace BenchmarkDotNet.Toolchains.InProcess;
+
+public abstract class InProcessSettings
+{
+    public bool ExecuteOnSeparateThread { get; set; } = true;
+}

--- a/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitExecutor.cs
@@ -1,80 +1,44 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using BenchmarkDotNet.Detectors;
 using BenchmarkDotNet.Engines;
-using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Toolchains.Parameters;
 using BenchmarkDotNet.Toolchains.Results;
 
-using JetBrains.Annotations;
-
 namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
 {
-    /// <summary>
-    /// Implementation of <see cref="IExecutor" /> for in-process (no emit) toolchain.
-    /// </summary>
-    [PublicAPI]
-    [SuppressMessage("ReSharper", "ArrangeBraces_using")]
-    public class InProcessNoEmitExecutor : IExecutor
+    internal class InProcessNoEmitExecutor(bool executeOnSeparateThread) : IExecutor
     {
-        private static readonly TimeSpan UnderDebuggerTimeout = TimeSpan.FromDays(1);
-
-        /// <summary> Default timeout for in-process benchmarks. </summary>
-        public static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
-
-        /// <summary>Initializes a new instance of the <see cref="InProcessNoEmitExecutor" /> class.</summary>
-        /// <param name="timeout">Timeout for the run.</param>
-        /// <param name="logOutput"><c>true</c> if the output should be logged.</param>
-        public InProcessNoEmitExecutor(TimeSpan timeout, bool logOutput)
-        {
-            if (timeout == TimeSpan.Zero)
-                timeout = DefaultTimeout;
-
-            ExecutionTimeout = timeout;
-            LogOutput = logOutput;
-        }
-
-        /// <summary>Timeout for the run.</summary>
-        /// <value>The timeout for the run.</value>
-        public TimeSpan ExecutionTimeout { get; }
-
-        /// <summary>Gets a value indicating whether the output should be logged.</summary>
-        /// <value><c>true</c> if the output should be logged; otherwise, <c>false</c>.</value>
-        public bool LogOutput { get; }
-
-        /// <summary>Executes the specified benchmark.</summary>
         public ExecuteResult Execute(ExecuteParameters executeParameters)
         {
-            // TODO: preallocate buffer for output (no direct logging)?
-            var hostLogger = LogOutput ? executeParameters.Logger : NullLogger.Instance;
-            var host = new InProcessHost(executeParameters.BenchmarkCase, hostLogger, executeParameters.Diagnoser);
+            var host = new InProcessHost(executeParameters.BenchmarkCase, executeParameters.Logger, executeParameters.Diagnoser);
 
             int exitCode = -1;
-            var runThread = new Thread(() => exitCode = ExecuteCore(host, executeParameters));
-
-            if (executeParameters.BenchmarkCase.Descriptor.WorkloadMethod.GetCustomAttributes<STAThreadAttribute>(false).Any() &&
-                OsDetector.IsWindows())
+            if (executeOnSeparateThread)
             {
-                runThread.SetApartmentState(ApartmentState.STA);
+                var runThread = new Thread(() => exitCode = ExecuteCore(host, executeParameters));
+
+                if (executeParameters.BenchmarkCase.Descriptor.WorkloadMethod.GetCustomAttributes<STAThreadAttribute>(false).Any()
+                    && OsDetector.IsWindows())
+                {
+                    runThread.SetApartmentState(ApartmentState.STA);
+                }
+
+                runThread.IsBackground = true;
+
+                runThread.Start();
+                runThread.Join();
             }
-
-            runThread.IsBackground = true;
-
-            var timeout = HostEnvironmentInfo.GetCurrent().HasAttachedDebugger ? UnderDebuggerTimeout : ExecutionTimeout;
-
-            runThread.Start();
-
-            if (!runThread.Join((int)timeout.TotalMilliseconds))
-                throw new InvalidOperationException(
-                    $"Benchmark {executeParameters.BenchmarkCase.DisplayInfo} takes too long to run. " +
-                    "Prefer to use out-of-process toolchains for long-running benchmarks.");
+            else
+            {
+                exitCode = ExecuteCore(host, executeParameters);
+            }
 
             host.HandleInProcessDiagnoserResults(executeParameters.BenchmarkCase, executeParameters.CompositeInProcessDiagnoser);
 

--- a/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitSettings.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitSettings.cs
@@ -1,0 +1,5 @@
+﻿namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+
+public class InProcessNoEmitSettings : InProcessSettings
+{
+}

--- a/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/NoEmit/InProcessNoEmitToolchain.cs
@@ -8,34 +8,21 @@ using JetBrains.Annotations;
 namespace BenchmarkDotNet.Toolchains.InProcess.NoEmit
 {
     /// <summary>
-    ///     A toolchain to run the benchmarks in-process (no emit).
+    /// An <see cref="IToolchain"/> to run the benchmarks in-process by reflection.
     /// </summary>
-    /// <seealso cref="IToolchain" />
     [PublicAPI]
     public sealed class InProcessNoEmitToolchain : IToolchain
     {
-        /// <summary>The default toolchain instance.</summary>
-        public static readonly IToolchain Instance = new InProcessNoEmitToolchain(true);
-
-        /// <summary>The toolchain instance without output logging.</summary>
-        public static readonly IToolchain DontLogOutput = new InProcessNoEmitToolchain(false);
+        /// <summary>A toolchain instance with default settings.</summary>
+        public static readonly IToolchain Default = new InProcessNoEmitToolchain(new() { ExecuteOnSeparateThread = true });
 
         /// <summary>Initializes a new instance of the <see cref="InProcessNoEmitToolchain" /> class.</summary>
-        /// <param name="logOutput"><c>true</c> if the output should be logged.</param>
-        public InProcessNoEmitToolchain(bool logOutput) : this(
-            InProcessNoEmitExecutor.DefaultTimeout,
-            logOutput)
-        {
-        }
-
-        /// <summary>Initializes a new instance of the <see cref="InProcessNoEmitToolchain" /> class.</summary>
-        /// <param name="timeout">Timeout for the run.</param>
-        /// <param name="logOutput"><c>true</c> if the output should be logged.</param>
-        public InProcessNoEmitToolchain(TimeSpan timeout, bool logOutput)
+        /// <param name="settings">The settings to use for the toolchain.</param>
+        public InProcessNoEmitToolchain(InProcessNoEmitSettings settings)
         {
             Generator = new InProcessNoEmitGenerator();
             Builder = new InProcessNoEmitBuilder();
-            Executor = new InProcessNoEmitExecutor(timeout, logOutput);
+            Executor = new InProcessNoEmitExecutor(settings.ExecuteOnSeparateThread);
         }
 
         public IEnumerable<ValidationError> Validate(BenchmarkCase benchmarkCase, IResolver resolver) =>

--- a/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
@@ -58,9 +58,9 @@ namespace BenchmarkDotNet.Toolchains
 
                 case MonoRuntime mono:
                     if (OsDetector.IsAndroid())
-                        return InProcessEmitToolchain.Instance;
+                        return InProcessEmitToolchain.Default;
                     if (OsDetector.IsIOS())
-                        return InProcessNoEmitToolchain.Instance;
+                        return InProcessNoEmitToolchain.Default;
                     if (mono.AotArgs.IsNotBlank())
                         return MonoAotToolchain.Instance;
                     if (mono.IsDotNetBuiltIn)
@@ -91,7 +91,7 @@ namespace BenchmarkDotNet.Toolchains
 
                 case CoreRuntime coreRuntime:
                     if (descriptor != null && descriptor.Type.Assembly.IsLinqPad())
-                        return InProcessEmitToolchain.Instance;
+                        return InProcessEmitToolchain.Default;
                     if (coreRuntime.RuntimeMoniker != RuntimeMoniker.NotRecognized && !coreRuntime.IsPlatformSpecific)
                         return GetToolchain(coreRuntime.RuntimeMoniker);
 

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/ExpectedBenchmarkResultsTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/ExpectedBenchmarkResultsTests.cs
@@ -40,7 +40,7 @@ namespace BenchmarkDotNet.IntegrationTests.ManualRunning
             => toolchain switch
             {
                 ToolchainType.Default => Job.Default.GetToolchain(),
-                ToolchainType.InProcess => InProcessEmitToolchain.Instance,
+                ToolchainType.InProcess => InProcessEmitToolchain.Default,
                 _ => throw new ArgumentOutOfRangeException()
             };
 

--- a/tests/BenchmarkDotNet.IntegrationTests/ArgumentsTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ArgumentsTests.cs
@@ -21,7 +21,7 @@ namespace BenchmarkDotNet.IntegrationTests
             => new[]
                 {
                     new object[] { Job.Default.GetToolchain() },
-                    new object[] { InProcessEmitToolchain.Instance },
+                    new object[] { InProcessEmitToolchain.Default },
                 };
 
         public ArgumentsTests(ITestOutputHelper output) : base(output) { }

--- a/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
@@ -28,7 +28,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
         public static IEnumerable<object[]> GetAllJits()
         {
-            yield return [JitInfo.GetCurrentJit(), RuntimeInformation.GetCurrentPlatform(), InProcessEmitToolchain.Instance]; // InProcess
+            yield return [JitInfo.GetCurrentJit(), RuntimeInformation.GetCurrentPlatform(), InProcessEmitToolchain.Default]; // InProcess
 
             if (RuntimeInformation.IsFullFramework)
             {

--- a/tests/BenchmarkDotNet.IntegrationTests/DotMemoryTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/DotMemoryTests.cs
@@ -29,7 +29,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
             var config = new ManualConfig().AddJob(
                 Job.Dry.WithId("ExternalProcess"),
-                Job.Dry.WithToolchain(InProcessEmitToolchain.Instance).WithId("InProcess")
+                Job.Dry.WithToolchain(InProcessEmitToolchain.Default).WithId("InProcess")
             );
             string snapshotDirectory = Path.Combine(Directory.GetCurrentDirectory(), "BenchmarkDotNet.Artifacts", "snapshots");
             if (Directory.Exists(snapshotDirectory))

--- a/tests/BenchmarkDotNet.IntegrationTests/DotTraceTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/DotTraceTests.cs
@@ -29,7 +29,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
             var config = new ManualConfig().AddJob(
                 Job.Dry.WithId("ExternalProcess"),
-                Job.Dry.WithToolchain(InProcessEmitToolchain.Instance).WithId("InProcess")
+                Job.Dry.WithToolchain(InProcessEmitToolchain.Default).WithId("InProcess")
             );
             string snapshotDirectory = Path.Combine(Directory.GetCurrentDirectory(), "BenchmarkDotNet.Artifacts", "snapshots");
             if (Directory.Exists(snapshotDirectory))

--- a/tests/BenchmarkDotNet.IntegrationTests/ExceptionHandlingTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ExceptionHandlingTests.cs
@@ -46,27 +46,27 @@ namespace BenchmarkDotNet.IntegrationTests
 
         [Fact]
         public void DryJobWithInProcessToolchainDoesNotEatExceptions()
-            => SourceExceptionMessageIsDisplayed<AlwaysThrow>(Job.Dry.WithToolchain(InProcessEmitToolchain.Instance));
+            => SourceExceptionMessageIsDisplayed<AlwaysThrow>(Job.Dry.WithToolchain(InProcessEmitToolchain.Default));
 
         [Fact]
         public void DryJobWithInProcessToolchainDoesNotEatExceptionsWhenIterationCleanupThrows()
-            => SourceExceptionMessageIsDisplayed<ThrowInBenchmarkAndInIterationCleanup>(Job.Dry.WithToolchain(InProcessEmitToolchain.Instance));
+            => SourceExceptionMessageIsDisplayed<ThrowInBenchmarkAndInIterationCleanup>(Job.Dry.WithToolchain(InProcessEmitToolchain.Default));
 
         [Fact]
         public void DryJobWithInProcessToolchainDoesNotEatExceptionsWhenGlobalCleanupThrows()
-            => SourceExceptionMessageIsDisplayed<ThrowInBenchmarkAndInGlobalCleanup>(Job.Dry.WithToolchain(InProcessEmitToolchain.Instance));
+            => SourceExceptionMessageIsDisplayed<ThrowInBenchmarkAndInGlobalCleanup>(Job.Dry.WithToolchain(InProcessEmitToolchain.Default));
 
         [Fact]
         public void DefaultJobWithInProcessToolchainDoesNotEatExceptions()
-            => SourceExceptionMessageIsDisplayed<AlwaysThrow>(Job.Default.WithToolchain(InProcessEmitToolchain.Instance));
+            => SourceExceptionMessageIsDisplayed<AlwaysThrow>(Job.Default.WithToolchain(InProcessEmitToolchain.Default));
 
         [Fact]
         public void DefaultJobWithInProcessToolchainDoesNotEatExceptionsWhenIterationCleanupThrows()
-            => SourceExceptionMessageIsDisplayed<ThrowInBenchmarkAndInIterationCleanup>(Job.Default.WithToolchain(InProcessEmitToolchain.Instance));
+            => SourceExceptionMessageIsDisplayed<ThrowInBenchmarkAndInIterationCleanup>(Job.Default.WithToolchain(InProcessEmitToolchain.Default));
 
         [Fact]
         public void DefaultJobWithInProcessToolchainDoesNotEatExceptionsWhenGlobalCleanupThrows()
-            => SourceExceptionMessageIsDisplayed<ThrowInBenchmarkAndInGlobalCleanup>(Job.Default.WithToolchain(InProcessEmitToolchain.Instance));
+            => SourceExceptionMessageIsDisplayed<ThrowInBenchmarkAndInGlobalCleanup>(Job.Default.WithToolchain(InProcessEmitToolchain.Default));
 
         [AssertionMethod]
         private void SourceExceptionMessageIsDisplayed<TBenchmark>(Job job)

--- a/tests/BenchmarkDotNet.IntegrationTests/InProcessDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/InProcessDiagnoserTests.cs
@@ -105,8 +105,8 @@ public class InProcessDiagnoserTests(ITestOutputHelper output) : BenchmarkTestEx
     {
         var job = toolchain switch
         {
-            ToolchainType.InProcessEmit => Job.Dry.WithToolchain(InProcessEmitToolchain.Instance),
-            ToolchainType.InProcessNoEmit => Job.Dry.WithToolchain(InProcessNoEmitToolchain.Instance),
+            ToolchainType.InProcessEmit => Job.Dry.WithToolchain(InProcessEmitToolchain.Default),
+            ToolchainType.InProcessNoEmit => Job.Dry.WithToolchain(InProcessNoEmitToolchain.Default),
             _ => Job.Dry
         };
 

--- a/tests/BenchmarkDotNet.IntegrationTests/InProcessEmitTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/InProcessEmitTest.cs
@@ -34,7 +34,7 @@ namespace BenchmarkDotNet.IntegrationTests
         private IConfig CreateInProcessConfig(OutputLogger logger)
         {
             return new ManualConfig()
-                .AddJob(Job.Dry.WithToolchain(new InProcessEmitToolchain(TimeSpan.Zero, true)).WithInvocationCount(UnrollFactor).WithUnrollFactor(UnrollFactor))
+                .AddJob(Job.Dry.WithToolchain(InProcessEmitToolchain.Default).WithInvocationCount(UnrollFactor).WithUnrollFactor(UnrollFactor))
                 .AddLogger(logger ?? (Output != null ? new OutputLogger(Output) : ConsoleLogger.Default))
                 .AddColumnProvider(DefaultColumnProviders.Instance);
         }
@@ -49,7 +49,7 @@ namespace BenchmarkDotNet.IntegrationTests
                 .AddLogger(DefaultConfig.Instance.GetLoggers().ToArray())
                 .AddJob(
                     Job.Dry
-                        .WithToolchain(InProcessEmitToolchain.DontLogOutput)
+                        .WithToolchain(InProcessEmitToolchain.Default)
                         .WithInvocationCount(4)
                         .WithUnrollFactor(4))
                 .AddJob(

--- a/tests/BenchmarkDotNet.IntegrationTests/InProcessTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/InProcessTest.cs
@@ -78,7 +78,7 @@ namespace BenchmarkDotNet.IntegrationTests
                 : Platform.X64;
 
             var otherPlatformConfig = new ManualConfig()
-                .AddJob(Job.Dry.WithToolchain(InProcessNoEmitToolchain.Instance).WithPlatform(otherPlatform))
+                .AddJob(Job.Dry.WithToolchain(InProcessNoEmitToolchain.Default).WithPlatform(otherPlatform))
                 .AddLogger(new OutputLogger(Output))
                 .AddColumnProvider(DefaultColumnProviders.Instance);
 
@@ -172,7 +172,7 @@ namespace BenchmarkDotNet.IntegrationTests
         private IConfig CreateInProcessConfig(OutputLogger? logger = null)
         {
             return new ManualConfig()
-                .AddJob(Job.Dry.WithToolchain(new InProcessNoEmitToolchain(TimeSpan.Zero, true)).WithInvocationCount(UnrollFactor).WithUnrollFactor(UnrollFactor))
+                .AddJob(Job.Dry.WithToolchain(InProcessNoEmitToolchain.Default).WithInvocationCount(UnrollFactor).WithUnrollFactor(UnrollFactor))
                 .AddLogger(logger ?? (Output != null ? new OutputLogger(Output) : ConsoleLogger.Default))
                 .AddColumnProvider(DefaultColumnProviders.Instance);
         }

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -39,7 +39,7 @@ namespace BenchmarkDotNet.IntegrationTests
             // InProcessEmit reports flaky allocations in current .Net 8.
             if (!RuntimeInformation.IsNetCore)
             {
-                yield return new object[] { InProcessEmitToolchain.Instance };
+                yield return new object[] { InProcessEmitToolchain.Default };
             }
         }
 

--- a/tests/BenchmarkDotNet.IntegrationTests/ParamSourceTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ParamSourceTests.cs
@@ -22,7 +22,7 @@ namespace BenchmarkDotNet.IntegrationTests
             => new[]
                 {
                     new object[] { Job.Default.GetToolchain() },
-                    new object[] { InProcessEmitToolchain.Instance },
+                    new object[] { InProcessEmitToolchain.Default },
                 };
 
         [Fact]
@@ -202,7 +202,7 @@ namespace BenchmarkDotNet.IntegrationTests
             // If that changes, this test and the one above should be merged into:
             //   [Theory, MemberData(nameof(GetToolchains))]
             //   public void SourceWithExplicitCastToTarget_Succeeds(IToolchain toolchain) => CanExecuteWithExtraInfo(typeof(SourceWithExplicitCastToTarget), toolchain);
-            Assert.ThrowsAny<Exception>(() => CanExecuteWithExtraInfo(typeof(SourceWithExplicitCastToTarget), InProcessEmitToolchain.Instance));
+            Assert.ThrowsAny<Exception>(() => CanExecuteWithExtraInfo(typeof(SourceWithExplicitCastToTarget), InProcessEmitToolchain.Default));
         }
 
         public abstract class OverridePropertyBase

--- a/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ValuesReturnedByBenchmarkTest.cs
@@ -19,7 +19,7 @@ namespace BenchmarkDotNet.IntegrationTests
         public static IEnumerable<object[]> GetToolchains() => new[]
         {
             new object[] { Job.Default.GetToolchain() },
-            new object[] { InProcessEmitToolchain.Instance },
+            new object[] { InProcessEmitToolchain.Default },
         };
 
         [Theory, MemberData(nameof(GetToolchains), DisableDiscoveryEnumeration = true)]


### PR DESCRIPTION
Added `InProcessSettings` option to run on same thread (fixes #2589).
Removed pointless timeout and `DontLogOutput` (logger comes from config).
`[InProcess]` and `--inProcess` now auto-select toolchain based on `IsAot`.