### PR TITLE
Fix #2581: Copy WarningsAsErrors setting to generated project

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -38,6 +38,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
             "UserSecretsId",
             "EnablePreviewFeatures",
             "RuntimeHostConfigurationOption",
+            "WarningsAsErrors",
         }.ToImmutableArray();
 
         public string RuntimeFrameworkVersion { get; }

--- a/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
@@ -182,6 +182,28 @@ namespace BenchmarkDotNet.Tests
         }
 
         [Fact]
+        public void WarningsAsErrorsSettingGetsCopied()
+        {
+            const string withWarningsAsErrors = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <WarningsAsErrors>NU1102;NU1603</WarningsAsErrors>
+  </PropertyGroup>
+</Project>
+";
+            var sut = new CsProjGenerator("netcoreapp3.1", null, null, null, true);
+
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(withWarningsAsErrors);
+            var (customProperties, sdkName) = sut.GetSettingsThatNeedToBeCopied(xmlDoc, TestAssemblyFileInfo);
+
+            AssertCustomProperties(@"<PropertyGroup>
+  <WarningsAsErrors>NU1102;NU1603</WarningsAsErrors>
+</PropertyGroup>", customProperties);
+            Assert.Equal("Microsoft.NET.Sdk", sdkName);
+        }
+
+        [Fact]
         public void TheDefaultFilePathShouldBeUsedWhenAnAssemblyLocationIsEmpty()
         {
             const string programName = "testProgram";


### PR DESCRIPTION
Add WarningsAsErrors to SettingsWeWantToCopy array in CsProjGenerator so that NuGet restore warnings configured in the source project are preserved in the generated benchmark project and fail the build.

Added test WarningsAsErrorsSettingGetsCopied() to verify the fix.