### PR TITLE
Add support for custom hardware counter names

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.Windows/HardwareCounters.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/HardwareCounters.cs
@@ -68,17 +68,15 @@ namespace BenchmarkDotNet.Diagnostics.Windows
             }
 
             // Validate custom counters
-            foreach (var customCounter in validationParameters.Config.GetCustomCounters())
+            foreach (var customCounter in validationParameters.Config.GetCustomCounters()
+                .Where(c => !availableCpuCounters.ContainsKey(c.ProfileSourceName)))
             {
-                if (!availableCpuCounters.ContainsKey(customCounter.ProfileSourceName))
-                {
-                    var availableCounterNames = availableCpuCounters.Keys.ToList();
-                    var displayedCounterNames = string.Join(", ", availableCounterNames.Take(20));
-                    var suffix = availableCounterNames.Count > 20 ? $" (and {availableCounterNames.Count - 20} more)" : string.Empty;
-                    yield return new ValidationError(true,
-                        $"Custom counter '{customCounter.ProfileSourceName}' is not available on this machine. " +
-                        $"Available counters: {displayedCounterNames}{suffix}");
-                }
+                var availableCounterNames = availableCpuCounters.Keys.ToList();
+                var displayedCounterNames = string.Join(", ", availableCounterNames.Take(20));
+                var suffix = availableCounterNames.Count > 20 ? $" (and {availableCounterNames.Count - 20} more)" : string.Empty;
+                yield return new ValidationError(true,
+                    $"Custom counter '{customCounter.ProfileSourceName}' is not available on this machine. " +
+                    $"Available counters: {displayedCounterNames}{suffix}");
             }
 
             foreach (var benchmark in validationParameters.Benchmarks)

--- a/src/BenchmarkDotNet.Diagnostics.Windows/HardwareCounters.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/HardwareCounters.cs
@@ -97,12 +97,8 @@ namespace BenchmarkDotNet.Diagnostics.Windows
         internal static PreciseMachineCounter FromCustomCounter(CustomCounter customCounter, Func<ProfileSourceInfo, int> intervalSelector)
         {
             var profileSource = TraceEventProfileSources.GetInfo()[customCounter.ProfileSourceName];
-            // Use the custom counter's interval if specified, otherwise use the intervalSelector
-            var interval = customCounter.Interval != CustomCounter.DefaultInterval 
-                ? customCounter.Interval 
-                : intervalSelector(profileSource);
 
-            return new PreciseMachineCounter(profileSource.ID, profileSource.Name, customCounter, interval);
+            return new PreciseMachineCounter(profileSource.ID, profileSource.Name, customCounter, customCounter.Interval);
         }
 
         internal static void Enable(IEnumerable<PreciseMachineCounter> counters)

--- a/src/BenchmarkDotNet.Diagnostics.Windows/HardwareCounters.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/HardwareCounters.cs
@@ -72,9 +72,12 @@ namespace BenchmarkDotNet.Diagnostics.Windows
             {
                 if (!availableCpuCounters.ContainsKey(customCounter.ProfileSourceName))
                 {
+                    var availableCounterNames = availableCpuCounters.Keys.ToList();
+                    var displayedCounterNames = string.Join(", ", availableCounterNames.Take(20));
+                    var suffix = availableCounterNames.Count > 20 ? $" (and {availableCounterNames.Count - 20} more)" : string.Empty;
                     yield return new ValidationError(true,
                         $"Custom counter '{customCounter.ProfileSourceName}' is not available on this machine. " +
-                        $"Available counters: {string.Join(", ", availableCpuCounters.Keys.Take(20))}...");
+                        $"Available counters: {displayedCounterNames}{suffix}");
                 }
             }
 

--- a/src/BenchmarkDotNet.Diagnostics.Windows/Sessions.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/Sessions.cs
@@ -69,7 +69,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
                 | KernelTraceEventParser.Keywords.ImageLoad // handles stack frames from native modules, SUPER IMPORTANT!
                 | KernelTraceEventParser.Keywords.Profile; // CPU stacks
 
-            if (Details.Config.GetHardwareCounters().Any())
+            if (Details.Config.GetHardwareCounters().Any() || Details.Config.GetCustomCounters().Any())
                 keywords |= KernelTraceEventParser.Keywords.PMCProfile; // Precise Machine Counters
 
             TraceEventSession.StackCompression = true;

--- a/src/BenchmarkDotNet/Attributes/CustomCountersAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/CustomCountersAttribute.cs
@@ -1,0 +1,40 @@
+using System;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using JetBrains.Annotations;
+
+namespace BenchmarkDotNet.Attributes
+{
+    /// <summary>
+    /// Specifies custom hardware counters to be collected during benchmarking.
+    /// Use this when the predefined HardwareCounter enum values don't match the counters 
+    /// available on your machine (e.g., AMD-specific counters like DcacheMisses, IcacheMisses).
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
+    public class CustomCountersAttribute : Attribute, IConfigSource
+    {
+        // CLS-Compliant Code requires a constructor without an array in the argument list
+        [PublicAPI]
+        protected CustomCountersAttribute()
+        {
+            Config = ManualConfig.CreateEmpty();
+        }
+
+        /// <summary>
+        /// Creates a CustomCountersAttribute with the specified counter names.
+        /// Counter names must match the ETW profile source names available on the machine.
+        /// Use TraceEventProfileSources.GetInfo().Keys to discover available counters.
+        /// </summary>
+        /// <param name="counterNames">The ETW profile source names (e.g., "DcacheMisses", "IcacheMisses")</param>
+        public CustomCountersAttribute(params string[] counterNames)
+        {
+            var config = ManualConfig.CreateEmpty();
+            foreach (var name in counterNames)
+            {
+                config.AddCustomCounters(new CustomCounter(name));
+            }
+            Config = config;
+        }
+        public IConfig Config { get; }
+    }
+}

--- a/src/BenchmarkDotNet/Configs/DebugConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DebugConfig.cs
@@ -57,6 +57,7 @@ namespace BenchmarkDotNet.Configs
         public IEnumerable<IDiagnoser> GetDiagnosers() => [];
         public IEnumerable<IAnalyser> GetAnalysers() => [];
         public IEnumerable<HardwareCounter> GetHardwareCounters() => [];
+        public IEnumerable<CustomCounter> GetCustomCounters() => [];
         public IEnumerable<EventProcessor> GetEventProcessors() => [];
         public IEnumerable<IFilter> GetFilters() => [];
         public IEnumerable<IColumnHidingRule> GetColumnHidingRules() => [];

--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -119,6 +119,8 @@ namespace BenchmarkDotNet.Configs
 
         public IEnumerable<HardwareCounter> GetHardwareCounters() => Array.Empty<HardwareCounter>();
 
+        public IEnumerable<CustomCounter> GetCustomCounters() => Array.Empty<CustomCounter>();
+
         public IEnumerable<IFilter> GetFilters() => Array.Empty<IFilter>();
 
         public IEnumerable<EventProcessor> GetEventProcessors() => Array.Empty<EventProcessor>();

--- a/src/BenchmarkDotNet/Configs/IConfig.cs
+++ b/src/BenchmarkDotNet/Configs/IConfig.cs
@@ -26,6 +26,7 @@ namespace BenchmarkDotNet.Configs
         IEnumerable<Job> GetJobs();
         IEnumerable<IValidator> GetValidators();
         IEnumerable<HardwareCounter> GetHardwareCounters();
+        IEnumerable<CustomCounter> GetCustomCounters();
         IEnumerable<IFilter> GetFilters();
         IEnumerable<BenchmarkLogicalGroupRule> GetLogicalGroupRules();
         IEnumerable<EventProcessor> GetEventProcessors();

--- a/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
@@ -30,6 +30,7 @@ namespace BenchmarkDotNet.Configs
         private readonly ImmutableHashSet<IValidator> validators;
         private readonly ImmutableHashSet<Job> jobs;
         private readonly ImmutableHashSet<HardwareCounter> hardwareCounters;
+        private readonly ImmutableHashSet<CustomCounter> customCounters;
         private readonly ImmutableHashSet<IFilter> filters;
         private readonly ImmutableArray<BenchmarkLogicalGroupRule> rules;
         private readonly ImmutableHashSet<EventProcessor> eventProcessors;
@@ -39,6 +40,7 @@ namespace BenchmarkDotNet.Configs
             ImmutableArray<IColumnProvider> uniqueColumnProviders,
             ImmutableHashSet<ILogger> uniqueLoggers,
             ImmutableHashSet<HardwareCounter> uniqueHardwareCounters,
+            ImmutableHashSet<CustomCounter> uniqueCustomCounters,
             ImmutableHashSet<IDiagnoser> uniqueDiagnosers,
             ImmutableArray<IExporter> uniqueExporters,
             ImmutableHashSet<IAnalyser> uniqueAnalyzers,
@@ -62,6 +64,7 @@ namespace BenchmarkDotNet.Configs
             columnProviders = uniqueColumnProviders;
             loggers = uniqueLoggers;
             hardwareCounters = uniqueHardwareCounters;
+            customCounters = uniqueCustomCounters;
             diagnosers = uniqueDiagnosers;
             exporters = uniqueExporters;
             analysers = uniqueAnalyzers;
@@ -101,6 +104,7 @@ namespace BenchmarkDotNet.Configs
         public IEnumerable<Job> GetJobs() => jobs;
         public IEnumerable<IValidator> GetValidators() => validators;
         public IEnumerable<HardwareCounter> GetHardwareCounters() => hardwareCounters;
+        public IEnumerable<CustomCounter> GetCustomCounters() => customCounters;
         public IEnumerable<IFilter> GetFilters() => filters;
         public IEnumerable<BenchmarkLogicalGroupRule> GetLogicalGroupRules() => rules;
         public IEnumerable<EventProcessor> GetEventProcessors() => eventProcessors;

--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -93,7 +93,7 @@ namespace BenchmarkDotNet.Configs
 
             if ((!uniqueHardwareCounters.IsEmpty || !uniqueCustomCounters.IsEmpty) && !diagnosers.OfType<IHardwareCountersDiagnoser>().Any())
             {
-                // if users define hardware counters via [HardwareCounters] we need to dynamically load the right diagnoser
+                // if users define hardware counters or custom counters (e.g. via [HardwareCounters] or [CustomCounters]), we need to dynamically load the right diagnoser
                 var hardwareCountersDiagnoser = DiagnosersLoader.GetImplementation<IHardwareCountersDiagnoser>();
 
                 if (hardwareCountersDiagnoser != default(IDiagnoser) && !builder.Contains(hardwareCountersDiagnoser))

--- a/src/BenchmarkDotNet/Configs/ManualConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ManualConfig.cs
@@ -32,6 +32,7 @@ namespace BenchmarkDotNet.Configs
         private readonly List<IValidator> validators = new List<IValidator>();
         private readonly List<Job> jobs = new List<Job>();
         private readonly HashSet<HardwareCounter> hardwareCounters = new HashSet<HardwareCounter>();
+        private readonly HashSet<CustomCounter> customCounters = new HashSet<CustomCounter>();
         private readonly List<IFilter> filters = new List<IFilter>();
         private readonly List<BenchmarkLogicalGroupRule> logicalGroupRules = new List<BenchmarkLogicalGroupRule>();
         private readonly List<EventProcessor> eventProcessors = new List<EventProcessor>();
@@ -45,6 +46,7 @@ namespace BenchmarkDotNet.Configs
         public IEnumerable<IValidator> GetValidators() => validators;
         public IEnumerable<Job> GetJobs() => jobs;
         public IEnumerable<HardwareCounter> GetHardwareCounters() => hardwareCounters;
+        public IEnumerable<CustomCounter> GetCustomCounters() => customCounters;
         public IEnumerable<IFilter> GetFilters() => filters;
         public IEnumerable<BenchmarkLogicalGroupRule> GetLogicalGroupRules() => logicalGroupRules;
         public IEnumerable<EventProcessor> GetEventProcessors() => eventProcessors;
@@ -170,6 +172,12 @@ namespace BenchmarkDotNet.Configs
             return this;
         }
 
+        public ManualConfig AddCustomCounters(params CustomCounter[] newCustomCounters)
+        {
+            customCounters.AddRange(newCustomCounters);
+            return this;
+        }
+
         public ManualConfig AddFilter(params IFilter[] newFilters)
         {
             filters.AddRange(newFilters);
@@ -225,6 +233,7 @@ namespace BenchmarkDotNet.Configs
             jobs.AddRange(config.GetJobs());
             validators.AddRange(config.GetValidators());
             hardwareCounters.AddRange(config.GetHardwareCounters());
+            customCounters.AddRange(config.GetCustomCounters());
             filters.AddRange(config.GetFilters());
             eventProcessors.AddRange(config.GetEventProcessors());
             Orderer = config.Orderer ?? Orderer;

--- a/src/BenchmarkDotNet/Diagnosers/CustomCounter.cs
+++ b/src/BenchmarkDotNet/Diagnosers/CustomCounter.cs
@@ -1,0 +1,71 @@
+using System;
+using JetBrains.Annotations;
+
+namespace BenchmarkDotNet.Diagnosers
+{
+    /// <summary>
+    /// Represents a custom hardware performance counter that can be specified by its ETW profile source name.
+    /// Use this when the predefined <see cref="HardwareCounter"/> enum values don't match the counters 
+    /// available on your machine (e.g., AMD-specific counters like DcacheMisses, IcacheMisses).
+    /// Run <c>TraceEventProfileSources.GetInfo().Keys</c> to discover available counters on your system.
+    /// </summary>
+    public class CustomCounter
+    {
+        /// <summary>
+        /// Default sampling interval for custom counters.
+        /// </summary>
+        public const int DefaultInterval = 1_000_003;
+
+        /// <summary>
+        /// The exact name of the ETW profile source as returned by TraceEventProfileSources.GetInfo().
+        /// </summary>
+        [PublicAPI]
+        public string ProfileSourceName { get; }
+
+        /// <summary>
+        /// A short name used for display in reports and columns.
+        /// </summary>
+        [PublicAPI]
+        public string ShortName { get; }
+
+        /// <summary>
+        /// The sampling interval for this counter.
+        /// </summary>
+        [PublicAPI]
+        public int Interval { get; }
+
+        /// <summary>
+        /// Indicates whether higher values are better for this counter.
+        /// Default is false (lower is better, e.g., cache misses).
+        /// </summary>
+        [PublicAPI]
+        public bool HigherIsBetter { get; }
+
+        /// <summary>
+        /// Creates a new custom hardware counter.
+        /// </summary>
+        /// <param name="profileSourceName">The exact name of the ETW profile source (e.g., "DcacheMisses", "IcacheMisses").</param>
+        /// <param name="shortName">Optional short name for display. If null, uses the profile source name.</param>
+        /// <param name="interval">Sampling interval. If not specified, uses DefaultInterval (1,000,003).</param>
+        /// <param name="higherIsBetter">Whether higher values are better for this counter.</param>
+        public CustomCounter(string profileSourceName, string? shortName = null, int interval = DefaultInterval, bool higherIsBetter = false)
+        {
+            if (profileSourceName == null)
+                throw new ArgumentNullException(nameof(profileSourceName));
+            if (string.IsNullOrWhiteSpace(profileSourceName))
+                throw new ArgumentException("Profile source name cannot be empty or whitespace.", nameof(profileSourceName));
+
+            ProfileSourceName = profileSourceName;
+            ShortName = shortName ?? profileSourceName;
+            Interval = interval;
+            HigherIsBetter = higherIsBetter;
+        }
+
+        public override string ToString() => ProfileSourceName;
+
+        public override bool Equals(object? obj)
+            => obj is CustomCounter other && ProfileSourceName == other.ProfileSourceName;
+
+        public override int GetHashCode() => ProfileSourceName.GetHashCode();
+    }
+}

--- a/src/BenchmarkDotNet/Diagnosers/CustomCounter.cs
+++ b/src/BenchmarkDotNet/Diagnosers/CustomCounter.cs
@@ -50,10 +50,8 @@ namespace BenchmarkDotNet.Diagnosers
         /// <param name="higherIsBetter">Whether higher values are better for this counter.</param>
         public CustomCounter(string profileSourceName, string? shortName = null, int interval = DefaultInterval, bool higherIsBetter = false)
         {
-            if (profileSourceName == null)
-                throw new ArgumentNullException(nameof(profileSourceName));
             if (string.IsNullOrWhiteSpace(profileSourceName))
-                throw new ArgumentException("Profile source name cannot be empty or whitespace.", nameof(profileSourceName));
+                throw new ArgumentException("Profile source name cannot be null, empty or whitespace.", nameof(profileSourceName));
 
             ProfileSourceName = profileSourceName;
             ShortName = shortName ?? profileSourceName;

--- a/src/BenchmarkDotNet/Diagnosers/CustomCounter.cs
+++ b/src/BenchmarkDotNet/Diagnosers/CustomCounter.cs
@@ -52,6 +52,9 @@ namespace BenchmarkDotNet.Diagnosers
         {
             if (string.IsNullOrWhiteSpace(profileSourceName))
                 throw new ArgumentException("Profile source name cannot be null, empty or whitespace.", nameof(profileSourceName));
+            
+            if (interval <= 0)
+                throw new ArgumentOutOfRangeException(nameof(interval), interval, "Interval must be positive.");
 
             ProfileSourceName = profileSourceName;
             ShortName = shortName ?? profileSourceName;

--- a/src/BenchmarkDotNet/Diagnosers/PmcMetricDescriptor.cs
+++ b/src/BenchmarkDotNet/Diagnosers/PmcMetricDescriptor.cs
@@ -8,9 +8,9 @@ namespace BenchmarkDotNet.Diagnosers
         internal PmcMetricDescriptor(PreciseMachineCounter counter)
         {
             Id = counter.Name;
-            DisplayName = $"{counter.Name}/Op";
+            DisplayName = $"{counter.ShortName}/Op";
             Legend = $"Hardware counter '{counter.Name}' per single operation";
-            TheGreaterTheBetter = counter.Counter.TheGreaterTheBetter();
+            TheGreaterTheBetter = counter.HigherIsBetter;
         }
 
         public string Id { get; }

--- a/src/BenchmarkDotNet/Diagnosers/PreciseMachineCounter.cs
+++ b/src/BenchmarkDotNet/Diagnosers/PreciseMachineCounter.cs
@@ -9,8 +9,20 @@ namespace BenchmarkDotNet.Diagnosers
         [PublicAPI] public int ProfileSourceId { get; }
         [PublicAPI] public string Name { get; }
         [PublicAPI] public HardwareCounter Counter { get; }
+        [PublicAPI] public CustomCounter? CustomCounter { get; }
         [PublicAPI] public int Interval { get; }
         [PublicAPI] public Dictionary<ulong, ulong> PerInstructionPointer { get; }
+
+        /// <summary>
+        /// Gets the short name for display purposes.
+        /// For custom counters, uses the custom short name. For built-in counters, uses the enum's short name.
+        /// </summary>
+        [PublicAPI] public string ShortName => CustomCounter?.ShortName ?? Counter.ToShortName();
+
+        /// <summary>
+        /// Gets whether this counter tracks a metric where higher values are better.
+        /// </summary>
+        [PublicAPI] public bool HigherIsBetter => CustomCounter?.HigherIsBetter ?? Counter.TheGreaterTheBetter();
 
         public ulong Count { get; private set; }
 
@@ -19,6 +31,17 @@ namespace BenchmarkDotNet.Diagnosers
             ProfileSourceId = profileSourceId;
             Name = name;
             Counter = counter;
+            CustomCounter = null;
+            Interval = interval;
+            PerInstructionPointer = new Dictionary<ulong, ulong>(capacity: 10000);
+        }
+
+        internal PreciseMachineCounter(int profileSourceId, string name, CustomCounter customCounter, int interval)
+        {
+            ProfileSourceId = profileSourceId;
+            Name = name;
+            Counter = HardwareCounter.NotSet;
+            CustomCounter = customCounter;
             Interval = interval;
             PerInstructionPointer = new Dictionary<ulong, ulong>(capacity: 10000);
         }

--- a/tests/BenchmarkDotNet.Tests/Configs/CustomCounterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/CustomCounterTests.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Linq;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.Configs
+{
+    public class CustomCounterTests
+    {
+        #region CustomCounter Class Tests
+
+        [Fact]
+        public void ProfileSourceNameIsSetCorrectly()
+        {
+            var counter = new CustomCounter("DCMiss");
+
+            Assert.Equal("DCMiss", counter.ProfileSourceName);
+            Assert.Equal("DCMiss", counter.ShortName); // ShortName defaults to ProfileSourceName
+            Assert.Equal(CustomCounter.DefaultInterval, counter.Interval);
+            Assert.False(counter.HigherIsBetter);
+        }
+
+        [Fact]
+        public void ShortNameIsSetWhenProvided()
+        {
+            var counter = new CustomCounter("DCMiss", shortName: "L1D$Miss");
+
+            Assert.Equal("DCMiss", counter.ProfileSourceName);
+            Assert.Equal("L1D$Miss", counter.ShortName);
+        }
+
+        [Fact]
+        public void IntervalIsSetWhenProvided()
+        {
+            var counter = new CustomCounter("DCMiss", interval: 500_000);
+
+            Assert.Equal(500_000, counter.Interval);
+        }
+
+        [Fact]
+        public void HigherIsBetterIsSetWhenProvided()
+        {
+            var counter = new CustomCounter("BranchInstructions", higherIsBetter: true);
+
+            Assert.True(counter.HigherIsBetter);
+        }
+
+        [Fact]
+        public void AllPropertiesAreSetWhenProvided()
+        {
+            var counter = new CustomCounter(
+                "BranchMispredictions",
+                shortName: "BrMisp",
+                interval: 100_000,
+                higherIsBetter: false);
+
+            Assert.Equal("BranchMispredictions", counter.ProfileSourceName);
+            Assert.Equal("BrMisp", counter.ShortName);
+            Assert.Equal(100_000, counter.Interval);
+            Assert.False(counter.HigherIsBetter);
+        }
+
+        [Fact]
+        public void NullProfileSourceNameThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CustomCounter(null!));
+        }
+
+        [Fact]
+        public void EmptyProfileSourceNameThrows()
+        {
+            Assert.Throws<ArgumentException>(() => new CustomCounter(""));
+        }
+
+        [Fact]
+        public void WhitespaceProfileSourceNameThrows()
+        {
+            Assert.Throws<ArgumentException>(() => new CustomCounter("   "));
+        }
+
+        [Fact]
+        public void CountersWithSameProfileSourceNameAreEqual()
+        {
+            var counter1 = new CustomCounter("DCMiss", shortName: "L1D$Miss");
+            var counter2 = new CustomCounter("DCMiss", shortName: "DifferentName");
+
+            Assert.Equal(counter1, counter2);
+            Assert.Equal(counter1.GetHashCode(), counter2.GetHashCode());
+        }
+
+        [Fact]
+        public void CountersWithDifferentProfileSourceNameAreNotEqual()
+        {
+            var counter1 = new CustomCounter("DCMiss");
+            var counter2 = new CustomCounter("ICMiss");
+
+            Assert.NotEqual(counter1, counter2);
+        }
+
+        [Fact]
+        public void SpecialCharactersInNameAreAllowed()
+        {
+            var counter = new CustomCounter("L1-D$-Cache_Misses");
+
+            Assert.Equal("L1-D$-Cache_Misses", counter.ProfileSourceName);
+        }
+
+        [Fact]
+        public void VeryLargeIntervalIsAccepted()
+        {
+            var counter = new CustomCounter("DCMiss", interval: int.MaxValue);
+
+            Assert.Equal(int.MaxValue, counter.Interval);
+        }
+
+        [Fact]
+        public void ZeroIntervalIsAccepted()
+        {
+            // Zero interval might be invalid for actual profiling but should be accepted by the class
+            var counter = new CustomCounter("DCMiss", interval: 0);
+
+            Assert.Equal(0, counter.Interval);
+        }
+
+        #endregion
+
+        #region ManualConfig.AddCustomCounters Tests
+
+        [Fact]
+        public void SingleCounterCanBeAdded()
+        {
+            var config = ManualConfig.CreateEmpty();
+
+            config.AddCustomCounters(new CustomCounter("DCMiss"));
+
+            Assert.Single(config.GetCustomCounters());
+            Assert.Equal("DCMiss", config.GetCustomCounters().Single().ProfileSourceName);
+        }
+
+        [Fact]
+        public void MultipleCountersCanBeAdded()
+        {
+            var config = ManualConfig.CreateEmpty();
+
+            config.AddCustomCounters(
+                new CustomCounter("DCMiss"),
+                new CustomCounter("ICMiss"),
+                new CustomCounter("BranchMispredictions"));
+
+            Assert.Equal(3, config.GetCustomCounters().Count());
+        }
+
+        [Fact]
+        public void DuplicateCustomCountersAreExcluded()
+        {
+            var config = ManualConfig.CreateEmpty();
+
+            config.AddCustomCounters(new CustomCounter("DCMiss"));
+            config.AddCustomCounters(new CustomCounter("DCMiss", shortName: "Different"));
+
+            Assert.Single(config.GetCustomCounters());
+        }
+
+        [Fact]
+        public void AddCustomCountersReturnsSameInstance()
+        {
+            var config = ManualConfig.CreateEmpty();
+
+            var result = config.AddCustomCounters(new CustomCounter("DCMiss"));
+
+            Assert.Same(config, result);
+        }
+
+        [Fact]
+        public void EmptyArrayHasNoEffect()
+        {
+            var config = ManualConfig.CreateEmpty();
+
+            config.AddCustomCounters();
+
+            Assert.Empty(config.GetCustomCounters());
+        }
+
+        #endregion
+
+        #region ImmutableConfig Custom Counters Tests
+
+        [Fact]
+        public void CustomCountersArePreservedInImmutableConfig()
+        {
+            var mutable = ManualConfig.CreateEmpty();
+            mutable.AddCustomCounters(
+                new CustomCounter("DCMiss", shortName: "L1D$Miss"),
+                new CustomCounter("ICMiss", shortName: "L1I$Miss"));
+
+            var immutable = ImmutableConfigBuilder.Create(mutable);
+
+            Assert.Equal(2, immutable.GetCustomCounters().Count());
+            Assert.Contains(immutable.GetCustomCounters(), c => c.ProfileSourceName == "DCMiss");
+            Assert.Contains(immutable.GetCustomCounters(), c => c.ProfileSourceName == "ICMiss");
+        }
+
+        [Fact]
+        public void DuplicateCustomCountersAreExcludedInImmutableConfig()
+        {
+            var mutable = ManualConfig.CreateEmpty();
+            mutable.AddCustomCounters(new CustomCounter("DCMiss"));
+            mutable.AddCustomCounters(new CustomCounter("DCMiss"));
+
+            var immutable = ImmutableConfigBuilder.Create(mutable);
+
+            Assert.Single(immutable.GetCustomCounters());
+        }
+
+        [Fact]
+        public void CustomCounterPropertiesArePreservedInImmutableConfig()
+        {
+            var mutable = ManualConfig.CreateEmpty();
+            mutable.AddCustomCounters(new CustomCounter(
+                "BranchMispredictions",
+                shortName: "BrMisp",
+                interval: 500_000,
+                higherIsBetter: false));
+
+            var immutable = ImmutableConfigBuilder.Create(mutable);
+            var counter = immutable.GetCustomCounters().Single();
+
+            Assert.Equal("BranchMispredictions", counter.ProfileSourceName);
+            Assert.Equal("BrMisp", counter.ShortName);
+            Assert.Equal(500_000, counter.Interval);
+            Assert.False(counter.HigherIsBetter);
+        }
+
+        #endregion
+
+        #region Config Merging Tests
+
+        [Fact]
+        public void CustomCountersAreCombinedWhenMergingConfigs()
+        {
+            var config1 = ManualConfig.CreateEmpty();
+            config1.AddCustomCounters(new CustomCounter("DCMiss"));
+
+            var config2 = ManualConfig.CreateEmpty();
+            config2.AddCustomCounters(new CustomCounter("ICMiss"));
+
+            config1.Add(config2);
+
+            Assert.Equal(2, config1.GetCustomCounters().Count());
+            Assert.Contains(config1.GetCustomCounters(), c => c.ProfileSourceName == "DCMiss");
+            Assert.Contains(config1.GetCustomCounters(), c => c.ProfileSourceName == "ICMiss");
+        }
+
+        [Fact]
+        public void DuplicateCustomCountersAreExcludedWhenMergingConfigs()
+        {
+            var config1 = ManualConfig.CreateEmpty();
+            config1.AddCustomCounters(new CustomCounter("DCMiss"));
+
+            var config2 = ManualConfig.CreateEmpty();
+            config2.AddCustomCounters(new CustomCounter("DCMiss"));
+
+            config1.Add(config2);
+
+            Assert.Single(config1.GetCustomCounters());
+        }
+
+        [Fact]
+        public void OriginalCountersArePreservedWhenMergingEmptyConfig()
+        {
+            var config1 = ManualConfig.CreateEmpty();
+            config1.AddCustomCounters(
+                new CustomCounter("DCMiss"),
+                new CustomCounter("ICMiss"));
+
+            var config2 = ManualConfig.CreateEmpty();
+
+            config1.Add(config2);
+
+            Assert.Equal(2, config1.GetCustomCounters().Count());
+        }
+
+        #endregion
+
+        #region DefaultConfig Tests
+
+        [Fact]
+        public void DefaultConfigHasNoCustomCounters()
+        {
+            var defaultConfig = DefaultConfig.Instance;
+
+            Assert.Empty(defaultConfig.GetCustomCounters());
+        }
+
+        #endregion
+
+        #region Combined Hardware and Custom Counters Tests
+
+        [Fact]
+        public void BothHardwareAndCustomCountersCanBeConfigured()
+        {
+            var config = ManualConfig.CreateEmpty();
+            config.AddHardwareCounters(HardwareCounter.CacheMisses);
+            config.AddCustomCounters(new CustomCounter("DCMiss"));
+
+            Assert.Single(config.GetHardwareCounters());
+            Assert.Single(config.GetCustomCounters());
+        }
+
+        [Fact]
+        public void BothHardwareAndCustomCountersArePreservedInImmutableConfig()
+        {
+            var mutable = ManualConfig.CreateEmpty();
+            mutable.AddHardwareCounters(HardwareCounter.CacheMisses);
+            mutable.AddCustomCounters(new CustomCounter("DCMiss"));
+
+            var immutable = ImmutableConfigBuilder.Create(mutable);
+
+            Assert.Single(immutable.GetHardwareCounters());
+            Assert.Single(immutable.GetCustomCounters());
+        }
+
+        #endregion
+    }
+}

--- a/tests/BenchmarkDotNet.Tests/Configs/CustomCounterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/CustomCounterTests.cs
@@ -64,7 +64,7 @@ namespace BenchmarkDotNet.Tests.Configs
         [Fact]
         public void NullProfileSourceNameThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => new CustomCounter(null!));
+            Assert.Throws<ArgumentException>(() => new CustomCounter(null!));
         }
 
         [Fact]

--- a/tests/BenchmarkDotNet.Tests/Configs/CustomCounterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/CustomCounterTests.cs
@@ -115,12 +115,15 @@ namespace BenchmarkDotNet.Tests.Configs
         }
 
         [Fact]
-        public void ZeroIntervalIsAccepted()
+        public void ZeroIntervalThrows()
         {
-            // Zero interval might be invalid for actual profiling but should be accepted by the class
-            var counter = new CustomCounter("DCMiss", interval: 0);
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CustomCounter("DCMiss", interval: 0));
+        }
 
-            Assert.Equal(0, counter.Interval);
+        [Fact]
+        public void NegativeIntervalThrows()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CustomCounter("DCMiss", interval: -1));
         }
 
         #endregion


### PR DESCRIPTION
Fixes #1520

This PR adds the ability to specify custom hardware counter names by their ETW profile source names, giving developers flexibility to use CPU-specific counters that aren't covered by the HardwareCounter enum.

Changes:
- Add CustomCounter class to represent custom PMC counters with configurable profile source name, short display name, interval, and higher-is-better flag
- Add CustomCountersAttribute for declarative counter specification
- Add IConfig.GetCustomCounters() and ManualConfig.AddCustomCounters() methods
- Update ImmutableConfig/ImmutableConfigBuilder to handle custom counters
- Update PreciseMachineCounter to support both enum and custom counters
- Update PmcStats to track custom counters separately
- Update PmcMetricDescriptor to use ShortName for column display
- Update EtwProfiler to collect both hardware and custom counters
- Update HardwareCounters.Validate() and Sessions to handle custom counters
- Fix ManualConfig.Add() to propagate custom counters during config merge

Usage example:
// Using attribute
[CustomCounters("DCMiss", "ICMiss", "BranchMispredictions")] public class MyBenchmark { }

// Using ManualConfig
var config = ManualConfig.CreateEmpty()
    .AddCustomCounters(
        new CustomCounter("DCMiss", shortName: "L1D$Miss"),
        new CustomCounter("ICMiss", shortName: "L1I$Miss")
    );

Developers can discover available counters on their system using: TraceEventProfileSources.GetInfo().Keys

**Note:** This is an initial implementation that has not been
thoroughly tested across different CPU architectures or edge cases. Further review
and testing is recommended before merging to confirm correctness of the changes.

If you spot issues or have improvements in mind,
please feel free to push commits directly to this branch or open your own PR with the changes.