### PR TITLE
chore: Fix VSTestAdapter throw exception on test discovery for project that targeting net462

### DIFF
--- a/src/BenchmarkDotNet.TestAdapter/BenchmarkEnumerator.cs
+++ b/src/BenchmarkDotNet.TestAdapter/BenchmarkEnumerator.cs
@@ -38,6 +38,26 @@ namespace BenchmarkDotNet.TestAdapter
                     }
                 }
 
+                if (eventArgs.Name.StartsWith("System.Collections.Immutable, Version="))
+                {
+                    var baseDir = Path.GetDirectoryName(assemblyPath);
+                    var path = Path.Combine(baseDir, "System.Collections.Immutable.dll");
+                    if (File.Exists(path))
+                    {
+                        return Assembly.LoadFrom(path);
+                    }
+                }
+
+                if (eventArgs.Name.StartsWith("System.Memory, Version="))
+                {
+                    var baseDir = Path.GetDirectoryName(assemblyPath);
+                    var path = Path.Combine(baseDir, "System.Memory.dll");
+                    if (File.Exists(path))
+                    {
+                        return Assembly.LoadFrom(path);
+                    }
+                }
+
                 // Fallback to default assembly resolver
                 return null;
             };


### PR DESCRIPTION
This PR intended to fix following VSTestAdapter issue on net462.

**How to reproduce error on VS**
1. Build `BenchmarkDotNet.Samples` project with `Release` configuration on Visual Studio
2. `FileLoadExceptionexception` are recorded on Test output pane on test discovery phase.
3. Test Explorer don't show benchmarks for net462 

---
As far as I've remember.
Test Explorer show benchmarks for `net462` previously.
So, it's expected to be caused by dependent package version conflict between TestAdaper/BenchmarkDotNet for following packages.
- `System.Collections.Immutable`
- `System.Memory`

It seems not resolved by adding PackageReference to TestAdapter project.
I've added temporary that manually resolve following assemblies by `AppDomain.CurrentDomain.AssemblyResolve`.
(That is same temporary workaround code that is used to load BenchmarkDotNet.dll for net462)