### PR TITLE
feat: Show log file path on benchmark finished

### DIFF
--- a/src/BenchmarkDotNet/Helpers/ConsoleHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/ConsoleHelper.cs
@@ -1,0 +1,135 @@
+using BenchmarkDotNet.Detectors;
+using BenchmarkDotNet.Extensions;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Text.RegularExpressions;
+
+namespace BenchmarkDotNet.Helpers;
+
+internal static class ConsoleHelper
+{
+    private const string ESC = "\e";          // Escape sequence.
+    private const string OSC8 = $"{ESC}]8;;"; // Operating System Command 8
+    private const string ST = ESC + @"\";     // String Terminator
+
+    /// <summary>
+    /// Try to gets clickable link text for console.
+    /// If console doesn't support clickable link, it returns false.
+    /// </summary>
+    public static bool TryGetClickableLink(string link, string? linkCaption, out string result)
+    {
+        if (!IsClickableLinkSupported)
+        {
+            result = "";
+            return false;
+        }
+
+        result = @$"{OSC8}{link}{ST}{linkCaption ?? link}{OSC8}{ST}";
+        return true;
+    }
+
+    public static bool IsWindowsTerminal => _isWindowsTerminal.Value;
+
+    public static bool IsClickableLinkSupported => _isClickableLinkSupported.Value;
+
+    private static readonly Lazy<bool> _isWindowsTerminal = new(()
+        => Environment.GetEnvironmentVariable("WT_SESSION") != null);
+
+    private static readonly Lazy<bool> _isClickableLinkSupported = new(() =>
+    {
+        if (Console.IsOutputRedirected)
+            return false;
+
+        // The current console doesn't have a valid buffer size, which means it is not a real console.
+        if (Console.BufferHeight == 0 || Console.BufferWidth == 0)
+            return false;
+
+        // Disable clickable link on CI environment.
+        if (Environment.GetEnvironmentVariable("CI").IsNotBlank())
+            return false;
+
+        // dumb terminal don't support ANSI escape sequence.
+        var term = Environment.GetEnvironmentVariable("TERM") ?? "";
+        if (term == "dumb")
+            return false;
+
+        if (OsDetector.IsWindows())
+        {
+            try
+            {
+                // conhost.exe don't support clickable link with OSC8.
+                if (IsRunningOnConhost())
+                    return false;
+
+                // ConEmu and don't support OSC8.
+                var conEmu = Environment.GetEnvironmentVariable("ConEmuANSI");
+                if (conEmu != null)
+                    return false;
+
+                // Return true if Virtual Terminal Processing mode is enabled.
+                return IsVirtualTerminalProcessingEnabled();
+            }
+            catch
+            {
+                return false; // Ignore unexpected exception.
+            }
+        }
+        else
+        {
+            // screen don't support OSC8 clickable link.
+            if (Regex.IsMatch(term, "^screen"))
+                return false;
+
+            // Other major terminal supports OSC8 by default. https://github.com/Alhadis/OSC8-Adoption
+            return true;
+        }
+    });
+
+    [SupportedOSPlatform("windows")]
+    private static bool IsVirtualTerminalProcessingEnabled()
+    {
+        const uint STD_OUTPUT_HANDLE = unchecked((uint)-11);
+        IntPtr handle = NativeMethods.GetStdHandle(STD_OUTPUT_HANDLE);
+        if (handle == IntPtr.Zero)
+            return false;
+
+        if (NativeMethods.GetConsoleMode(handle, out uint consoleMode))
+        {
+            const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
+            if ((consoleMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) > 0)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool IsRunningOnConhost()
+    {
+        IntPtr hwnd = NativeMethods.GetConsoleWindow();
+        if (hwnd == IntPtr.Zero)
+            return false;
+
+        NativeMethods.GetWindowThreadProcessId(hwnd, out uint pid);
+        using var process = Process.GetProcessById((int)pid);
+        return process.ProcessName == "conhost";
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static class NativeMethods
+    {
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr GetStdHandle(uint nStdHandle);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr GetConsoleWindow();
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+    }
+}

--- a/src/BenchmarkDotNet/Helpers/PathHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/PathHelper.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace BenchmarkDotNet.Helpers;
+
+internal static class PathHelper
+{
+    public static string GetRelativePath(string relativeTo, string path)
+    {
+#if NETSTANDARD2_0
+        return GetRelativePathCompat(relativeTo, path);
+#else
+        return Path.GetRelativePath(relativeTo, path);
+#endif
+    }
+
+#if NETSTANDARD2_0
+    private static string GetRelativePathCompat(string relativeTo, string path)
+    {
+        // Get absolute full paths
+        string basePath = Path.GetFullPath(relativeTo);
+        string targetPath = Path.GetFullPath(path);
+
+        // Normalize base to directory (Path.GetRelativePath treats base as directory always)
+        if (!basePath.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            basePath += Path.DirectorySeparatorChar;
+
+        // If roots differ, return the absolute target
+        string baseRoot = Path.GetPathRoot(basePath)!;
+        string targetRoot = Path.GetPathRoot(targetPath)!;
+        if (!string.Equals(baseRoot, targetRoot, StringComparison.OrdinalIgnoreCase))
+            return targetPath;
+
+        // Break into segments
+        var baseSegments = SplitPath(basePath);
+        var targetSegments = SplitPath(targetPath);
+
+        // Find common prefix
+        int i = 0;
+        while (i < baseSegments.Count && i < targetSegments.Count && string.Equals(baseSegments[i], targetSegments[i], StringComparison.OrdinalIgnoreCase))
+        {
+            i++;
+        }
+
+        // Build relative parts
+        var relativeParts = new List<string>();
+
+        // For each remaining segment in base -> go up one level
+        for (int j = i; j < baseSegments.Count; j++)
+            relativeParts.Add("..");
+
+        // For each remaining in target -> add those segments
+        for (int j = i; j < targetSegments.Count; j++)
+            relativeParts.Add(targetSegments[j]);
+
+        // If nothing added, it is the same directory
+        if (relativeParts.Count == 0)
+            return ".";
+
+        // Join with separator and return
+        return string.Join(Path.DirectorySeparatorChar.ToString(), relativeParts);
+    }
+
+    private static List<string> SplitPath(string path)
+    {
+        var segments = new List<string>();
+        string[] raw = path.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var seg in raw)
+        {
+            // Skip root parts like "C:\"
+            if (seg.EndsWith(":"))
+                continue;
+            segments.Add(seg);
+        }
+
+        return segments;
+    }
+#endif
+}

--- a/src/BenchmarkDotNet/Loggers/CompositeLogger.cs
+++ b/src/BenchmarkDotNet/Loggers/CompositeLogger.cs
@@ -2,7 +2,7 @@ using System.Collections.Immutable;
 
 namespace BenchmarkDotNet.Loggers
 {
-    internal class CompositeLogger : ILogger
+    internal class CompositeLogger : ILogger, ILinkLogger
     {
         private readonly ImmutableHashSet<ILogger> loggers;
 

--- a/src/BenchmarkDotNet/Loggers/ConsoleLogger.cs
+++ b/src/BenchmarkDotNet/Loggers/ConsoleLogger.cs
@@ -6,7 +6,7 @@ using JetBrains.Annotations;
 
 namespace BenchmarkDotNet.Loggers
 {
-    public sealed class ConsoleLogger : ILogger
+    public sealed class ConsoleLogger : ILogger, ILinkLogger
     {
         private const ConsoleColor DefaultColor = ConsoleColor.Gray;
 

--- a/src/BenchmarkDotNet/Loggers/ILinkLogger.cs
+++ b/src/BenchmarkDotNet/Loggers/ILinkLogger.cs
@@ -1,0 +1,5 @@
+﻿namespace BenchmarkDotNet.Loggers;
+
+internal interface ILinkLogger : ILogger
+{
+}

--- a/src/BenchmarkDotNet/Loggers/ILoggerExtensions.cs
+++ b/src/BenchmarkDotNet/Loggers/ILoggerExtensions.cs
@@ -1,0 +1,34 @@
+using BenchmarkDotNet.Helpers;
+
+namespace BenchmarkDotNet.Loggers;
+
+public static class ILoggerExtensions
+{
+    /// <summary>
+    /// Write clickable link to logger.
+    /// If the logger doesn't implement <see cref="ILinkLogger"/>. It's written as plain text.
+    /// </summary>
+    public static void WriteLink(this ILogger logger, string link, string? linkCaption = null, LogKind logKind = LogKind.Info)
+    {
+        if (logger is ILinkLogger && ConsoleHelper.TryGetClickableLink(link, linkCaption, out var clickableLink))
+        {
+            link = clickableLink;
+        }
+
+        logger.Write(logKind, link);
+    }
+
+    /// <summary>
+    /// Write clickable link to logger.
+    /// If the logger doesn't implement <see cref="ILinkLogger"/>. It's written as plain text.
+    /// </summary>
+    public static void WriteLineLink(this ILogger logger, string link, string? linkCaption = null, string prefixText = "", string suffixText = "", LogKind logKind = LogKind.Info)
+    {
+        if (logger is ILinkLogger && ConsoleHelper.TryGetClickableLink(link, linkCaption, out var clickableLink))
+        {
+            link = clickableLink;
+        }
+
+        logger.WriteLine(logKind, link);
+    }
+}

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -178,6 +178,21 @@ namespace BenchmarkDotNet.Running
                     benchmarkInfo.Dispose();
                 }
 
+                // Output additional information to console.
+                var logFileEnabled = benchmarkRunInfos.All(info => !info.Config.Options.IsSet(ConfigOptions.DisableLogFile));
+                if (logFileEnabled)
+                {
+                    var artifactDirectoryFullPath = Path.GetFullPath(rootArtifactsFolderPath);
+                    var logFileFullPath = Path.GetFullPath(logFilePath);
+                    var logFileRelativePath = PathHelper.GetRelativePath(artifactDirectoryFullPath, logFileFullPath);
+
+                    compositeLogger.WriteLine();
+                    compositeLogger.WriteLineHeader("// * Benchmark LogFile *");
+                    compositeLogger.WriteLineLink(artifactDirectoryFullPath);
+                    compositeLogger.WriteLineLink(logFileFullPath, linkCaption: logFileRelativePath, prefixText: "  ");
+                    compositeLogger.WriteLine();
+                }
+
                 compositeLogger.WriteLineHeader("// * Artifacts cleanup *");
                 Cleanup(compositeLogger, new HashSet<string>(artifactsToCleanup.Distinct()));
                 compositeLogger.WriteLineInfo("Artifacts cleanup is finished");

--- a/tests/BenchmarkDotNet.Tests/Helpers/PathHelperTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Helpers/PathHelperTests.cs
@@ -1,0 +1,55 @@
+using BenchmarkDotNet.Helpers;
+using BenchmarkDotNet.Tests.XUnit;
+
+namespace BenchmarkDotNet.Tests.Helpers;
+
+// Using test patterns of Path.GetRelativePath
+// https://github.com/dotnet/runtime/blob/v10.0.0/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/IO/Path.GetRelativePath.cs
+public class PathHelperTests
+{
+    [TheoryEnvSpecific(EnvRequirement.WindowsOnly)]
+    [InlineData(@"C:\", @"C:\", @".")]
+    [InlineData(@"C:\a", @"C:\a\", @".")]
+    [InlineData(@"C:\A", @"C:\a\", @".")]
+    [InlineData(@"C:\a\", @"C:\a", @".")]
+    [InlineData(@"C:\", @"C:\b", @"b")]
+    [InlineData(@"C:\a", @"C:\b", @"..\b")]
+    // [InlineData(@"C:\a", @"C:\b\", @"..\b\")] // This test failed with GetRelativePathCompat.
+    [InlineData(@"C:\a\b", @"C:\a", @"..")]
+    [InlineData(@"C:\a\b", @"C:\a\", @"..")]
+    [InlineData(@"C:\a\b\", @"C:\a", @"..")]
+    [InlineData(@"C:\a\b\", @"C:\a\", @"..")]
+    [InlineData(@"C:\a\b\c", @"C:\a\b", @"..")]
+    [InlineData(@"C:\a\b\c", @"C:\a\b\", @"..")]
+    [InlineData(@"C:\a\b\c", @"C:\a", @"..\..")]
+    [InlineData(@"C:\a\b\c", @"C:\a\", @"..\..")]
+    [InlineData(@"C:\a\b\c\", @"C:\a\b", @"..")]
+    [InlineData(@"C:\a\b\c\", @"C:\a\b\", @"..")]
+    [InlineData(@"C:\a\b\c\", @"C:\a", @"..\..")]
+    [InlineData(@"C:\a\b\c\", @"C:\a\", @"..\..")]
+    [InlineData(@"C:\a\", @"C:\b", @"..\b")]
+    [InlineData(@"C:\a", @"C:\a\b", @"b")]
+    [InlineData(@"C:\a", @"C:\A\b", @"b")]
+    [InlineData(@"C:\a", @"C:\b\c", @"..\b\c")]
+    [InlineData(@"C:\a\", @"C:\a\b", @"b")]
+    [InlineData(@"C:\", @"D:\", @"D:\")]
+    [InlineData(@"C:\", @"D:\b", @"D:\b")]
+    [InlineData(@"C:\", @"D:\b\", @"D:\b\")]
+    [InlineData(@"C:\a", @"D:\b", @"D:\b")]
+    [InlineData(@"C:\a\", @"D:\b", @"D:\b")]
+    [InlineData(@"C:\ab", @"C:\a", @"..\a")]
+    [InlineData(@"C:\a", @"C:\ab", @"..\ab")]
+    [InlineData(@"C:\", @"\\LOCALHOST\Share\b", @"\\LOCALHOST\Share\b")]
+    [InlineData(@"\\LOCALHOST\Share\a", @"\\LOCALHOST\Share\b", @"..\b")]
+    public void GetRelativePathTest(string relativeTo, string path, string expected)
+    {
+        // Arrange
+        expected = expected.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
+        // Act
+        var result = PathHelper.GetRelativePath(relativeTo, path);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+}


### PR DESCRIPTION
Currently ArtifactsDirectory and generated log file path is not shown on console.
And it need to find log files from `bin\Debug\net8.0\BenchmarkDotNet.Artifacts`.

This PR add feature to show following paths as clickable link when benchmark finished.
- `ArtifactsDirectory`
- `LogFilePath`

This behavior is skipped when `--disableLogFile` is passed.

**Sample Image**
<img width="1120" height="230" alt="image" src="https://github.com/user-attachments/assets/368396eb-fdf9-4f68-860a-1f3fe7e2d3dd" />

**What's Changed in this PR**
1. Add `Helpers/ConsoleHelper.cs` to output clickable link by using ANSI Escape Sequence OSC8.  
    When stdout is redirected or terminal don't support OSC8. It write URL as plain text. 
3. Add `Helpers/PathHelper.cs` to gets relative path. (It's required because `netstandard2.0` don't support `Path.GetRelativePath`)
4. Modify `CompositeLogger.cs` and add code to get ConsoleLogger-like logger.
5. Modify `BenchmarkRunnerClean.cs` and add code to output clickable links.
6. Add `Helpers/PathHelperTests.cs` unit tests for `PathHelper.GetRelativePath`.

**Other Changes**
- Modify `ConfigParser.cs` to suppress exception thrown when running on VS TestExplorer.
- Modify `BenchmarkRunnerClean.cs`  and insert empty line after `Global total time`.
