### PR TITLE
fix: Duplicated config items issue

### DIFF
--- a/src/BenchmarkDotNet/Columns/ColumnHidingByIdRule.cs
+++ b/src/BenchmarkDotNet/Columns/ColumnHidingByIdRule.cs
@@ -1,14 +1,30 @@
 ﻿using JetBrains.Annotations;
+using System;
 
 namespace BenchmarkDotNet.Columns
 {
     [PublicAPI]
-    public class ColumnHidingByIdRule: IColumnHidingRule
+    public sealed class ColumnHidingByIdRule : IColumnHidingRule, IEquatable<ColumnHidingByIdRule>
     {
         public string Id { get; }
 
         public ColumnHidingByIdRule(IColumn column) => Id = column.Id;
 
         public bool NeedToHide(IColumn column) => column.Id == Id;
+
+        public bool Equals(ColumnHidingByIdRule? other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return Id == other.Id;
+        }
+
+        public override bool Equals(object? obj)
+            => Equals(obj as ColumnHidingByIdRule);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Id);
     }
 }

--- a/src/BenchmarkDotNet/Columns/ColumnHidingByNameRule.cs
+++ b/src/BenchmarkDotNet/Columns/ColumnHidingByNameRule.cs
@@ -1,14 +1,31 @@
 ﻿using JetBrains.Annotations;
+using System;
 
 namespace BenchmarkDotNet.Columns
 {
     [PublicAPI]
-    public class ColumnHidingByNameRule: IColumnHidingRule
+    public sealed class ColumnHidingByNameRule : IColumnHidingRule, IEquatable<ColumnHidingByNameRule>
     {
         public string Name { get; }
 
         public ColumnHidingByNameRule(string name) => Name = name;
 
         public bool NeedToHide(IColumn column) => column.ColumnName == Name;
+
+        public bool Equals(ColumnHidingByNameRule? other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return Name == other.Name;
+        }
+
+        public override bool Equals(object? obj)
+            => Equals(obj as ColumnHidingByNameRule);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Name);
     }
 }

--- a/src/BenchmarkDotNet/Configs/ManualConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ManualConfig.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using BenchmarkDotNet.Analysers;
@@ -118,49 +117,49 @@ namespace BenchmarkDotNet.Configs
 
         public ManualConfig AddColumn(params IColumn[] newColumns)
         {
-            columnProviders.AddRange(newColumns.Select(c => c.ToProvider()));
+            columnProviders.AddRangeDistinct(newColumns.Select(c => c.ToProvider()));
             return this;
         }
 
         public ManualConfig AddColumnProvider(params IColumnProvider[] newColumnProviders)
         {
-            columnProviders.AddRange(newColumnProviders);
+            columnProviders.AddRangeDistinct(newColumnProviders);
             return this;
         }
 
         public ManualConfig AddExporter(params IExporter[] newExporters)
         {
-            exporters.AddRange(newExporters);
+            exporters.AddRangeDistinct(newExporters);
             return this;
         }
 
         public ManualConfig AddLogger(params ILogger[] newLoggers)
         {
-            loggers.AddRange(newLoggers);
+            loggers.AddRangeDistinct(newLoggers);
             return this;
         }
 
         public ManualConfig AddDiagnoser(params IDiagnoser[] newDiagnosers)
         {
-            diagnosers.AddRange(newDiagnosers);
+            diagnosers.AddRangeDistinct(newDiagnosers);
             return this;
         }
 
         public ManualConfig AddAnalyser(params IAnalyser[] newAnalysers)
         {
-            analysers.AddRange(newAnalysers);
+            analysers.AddRangeDistinct(newAnalysers);
             return this;
         }
 
         public ManualConfig AddValidator(params IValidator[] newValidators)
         {
-            validators.AddRange(newValidators);
+            validators.AddRangeDistinct(newValidators);
             return this;
         }
 
         public ManualConfig AddJob(params Job[] newJobs)
         {
-            jobs.AddRange(newJobs.Select(j => j.Freeze())); // DONTTOUCH: please DO NOT remove .Freeze() call.
+            jobs.AddRangeDistinct(newJobs.Select(j => j.Freeze())); // DONTTOUCH: please DO NOT remove .Freeze() call.
             return this;
         }
 
@@ -172,68 +171,63 @@ namespace BenchmarkDotNet.Configs
 
         public ManualConfig AddFilter(params IFilter[] newFilters)
         {
-            filters.AddRange(newFilters);
+            filters.AddRangeDistinct(newFilters);
             return this;
         }
 
         public ManualConfig AddLogicalGroupRules(params BenchmarkLogicalGroupRule[] rules)
         {
-            foreach (var rule in rules)
-            {
-                if (logicalGroupRules.Contains(rule))
-                    logicalGroupRules.Remove(rule);
-                logicalGroupRules.Add(rule);
-            }
+            logicalGroupRules.AddRangeDistinct(rules);
             return this;
         }
 
         public ManualConfig AddEventProcessor(params EventProcessor[] newEventProcessors)
         {
-            this.eventProcessors.AddRange(newEventProcessors);
+            eventProcessors.AddRangeDistinct(newEventProcessors);
             return this;
         }
 
         [PublicAPI]
         public ManualConfig HideColumns(params string[] columnNames)
         {
-            columnHidingRules.AddRange(columnNames.Select(c => new ColumnHidingByNameRule(c)));
+            columnHidingRules.AddRangeDistinct(columnNames.Select(c => new ColumnHidingByNameRule(c)));
             return this;
         }
 
         [PublicAPI]
         public ManualConfig HideColumns(params IColumn[] columns)
         {
-            columnHidingRules.AddRange(columns.Select(c => new ColumnHidingByIdRule(c)));
+            columnHidingRules.AddRangeDistinct(columns.Select(c => new ColumnHidingByIdRule(c)));
             return this;
         }
 
         [PublicAPI]
         public ManualConfig HideColumns(params IColumnHidingRule[] rules)
         {
-            columnHidingRules.AddRange(rules);
+            columnHidingRules.AddRangeDistinct(rules);
             return this;
         }
 
         [PublicAPI]
         public void Add(IConfig config)
         {
-            columnProviders.AddRange(config.GetColumnProviders());
-            exporters.AddRange(config.GetExporters());
-            loggers.AddRange(config.GetLoggers());
-            diagnosers.AddRange(config.GetDiagnosers());
-            analysers.AddRange(config.GetAnalysers());
-            jobs.AddRange(config.GetJobs());
-            validators.AddRange(config.GetValidators());
+            columnProviders.AddRangeDistinct(config.GetColumnProviders());
+            exporters.AddRangeDistinct(config.GetExporters());
+            loggers.AddRangeDistinct(config.GetLoggers());
+            diagnosers.AddRangeDistinct(config.GetDiagnosers());
+            analysers.AddRangeDistinct(config.GetAnalysers());
+            jobs.AddRangeDistinct(config.GetJobs());
+            validators.AddRangeDistinct(config.GetValidators());
             hardwareCounters.AddRange(config.GetHardwareCounters());
-            filters.AddRange(config.GetFilters());
-            eventProcessors.AddRange(config.GetEventProcessors());
+            filters.AddRangeDistinct(config.GetFilters());
+            eventProcessors.AddRangeDistinct(config.GetEventProcessors());
             Orderer = config.Orderer ?? Orderer;
             CategoryDiscoverer = config.CategoryDiscoverer ?? CategoryDiscoverer;
             ArtifactsPath = config.ArtifactsPath ?? ArtifactsPath;
             CultureInfo = config.CultureInfo ?? CultureInfo;
             SummaryStyle = config.SummaryStyle ?? SummaryStyle;
-            logicalGroupRules.AddRange(config.GetLogicalGroupRules());
-            columnHidingRules.AddRange(config.GetColumnHidingRules());
+            logicalGroupRules.AddRangeDistinct(config.GetLogicalGroupRules());
+            columnHidingRules.AddRangeDistinct(config.GetColumnHidingRules());
             Options |= config.Options;
             BuildTimeout = GetBuildTimeout(BuildTimeout, config.BuildTimeout);
             WakeLock = GetWakeLock(WakeLock, config.WakeLock);

--- a/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/CommonExtensions.cs
@@ -45,6 +45,16 @@ namespace BenchmarkDotNet.Extensions
                 hashSet.Add(item);
         }
 
+        public static void AddRangeDistinct<T>(this List<T> list, IEnumerable<T> items, IEqualityComparer<T>? comparer = null)
+        {
+            var hashSet = new HashSet<T>(list, comparer);
+            foreach (var item in items)
+            {
+                if (hashSet.Add(item))
+                    list.Add(item);
+            }
+        }
+
 #if NETSTANDARD2_0
         public static TValue? GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
             => dictionary.TryGetValue(key, out var value) ? value : default;

--- a/src/BenchmarkDotNet/Order/DefaultOrderer.cs
+++ b/src/BenchmarkDotNet/Order/DefaultOrderer.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Parameters;
 using BenchmarkDotNet.Reports;
@@ -110,8 +111,7 @@ namespace BenchmarkDotNet.Order
             }
 
             var rules = new List<BenchmarkLogicalGroupRule>(explicitRules);
-            foreach (var rule in implicitRules.Where(rule => !rules.Contains(rule)))
-                rules.Add(rule);
+            rules.AddRangeDistinct(implicitRules);
 
             var keys = new List<string>();
             foreach (var rule in rules)


### PR DESCRIPTION
This PR intended to fix duplicated list items issue when **multiple** configs are merged with `ConfigUnionRule.Union`.

When [creating ImmutableConfig instance](https://github.com/dotnet/BenchmarkDotNet/blob/db0546dbe6e5defae530c35001bfec6e44533004/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs#L40-L53). It's expected contains **unique** items.
But it seems not unique when multiple config is merged with union rule or manually add items with `Add*` method.

#### What's changed in this PR

1. Add `AddRangeDistinct` helper method to `Extensions/CommonExtensions.cs`
2. Replace `AddRange` to `AddRangeDistinct` when union config items.
3. Implement `IEquatable<T>` and `sealed` modifier to `ColumnHidingByNameRule`/`ColumnHidingByNameRule`
