### PR TITLE
chore: Modify windows defender settings on CI

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -18,9 +18,11 @@ jobs:
         os: [windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+      - name: Add Windows Defender Exclusions
         shell: powershell
+        run: |
+          Add-MpPreference -ExclusionPath $env:GITHUB_WORKSPACE
+          Add-MpPreference -ExclusionPath $env:TEMP
       - uses: actions/checkout@v6
       # Build and Test
       - name: Run task 'build'
@@ -51,9 +53,11 @@ jobs:
         os: [windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+      - name: Add Windows Defender Exclusions
         shell: powershell
+        run: |
+          Add-MpPreference -ExclusionPath $env:GITHUB_WORKSPACE
+          Add-MpPreference -ExclusionPath $env:TEMP
       - uses: actions/checkout@v6
       # Build and Test
       - name: Run task 'build'


### PR DESCRIPTION
On Windows CI environment.
`Set-MpPreference -DisableRealtimeMonitoring $true` command sometimes failed with following error.
(e.g. https://github.com/dotnet/BenchmarkDotNet/actions/runs/21105743318/job/60696964630)

```
Set-MpPreference : Operation failed with the following error: 0x800106ba. Operation: Set-MpPreference. Target: 
DisableRealtimeMonitoring.
At C:\a\_temp\59c177be-e82b-4480-9398-c47727230783.ps1:2 char:1
+ Set-MpPreference -DisableRealtimeMonitoring $true
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (MSFT_MpPreference:root\Microsoft\...FT_MpPreference) [Set-MpPreference],  
   CimException
    + FullyQualifiedErrorId : HRESULT 0x800106ba,Set-MpPreference
```

It seems there is some race conditions that can't disable Windows Defender.

**What's changed in this PR**
1. Remove code that disabling Windows Defender.
2. Add following exclude path settings instead.
  2.1.  `$env:GITHUB_WORKSPACE`
  2.2.  `$env:Temp`

I though this approach is less likely to fail than `DisableRealtimeMonitoring`.

If it failed with this PR settings.
It need to add retry logics to wait Windows Defender service is available.