### PR TITLE
Fix PerfCollectProfiler failure issue

### DIFF
--- a/src/BenchmarkDotNet/Diagnosers/PerfCollectProfiler.cs
+++ b/src/BenchmarkDotNet/Diagnosers/PerfCollectProfiler.cs
@@ -138,7 +138,7 @@ namespace BenchmarkDotNet.Diagnosers
         {
             EnsureSymbolsForNativeRuntime(parameters);
 
-            var traceName = GetTraceFile(parameters, extension: null).Name;
+            var traceName = GetTraceFile(parameters, extension: "").Name;
 
             var start = new ProcessStartInfo
             {


### PR DESCRIPTION
This PR intend to fix issue that PerfCollectProfiler throw `NullReferenceException`.

PR #2808 add extra logic that calculate path length.
But it seems not expected `null` value is passed as extension argument.

And it cause NullReferenceException because [`PerfCollectProfiler` that passing `null` value](https://github.com/dotnet/BenchmarkDotNet/blob/a2871df3de2c869a4cf1c639ecba41f8a073f34b/src/BenchmarkDotNet/Diagnosers/PerfCollectProfiler.cs#L141).

This PR replace `null` to empty string.
This change will not affect results. Because it's skipped by following lines. 
https://github.com/dotnet/BenchmarkDotNet/blob/a2871df3de2c869a4cf1c639ecba41f8a073f34b/src/BenchmarkDotNet/Helpers/ArtifactFileNameHelper.cs#L81-L82
