### PR TITLE
chore: Modify code to re-throw exception

### DIFF
--- a/src/BenchmarkDotNet.TestAdapter/Utility/TestCaseFilter.cs
+++ b/src/BenchmarkDotNet.TestAdapter/Utility/TestCaseFilter.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 
 namespace BenchmarkDotNet.TestAdapter;
 
@@ -138,7 +139,8 @@ internal class TestCaseFilter
                     return false;
                 }
 
-                throw e.InnerException ?? e;
+                ExceptionDispatchInfo.Capture(e.InnerException ?? e).Throw();
+                return default!;// It's required to suppress error CS0161.
             }
         }
     }

--- a/src/BenchmarkDotNet/Toolchains/InProcess/Emit/Implementation/Emitters/EmitExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/Emit/Implementation/Emitters/EmitExtensions.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.ExceptionServices;
 
 #nullable enable
 
@@ -34,7 +35,9 @@ namespace BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation
             }
             catch (TargetInvocationException wrappedByReflection)
             {
-                throw wrappedByReflection.InnerException ?? wrappedByReflection;
+                var ex = wrappedByReflection.InnerException ?? wrappedByReflection;
+                ExceptionDispatchInfo.Capture(ex).Throw();
+                return default!;// It's required to suppress error CS0161.
             }
         }
     }


### PR DESCRIPTION
This PR is follow up of https://github.com/dotnet/BenchmarkDotNet/pull/2986#discussion_r2748892277

To keep original StackTrace,
Use `ExceptionDispatchInfo.Capture(ex).Throw()` when it need to rethrow exception.

As far as I've confirmed, Rethrow exception is occurs in two places.
So directly replace these code.

It might be better to helper method or extension method in future.