### PR TITLE
Fix WASM restore failing with runtime pack missing

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using BenchmarkDotNet.Characteristics;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
@@ -139,6 +140,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
                 .AppendArgument($"\"{filePath}\"")
                 // restore doesn't support -f argument.
                 .AppendArgument(artifactsPaths.PackagesDirectoryName.IsBlank() ? string.Empty : $"--packages \"{artifactsPaths.PackagesDirectoryName}\"")
+                .AppendArgument(buildPartition?.Runtime is WasmRuntime ? "-r browser-wasm" : string.Empty)
                 .AppendArgument(GetCustomMsBuildArguments(buildPartition.RepresentativeBenchmarkCase, buildPartition.Resolver))
                 .AppendArgument(extraArguments)
                 .AppendArgument(GetMandatoryMsBuildSettings(buildPartition.BuildConfiguration))


### PR DESCRIPTION
This should fix perf tests failures in runtime, e.g https://github.com/dotnet/runtime/pull/124134.

When running WASM benchmarks, the build fails with error NETSDK1112:
"The runtime pack for Microsoft.NETCore.App.Runtime.browser-wasm was not downloaded."

`BenchmarkDotNet` runs:
```
# restore that works for portable packages only
dotnet restore

# build without restore, when the project has `<RuntimeIdentifier>browser-wasm</RuntimeIdentifier>`, build fails because the runtime pack was not downloaded
dotnet build --no-restore
```

Runtime restore must be explicitly specified on the command line. 
This change adds `-r browser-wasm` to the restore command when the runtime is WasmRuntime.

[log](https://[helixr1107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-124134-merge-4d980ecbc92f455ea0/wasm.x64.micro.net11.0.Partition0/1/console.79d18797.log?helixlogtype=result&skoid=8eda00af-b5ec-4be9-b69b-0919a2338892&sktid=72f988bf-86f1-41af-91ab-2d7cd011db47&skt=2026-02-09T10%3A44%3A57Z&ske=2026-02-09T11%3A44%3A57Z&sks=b&skv=2024-11-04&sv=2024-11-04&se=2026-02-09T11%3A44%3A57Z&sr=b&sp=rl&sig=f3qw1DcELDw63fPDrmdwAjBiYrOuPMS6wawC5hOBvYA%3D](https://helixr1107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-124134-merge-4d980ecbc92f455ea0/wasm.x64.micro.net11.0.Partition0/1/console.79d18797.log?helixlogtype=result&skoid=8eda00af-b5ec-4be9-b69b-0919a2338892&sktid=72f988bf-86f1-41af-91ab-2d7cd011db47&skt=2026-02-09T10%3A44%3A57Z&ske=2026-02-09T11%3A44%3A57Z&sks=b&skv=2024-11-04&sv=2024-11-04&se=2026-02-09T11%3A44%3A57Z&sr=b&sp=rl&sig=f3qw1DcELDw63fPDrmdwAjBiYrOuPMS6wawC5hOBvYA%3D))
```
[2026/02/08 01:19:45][INFO] // start /datadisks/disk1/work/B6C309DE/p/dotnet/dotnet  build "/datadisks/disk1/work/B6C309DE/w/C16D0A77/e/performance/artifacts/bin/for-running/MicroBenchmarks/MicroBenchmarks-Wasm-1/BenchmarkDotNet.Autogenerated.csproj" -f net11.0 -c Release --no-restore --nodeReuse:false /p:UseSharedCompilation=false /p:Deterministic=true /p:Optimize=true /p:NuGetPackageRoot="/datadisks/disk1/work/B6C309DE/w/C16D0A77/e/performance/artifacts/packages" -bl:MicroBenchmarks-Wasm-1-build-no-restore.binlog /p:ArtifactsPath="/datadisks/disk1/work/B6C309DE/w/C16D0A77/e/performance/artifacts/bin/for-running/MicroBenchmarks/MicroBenchmarks-Wasm-1/" /p:OutDir="/datadisks/disk1/work/B6C309DE/w/C16D0A77/e/performance/artifacts/bin/for-running/MicroBenchmarks/MicroBenchmarks-Wasm-1/bin/Release/net11.0/browser-wasm/" /p:OutputPath="/datadisks/disk1/work/B6C309DE/w/C16D0A77/e/performance/artifacts/bin/for-running/MicroBenchmarks/MicroBenchmarks-Wasm-1/bin/Release/net11.0/browser-wasm/" /p:PublishDir="/datadisks/disk1/work/B6C309DE/w/C16D0A77/e/performance/artifacts/bin/for-running/MicroBenchmarks/MicroBenchmarks-Wasm-1/publish/" --output "/datadisks/disk1/work/B6C309DE/w/C16D0A77/e/performance/artifacts/bin/for-running/MicroBenchmarks/MicroBenchmarks-Wasm-1/bin/Release/net11.0/browser-wasm/" in /datadisks/disk1/work/B6C309DE/w/C16D0A77/e/performance/artifacts/bin/for-running/MicroBenchmarks/MicroBenchmarks-Wasm-1
[2026/02/08 01:19:46][INFO] /datadisks/disk1/work/B6C309DE/p/dotnet/sdk/11.0.100-preview.1.26069.103/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(546,5): error NETSDK1112: The runtime pack for Microsoft.NETCore.App.Runtime.browser-wasm was not downloaded. Try running a NuGet restore with the RuntimeIdentifier 'browser-wasm'. [/datadisks/disk1/work/B6C309DE/w/C16D0A77/e/performance/artifacts/bin/for-running/MicroBenchmarks/MicroBenchmarks-Wasm-1/BenchmarkDotNet.Autogenerated.csproj::TargetFramework=net11.0]
[2026/02/08 01:19:46][INFO] Build FAILED.
[2026/02/08 01:19:46][INFO] /datadisks/disk1/work/B6C309DE/p/dotnet/sdk/11.0.100-preview.1.26069.103/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(546,5): error NETSDK1112: The runtime pack for Microsoft.NETCore.App.Runtime.browser-wasm was not downloaded. Try running a NuGet restore with the RuntimeIdentifier 'browser-wasm'. [/datadisks/disk1/work/B6C309DE/w/C16D0A77/e/performance/artifacts/bin/for-running/MicroBenchmarks/MicroBenchmarks-Wasm-1/BenchmarkDotNet.Autogenerated.csproj::TargetFramework=net11.0]
```
