### PR TITLE
chore: Fix NullLogger used when no global config

### DIFF
--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -46,7 +46,7 @@ namespace BenchmarkDotNet.Configs
         public IEnumerable<ILogger> GetLoggers()
         {
             if (LinqPadLogger.IsAvailable)
-                yield return LinqPadLogger.Instance;
+                yield return LinqPadLogger.Instance!;
             else
                 yield return ConsoleLogger.Default;
         }

--- a/src/BenchmarkDotNet/Loggers/LinqPadLogger.cs
+++ b/src/BenchmarkDotNet/Loggers/LinqPadLogger.cs
@@ -46,7 +46,7 @@ namespace BenchmarkDotNet.Loggers
 
         public static bool IsAvailable => Instance != null;
 
-        public static ILogger Instance => lazyInstance.Value ?? NullLogger.Instance;
+        public static ILogger? Instance => lazyInstance.Value;
 
         private LinqPadLogger(MethodInfo withStyle, IReadOnlyDictionary<LogKind, string> colorScheme)
         {


### PR DESCRIPTION
This PR fix bug that introduced by #2986. (It's not released to NuGet yet)

PR `#2986` replace null to `NullLogger.Instance` but it cause side effect that `LinqPadLogger.IsAvailable` returns true.
So when global config is not provided. it always using `NullLogger`.

Automated tests using custom loggers.
So it's not validated by CI tests.