### PR TITLE
chore: Add retry for curl that download dotnet-install.sh/ps1

### DIFF
--- a/build/build.bat
+++ b/build/build.bat
@@ -1,2 +1,2 @@
 @ECHO OFF
-PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0build.ps1' %*; exit $LASTEXITCODE"
+pwsh -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0build.ps1' %*; exit $LASTEXITCODE"

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -20,6 +20,9 @@ if ($PSVersionTable.PSEdition -ne 'Core') {
       }
 }
 
+# Temporary remove curl alias.
+Remove-Item alias:curl
+
 ###########################################################################
 # INSTALL .NET CORE CLI
 ###########################################################################
@@ -55,7 +58,9 @@ $GlobalJsonPath = Join-Path $SdkPath "global.json"
 if (!(Test-Path $InstallPath)) {
     New-Item -Path $InstallPath -ItemType Directory -Force | Out-Null;
     $ScriptPath = Join-Path $InstallPath 'dotnet-install.ps1'
-    (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, $ScriptPath);
+
+    curl -LsSfo $ScriptPath $DotNetInstallerUri --retry 5 --retry-delay 5
+
     & $ScriptPath -JSonFile $GlobalJsonPath -InstallDir $InstallPath;
 
     # Install .NET 8 SDK

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -1,5 +1,7 @@
 #!/usr/bin/env pwsh
 
+#Requires -PSEdition Core
+
 $DotNetInstallerUri = 'https://dot.net/v1/dotnet-install.ps1';
 $BuildPath = Split-Path $MyInvocation.MyCommand.Path -Parent
 $PSScriptRoot = Split-Path $PSScriptRoot -Parent
@@ -19,9 +21,6 @@ if ($PSVersionTable.PSEdition -ne 'Core') {
         Write-Output 'Unable to set PowerShell to use TLS 1.2 and TLS 1.1 due to old .NET Framework installed. If you see underlying connection closed or trust errors, you may need to upgrade to .NET Framework 4.5+ and PowerShell v3'
       }
 }
-
-# Temporary remove curl alias.
-Remove-Item alias:curl
 
 ###########################################################################
 # INSTALL .NET CORE CLI

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -6,22 +6,6 @@ $DotNetInstallerUri = 'https://dot.net/v1/dotnet-install.ps1';
 $BuildPath = Split-Path $MyInvocation.MyCommand.Path -Parent
 $PSScriptRoot = Split-Path $PSScriptRoot -Parent
 
-if ($PSVersionTable.PSEdition -ne 'Core') {
-    # Attempt to set highest encryption available for SecurityProtocol.
-    # PowerShell will not set this by default (until maybe .NET 4.6.x). This
-    # will typically produce a message for PowerShell v2 (just an info
-    # message though)
-    try {
-        # Set TLS 1.2 (3072), then TLS 1.1 (768), then TLS 1.0 (192), finally SSL 3.0 (48)
-        # Use integers because the enumeration values for TLS 1.2 and TLS 1.1 won't
-        # exist in .NET 4.0, even though they are addressable if .NET 4.5+ is
-        # installed (.NET 4.5 is an in-place upgrade).
-        [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48
-      } catch {
-        Write-Output 'Unable to set PowerShell to use TLS 1.2 and TLS 1.1 due to old .NET Framework installed. If you see underlying connection closed or trust errors, you may need to upgrade to .NET Framework 4.5+ and PowerShell v3'
-      }
-}
-
 ###########################################################################
 # INSTALL .NET CORE CLI
 ###########################################################################

--- a/build/build.sh
+++ b/build/build.sh
@@ -13,7 +13,7 @@ export DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER=0
 
 if [ ! -d "$PROJECT_ROOT/.dotnet" ]; then
     mkdir "$PROJECT_ROOT/.dotnet"
-    curl -Lsfo "$PROJECT_ROOT/.dotnet/dotnet-install.sh" https://dot.net/v1/dotnet-install.sh
+    curl -LsSfo "$PROJECT_ROOT/.dotnet/dotnet-install.sh" https://dot.net/v1/dotnet-install.sh --retry 5 --retry-delay 5
     bash "$PROJECT_ROOT/.dotnet/dotnet-install.sh" --jsonfile ./build/sdk/global.json --install-dir .dotnet --no-path
 
     # Install .NET 8 SDK

--- a/docs/articles/contributing/building.md
+++ b/docs/articles/contributing/building.md
@@ -17,7 +17,7 @@ Once all the necessary tools are in place, building is trivial. Simply open solu
 The build currently depends on the following prerequisites:
 
 - Windows:
-  - PowerShell version 5 or higher
+  - PowerShell Core
   - MSBuild version 15.1 or higher
   - .NET Framework 4.6 or higher
 


### PR DESCRIPTION
This PR intended to fix transient error on CI when downloading `dotnet-install.ps1`/ `dotnet-install.sh`.

**Background**
I've recently encountered following errors on CI multiple times.

```
Exception calling "DownloadFile" with "2" argument(s): "The underlying connection was closed: An unexpected error occur
red on a send."
At C:\a\BenchmarkDotNet\BenchmarkDotNet\build\build.ps1:58 char:5
+     (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUr ...
```

```
Run ./build.cmd install-wasm-tools
bash: /home/runner/work/BenchmarkDotNet/BenchmarkDotNet/.dotnet/dotnet-install.sh: No such file or directory
```

---

It seems to be failed to download `dotnet-install.ps1`/ `dotnet-install.sh` with temporary network errors.

Currently curl is executed on `-Lsfo` option so error is **silently** ignored.
So I've added `S` option to show failure on script download.

And I've added following setting to reduce transient errors.
> --retry 5 --retry-delay 5

On windows environment.
I've also modified to use `curl` executable instead of `Invoke-WebRequest`