### PR TITLE
 Fix #2793: Use proper FQN in VS Test Explorer to avoid hierarchy split

### DIFF
--- a/src/BenchmarkDotNet.TestAdapter/BenchmarkCaseExtensions.cs
+++ b/src/BenchmarkDotNet.TestAdapter/BenchmarkCaseExtensions.cs
@@ -35,6 +35,15 @@ namespace BenchmarkDotNet.TestAdapter
             // See: https://github.com/dotnet/BenchmarkDotNet/issues/2494
             var fullyQualifiedName = displayName;
 
+            // Use benchmark method FQN on Visual Studio environment to avoid TestExplorer hierarchy split
+            // when job display name contains '.' which is interpreted as a namespace separator by VS.
+            // See: https://github.com/dotnet/BenchmarkDotNet/issues/2793
+            if (Environment.GetEnvironmentVariable("VSAPPIDNAME") != null)
+            {
+                var benchmarkMethodName = benchmarkMethod.Name;
+                fullyQualifiedName = $"{fullClassName}.{benchmarkMethodName}";
+            }
+
             var vsTestCase = new TestCase(fullyQualifiedName, VsTestAdapter.ExecutorUri, assemblyPath)
             {
                 DisplayName = displayName,

--- a/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
+++ b/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
@@ -37,6 +37,7 @@
     <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.dotTrace\BenchmarkDotNet.Diagnostics.dotTrace.csproj" />
     <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.dotMemory\BenchmarkDotNet.Diagnostics.dotMemory.csproj" />
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />
+    <ProjectReference Include="..\..\src\BenchmarkDotNet.TestAdapter\BenchmarkDotNet.TestAdapter.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/tests/BenchmarkDotNet.Tests/TestAdapter/BenchmarkCaseExtensionsTests.cs
+++ b/tests/BenchmarkDotNet.Tests/TestAdapter/BenchmarkCaseExtensionsTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.TestAdapter;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.TestAdapter
+{
+    public class BenchmarkCaseExtensionsTests
+    {
+        [Fact]
+        public void ToVsTestCase_WithoutVSAPPIDNAME_UsesDisplayNameAsFQN()
+        {
+            // Arrange
+            var originalValue = Environment.GetEnvironmentVariable("VSAPPIDNAME");
+            try
+            {
+                Environment.SetEnvironmentVariable("VSAPPIDNAME", null);
+                var benchmarkCase = BenchmarkConverter.TypeToBenchmarks(typeof(SimpleBenchmark)).BenchmarksCases.Single();
+
+                // Act
+                var testCase = benchmarkCase.ToVsTestCase("test.dll", includeJobInName: true);
+
+                // Assert
+                // FQN should be the displayName which includes job info
+                Assert.Equal(testCase.DisplayName, testCase.FullyQualifiedName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("VSAPPIDNAME", originalValue);
+            }
+        }
+
+        [Fact]
+        public void ToVsTestCase_WithVSAPPIDNAME_UsesMethodFQNToAvoidHierarchySplit()
+        {
+            // Arrange
+            var originalValue = Environment.GetEnvironmentVariable("VSAPPIDNAME");
+            try
+            {
+                Environment.SetEnvironmentVariable("VSAPPIDNAME", "devenv.exe");
+                var benchmarkCase = BenchmarkConverter.TypeToBenchmarks(typeof(SimpleBenchmark)).BenchmarksCases.Single();
+
+                // Act
+                var testCase = benchmarkCase.ToVsTestCase("test.dll", includeJobInName: true);
+
+                // Assert
+                // FQN should be the method FQN (without job info) to avoid hierarchy split
+                // when job display name contains '.' (e.g., ".NET 8.0.6")
+                var fullClassName = benchmarkCase.Descriptor.Type.GetCorrectCSharpTypeName(prefixWithGlobal: false);
+                var expectedFQN = $"{fullClassName}.{nameof(SimpleBenchmark.Method)}";
+                Assert.Equal(expectedFQN, testCase.FullyQualifiedName);
+                // DisplayName should still include job info
+                Assert.Contains("[", testCase.DisplayName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("VSAPPIDNAME", originalValue);
+            }
+        }
+
+        [Fact]
+        public void ToVsTestCase_WithVSAPPIDNAME_FQNDoesNotContainDotFromJobName()
+        {
+            // Arrange - This test verifies the fix for issue #2793
+            // Job display names like ".NET 8.0.6" contain dots that VS Test Explorer
+            // interprets as namespace separators, causing incorrect hierarchy grouping
+            var originalValue = Environment.GetEnvironmentVariable("VSAPPIDNAME");
+            try
+            {
+                Environment.SetEnvironmentVariable("VSAPPIDNAME", "devenv.exe");
+                var benchmarkCase = BenchmarkConverter.TypeToBenchmarks(typeof(SimpleBenchmark)).BenchmarksCases.Single();
+
+                // Act
+                var testCase = benchmarkCase.ToVsTestCase("test.dll", includeJobInName: true);
+
+                // Assert
+                // The FQN should only contain the class and method name,
+                // not the job display info which may contain dots
+                var fqnParts = testCase.FullyQualifiedName.Split('.');
+                // Should end with ClassName.MethodName, not have extra parts from job name
+                Assert.Equal(nameof(SimpleBenchmark), fqnParts[fqnParts.Length - 2]);
+                Assert.Equal(nameof(SimpleBenchmark.Method), fqnParts[fqnParts.Length - 1]);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("VSAPPIDNAME", originalValue);
+            }
+        }
+
+        public class SimpleBenchmark
+        {
+            [Benchmark]
+            public void Method() { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
  - Fix incorrect VS Test Explorer hierarchy when job display name contains `.` (e.g., ".NET 8.0.6")
  - Detect Visual Studio environment via `VSAPPIDNAME` environment variable
  - Use benchmark method FQN instead of displayName for test case in VS, preventing dots in job names from being
  misinterpreted as namespace separators
  - Preserve existing Rider/R# workaround (#2494) for non-VS environments

  ## Test plan
  - [x] Added unit tests for `BenchmarkCaseExtensions.ToVsTestCase`:
    - `ToVsTestCase_WithoutVSAPPIDNAME_UsesDisplayNameAsFQN`
    - `ToVsTestCase_WithVSAPPIDNAME_UsesMethodFQNToAvoidHierarchySplit`
    - `ToVsTestCase_WithVSAPPIDNAME_FQNDoesNotContainDotFromJobName`