### PR TITLE
perf: Optimize logics to find project files

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -368,24 +368,8 @@ namespace BenchmarkDotNet.Toolchains.CsProj
             // important assumption! project's file name === output dll name
             string projectName = benchmarkTarget.GetTypeInfo().Assembly.GetName().Name!;
 
-            var possibleNames = new HashSet<string> { $"{projectName}.csproj", $"{projectName}.fsproj", $"{projectName}.vbproj" };
-            var projectFiles = rootDirectory
-                .EnumerateFiles("*proj", SearchOption.AllDirectories)
-                .Where(file => possibleNames.Contains(file.Name))
-                .ToArray();
-
-            if (projectFiles.Length == 0)
-            {
-                throw new NotSupportedException(
-                    $"Unable to find {projectName} in {rootDirectory.FullName} and its subfolders. Most probably the name of output exe is different than the name of the .(c/f)sproj");
-            }
-            else if (projectFiles.Length > 1)
-            {
-                throw new NotSupportedException(
-                    $"Found more than one matching project file for {projectName} in {rootDirectory.FullName} and its subfolders: {string.Join(",", projectFiles.Select(pf => $"'{pf.FullName}'"))}. Benchmark project names needs to be unique.");
-            }
-
-            return projectFiles[0];
+            var projectFile = Helpers.FindProjectFile(rootDirectory, projectName);
+            return projectFile;
         }
 
         public override bool Equals(object? obj) => obj is CsProjGenerator other && Equals(other);
@@ -406,5 +390,120 @@ namespace BenchmarkDotNet.Toolchains.CsProj
 
         public override int GetHashCode()
             => HashCode.Combine(TargetFrameworkMoniker, RuntimeFrameworkVersion, CliPath, PackagesPath);
+    }
+
+    file static class Helpers
+    {
+        private static readonly HashSet<string> IgnoredDirectoryNames = new(StringComparer.Ordinal)
+        {
+            ".git",
+            ".vs",
+            "bin",
+            "obj",
+        };
+
+        private static readonly HashSet<string> ProjectExtensions = new(StringComparer.Ordinal)
+        {
+            ".csproj",
+            ".fsproj",
+            ".vbproj"
+        };
+
+        public static FileInfo FindProjectFile(DirectoryInfo rootDirectory, string projectName)
+        {
+            var projectFiles = EnumerateProjectFiles(rootDirectory, projectName);
+
+            // Take first 2 items for performance reasons
+            var files = projectFiles.Take(2).ToArray();
+            return files.Length switch
+            {
+                1 => files[0],
+                0 => throw new NotSupportedException(
+                    $"Unable to find {projectName} in {rootDirectory.FullName} and its subfolders. Most probably the name of output exe is different than the name of the .(c/f)sproj"),
+                _ => throw new NotSupportedException(
+                    $"Found more than one matching project file for {projectName} in {rootDirectory.FullName} and its subfolders: '{files[0].FullName}','{files[1].FullName}'. Benchmark project names needs to be unique."),
+            };
+        }
+
+        private static IEnumerable<FileInfo> EnumerateProjectFiles(DirectoryInfo rootDirectory, string projectName)
+        {
+            var stack = new Stack<DirectoryInfo>();
+            stack.Push(rootDirectory);
+
+            while (stack.Count > 0)
+            {
+                var currentDir = stack.Pop();
+
+                // 1. Search '*.proj' files in the current directory
+                IEnumerable<FileInfo> files = EnumerateProjectFiles(currentDir);
+
+                foreach (var file in files)
+                {
+                    if (!ProjectExtensions.Contains(file.Extension))
+                        continue;
+
+                    if (Path.GetFileNameWithoutExtension(file.Name) == projectName)
+                        yield return file;
+                }
+
+                var subDirectories = GetSubDirectories(currentDir);
+
+                // 2. Handle sub directories.
+                foreach (var dir in subDirectories)
+                {
+                    if (IgnoredDirectoryNames.Contains(dir.Name))
+                        continue;
+#if NETSTANDARD2_0
+                    // Ignore reparse point / symlink to avoid infinite loops
+                    if (dir.Attributes.HasFlag(FileAttributes.ReparsePoint))
+                        continue;
+#endif
+                    stack.Push(dir);
+                }
+            }
+        }
+
+#if NETSTANDARD2_0
+        private static IEnumerable<FileInfo> EnumerateProjectFiles(DirectoryInfo directory)
+        {
+            IEnumerable<FileInfo> projectFiles;
+            try
+            {
+                projectFiles = directory.EnumerateFiles("*proj", SearchOption.TopDirectoryOnly);
+            }
+            catch
+            {
+                yield break;
+            }
+
+            foreach (var file in projectFiles)
+                yield return file;
+        }
+
+        private static IEnumerable<DirectoryInfo> GetSubDirectories(DirectoryInfo currentDir)
+        {
+            try
+            {
+                return currentDir.EnumerateDirectories();
+            }
+            catch
+            {
+                return [];
+            }
+        }
+#else
+        private static readonly EnumerationOptions DirectoryEnumerationOptions = new()
+        {
+            RecurseSubdirectories = false,
+            IgnoreInaccessible = true,
+            AttributesToSkip = FileAttributes.ReparsePoint
+        };
+
+        private static IEnumerable<FileInfo> EnumerateProjectFiles(DirectoryInfo directory)
+            => directory.EnumerateFiles("*proj", DirectoryEnumerationOptions);
+
+        private static IEnumerable<DirectoryInfo> GetSubDirectories(DirectoryInfo currentDir)
+            => currentDir.EnumerateDirectories("*", DirectoryEnumerationOptions);
+#endif
     }
 }


### PR DESCRIPTION
On current CsProjGenerator::GetProjectFilePath method implementation.

It enumerate **all** files under benchmark root directory.

When running BenchmarkDotNet.Samples benchmarks.
It enumerate all files under BenchmarkDotNet` directory and it takes about 500ms -1000ms.

This PR replace `SearchOption.AllDirectories`  to custom depth-first search.
And add exclude specific directories names (obj/bin)
And only takes first 2 items to optimize performance. 

By this changes. enumeration time is reduced to about 50ms;