### PR TITLE
chore: Remove unused code from NativeAotToolchain

### DIFF
--- a/docs/articles/configs/toolchains.md
+++ b/docs/articles/configs/toolchains.md
@@ -243,7 +243,6 @@ var config = DefaultConfig.Instance
 The builder allows to configure more settings:
 - specify packages restore path by using `PackagesRestorePath($path)`
 - rooting all application assemblies by using `RootAllApplicationAssemblies($bool)`. This is disabled by default.
-- generating complete type metadata by using `IlcGenerateCompleteTypeMetadata($bool)`. This option is enabled by default.
 - generating stack trace metadata by using `IlcGenerateStackTraceData($bool)`. This option is enabled by default.
 - set optimization preference by using `IlcOptimizationPreference($value)`. The default is `Speed`, you can configure it to `Size` or nothing
 - set instruction set for the target OS, architecture and hardware by using `IlcInstructionSet($value)`. By default BDN recognizes most of the instruction sets on your machine and enables them.

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -32,7 +32,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             string runtimeFrameworkVersion, string targetFrameworkMoniker, string cliPath,
             string runtimeIdentifier, IReadOnlyDictionary<string, string> feeds, bool useNuGetClearTag,
             bool useTempFolderForRestore, string packagesRestorePath,
-            bool rootAllApplicationAssemblies, bool ilcGenerateCompleteTypeMetadata, bool ilcGenerateStackTraceData,
+            bool rootAllApplicationAssemblies, bool ilcGenerateStackTraceData,
             string ilcOptimizationPreference, string ilcInstructionSet)
             : base(targetFrameworkMoniker, cliPath, GetPackagesDirectoryPath(useTempFolderForRestore, packagesRestorePath), runtimeFrameworkVersion)
         {
@@ -42,7 +42,6 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             this.useNuGetClearTag = useNuGetClearTag;
             this.useTempFolderForRestore = useTempFolderForRestore;
             this.rootAllApplicationAssemblies = rootAllApplicationAssemblies;
-            this.ilcGenerateCompleteTypeMetadata = ilcGenerateCompleteTypeMetadata;
             this.ilcGenerateStackTraceData = ilcGenerateStackTraceData;
             this.ilcOptimizationPreference = ilcOptimizationPreference;
             this.ilcInstructionSet = ilcInstructionSet;
@@ -55,7 +54,6 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         private readonly bool useNuGetClearTag;
         private readonly bool useTempFolderForRestore;
         private readonly bool rootAllApplicationAssemblies;
-        private readonly bool ilcGenerateCompleteTypeMetadata;
         private readonly bool ilcGenerateStackTraceData;
         private readonly string ilcOptimizationPreference;
         private readonly string ilcInstructionSet;

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
@@ -61,12 +61,12 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             string runtimeFrameworkVersion, string targetFrameworkMoniker, string runtimeIdentifier,
             string customDotNetCliPath, string packagesRestorePath,
             Dictionary<string, string> feeds, bool useNuGetClearTag, bool useTempFolderForRestore,
-            bool rootAllApplicationAssemblies, bool ilcGenerateCompleteTypeMetadata, bool ilcGenerateStackTraceData,
+            bool rootAllApplicationAssemblies, bool ilcGenerateStackTraceData,
             string ilcOptimizationPreference, string ilcInstructionSet)
             : base(displayName,
                 new Generator(ilCompilerVersion, runtimeFrameworkVersion, targetFrameworkMoniker, customDotNetCliPath,
                     runtimeIdentifier, feeds, useNuGetClearTag, useTempFolderForRestore, packagesRestorePath,
-                    rootAllApplicationAssemblies, ilcGenerateCompleteTypeMetadata, ilcGenerateStackTraceData,
+                    rootAllApplicationAssemblies, ilcGenerateStackTraceData,
                     ilcOptimizationPreference, ilcInstructionSet),
                 new DotNetCliPublisher(targetFrameworkMoniker, customDotNetCliPath, GetExtraArguments(runtimeIdentifier)),
                 new Executor())

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchainBuilder.cs
@@ -15,7 +15,6 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         private string packagesRestorePath;
         // we set those default values on purpose https://github.com/dotnet/BenchmarkDotNet/pull/1057#issuecomment-461832612
         private bool rootAllApplicationAssemblies;
-        private bool ilcGenerateCompleteTypeMetadata = true;
         private bool ilcGenerateStackTraceData = true;
         private string ilcOptimizationPreference = "Speed";
         private string? ilcInstructionSet = null;
@@ -90,20 +89,6 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         }
 
         /// <summary>
-        /// This controls the generation of complete type metadata.
-        /// This option is enabled by default.
-        /// This is a compilation mode that prevents a situation where some members of a type are visible to reflection at runtime, but others aren't, because they weren't compiled.
-        /// </summary>
-        /// <param name="value"></param>
-        [PublicAPI]
-        public NativeAotToolchainBuilder IlcGenerateCompleteTypeMetadata(bool value)
-        {
-            ilcGenerateCompleteTypeMetadata = value;
-
-            return this;
-        }
-
-        /// <summary>
         /// This controls generation of stack trace metadata that provides textual names in stack traces.
         /// This option is enabled by default.
         /// This is for example the text string one gets by calling Exception.ToString() on a caught exception.
@@ -163,7 +148,6 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
                 useNuGetClearTag: useNuGetClearTag,
                 useTempFolderForRestore: useTempFolderForRestore,
                 rootAllApplicationAssemblies: rootAllApplicationAssemblies,
-                ilcGenerateCompleteTypeMetadata: ilcGenerateCompleteTypeMetadata,
                 ilcGenerateStackTraceData: ilcGenerateStackTraceData,
                 ilcOptimizationPreference: ilcOptimizationPreference,
                 ilcInstructionSet: ilcInstructionSet


### PR DESCRIPTION
This PR remove `ilcGenerateCompleteTypeMetadata` relating code from NativeAotToolchain.

As stated on #2616.
`ilcGenerateCompleteTypeMetadata` actually do nothing and leaved for backward compatibility.

So it can be safely removed on next version release.

Note: It's breaking changes because PublicAPI is removed.
