### PR TITLE
Fix #2793: Use proper FQN in VS Test Explorer to avoid hierarchy split

### DIFF
--- a/src/BenchmarkDotNet.TestAdapter/BenchmarkCaseExtensions.cs
+++ b/src/BenchmarkDotNet.TestAdapter/BenchmarkCaseExtensions.cs
@@ -35,6 +35,15 @@ namespace BenchmarkDotNet.TestAdapter
             // See: https://github.com/dotnet/BenchmarkDotNet/issues/2494
             var fullyQualifiedName = displayName;
 
+            // Use benchmark method FQN on Visual Studio environment to avoid TestExplorer hierarchy split
+            // when job display name contains '.' which is interpreted as a namespace separator by VS.
+            // See: https://github.com/dotnet/BenchmarkDotNet/issues/2793
+            if (Environment.GetEnvironmentVariable("VSAPPIDNAME") != null)
+            {
+                var benchmarkMethodName = benchmarkMethod.Name;
+                fullyQualifiedName = $"{fullClassName}.{benchmarkMethodName}";
+            }
+
             var vsTestCase = new TestCase(fullyQualifiedName, VsTestAdapter.ExecutorUri, assemblyPath)
             {
                 DisplayName = displayName,


### PR DESCRIPTION
 - Fix incorrect VS Test Explorer hierarchy when job display name contains `.` (e.g., ".NET 8.0.6")
  - Detect Visual Studio environment via `VSAPPIDNAME` environment variable
  - Use benchmark method FQN instead of displayName for test case in VS, preventing dots in job names from being
  misinterpreted as namespace separators
  - Preserve existing Rider/R# workaround (#2494) for non-VS environments

  ## Test plan
  - [ ] Manual testing: Verify in VS Test Explorer that benchmarks with multi-version jobs (containing dots in names
  like ".NET 8.0.6") display correct hierarchy without unintended grouping

  ### Why no automated tests
  The `ToVsTestCase` extension method and `BenchmarkCaseExtensions` class are `internal` to the
  `BenchmarkDotNet.TestAdapter` assembly. Adding unit tests would require exposing internals via `InternalsVisibleTo`,
  which introduces cross-project dependencies and framework compatibility complexity between TestAdapter
  (`netstandard2.0`) and the test project. Since the fix is straightforward and follows the exact pattern suggested in
  the issue, manual verification in VS Test Explorer is sufficient.