### PR TITLE
chore: add ConfigUnionTests and add fix issue of SimpleColumnProvider comparison

### DIFF
--- a/src/BenchmarkDotNet/Columns/SimpleColumnProvider.cs
+++ b/src/BenchmarkDotNet/Columns/SimpleColumnProvider.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Reports;
 
 namespace BenchmarkDotNet.Columns
 {
-    public class SimpleColumnProvider : IColumnProvider
+    public class SimpleColumnProvider : IColumnProvider, IEquatable<SimpleColumnProvider>
     {
         private readonly IColumn[] columns;
 
@@ -14,5 +15,27 @@ namespace BenchmarkDotNet.Columns
         }
 
         public IEnumerable<IColumn> GetColumns(Summary summary) => columns.Where(c => c.IsAvailable(summary));
+
+        public bool Equals(SimpleColumnProvider? other)
+        {
+            if (ReferenceEquals(this, other))
+                return true;
+            if (other is null)
+                return false;
+
+            return columns.SequenceEqual(other.columns);
+        }
+
+        public override bool Equals(object? obj)
+           => Equals(obj as SimpleColumnProvider);
+
+        public override int GetHashCode()
+        {
+            // Compute hashcode of each column.
+            var hash = new HashCode();
+            foreach (var column in columns)
+                hash.Add(column);
+            return hash.ToHashCode();
+        }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/Configs/ConfigUnionTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Configs/ConfigUnionTests.cs
@@ -1,0 +1,106 @@
+﻿using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.EventProcessors;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Filters;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
+using System.Linq;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.Configs;
+
+public class ConfigUnionTests
+{
+    [Fact]
+    public void UnionConfig()
+    {
+        // Arrange
+        var config = CreateDummyConfig();
+        var expected = config.CreateImmutableConfig();
+
+        // Act
+        config = ManualConfig.Union(config, CreateDummyConfig());
+        var result = config.CreateImmutableConfig();
+
+        // Assert
+        Validate(expected, result);
+    }
+
+    [Fact]
+    public void UnionConfigByAddMethods()
+    {
+        var p1 = new SimpleColumnProvider(TargetMethodColumn.Namespace).GetHashCode();
+        var p2 = new SimpleColumnProvider(TargetMethodColumn.Namespace).GetHashCode();
+
+        // Arrange
+        var config = CreateDummyConfig();
+        var otherConfig = CreateDummyConfig();
+        var expected = config.CreateImmutableConfig();
+
+        // Act
+        config.AddAnalyser(otherConfig.GetAnalysers().ToArray())
+              .AddColumnProvider(otherConfig.GetColumnProviders().ToArray())
+              .AddDiagnoser(otherConfig.GetDiagnosers().ToArray())
+              .AddExporter(otherConfig.GetExporters().ToArray())
+              .AddEventProcessor(otherConfig.GetEventProcessors().ToArray())
+              .AddFilter(otherConfig.GetFilters().ToArray())
+              .AddHardwareCounters(otherConfig.GetHardwareCounters().ToArray())
+              .AddLogger(otherConfig.GetLoggers().ToArray())
+              .AddLogicalGroupRules(otherConfig.GetLogicalGroupRules().ToArray())
+              .AddValidator(otherConfig.GetValidators().ToArray());
+
+        var result = config.CreateImmutableConfig();
+
+        // Assert
+        Validate(expected, result);
+    }
+
+    private static void Validate(ImmutableConfig expected, ImmutableConfig result)
+    {
+        Assert.Equal(expected.GetAnalysers(), result.GetAnalysers());
+        Assert.Equal(expected.GetColumnProviders(), result.GetColumnProviders());
+        Assert.Equal(expected.GetDiagnosers(), result.GetDiagnosers());
+        Assert.Equal(expected.GetExporters(), result.GetExporters());
+        Assert.Equal(expected.GetEventProcessors(), result.GetEventProcessors());
+        Assert.Equal(expected.GetFilters(), result.GetFilters());
+        Assert.Equal(expected.GetHardwareCounters(), result.GetHardwareCounters());
+        Assert.Equal(expected.GetLoggers(), result.GetLoggers());
+        Assert.Equal(expected.GetLogicalGroupRules(), result.GetLogicalGroupRules());
+        Assert.Equal(expected.GetValidators(), result.GetValidators());
+    }
+
+    private static ManualConfig CreateDummyConfig() =>
+        ManualConfig.CreateEmpty()
+                    .AddAnalyser([EnvironmentAnalyser.Default])
+                    .AddColumn(TargetMethodColumn.Namespace)
+                    .AddColumnProvider(DefaultColumnProviders.Instance)
+                    .AddDiagnoser([MemoryDiagnoser.Default])
+                    .AddExporter(MarkdownExporter.Default)
+                    .AddEventProcessor(DummyEventProcessor.Instance)
+                    .AddFilter(DummyFilter.Instance)
+                    .AddHardwareCounters([HardwareCounter.BranchMispredictions])
+                    .AddLogger(ConsoleLogger.Default)
+                    .AddLogicalGroupRules([BenchmarkLogicalGroupRule.ByCategory])
+                    .AddValidator([BaselineValidator.FailOnError])
+                    .HideColumns([Column.Id]);
+
+    private class DummyFilter : IFilter
+    {
+        public static DummyFilter Instance = new DummyFilter();
+
+        private DummyFilter() { }
+
+        public bool Predicate(BenchmarkCase benchmarkCase) => true;
+    }
+
+    private class DummyEventProcessor : EventProcessor
+    {
+        public static DummyEventProcessor Instance = new DummyEventProcessor();
+
+        private DummyEventProcessor() { }
+    }
+}


### PR DESCRIPTION
This PR is follow up of #2954

#### What's changed in this PR

**1.** Add `ConfigUnionTests` unit tests.

**2.** Add `IEquatable<T>` interface implementation to `SimpleColumnProvider`.
It's required because [AddColumn API internally create different `SimpleColumnProvider` instance.](https://github.com/dotnet/BenchmarkDotNet/blob/d75bb3b3ad620b13b624d4deedfa9af371d13ef3/src/BenchmarkDotNet/Configs/ManualConfig.cs#L120)
