### PR TITLE
chore: Temporary comment-out job that seems to be causing flaky tests that relating dotMemory/dotTrace 

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/DotMemoryTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/DotMemoryTests.cs
@@ -28,8 +28,11 @@ namespace BenchmarkDotNet.IntegrationTests
             }
 
             var config = new ManualConfig().AddJob(
+            [
                 Job.Dry.WithId("ExternalProcess"),
-                Job.Dry.WithToolchain(InProcessEmitToolchain.Default).WithId("InProcess")
+                // TODO: Add InProcessEmitToolchain job when flaky test issue is resolved https://github.com/dotnet/BenchmarkDotNet/issues/2950
+                //Job.Dry.WithToolchain(InProcessEmitToolchain.Default).WithId("InProcess"),
+            ]
             );
             string snapshotDirectory = Path.Combine(Directory.GetCurrentDirectory(), "BenchmarkDotNet.Artifacts", "snapshots");
             if (Directory.Exists(snapshotDirectory))
@@ -47,7 +50,9 @@ namespace BenchmarkDotNet.IntegrationTests
             Output.WriteLine("Snapshots:");
             foreach (string snapshot in snapshots)
                 Output.WriteLine("* " + snapshot);
-            Assert.Equal(4, snapshots.Count);
+
+            Assert.Equal(2, snapshots.Count);
+            // Assert.Equal(4, snapshots.Count);
         }
 
         [DotMemoryDiagnoser]

--- a/tests/BenchmarkDotNet.IntegrationTests/DotTraceTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/DotTraceTests.cs
@@ -28,8 +28,11 @@ namespace BenchmarkDotNet.IntegrationTests
             }
 
             var config = new ManualConfig().AddJob(
-                Job.Dry.WithId("ExternalProcess"),
-                Job.Dry.WithToolchain(InProcessEmitToolchain.Default).WithId("InProcess")
+            [
+                Job.Dry.WithId("ExternalProcess")
+                // TODO: Add InProcessEmitToolchain job when flaky test issue is resolved https://github.com/dotnet/BenchmarkDotNet/issues/2950
+                // Job.Dry.WithToolchain(InProcessEmitToolchain.Default).WithId("InProcess")
+            ]
             );
             string snapshotDirectory = Path.Combine(Directory.GetCurrentDirectory(), "BenchmarkDotNet.Artifacts", "snapshots");
             if (Directory.Exists(snapshotDirectory))
@@ -47,7 +50,9 @@ namespace BenchmarkDotNet.IntegrationTests
             Output.WriteLine("Snapshots:");
             foreach (string snapshot in snapshots)
                 Output.WriteLine("* " + snapshot);
-            Assert.Equal(2, snapshots.Count);
+
+            Assert.Single(snapshots);
+            // Assert.Equal(2, snapshots.Count);
         }
 
         [DotTraceDiagnoser]


### PR DESCRIPTION
This PR is temporary workaround for #2950.

It seems VSTest process crash issue is caused when `InProcessEmitToolchain` or `InProcessNoEmitToolchain` is used.
And it's not occurred when using `CsProjCoreToolchain` only.
So temporary comment-out related job from dotMemory/dotTrace tests.
