### PR TITLE
chore(deps): upgrade Perfolizer from 0.6.1 to 0.6.6

### DIFF
--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Gee.External.Capstone" Version="2.3.0" />
     <PackageReference Include="Iced" Version="1.21.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="3.1.512801" />
-    <PackageReference Include="Perfolizer" Version="[0.6.1]" />
+    <PackageReference Include="Perfolizer" Version="[0.6.6]" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.28" PrivateAssets="contentfiles;analyzers" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />

--- a/tests/BenchmarkDotNet.Tests/Mathematics/StatisticsTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Mathematics/StatisticsTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using BenchmarkDotNet.Mathematics;
 using BenchmarkDotNet.Tests.Common;
 using JetBrains.Annotations;
+using Pragmastat.Exceptions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -32,7 +33,7 @@ public class StatisticsTests(ITestOutputHelper output)
     [Fact]
     public void StatisticsWithN0Test()
     {
-        Assert.Throws<ArgumentException>(() => new Statistics());
+        Assert.Throws<AssumptionException>(() => new Statistics());
     }
 
     [Fact]


### PR DESCRIPTION
Upgrades Perfolizer to 0.6.6 which transitively bumps Pragmastat from 3.2.4 to 8.0.0. Updates StatisticsWithN0Test to expect AssumptionException instead of ArgumentException, matching the new Pragmastat validation behavior for empty samples.