### PR TITLE
chore: fix SummarySerializationTests on specific Windows environment

### DIFF
--- a/tests/BenchmarkDotNet.Tests/Serialization/SummaryJsonSerializationTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Serialization/SummaryJsonSerializationTests.cs
@@ -59,7 +59,7 @@ public class SummarySerializationTests
               "Statistic6": ""
             }
             """;
-        Assert.Equal(expected, json);
+        Assert.Equal(expected, json, ignoreLineEndingDifferences: true);
     }
 
     private const string JSON_EMPTY_STRING = "\"\"";


### PR DESCRIPTION
This PR is follow up of #2970.

On Windows environment.
`SimpleJson_SerializeObjectWithUnsupportedNumericValues_ReturnsValidJson` test  failed with line ending differences. (CRLF/LF)

It's occurred when source code is checked out with `LF` line endings. (`autocrlf` option is disabled)

This is a separate matter from the PR content, but it seems don't run unit tests on Windows CI.
Is there a reason for this?
