### PR TITLE
chore: Add workflow to generate code coverage report

### DIFF
--- a/.github/workflows/generate-coverage-report.yaml
+++ b/.github/workflows/generate-coverage-report.yaml
@@ -1,0 +1,164 @@
+name: generate-coverage-report
+run-name: Generate coverage coverage report  ${{ github.event.head_commit.message }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_integration_tests:
+        type: boolean
+        description: Set `true` to skip integration tests.
+        default: true
+        
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.skip_integration_tests }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  collect-coverage:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: pwsh
+    strategy:
+      matrix:
+        # Note: ARM64 on linux/macos are not supported.
+        # https://github.com/microsoft/codecoverage/blob/main/docs/supported-os.md
+        os: [windows-latest, ubuntu-latest, macos-15-intel, windows-11-arm]
+    steps:
+      - uses: actions/checkout@v6
+
+      # Ensure DOTNET_ROOT environment variable set on macos-15-intel 
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.x  
+
+      - name: Install dotnet-coverage
+        run: dotnet tool install --global dotnet-coverage
+
+      - name: Run task 'build'
+        run: dotnet build BenchmarkDotNet.slnx -c Release
+
+      - name: Start dotnet-coverage with background server mode
+        run: dotnet coverage collect --session-id bdn_coverage --settings tests/CodeCoverage.config --server-mode --background
+
+      - name: Collect Code Coverage
+        run: |
+          dotnet coverage connect bdn_coverage "dotnet test tests/BenchmarkDotNet.Tests -c Release --no-build --framework net8.0"
+          dotnet coverage connect bdn_coverage "dotnet test tests/BenchmarkDotNet.Analyzers.Tests  -c Release --no-build --framework net8.0"
+
+      - name: Collect Code Coverage for BenchmarkDotNet.IntegrationTests 
+        if: ${{ github.event.inputs.skip_integration_tests == 'false'}} 
+        run: |
+          dotnet coverage connect bdn_coverage 'dotnet test tests/BenchmarkDotNet.IntegrationTests -c Release --no-build --framework net8.0 --filter "(FullyQualifiedName!~DotMemoryTests) & (FullyQualifiedName!~DotTraceTests) & (FullyQualifiedName!~WasmIsSupported) & (FullyQualifiedName!~WasmSupportsInProcessDiagnosers)"'
+
+      - name: Shutdown dotnet-coverage server.
+        run: dotnet coverage shutdown bdn_coverage --timeout 60000
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-${{ matrix.os }}
+          path: "**/*.cobertura.xml"
+
+  collect-coverage-netfx:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dotnet-coverage
+        run: dotnet tool install --global dotnet-coverage
+
+      - name: Run task 'build'
+        run: dotnet build BenchmarkDotNet.slnx -c Release
+
+      - name: Start dotnet-coverage with background server mode
+        run: dotnet coverage collect --session-id bdn_coverage --settings tests/CodeCoverage.config --server-mode --background
+
+      - name: Collect Code Coverage
+        run: |
+          dotnet coverage connect bdn_coverage "dotnet test tests/BenchmarkDotNet.Tests -c Release --no-build --framework net462"
+          dotnet coverage connect bdn_coverage "dotnet test tests/BenchmarkDotNet.Analyzers.Tests  -c Release --no-build --framework net462"
+
+      - name: Collect Code Coverage for BenchmarkDotNet.IntegrationTests 
+        if: ${{ github.event.inputs.skip_integration_tests == 'false'}} 
+        run: |
+          dotnet coverage connect bdn_coverage 'dotnet test tests/BenchmarkDotNet.IntegrationTests -c Release --no-build --framework net462 --filter "(FullyQualifiedName!~DotMemoryTests) & (FullyQualifiedName!~DotTraceTests) & (FullyQualifiedName!~WasmIsSupported) & (FullyQualifiedName!~WasmSupportsInProcessDiagnosers)"'
+
+      - name: Shutdown dotnet-coverage server.
+        run: dotnet coverage shutdown bdn_coverage --timeout 60000
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-windows-netfx
+          path: "**/*.cobertura.xml"
+
+  generate-coverage-report:
+    needs: [collect-coverage, collect-coverage-netfx]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v6
+        with:
+          path: coverage
+
+      - name: Upload raw coverage data
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage
+          path: coverage
+
+      - name: Rewrite file path map to absolute path
+        run: |
+          $baseSourcePath = Get-Location
+          $files =  [IO.Directory]::GetFiles("coverage", "coverage.cobertura.xml", [IO.SearchOption]::AllDirectories)
+          foreach($file in $files)
+          {
+            $content = [IO.File]::ReadAllText($file).Replace("/_/", [Environment]::CurrentDirectory + '/')
+            [IO.File]::WriteAllText($file, $content)
+          }
+
+      - name: Install ReportGenerator as global tool
+        run: dotnet tool install --global dotnet-reportgenerator-globaltool
+
+      - name: Geterate reports
+        run: |
+          reportgenerator `
+            -reports:"coverage/**/coverage.cobertura.xml" `
+            -targetdir:"coverage_report/reports" `
+            -reporttypes:"Html;MarkdownSummaryGithub"
+
+      - name: Create index.html
+        run: |
+          $html = @"
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta http-equiv="refresh" content="0; url=reports/index.html">
+            <title>Redirect</title>
+          </head>
+          <body>
+            <p>If you are not redirected automatically, <a href="reports/index.html">click here</a>.</p>
+          </body>
+          </html>
+          "@
+          [IO.File]::WriteAllText("coverage_report/index.html", $html)
+
+      - name: Write coverage summary
+        run: |
+          $markdown = Get-Content coverage_report/reports/SummaryGithub.md -Raw
+          Write-Output $markdown >> $env:GITHUB_STEP_SUMMARY
+
+      - name: Upload HTML report files
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage_report
+          path: coverage_report

--- a/tests/CodeCoverage.config
+++ b/tests/CodeCoverage.config
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <!-- Available Options: https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md -->
+  <CoverageFileName>coverage.cobertura.xml</CoverageFileName>
+  <Format>cobertura</Format>
+  <IncludeTestAssembly>false</IncludeTestAssembly>
+  <DeterministicReport>true</DeterministicReport>
+  <CollectFromChildProcesses>true</CollectFromChildProcesses>
+  <CodeCoverage>
+    <ModulePaths>
+      <Include>
+        <ModulePath>.*BenchmarkDotNet\.dll$</ModulePath>
+        <ModulePath>.*BenchmarkDotNet.*\.dll$</ModulePath>
+      </Include>
+      <Exclude>
+        <!-- Exclude third party DLLs -->
+        <ModulePath>.*Argon\.dll$</ModulePath>
+        <ModulePath>.*DiffEngine\.dll$</ModulePath>
+        <ModulePath>.*EmptyFiles\.dll$</ModulePath>
+        <ModulePath>.*Microsoft\.CodeAnalysis\.Analyzer\.Testing\.dll$</ModulePath>
+        <ModulePath>.*Microsoft\.CodeAnalysis\.CSharp\.Analyzer\.Testing\.dll$</ModulePath>
+        <ModulePath>.*Verify\.dll$</ModulePath>
+        <ModulePath>.*Verify\.Xunit\.dll$</ModulePath>
+
+        <!-- Exclude test DLLs -->
+        <ModulePath>.*BenchmarkDotNet\.Analyzers\.Tests\.dll$</ModulePath>
+        <ModulePath>.*BenchmarkDotNet\.Tests\.dll$</ModulePath>
+        <ModulePath>.*BenchmarkDotNet\.IntegrationTests\.dll$</ModulePath>
+
+        <!-- Exclude auto generated project DLLs -->
+        <ModulePath>.*IntegrationTests.*\.dll$</ModulePath>
+        <ModulePath>.*Dry.*\.dll$</ModulePath>
+        <ModulePath>.*FSharp.Core\.dll$</ModulePath>
+      </Exclude>
+    </ModulePaths>
+    <Attributes>
+      <Exclude>
+        <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+      </Exclude>
+    </Attributes>
+    <Sources>
+      <Exclude>
+        <Source>.*\\[^\\]*\CodeAnnotations\.cs</Source>
+        <Source>.*\\[^\\]*\.g\.cs</Source>
+        <Source>.*\\[^\\]*\.notcs</Source>
+      </Exclude>
+    </Sources>
+    <!-- Disable following settings. Because C++ code is not contained (See: https://github.com/microsoft/codecoverage/blob/main/README.md#get-started)-->
+    <EnableStaticNativeInstrumentation>False</EnableStaticNativeInstrumentation>
+    <EnableDynamicNativeInstrumentation>False</EnableDynamicNativeInstrumentation>
+  </CodeCoverage>
+</Configuration>


### PR DESCRIPTION
This PR add GitHub Actions workflow `generate-coverage-report.yaml`.

This workflow contains following steps.
1. Run code coverage collection by using [dotnet-coverage](https://learn.microsoft.com/en-us/dotnet/core/additional-tools/dotnet-coverage).
2. Aggregate code coverage data between runs
3. Upload raw coverage data
4. Rewrite coverage file path to absolute path
5. Generate code coverage by using [ReportGenerator](https://reportgenerator.io) 
5.1. Write generated markdown to job summary.
5.2. Upload generated HTML report files

### How to run  `generate-coverate-report.yaml` workflow
This workflow is expected to be manually invoked.
It can run workflow with following command. (Note: Workflow file need be merged to `master` before execute workflow)

**1. Run workflow with Web UI**
https://github.com/dotnet/BenchmarkDotNet/actions/workflows/generate-coverage-report.yaml

**2.1. Collect full coverage data with gh command**
> gh workflow run generate-coverage-report --ref [branch_name] -f skip_integration_tests=false 

**2.2 Collect code coverage without IntegrationTests with gh command**
> gh workflow run generate-coverage-report --ref [branch_name]

# Example report summary

<details open><summary>Summary</summary>

|||
|:---|:---|
| Generated on: | 02/24/2026 - 06:57:36 |
| Parser: | MultiReport (2x Cobertura) |
| Assemblies: | 388 |
| Classes: | 2811 |
| Files: | 975 |
| **Line coverage:** | 60.9% (69593 of 114105) |
| Covered lines: | 69593 |
| Uncovered lines: | 44512 |
| Coverable lines: | 114105 |
| Total lines: | 176975 |
| **Branch coverage:** | 46.1% (21161 of 45881) |
| Covered branches: | 21161 |
| Total branches: | 45881 |
| **Method coverage:** | [Feature is only available for sponsors](https://reportgenerator.io/pro) |

</details>

## Coverage
<details><summary>BenchmarkDotNet - 72.8%</summary>

|**Name**|**Line**|**Branch**|
|:---|---:|---:|
|**BenchmarkDotNet**|**72.8%**|**65.1%**|
|BenchmarkDotNet.Analysers.AnalyserBase|81.8%|100%|
|BenchmarkDotNet.Analysers.BaselineCustomAnalyzer|100%|100%|
|BenchmarkDotNet.Analysers.CompositeAnalyser|66.6%||
|BenchmarkDotNet.Analysers.Conclusion|70.5%|20%|
|BenchmarkDotNet.Analysers.ConclusionHelper|100%|83.3%|
|BenchmarkDotNet.Analysers.EnvironmentAnalyser|61.5%|68.7%|
|BenchmarkDotNet.Analysers.HideColumnsAnalyser|44.4%|50%|
|BenchmarkDotNet.Analysers.MinIterationTimeAnalyser|100%|100%|
|BenchmarkDotNet.Analysers.MultimodalDistributionAnalyzer|33.3%|30%|
|BenchmarkDotNet.Analysers.OutliersAnalyser|94.4%|95%|
|BenchmarkDotNet.Analysers.RuntimeErrorAnalyser|71.4%|75%|
|BenchmarkDotNet.Analysers.ZeroMeasurementAnalyser|85.7%|68.7%|
|BenchmarkDotNet.Analysers.ZeroMeasurementHelper|83.3%|66.6%|
|BenchmarkDotNet.Attributes.AllCategoriesFilterAttribute|0%||
|BenchmarkDotNet.Attributes.AllStatisticsColumnAttribute|0%||
|BenchmarkDotNet.Attributes.AnyCategoriesFilterAttribute|0%||
|BenchmarkDotNet.Attributes.ArtifactsPathAttribute|0%||
|BenchmarkDotNet.Attributes.AsciiDocExporterAttribute|0%||
|BenchmarkDotNet.Attributes.BaselineColumnAttribute|100%||
|BenchmarkDotNet.Attributes.CategoriesColumnAttribute|0%||
|BenchmarkDotNet.Attributes.CategoryDiscovererAttribute|100%||
|BenchmarkDotNet.Attributes.ColumnConfigBaseAttribute|57.1%||
|BenchmarkDotNet.Attributes.ConfidenceIntervalErrorColumnAttribute|0%||
|BenchmarkDotNet.Attributes.ConfigAttribute|100%||
|BenchmarkDotNet.Attributes.CsvExporterAttribute|0%||
|BenchmarkDotNet.Attributes.CsvMeasurementsExporterAttribute|0%||
|BenchmarkDotNet.Attributes.DisassemblyDiagnoserAttribute|0%||
|BenchmarkDotNet.Attributes.DryJobAttribute|33.3%||
|BenchmarkDotNet.Attributes.EvaluateOverheadAttribute|0%||
|BenchmarkDotNet.Attributes.EventPipeProfilerAttribute|0%||
|BenchmarkDotNet.Attributes.ExceptionDiagnoserAttribute|0%||
|BenchmarkDotNet.Attributes.ExceptionDiagnoserConfig|100%||
|BenchmarkDotNet.Attributes.ExecutionValidatorAttribute|0%|0%|
|BenchmarkDotNet.Attributes.ExporterConfigBaseAttribute|0%||
|BenchmarkDotNet.Attributes.FilterConfigBaseAttribute|57.1%||
|BenchmarkDotNet.Attributes.Filters.AotFilterAttribute|0%|0%|
|BenchmarkDotNet.Attributes.GcConcurrentAttribute|0%||
|BenchmarkDotNet.Attributes.GcForceAttribute|0%||
|BenchmarkDotNet.Attributes.GcServerAttribute|0%||
|BenchmarkDotNet.Attributes.GroupBenchmarksByAttribute|57.1%||
|BenchmarkDotNet.Attributes.HardwareCountersAttribute|0%||
|BenchmarkDotNet.Attributes.HideColumnsAttribute|0%||
|BenchmarkDotNet.Attributes.HtmlExporterAttribute|0%||
|BenchmarkDotNet.Attributes.InnerIterationCountAttribute|0%||
|BenchmarkDotNet.Attributes.InProcessAttribute|100%|66.6%|
|BenchmarkDotNet.Attributes.InvocationCountAttribute|0%||
|BenchmarkDotNet.Attributes.IterationCountAttribute|0%||
|BenchmarkDotNet.Attributes.IterationsColumnAttribute|0%||
|BenchmarkDotNet.Attributes.IterationTimeAttribute|0%||
|BenchmarkDotNet.Attributes.JobConfigBaseAttribute|15.3%|0%|
|BenchmarkDotNet.Attributes.JobMutatorConfigBaseAttribute|66.6%||
|BenchmarkDotNet.Attributes.JsonExporterAttribute|0%||
|BenchmarkDotNet.Attributes.JsonExporterAttribute.BriefAttribute|0%||
|BenchmarkDotNet.Attributes.JsonExporterAttribute.BriefCompressed|0%||
|BenchmarkDotNet.Attributes.JsonExporterAttribute.Full|0%||
|BenchmarkDotNet.Attributes.JsonExporterAttribute.FullCompressed|0%||
|BenchmarkDotNet.Attributes.KeepBenchmarkFilesAttribute|0%||
|BenchmarkDotNet.Attributes.KurtosisColumnAttribute|0%||
|BenchmarkDotNet.Attributes.LegacyJitX64JobAttribute|0%||
|BenchmarkDotNet.Attributes.LegacyJitX86JobAttribute|0%||
|BenchmarkDotNet.Attributes.LogicalGroupColumnAttribute|100%||
|BenchmarkDotNet.Attributes.LongRunJobAttribute|33.3%||
|BenchmarkDotNet.Attributes.MarkdownExporterAttribute|0%||
|BenchmarkDotNet.Attributes.MarkdownExporterAttribute.Atlassian|0%||
|BenchmarkDotNet.Attributes.MarkdownExporterAttribute.Default|0%||
|BenchmarkDotNet.Attributes.MarkdownExporterAttribute.GitHub|0%||
|BenchmarkDotNet.Attributes.MarkdownExporterAttribute.StackOverflow|0%||
|BenchmarkDotNet.Attributes.MaxAbsoluteErrorAttribute|0%||
|BenchmarkDotNet.Attributes.MaxColumnAttribute|0%||
|BenchmarkDotNet.Attributes.MaxIterationCountAttribute|100%||
|BenchmarkDotNet.Attributes.MaxRelativeErrorAttribute|0%||
|BenchmarkDotNet.Attributes.MaxWarmupCountAttribute|100%|50%|
|BenchmarkDotNet.Attributes.MeanColumnAttribute|0%||
|BenchmarkDotNet.Attributes.MedianColumnAttribute|0%||
|BenchmarkDotNet.Attributes.MediumRunJobAttribute|0%||
|BenchmarkDotNet.Attributes.MemoryDiagnoserAttribute|0%||
|BenchmarkDotNet.Attributes.MemoryRandomizationAttribute|100%||
|BenchmarkDotNet.Attributes.MinColumnAttribute|0%||
|BenchmarkDotNet.Attributes.MinInvokeCountAttribute|0%||
|BenchmarkDotNet.Attributes.MinIterationCountAttribute|0%||
|BenchmarkDotNet.Attributes.MinIterationTimeAttribute|0%||
|BenchmarkDotNet.Attributes.MinWarmupCountAttribute|100%|50%|
|BenchmarkDotNet.Attributes.MonoJobAttribute|0%||
|BenchmarkDotNet.Attributes.MValueColumnAttribute|0%||
|BenchmarkDotNet.Attributes.NamespaceColumnAttribute|0%||
|BenchmarkDotNet.Attributes.OpenMetricsExporterAttribute|0%||
|BenchmarkDotNet.Attributes.OperatingSystemsArchitectureFilterAttribute|87.5%|100%|
|BenchmarkDotNet.Attributes.OperatingSystemsFilterAttribute|64.2%|100%|
|BenchmarkDotNet.Attributes.OperationsPerSecondAttribute|0%||
|BenchmarkDotNet.Attributes.OrdererAttribute|0%||
|BenchmarkDotNet.Attributes.OutliersAttribute|100%||
|BenchmarkDotNet.Attributes.PerfCollectProfilerAttribute|0%||
|BenchmarkDotNet.Attributes.PerfonarExporterAttribute|0%||
|BenchmarkDotNet.Attributes.PlainExporterAttribute|0%||
|BenchmarkDotNet.Attributes.ProcessCountAttribute|0%||
|BenchmarkDotNet.Attributes.Q1ColumnAttribute|0%||
|BenchmarkDotNet.Attributes.Q3ColumnAttribute|0%||
|BenchmarkDotNet.Attributes.RankColumnAttribute|100%||
|BenchmarkDotNet.Attributes.ReturnValueValidatorAttribute|0%|0%|
|BenchmarkDotNet.Attributes.RPlotExporterAttribute|0%||
|BenchmarkDotNet.Attributes.RunOncePerIterationAttribute|100%||
|BenchmarkDotNet.Attributes.RyuJitX64JobAttribute|0%||
|BenchmarkDotNet.Attributes.RyuJitX86JobAttribute|0%||
|BenchmarkDotNet.Attributes.ShortRunJobAttribute|0%||
|BenchmarkDotNet.Attributes.SimpleJobAttribute|84.8%|72.7%|
|BenchmarkDotNet.Attributes.SkewnessColumnAttribute|0%||
|BenchmarkDotNet.Attributes.StatisticalTestColumnAttribute|33.3%||
|BenchmarkDotNet.Attributes.StdDevColumnAttribute|0%||
|BenchmarkDotNet.Attributes.StdErrorColumnAttribute|0%||
|BenchmarkDotNet.Attributes.StopOnFirstErrorAttribute|0%||
|BenchmarkDotNet.Attributes.ThreadingDiagnoserAttribute|0%||
|BenchmarkDotNet.Attributes.UnicodeConsoleLoggerAttribute|0%||
|BenchmarkDotNet.Attributes.ValidatorConfigBaseAttribute|0%||
|BenchmarkDotNet.Attributes.VeryLongRunJobAttribute|0%||
|BenchmarkDotNet.Attributes.WakeLockAttribute|100%||
|BenchmarkDotNet.Attributes.WarmupCountAttribute|0%||
|BenchmarkDotNet.Attributes.XmlExporterAttribute|0%||
|BenchmarkDotNet.Attributes.XmlExporterAttribute.Brief|0%||
|BenchmarkDotNet.Attributes.XmlExporterAttribute.BriefCompressed|0%||
|BenchmarkDotNet.Attributes.XmlExporterAttribute.Full|0%||
|BenchmarkDotNet.Attributes.XmlExporterAttribute.FullCompressed|0%||
|BenchmarkDotNet.Characteristics.Characteristic|94.8%|62.5%|
|BenchmarkDotNet.Characteristics.Characteristic<T>|100%|100%|
|BenchmarkDotNet.Characteristics.CharacteristicHelper|86%|83.3%|
|BenchmarkDotNet.Characteristics.CharacteristicObject|87.6%|87.5%|
|BenchmarkDotNet.Characteristics.CharacteristicObject<T>|92.8%|100%|
|BenchmarkDotNet.Characteristics.CharacteristicPresenter|89.4%|94.4%|
|BenchmarkDotNet.Characteristics.CharacteristicPresenter.DefaultCharacterist<br/>icPresenter|100%|100%|
|BenchmarkDotNet.Characteristics.CharacteristicPresenter.FolderCharacteristi<br/>cPresenter|0%|0%|
|BenchmarkDotNet.Characteristics.CharacteristicPresenter.SourceCodeCharacter<br/>isticPresenter|100%||
|BenchmarkDotNet.Characteristics.CharacteristicSet|75%||
|BenchmarkDotNet.Characteristics.CharacteristicSetPresenter|77.1%|100%|
|BenchmarkDotNet.Characteristics.CharacteristicSetPresenter.DefaultPresenter|0%||
|BenchmarkDotNet.Characteristics.CharacteristicSetPresenter.DisplayPresenter|100%|100%|
|BenchmarkDotNet.Characteristics.CharacteristicSetPresenter.FolderPresenter|0%||
|BenchmarkDotNet.Characteristics.CharacteristicSetPresenter.SourceCodePresen<br/>ter|100%|100%|
|BenchmarkDotNet.Characteristics.CompositeResolver|67.8%|56.2%|
|BenchmarkDotNet.Characteristics.CompositeResolver<T>|67.8%|56.2%|
|BenchmarkDotNet.Characteristics.Resolver|45.8%|31.2%|
|BenchmarkDotNet.Characteristics.Resolver<T>|45.8%|31.2%|
|BenchmarkDotNet.Code.ArrayParam|100%|100%|
|BenchmarkDotNet.Code.ArrayParam<T>|80.9%|58.3%|
|BenchmarkDotNet.Code.AsyncDeclarationsProvider|100%||
|BenchmarkDotNet.Code.CodeGenerator|95.1%|88.5%|
|BenchmarkDotNet.Code.CodeGenerator.SmartStringBuilder|88.8%|50%|
|BenchmarkDotNet.Code.DeclarationsProvider|100%|95.4%|
|BenchmarkDotNet.Code.EnumParam|66.6%|38.4%|
|BenchmarkDotNet.Code.SyncDeclarationsProvider|100%||
|BenchmarkDotNet.Columns.BaselineAllocationRatioColumn|4.7%|0%|
|BenchmarkDotNet.Columns.BaselineColumn|84.6%|100%|
|BenchmarkDotNet.Columns.BaselineCustomColumn|95.4%|83.3%|
|BenchmarkDotNet.Columns.BaselineRatioColumn|84.8%|75%|
|BenchmarkDotNet.Columns.CategoriesColumn|0%|0%|
|BenchmarkDotNet.Columns.ColumnExtensions|100%||
|BenchmarkDotNet.Columns.ColumnHidingByIdRule|0%|0%|
|BenchmarkDotNet.Columns.ColumnHidingByNameRule|70%|50%|
|BenchmarkDotNet.Columns.CompositeColumnProvider|0%||
|BenchmarkDotNet.Columns.DefaultColumnProviders|91.1%|91.3%|
|BenchmarkDotNet.Columns.DefaultColumnProviders.DescriptorColumnProvider|66.6%|75%|
|BenchmarkDotNet.Columns.DefaultColumnProviders.JobColumnProvider|100%||
|BenchmarkDotNet.Columns.DefaultColumnProviders.MetricsColumnProvider|100%|100%|
|BenchmarkDotNet.Columns.DefaultColumnProviders.ParamsColumnProvider|100%|100%|
|BenchmarkDotNet.Columns.DefaultColumnProviders.StatisticsColumnProvider|90.9%|92.3%|
|BenchmarkDotNet.Columns.EmptyColumnProvider|0%||
|BenchmarkDotNet.Columns.JobCharacteristicColumn|100%|100%|
|BenchmarkDotNet.Columns.LogicalGroupColumn|84.6%|50%|
|BenchmarkDotNet.Columns.MetricColumn|91.8%|100%|
|BenchmarkDotNet.Columns.ParamColumn|94.4%|100%|
|BenchmarkDotNet.Columns.RankColumn|74%|50%|
|BenchmarkDotNet.Columns.SimpleColumnProvider|92.8%|83.3%|
|BenchmarkDotNet.Columns.StatisticalTestColumn|78.5%|71.4%|
|BenchmarkDotNet.Columns.StatisticColumn|75.5%|85%|
|BenchmarkDotNet.Columns.TagColumn|38.8%|0%|
|BenchmarkDotNet.Columns.TargetMethodColumn|85.7%|0%|
|BenchmarkDotNet.Configs.ConfigExtensions|53.1%|100%|
|BenchmarkDotNet.Configs.ConfigOptionsExtensions|100%|100%|
|BenchmarkDotNet.Configs.DebugBuildConfig|0%||
|BenchmarkDotNet.Configs.DebugConfig|4.5%||
|BenchmarkDotNet.Configs.DebugInProcessConfig|0%||
|BenchmarkDotNet.Configs.DefaultConfig|94.2%|50%|
|BenchmarkDotNet.Configs.ImmutableConfig|98.7%|100%|
|BenchmarkDotNet.Configs.ImmutableConfigBuilder|97.6%|95%|
|BenchmarkDotNet.Configs.ImmutableConfigBuilder.TypeComparer<TInterface>|83.3%|70%|
|BenchmarkDotNet.Configs.ManualConfig|83.5%|78.1%|
|BenchmarkDotNet.Configs.ManualConfig<T>|83.5%|78.1%|
|BenchmarkDotNet.ConsoleArguments.CommandLineOptions|100%|100%|
|BenchmarkDotNet.ConsoleArguments.ConfigParser|76.1%|81.9%|
|BenchmarkDotNet.ConsoleArguments.CorrectionsSuggester|100%|100%|
|BenchmarkDotNet.ConsoleArguments.LevenshteinDistanceCalculator|100%|100%|
|BenchmarkDotNet.ConsoleArguments.ListBenchmarks.BenchmarkCasesPrinter|46.1%|16.6%|
|BenchmarkDotNet.ConsoleArguments.ListBenchmarks.FlatBenchmarkCasesPrinter|100%|100%|
|BenchmarkDotNet.ConsoleArguments.ListBenchmarks.Node|0%||
|BenchmarkDotNet.ConsoleArguments.ListBenchmarks.TreeBenchmarkCasesPrinter|0%|0%|
|BenchmarkDotNet.ConsoleArguments.LoggerWrapper|83.3%|50%|
|BenchmarkDotNet.Detectors.Cpu.HardwareIntrinsics|72.5%|34.7%|
|BenchmarkDotNet.Detectors.Cpu.Linux.LinuxCpuDetector|92.3%|40%|
|BenchmarkDotNet.Detectors.Cpu.Linux.LinuxCpuInfoParser|97.4%|93.4%|
|BenchmarkDotNet.Detectors.Cpu.macOS.MacOsCpuDetector|0%|0%|
|BenchmarkDotNet.Detectors.Cpu.macOS.SysctlCpuInfoParser|100%|100%|
|BenchmarkDotNet.Detectors.Cpu.Windows.MosCpuDetector|100%|63.8%|
|BenchmarkDotNet.Detectors.Cpu.Windows.PowershellWmiCpuDetector|90%|50%|
|BenchmarkDotNet.Detectors.Cpu.Windows.PowershellWmiCpuInfoParser|100%|100%|
|BenchmarkDotNet.Detectors.Cpu.Windows.WindowsCpuDetector|100%||
|BenchmarkDotNet.Detectors.Cpu.Windows.WmicCpuDetector|14.2%|0%|
|BenchmarkDotNet.Detectors.Cpu.Windows.WmicCpuInfoParser|100%|100%|
|BenchmarkDotNet.Detectors.CpuDetector|84.6%|100%|
|BenchmarkDotNet.Detectors.OsDetector|74.2%|53.8%|
|BenchmarkDotNet.Diagnosers.AllocatedMemoryMetricDescriptor|80%||
|BenchmarkDotNet.Diagnosers.AllocatedNativeMemoryDescriptor|0%||
|BenchmarkDotNet.Diagnosers.CompositeDiagnoser|68.7%|40%|
|BenchmarkDotNet.Diagnosers.CompositeInProcessDiagnoser|100%||
|BenchmarkDotNet.Diagnosers.CompositeInProcessDiagnoserHandler|100%|100%|
|BenchmarkDotNet.Diagnosers.DiagnoserActionParameters|100%|50%|
|BenchmarkDotNet.Diagnosers.DiagnoserResults|100%||
|BenchmarkDotNet.Diagnosers.DiagnosersLoader|73.3%|65%|
|BenchmarkDotNet.Diagnosers.DiagnosersLoader<TDiagnoser>|73.3%|65%|
|BenchmarkDotNet.Diagnosers.DisassemblyDiagnoser|73.9%|54.6%|
|BenchmarkDotNet.Diagnosers.DisassemblyDiagnoser.NativeCodeSizeMetricDescrip<br/>tor|80%||
|BenchmarkDotNet.Diagnosers.DisassemblyDiagnoserConfig|90.5%|62.5%|
|BenchmarkDotNet.Diagnosers.DisassemblyDiagnoserInProcessHandler|100%|100%|
|BenchmarkDotNet.Diagnosers.EventPipeProfileMapper|100%||
|BenchmarkDotNet.Diagnosers.EventPipeProfiler|33.3%|34.6%|
|BenchmarkDotNet.Diagnosers.EventPipeProfiler.EventPipeProviderEqualityCompa<br/>rer|71.4%|50%|
|BenchmarkDotNet.Diagnosers.ExceptionDiagnoser|92.5%|87.5%|
|BenchmarkDotNet.Diagnosers.ExceptionDiagnoser.ExceptionsFrequencyMetricDesc<br/>riptor|80%|75%|
|BenchmarkDotNet.Diagnosers.ExceptionDiagnoserInProcessHandler|100%||
|BenchmarkDotNet.Diagnosers.HardwareCounterExtensions|0%||
|BenchmarkDotNet.Diagnosers.InProcessDiagnoserActionArgs|100%||
|BenchmarkDotNet.Diagnosers.InProcessDiagnoserHandlerData|100%||
|BenchmarkDotNet.Diagnosers.InProcessDiagnoserRouter|100%|100%|
|BenchmarkDotNet.Diagnosers.MemoryDiagnoser|94.1%|75%|
|BenchmarkDotNet.Diagnosers.MemoryDiagnoser.GarbageCollectionsMetricDescript<br/>or|88.8%||
|BenchmarkDotNet.Diagnosers.MemoryDiagnoserConfig|100%||
|BenchmarkDotNet.Diagnosers.NativeMemoryLeakDescriptor|0%||
|BenchmarkDotNet.Diagnosers.PerfCollectProfiler|4%|0%|
|BenchmarkDotNet.Diagnosers.PerfCollectProfilerConfig|66.6%|50%|
|BenchmarkDotNet.Diagnosers.PmcMetricDescriptor|0%||
|BenchmarkDotNet.Diagnosers.PmcStats|0%|0%|
|BenchmarkDotNet.Diagnosers.PreciseMachineCounter|0%||
|BenchmarkDotNet.Diagnosers.SnapshotProfilerBase|0.9%|0%|
|BenchmarkDotNet.Diagnosers.SnapshotProfilerBase.Progress|0%|0%|
|BenchmarkDotNet.Diagnosers.SpeedScopeExporter|0%|0%|
|BenchmarkDotNet.Diagnosers.ThreadingDiagnoser|89.1%|83.3%|
|BenchmarkDotNet.Diagnosers.ThreadingDiagnoser.CompletedWorkItemCountMetricD<br/>escriptor|80%|75%|
|BenchmarkDotNet.Diagnosers.ThreadingDiagnoser.LockContentionCountMetricDesc<br/>riptor|80%|75%|
|BenchmarkDotNet.Diagnosers.ThreadingDiagnoserConfig|100%||
|BenchmarkDotNet.Diagnosers.ThreadingDiagnoserInProcessHandler|58.3%|0%|
|BenchmarkDotNet.Diagnosers.UnresolvedDiagnoser|20%|0%|
|BenchmarkDotNet.Disassemblers.Arm64Asm|83%|45.4%|
|BenchmarkDotNet.Disassemblers.Arm64Asm.Arm64AsmData|100%||
|BenchmarkDotNet.Disassemblers.Arm64Asm.Arm64AsmDataConverter|84.4%|55.5%|
|BenchmarkDotNet.Disassemblers.Arm64Disassembler|0%|0%|
|BenchmarkDotNet.Disassemblers.Arm64Disassembler.RuntimeSpecificData|0%|0%|
|BenchmarkDotNet.Disassemblers.Arm64InstructionFormatter|0%|0%|
|BenchmarkDotNet.Disassemblers.Asm|100%||
|BenchmarkDotNet.Disassemblers.ClrMdArgs|45%|83.3%|
|BenchmarkDotNet.Disassemblers.ClrMdDisassembler|78%|71.5%|
|BenchmarkDotNet.Disassemblers.ClrMdDisassembler.SharpComparer|66.6%|50%|
|BenchmarkDotNet.Disassemblers.CodeFormatter|50%|12.5%|
|BenchmarkDotNet.Disassemblers.DisassembledMethod|45.4%||
|BenchmarkDotNet.Disassemblers.DisassemblyAnalyzer|60%|100%|
|BenchmarkDotNet.Disassemblers.DisassemblyResult|100%||
|BenchmarkDotNet.Disassemblers.Exporters.CombinedDisassemblyExporter|0%|0%|
|BenchmarkDotNet.Disassemblers.Exporters.DisassemblyPrettifier|93.3%|96.8%|
|BenchmarkDotNet.Disassemblers.Exporters.DisassemblyPrettifier.Element|100%||
|BenchmarkDotNet.Disassemblers.Exporters.DisassemblyPrettifier.Label|50%||
|BenchmarkDotNet.Disassemblers.Exporters.DisassemblyPrettifier.Reference|50%||
|BenchmarkDotNet.Disassemblers.Exporters.GithubMarkdownDiffDisassemblyExport<br/>er|0%|0%|
|BenchmarkDotNet.Disassemblers.Exporters.GithubMarkdownDisassemblyExporter|84.6%|78.5%|
|BenchmarkDotNet.Disassemblers.Exporters.HtmlDisassemblyExporter|0%|0%|
|BenchmarkDotNet.Disassemblers.Exporters.SymbolResolver|100%|100%|
|BenchmarkDotNet.Disassemblers.IntelAsm|100%||
|BenchmarkDotNet.Disassemblers.IntelDisassembler|96.9%|98.1%|
|BenchmarkDotNet.Disassemblers.IntelDisassembler.RuntimeSpecificData|100%|100%|
|BenchmarkDotNet.Disassemblers.IntelInstructionFormatter|36.3%|16.6%|
|BenchmarkDotNet.Disassemblers.Map|100%||
|BenchmarkDotNet.Disassemblers.MethodInfo|100%||
|BenchmarkDotNet.Disassemblers.MonoCode|100%||
|BenchmarkDotNet.Disassemblers.MonoDisassembler|81.3%|80.5%|
|BenchmarkDotNet.Disassemblers.MonoDisassembler.OutputParser|98.3%|96.6%|
|BenchmarkDotNet.Disassemblers.RegisterValueAccumulator|0%|0%|
|BenchmarkDotNet.Disassemblers.Sharp|100%||
|BenchmarkDotNet.Disassemblers.SourceCode|100%||
|BenchmarkDotNet.Disassemblers.SourceCodeProvider|97%|75%|
|BenchmarkDotNet.Disassemblers.State|82.7%|62.5%|
|BenchmarkDotNet.Disassemblers.State.ClrMethodComparer|16.6%|0%|
|BenchmarkDotNet.Engines.AnonymousPipesHost|86.6%|41.6%|
|BenchmarkDotNet.Engines.Consumer|0%|0%|
|BenchmarkDotNet.Engines.ConsumerExtensions|0%|0%|
|BenchmarkDotNet.Engines.DeadCodeEliminationHelper|33.3%||
|BenchmarkDotNet.Engines.Engine|89.7%|69.3%|
|BenchmarkDotNet.Engines.Engine.FinalizerBlocker|100%|100%|
|BenchmarkDotNet.Engines.Engine.FinalizerBlocker.Impl|100%||
|BenchmarkDotNet.Engines.Engine.Signals|100%||
|BenchmarkDotNet.Engines.EngineActualStage|100%|90%|
|BenchmarkDotNet.Engines.EngineActualStageAuto|100%|93.7%|
|BenchmarkDotNet.Engines.EngineActualStageSpecific|100%|100%|
|BenchmarkDotNet.Engines.EngineEventSource|3.1%|0%|
|BenchmarkDotNet.Engines.EngineFactory|100%||
|BenchmarkDotNet.Engines.EngineFirstJitStage|88.7%|71.8%|
|BenchmarkDotNet.Engines.EngineJitStage|100%||
|BenchmarkDotNet.Engines.EngineParameters|100%||
|BenchmarkDotNet.Engines.EnginePilotStage|100%|100%|
|BenchmarkDotNet.Engines.EnginePilotStageAuto|100%|92.8%|
|BenchmarkDotNet.Engines.EnginePilotStageInitial|100%|100%|
|BenchmarkDotNet.Engines.EnginePilotStageSpecific|100%|100%|
|BenchmarkDotNet.Engines.EngineResolver|94.1%|92.8%|
|BenchmarkDotNet.Engines.EngineSecondJitStage|85.7%|25%|
|BenchmarkDotNet.Engines.EngineStage|92.5%|88.8%|
|BenchmarkDotNet.Engines.EngineWarmupStage|100%|91.6%|
|BenchmarkDotNet.Engines.EngineWarmupStageAuto|100%|100%|
|BenchmarkDotNet.Engines.EngineWarmupStageSpecific|100%|100%|
|BenchmarkDotNet.Engines.GcStats|60.6%|47.2%|
|BenchmarkDotNet.Engines.GcStats.GcHelpers|0%|0%|
|BenchmarkDotNet.Engines.HostExtensions|100%||
|BenchmarkDotNet.Engines.IterationData|100%||
|BenchmarkDotNet.Engines.NoAcknowledgementConsoleHost|12.5%||
|BenchmarkDotNet.Engines.RunResults|100%|100%|
|BenchmarkDotNet.Environments.BenchmarkEnvironmentInfo|97.7%|86.3%|
|BenchmarkDotNet.Environments.ClrRuntime|75.6%|29.5%|
|BenchmarkDotNet.Environments.CoreRuntime|73.3%|59.5%|
|BenchmarkDotNet.Environments.CustomRuntime|0%||
|BenchmarkDotNet.Environments.EnvironmentResolver|96%|90%|
|BenchmarkDotNet.Environments.GcResolver|100%|100%|
|BenchmarkDotNet.Environments.HostEnvironmentInfo|93.7%|96.6%|
|BenchmarkDotNet.Environments.InfrastructureResolver|100%|100%|
|BenchmarkDotNet.Environments.MonoAotLLVMRuntime|0%|0%|
|BenchmarkDotNet.Environments.MonoRuntime|36.8%|0%|
|BenchmarkDotNet.Environments.NativeAotRuntime|66.6%|21.8%|
|BenchmarkDotNet.Environments.R2RRuntime|100%||
|BenchmarkDotNet.Environments.Runtime|86.6%|41.6%|
|BenchmarkDotNet.Environments.WasmRuntime|50%|16.6%|
|BenchmarkDotNet.EventProcessors.CompositeEventProcessor|100%|100%|
|BenchmarkDotNet.EventProcessors.EventProcessor|0%||
|BenchmarkDotNet.Exporters.AsciiDocExporter|61.5%|71.4%|
|BenchmarkDotNet.Exporters.BenchmarkReportExporter|100%|100%|
|BenchmarkDotNet.Exporters.CompositeExporter|45.8%|0%|
|BenchmarkDotNet.Exporters.Csv.CsvExporter|100%|100%|
|BenchmarkDotNet.Exporters.Csv.CsvHelper|83.3%|83.3%|
|BenchmarkDotNet.Exporters.Csv.CsvMeasurementsExporter|39.6%|68%|
|BenchmarkDotNet.Exporters.Csv.CsvMeasurementsExporter.MeasurementColumn|80%||
|BenchmarkDotNet.Exporters.Csv.CsvSeparatorExtensions|25%||
|BenchmarkDotNet.Exporters.DefaultExporters|0%||
|BenchmarkDotNet.Exporters.ExporterBase|100%|100%|
|BenchmarkDotNet.Exporters.FullNameProvider|98%|96.5%|
|BenchmarkDotNet.Exporters.HtmlExporter|94.7%|100%|
|BenchmarkDotNet.Exporters.HtmlExporter.HtmlLoggerWrapper|62.5%||
|BenchmarkDotNet.Exporters.InstructionPointerExporter|2.6%|0%|
|BenchmarkDotNet.Exporters.InstructionPointerExporter.CodeWithCounters|0%||
|BenchmarkDotNet.Exporters.InstructionPointerExporter.MethodWithCounters|0%|0%|
|BenchmarkDotNet.Exporters.Json.JsonExporter|90%||
|BenchmarkDotNet.Exporters.Json.JsonExporterBase|98.6%|81.2%|
|BenchmarkDotNet.Exporters.MarkdownExporter|100%|100%|
|BenchmarkDotNet.Exporters.OpenMetrics.OpenMetricsExporter|97%|77.4%|
|BenchmarkDotNet.Exporters.OpenMetrics.OpenMetricsExporter.OpenMetric|94.8%|61.7%|
|BenchmarkDotNet.Exporters.PerfonarJsonExporter|0%||
|BenchmarkDotNet.Exporters.PerfonarMdExporter|0%||
|BenchmarkDotNet.Exporters.PlainExporter|100%|100%|
|BenchmarkDotNet.Exporters.RPlotExporter|5.1%|0%|
|BenchmarkDotNet.Exporters.Xml.BenchmarkReportDto|100%|50%|
|BenchmarkDotNet.Exporters.Xml.ChronometerDto|100%||
|BenchmarkDotNet.Exporters.Xml.GcStats|100%||
|BenchmarkDotNet.Exporters.Xml.HostEnvironmentInfoDto|100%|50%|
|BenchmarkDotNet.Exporters.Xml.SimpleXmlWriter|90.9%|50%|
|BenchmarkDotNet.Exporters.Xml.SummaryDto|100%||
|BenchmarkDotNet.Exporters.Xml.Utf8StringWriter|100%||
|BenchmarkDotNet.Exporters.Xml.XmlExporter|90%||
|BenchmarkDotNet.Exporters.Xml.XmlExporterBase|96.1%|100%|
|BenchmarkDotNet.Exporters.Xml.XmlSerializer|100%|100%|
|BenchmarkDotNet.Exporters.Xml.XmlSerializer.XmlSerializerBuilder|100%|100%|
|BenchmarkDotNet.Extensions.AssemblyExtensions|77.7%|83.3%|
|BenchmarkDotNet.Extensions.CommonExtensions|55.7%|48.8%|
|BenchmarkDotNet.Extensions.CommonExtensions<T>|55.7%|48.8%|
|BenchmarkDotNet.Extensions.CommonExtensions<TItem, TValue>|55.7%|48.8%|
|BenchmarkDotNet.Extensions.ConfigurationExtensions|71.4%|100%|
|BenchmarkDotNet.Extensions.CultureInfoExtensions|80%|50%|
|BenchmarkDotNet.Extensions.DoubleExtensions|50%||
|BenchmarkDotNet.Extensions.EncodingExtensions|0%||
|BenchmarkDotNet.Extensions.Hashing|87.5%|66.6%|
|BenchmarkDotNet.Extensions.MathExtensions|50%||
|BenchmarkDotNet.Extensions.PathFeatures|0%|0%|
|BenchmarkDotNet.Extensions.ProcessExtensions|72.4%|48.8%|
|BenchmarkDotNet.Extensions.ReflectionExtensions|98.4%|95%|
|BenchmarkDotNet.Extensions.ReflectionExtensions<TAttribute>|98.4%|95%|
|BenchmarkDotNet.Extensions.ReportExtensions|18.7%|18.7%|
|BenchmarkDotNet.Extensions.ReportExtensions<T>|18.7%|18.7%|
|BenchmarkDotNet.Extensions.RuntimeMonikerExtensions|39.5%|12.5%|
|BenchmarkDotNet.Extensions.StatisticsExtensions|98.8%|87.5%|
|BenchmarkDotNet.Extensions.StringAndTextExtensions|97.7%|96.8%|
|BenchmarkDotNet.Extensions.ThreadExtensions|41.6%|50%|
|BenchmarkDotNet.Filters.AllCategoriesFilter|100%||
|BenchmarkDotNet.Filters.AnyCategoriesFilter|100%||
|BenchmarkDotNet.Filters.AttributesFilter|100%|100%|
|BenchmarkDotNet.Filters.DisjunctionFilter|0%||
|BenchmarkDotNet.Filters.GlobFilter|100%|100%|
|BenchmarkDotNet.Filters.NameFilter|100%||
|BenchmarkDotNet.Filters.SimpleFilter|100%||
|BenchmarkDotNet.Filters.UnionFilter|100%||
|BenchmarkDotNet.HashCode|68.4%|50%|
|BenchmarkDotNet.Helpers.ArtifactFileNameHelper|87%|46.1%|
|BenchmarkDotNet.Helpers.AsciiHelper|100%||
|BenchmarkDotNet.Helpers.Assertion|66.6%|50%|
|BenchmarkDotNet.Helpers.AwaitHelper|97.7%|86.3%|
|BenchmarkDotNet.Helpers.AwaitHelper.ValueTaskWaiter|100%|100%|
|BenchmarkDotNet.Helpers.ConsoleExitHandler|58.6%||
|BenchmarkDotNet.Helpers.DefaultCultureInfo|100%||
|BenchmarkDotNet.Helpers.DisposeAtProcessTermination|78.5%|58.3%|
|BenchmarkDotNet.Helpers.ExternalToolsHelper|57.1%|0%|
|BenchmarkDotNet.Helpers.ExternalToolsHelper<T>|57.1%|0%|
|BenchmarkDotNet.Helpers.FolderNameHelper|87.5%|80%|
|BenchmarkDotNet.Helpers.FrameworkVersionHelper|82%|54.4%|
|BenchmarkDotNet.Helpers.GenericBenchmarksBuilder|100%|100%|
|BenchmarkDotNet.Helpers.LinuxOsReleaseHelper|70%|62.5%|
|BenchmarkDotNet.Helpers.PowerManagementHelper|85%|62.5%|
|BenchmarkDotNet.Helpers.PowerShellLocator|76.6%|70%|
|BenchmarkDotNet.Helpers.ProcessHelper|28.7%|37.5%|
|BenchmarkDotNet.Helpers.Reflection.Emit.EmitParameterInfo|100%|100%|
|BenchmarkDotNet.Helpers.Reflection.Emit.IlGeneratorCallExtensions|50%|45.8%|
|BenchmarkDotNet.Helpers.Reflection.Emit.IlGeneratorEmitOpExtensions|62.5%|63.6%|
|BenchmarkDotNet.Helpers.Reflection.Emit.IlGeneratorStatementExtensions|75.5%|50%|
|BenchmarkDotNet.Helpers.Reflection.Emit.MethodBuilderExtensions|100%||
|BenchmarkDotNet.Helpers.Reflection.Emit.TypeBuilderExtensions|95.9%|90%|
|BenchmarkDotNet.Helpers.ResourceHelper|87.5%|50%|
|BenchmarkDotNet.Helpers.SectionsHelper|100%|83.3%|
|BenchmarkDotNet.Helpers.SourceCodeHelper|77%|74.6%|
|BenchmarkDotNet.Helpers.TaskbarProgress|34.2%|42.3%|
|BenchmarkDotNet.Helpers.TaskbarProgress.Com|26.6%|50%|
|BenchmarkDotNet.Helpers.TaskbarProgress.Terminal|13.8%|33.3%|
|BenchmarkDotNet.Helpers.UnitHelper|100%||
|BenchmarkDotNet.Helpers.UserInteractionHelper|100%|50%|
|BenchmarkDotNet.Helpers.XUnitHelper|100%|100%|
|BenchmarkDotNet.Jobs.AccuracyMode|57.1%||
|BenchmarkDotNet.Jobs.Argument|0%|0%|
|BenchmarkDotNet.Jobs.EnvironmentMode|83.6%|50%|
|BenchmarkDotNet.Jobs.EnvironmentVariable|50%|43.7%|
|BenchmarkDotNet.Jobs.GcMode|80.5%|50%|
|BenchmarkDotNet.Jobs.GcModeExtensions|0%||
|BenchmarkDotNet.Jobs.InfrastructureMode|86.3%|100%|
|BenchmarkDotNet.Jobs.Job|100%|100%|
|BenchmarkDotNet.Jobs.JobComparer|95.8%|91.6%|
|BenchmarkDotNet.Jobs.JobComparer.NumericStringComparer|100%|95%|
|BenchmarkDotNet.Jobs.JobExtensions|72.2%|85.7%|
|BenchmarkDotNet.Jobs.JobIdGenerator|100%|100%|
|BenchmarkDotNet.Jobs.JobMode<T>|100%||
|BenchmarkDotNet.Jobs.MetaMode|100%||
|BenchmarkDotNet.Jobs.MonoArgument|0%|0%|
|BenchmarkDotNet.Jobs.MsBuildArgument|0%||
|BenchmarkDotNet.Jobs.RunMode|80.2%|0%|
|BenchmarkDotNet.Loggers.AccumulationLogger|91.6%||
|BenchmarkDotNet.Loggers.AsyncProcessOutputReader|83.7%|71.4%|
|BenchmarkDotNet.Loggers.Broker|94.2%|84.6%|
|BenchmarkDotNet.Loggers.CompositeLogger|89.4%|100%|
|BenchmarkDotNet.Loggers.ConsoleLogger|86.2%|63.6%|
|BenchmarkDotNet.Loggers.LinqPadLogger|31.3%|12.5%|
|BenchmarkDotNet.Loggers.LogCapture|4.7%||
|BenchmarkDotNet.Loggers.LoggerExtensions|66.6%||
|BenchmarkDotNet.Loggers.LoggerWithPrefix|90%|100%|
|BenchmarkDotNet.Loggers.NullLogger|50%||
|BenchmarkDotNet.Loggers.OutputLine|0%||
|BenchmarkDotNet.Loggers.StreamLogger|50%||
|BenchmarkDotNet.Loggers.TextLogger|75%||
|BenchmarkDotNet.Mathematics.ConfidenceLevelExtensions|77.7%|66.6%|
|BenchmarkDotNet.Mathematics.LegacyConfidenceInterval|55.5%|33.3%|
|BenchmarkDotNet.Mathematics.MathHelper|100%||
|BenchmarkDotNet.Mathematics.MeasurementsStatistics|89.5%|84.6%|
|BenchmarkDotNet.Mathematics.NumeralSystemExtensions|90%|65.6%|
|BenchmarkDotNet.Mathematics.PercentileValues|97.2%||
|BenchmarkDotNet.Mathematics.RankHelper|100%|100%|
|BenchmarkDotNet.Mathematics.RatioStatistics|86.3%|75%|
|BenchmarkDotNet.Mathematics.Statistics|81.9%|16.6%|
|BenchmarkDotNet.Models.BdnBenchmark|94.1%|80%|
|BenchmarkDotNet.Models.BdnEnvironment|100%||
|BenchmarkDotNet.Models.BdnExecution|0%||
|BenchmarkDotNet.Models.BdnHostInfo|100%||
|BenchmarkDotNet.Models.BdnLifecycle|0%|0%|
|BenchmarkDotNet.Models.BdnSchema|0%||
|BenchmarkDotNet.Order.CategoryComparer|100%|66.6%|
|BenchmarkDotNet.Order.DefaultOrderer|93.2%|69.2%|
|BenchmarkDotNet.Order.DefaultOrderer.BenchmarkComparer|97.3%|72.4%|
|BenchmarkDotNet.Order.DefaultOrderer.BenchmarkParamsEqualityComparer|71.4%|66.6%|
|BenchmarkDotNet.Order.DefaultOrderer.LogicalGroupComparer|100%|50%|
|BenchmarkDotNet.Parameters.ParameterComparer|69%|64.5%|
|BenchmarkDotNet.Parameters.ParameterDefinition|100%||
|BenchmarkDotNet.Parameters.ParameterDefinitions|93.3%|60%|
|BenchmarkDotNet.Parameters.ParameterEqualityComparer|30.9%|30.3%|
|BenchmarkDotNet.Parameters.ParameterExtractor|88.8%|83.3%|
|BenchmarkDotNet.Parameters.ParameterInstance|97.2%|90%|
|BenchmarkDotNet.Parameters.ParameterInstances|34.2%|30%|
|BenchmarkDotNet.Parameters.SmartArgument|100%|53.3%|
|BenchmarkDotNet.Parameters.SmartParamBuilder|91.3%|88.8%|
|BenchmarkDotNet.Parameters.SmartParameter|100%|100%|
|BenchmarkDotNet.Portability.Antivirus|0%||
|BenchmarkDotNet.Portability.HyperV|100%|100%|
|BenchmarkDotNet.Portability.JitInfo|86.1%|71.1%|
|BenchmarkDotNet.Portability.RuntimeInformation|58.5%|37.2%|
|BenchmarkDotNet.Portability.StringExtensions|100%|50%|
|BenchmarkDotNet.Portability.VirtualBox|100%||
|BenchmarkDotNet.Portability.VirtualMachineHypervisor|100%|100%|
|BenchmarkDotNet.Portability.VMware|100%||
|BenchmarkDotNet.Properties.BenchmarkDotNetInfo|85%|83.3%|
|BenchmarkDotNet.Reports.BaseliningStrategy|100%|100%|
|BenchmarkDotNet.Reports.BenchmarkReport|41.1%|66.6%|
|BenchmarkDotNet.Reports.BenchmarkReportExtensions|100%||
|BenchmarkDotNet.Reports.DisplayPrecisionManager|100%|95%|
|BenchmarkDotNet.Reports.Measurement|98.5%|85.7%|
|BenchmarkDotNet.Reports.MeasurementExtensions|25%|100%|
|BenchmarkDotNet.Reports.Metric|100%||
|BenchmarkDotNet.Reports.MetricDescriptorEqualityComparer|85.7%|66.6%|
|BenchmarkDotNet.Reports.Summary|71.3%|84%|
|BenchmarkDotNet.Reports.SummaryExtensions|100%|81.2%|
|BenchmarkDotNet.Reports.SummaryStyle|95.7%|76.6%|
|BenchmarkDotNet.Reports.SummaryTable|96.5%|95.6%|
|BenchmarkDotNet.Reports.SummaryTable.SummaryTableColumn|96%|85.7%|
|BenchmarkDotNet.Reports.SummaryTableExtensions|80.9%|82.6%|
|BenchmarkDotNet.Running.BenchmarkBuildInfo|100%||
|BenchmarkDotNet.Running.BenchmarkCase|78.2%|50%|
|BenchmarkDotNet.Running.BenchmarkConverter|97.2%|94%|
|BenchmarkDotNet.Running.BenchmarkConverter<T>|97.2%|94%|
|BenchmarkDotNet.Running.BenchmarkConverter<TAttribute>|97.2%|94%|
|BenchmarkDotNet.Running.BenchmarkId|86.3%|75%|
|BenchmarkDotNet.Running.BenchmarkPartitioner|70.3%|54.7%|
|BenchmarkDotNet.Running.BenchmarkPartitioner.BenchmarkRuntimePropertiesComp<br/>arer|67.3%|47.2%|
|BenchmarkDotNet.Running.BenchmarkRunInfo|100%|100%|
|BenchmarkDotNet.Running.BenchmarkRunner|80.4%|80%|
|BenchmarkDotNet.Running.BenchmarkRunner<T>|80.4%|80%|
|BenchmarkDotNet.Running.BenchmarkRunnerClean|93%|83.5%|
|BenchmarkDotNet.Running.BenchmarkSwitcher|44.2%|42.6%|
|BenchmarkDotNet.Running.BuildPartition|92.4%|84.6%|
|BenchmarkDotNet.Running.ConsoleTitler|36.6%|37.5%|
|BenchmarkDotNet.Running.DefaultCategoryDiscoverer|100%|100%|
|BenchmarkDotNet.Running.Descriptor|92.1%|50%|
|BenchmarkDotNet.Running.DescriptorComparer|75%|70%|
|BenchmarkDotNet.Running.InvalidBenchmarkDeclarationException|100%||
|BenchmarkDotNet.Running.PowerManagementApplier|83.7%|83.3%|
|BenchmarkDotNet.Running.TypeFilter|100%|100%|
|BenchmarkDotNet.Running.UserInteraction|27.5%|25%|
|BenchmarkDotNet.Running.WakeLock|82.3%|83.3%|
|BenchmarkDotNet.Running.WakeLock.PInvoke|90.4%|62.5%|
|BenchmarkDotNet.Running.WakeLock.SafePowerHandle|50%||
|BenchmarkDotNet.Running.WakeLock.WakeLockSentinel|73.9%|100%|
|BenchmarkDotNet.Serialization.BdnJsonSerializer|96.4%|50%|
|BenchmarkDotNet.Serialization.BdnSimpleJsonSerializer|78.3%|64.2%|
|BenchmarkDotNet.Serialization.BdnSimpleJsonSerializer.SimpleJsonDoubleConve<br/>rter|57.1%|66.6%|
|BenchmarkDotNet.Serialization.BdnSimpleJsonSerializer.SimpleJsonFloatConver<br/>ter|28.5%|50%|
|BenchmarkDotNet.Toolchains.AppConfigGenerator|88.5%|75%|
|BenchmarkDotNet.Toolchains.ArtifactsPaths|100%||
|BenchmarkDotNet.Toolchains.CoreRun.CoreRunGenerator|17.3%|0%|
|BenchmarkDotNet.Toolchains.CoreRun.CoreRunPublisher|5.2%|20%|
|BenchmarkDotNet.Toolchains.CoreRun.CoreRunToolchain|64.5%|53.5%|
|BenchmarkDotNet.Toolchains.CsProj|85.3%|70%|
|BenchmarkDotNet.Toolchains.CsProj.CsProjClassicNetToolchain|80%|50%|
|BenchmarkDotNet.Toolchains.CsProj.CsProjCoreToolchain|75%|61.1%|
|BenchmarkDotNet.Toolchains.CsProj.CsProjGenerator|91.5%|72.9%|
|BenchmarkDotNet.Toolchains.DotNetCli.CustomDotNetCliToolchainBuilder|50%|35%|
|BenchmarkDotNet.Toolchains.DotNetCli.DotNetCliBuilder|100%|100%|
|BenchmarkDotNet.Toolchains.DotNetCli.DotNetCliCommand|93.1%|58.8%|
|BenchmarkDotNet.Toolchains.DotNetCli.DotNetCliCommandExecutor|65.9%|60.8%|
|BenchmarkDotNet.Toolchains.DotNetCli.DotNetCliCommandExtensions|100%|100%|
|BenchmarkDotNet.Toolchains.DotNetCli.DotNetCliCommandResult|87.5%|50%|
|BenchmarkDotNet.Toolchains.DotNetCli.DotNetCliExecutor|88.7%|68.7%|
|BenchmarkDotNet.Toolchains.DotNetCli.DotNetCliGenerator|59.1%|62.5%|
|BenchmarkDotNet.Toolchains.DotNetCli.DotNetCliPublisher|100%|100%|
|BenchmarkDotNet.Toolchains.DotNetCli.MsBuildErrorMapper|66.6%|27.8%|
|BenchmarkDotNet.Toolchains.DotNetCli.NetCoreAppSettings|96.2%|72.2%|
|BenchmarkDotNet.Toolchains.Executor|64.7%|47.6%|
|BenchmarkDotNet.Toolchains.GeneratorBase|87.2%|100%|
|BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation.ConsumableTypeInfo|82.7%|88.8%|
|BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation.EmitExtensions|0%|0%|
|BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation.EmitExtensions<T>|0%|0%|
|BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation.RunnableEmitter|95.9%|76.1%|
|BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation.RunnableEmitter.Ar<br/>gFieldInfo|100%||
|BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation.RunnableProgram|60.6%|50%|
|BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation.RunnableReflection<br/>Helpers|89.5%|76.6%|
|BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation.RunnableReuse|98.4%|92.8%|
|BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation.RunnableReuse<T>|98.4%|92.8%|
|BenchmarkDotNet.Toolchains.InProcess.Emit.InProcessEmitArtifactsPath|100%||
|BenchmarkDotNet.Toolchains.InProcess.Emit.InProcessEmitBuilder|75%|50%|
|BenchmarkDotNet.Toolchains.InProcess.Emit.InProcessEmitExecutor|81.5%|33.3%|
|BenchmarkDotNet.Toolchains.InProcess.Emit.InProcessEmitGenerator|89.2%||
|BenchmarkDotNet.Toolchains.InProcess.Emit.InProcessEmitToolchain|100%||
|BenchmarkDotNet.Toolchains.InProcess.InProcessHost|91.1%|81.2%|
|BenchmarkDotNet.Toolchains.InProcess.InProcessSettings|100%||
|BenchmarkDotNet.Toolchains.InProcess.InProcessValidator|89.1%|63.6%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkAction|100%||
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory|80.3%|73%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.Benchmar<br/>kAction<T>|76.9%|50%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.Benchmar<br/>kActionBase|87.5%|85.7%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.Benchmar<br/>kActionByRef<T>|76.9%|50%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.Benchmar<br/>kActionByRefReadonly<T>|76.9%|50%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.Benchmar<br/>kActionTask|72.2%|50%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.Benchmar<br/>kActionTask<T>|72.2%|50%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.Benchmar<br/>kActionValueTask|72.2%|50%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.Benchmar<br/>kActionValueTask<T>|72.2%|50%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.Benchmar<br/>kActionVoid|100%|100%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.BenchmarkActionFactory.Benchmar<br/>kActionVoidPointer|76.9%|50%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.InProcessNoEmitBuilder|100%||
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.InProcessNoEmitExecutor|80.5%|33.3%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.InProcessNoEmitGenerator|100%||
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.InProcessNoEmitRunner|78%|50%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.InProcessNoEmitRunner.Runnable|98.2%|87.5%|
|BenchmarkDotNet.Toolchains.InProcess.NoEmit.InProcessNoEmitToolchain|84.6%||
|BenchmarkDotNet.Toolchains.LargeAddressAware|89.2%|70%|
|BenchmarkDotNet.Toolchains.Mono.MonoAotBuilder|0%|0%|
|BenchmarkDotNet.Toolchains.Mono.MonoAotToolchain|15.7%|0%|
|BenchmarkDotNet.Toolchains.Mono.MonoGenerator|100%||
|BenchmarkDotNet.Toolchains.Mono.MonoPublisher|100%||
|BenchmarkDotNet.Toolchains.Mono.MonoToolchain|64.7%|0%|
|BenchmarkDotNet.Toolchains.MonoAotLLVM.MonoAotLLVMGenerator|0%|0%|
|BenchmarkDotNet.Toolchains.MonoAotLLVM.MonoAotLLVMToolChain|0%|0%|
|BenchmarkDotNet.Toolchains.MonoWasm.WasmExecutor|0%|0%|
|BenchmarkDotNet.Toolchains.MonoWasm.WasmGenerator|8.3%|12.5%|
|BenchmarkDotNet.Toolchains.MonoWasm.WasmToolchain|60%|0%|
|BenchmarkDotNet.Toolchains.NativeAot.Generator|70%|22.4%|
|BenchmarkDotNet.Toolchains.NativeAot.NativeAotToolchain|95.1%|50%|
|BenchmarkDotNet.Toolchains.NativeAot.NativeAotToolchainBuilder|80%|80%|
|BenchmarkDotNet.Toolchains.Parameters.ExecuteParameters|100%||
|BenchmarkDotNet.Toolchains.R2R.R2RGenerator|100%||
|BenchmarkDotNet.Toolchains.R2R.R2RToolchain|68.1%|12.5%|
|BenchmarkDotNet.Toolchains.Results.BuildResult|90.9%|0%|
|BenchmarkDotNet.Toolchains.Results.ExecuteResult|94.3%|94.1%|
|BenchmarkDotNet.Toolchains.Results.GenerateResult|92.8%|0%|
|BenchmarkDotNet.Toolchains.Roslyn.Builder|2.2%|0%|
|BenchmarkDotNet.Toolchains.Roslyn.Generator|0%|0%|
|BenchmarkDotNet.Toolchains.Roslyn.RoslynToolchain|15.7%|0%|
|BenchmarkDotNet.Toolchains.Roslyn.RoslynWorkarounds|0%|0%|
|BenchmarkDotNet.Toolchains.Toolchain|60.7%|33.3%|
|BenchmarkDotNet.Toolchains.ToolchainExtensions|43.6%|59%|
|BenchmarkDotNet.Validators.BaselineValidator|100%|93.7%|
|BenchmarkDotNet.Validators.BenchmarkProcessValidator|58.3%|87.5%|
|BenchmarkDotNet.Validators.CompilationValidator|91.2%|88.4%|
|BenchmarkDotNet.Validators.CompilationValidator.BenchmarkMethodEqualityComp<br/>arer|85.7%|40%|
|BenchmarkDotNet.Validators.CompositeValidator|66.6%|0%|
|BenchmarkDotNet.Validators.ConfigValidator|67.8%|62.5%|
|BenchmarkDotNet.Validators.DeferredExecutionValidator|100%|100%|
|BenchmarkDotNet.Validators.DiagnosersValidator|100%||
|BenchmarkDotNet.Validators.DotNetSdkValidator|51.1%|36.6%|
|BenchmarkDotNet.Validators.ExecutionValidator|100%|100%|
|BenchmarkDotNet.Validators.ExecutionValidatorBase|78.7%|86.5%|
|BenchmarkDotNet.Validators.ExecutionValidatorBase<T>|78.7%|86.5%|
|BenchmarkDotNet.Validators.GenericBenchmarksValidator|100%|100%|
|BenchmarkDotNet.Validators.JitOptimizationsValidator|89.6%|92.8%|
|BenchmarkDotNet.Validators.ParamsAllValuesValidator|100%|100%|
|BenchmarkDotNet.Validators.ParamsValidator|100%|100%|
|BenchmarkDotNet.Validators.ReturnValueValidator|93.9%|91.4%|
|BenchmarkDotNet.Validators.ReturnValueValidator.InDepthEqualityComparer|92.3%|90%|
|BenchmarkDotNet.Validators.ReturnValueValidator.ParameterInstancesEqualityC<br/>omparer|86.6%|86.3%|
|BenchmarkDotNet.Validators.RunModeValidator|70%|61.1%|
|BenchmarkDotNet.Validators.RuntimeValidator|100%|100%|
|BenchmarkDotNet.Validators.SetupCleanupValidator|100%|100%|
|BenchmarkDotNet.Validators.SetupCleanupValidator<T>|100%|100%|
|BenchmarkDotNet.Validators.ShadowCopyValidator|75%|100%|
|BenchmarkDotNet.Validators.ValidationError|54.1%|28.5%|
|BenchmarkDotNet.Validators.ValidationErrorReporter|100%|100%|
|BenchmarkDotNet.Validators.ValidationParameters|100%||
|DirtyAssemblyResolveHelper|80%|50%|
|JetBrains.Annotations.AspAttributeRoutingAttribute|0%||
|JetBrains.Annotations.AspChildControlTypeAttribute|0%||
|JetBrains.Annotations.AspMinimalApiDeclarationAttribute|0%||
|JetBrains.Annotations.AspMvcActionAttribute|0%||
|JetBrains.Annotations.AspMvcAreaAttribute|0%||
|JetBrains.Annotations.AspMvcAreaMasterLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcAreaPartialViewLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcAreaViewComponentViewLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcAreaViewLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcControllerAttribute|0%||
|JetBrains.Annotations.AspMvcMasterLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcPartialViewLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcViewComponentViewLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcViewLocationFormatAttribute|0%||
|JetBrains.Annotations.AspRequiredAttributeAttribute|0%||
|JetBrains.Annotations.AspRouteConventionAttribute|0%||
|JetBrains.Annotations.AspTypePropertyAttribute|0%||
|JetBrains.Annotations.AssertionConditionAttribute|0%||
|JetBrains.Annotations.BaseTypeRequiredAttribute|0%||
|JetBrains.Annotations.CodeTemplateAttribute|0%||
|JetBrains.Annotations.CollectionAccessAttribute|0%||
|JetBrains.Annotations.ContractAnnotationAttribute|0%||
|JetBrains.Annotations.HtmlAttributeValueAttribute|0%||
|JetBrains.Annotations.HtmlElementAttributesAttribute|0%||
|JetBrains.Annotations.InstantHandleAttribute|0%||
|JetBrains.Annotations.LanguageInjectionAttribute|0%||
|JetBrains.Annotations.LocalizationRequiredAttribute|0%||
|JetBrains.Annotations.MacroAttribute|0%||
|JetBrains.Annotations.MeansImplicitUseAttribute|0%||
|JetBrains.Annotations.MustUseReturnValueAttribute|0%||
|JetBrains.Annotations.NotifyPropertyChangedInvocatorAttribute|0%||
|JetBrains.Annotations.PathReferenceAttribute|0%||
|JetBrains.Annotations.PublicAPIAttribute|20%||
|JetBrains.Annotations.RazorDirectiveAttribute|0%||
|JetBrains.Annotations.RazorImportNamespaceAttribute|0%||
|JetBrains.Annotations.RazorInjectionAttribute|0%||
|JetBrains.Annotations.RazorPageBaseTypeAttribute|0%||
|JetBrains.Annotations.RequireStaticDelegateAttribute|0%||
|JetBrains.Annotations.RouteParameterConstraintAttribute|0%||
|JetBrains.Annotations.StringFormatMethodAttribute|0%||
|JetBrains.Annotations.TestSubjectAttribute|0%||
|JetBrains.Annotations.UriStringAttribute|0%||
|JetBrains.Annotations.UsedImplicitlyAttribute|66.6%||
|JetBrains.Annotations.ValueProviderAttribute|0%||
|JetBrains.Annotations.ValueRangeAttribute|0%||

</details>
<details><summary>BenchmarkDotNet.Analyzers - 93.1%</summary>

|**Name**|**Line**|**Branch**|
|:---|---:|---:|
|**BenchmarkDotNet.Analyzers**|**93.1%**|**86%**|
|BenchmarkDotNet.Analyzers.AnalyzerHelper|91.8%|80.7%|
|BenchmarkDotNet.Analyzers.Attributes.ArgumentsAttributeAnalyzer|96.7%|90.7%|
|BenchmarkDotNet.Analyzers.Attributes.GeneralArgumentAttributesAnalyzer|92.8%|80%|
|BenchmarkDotNet.Analyzers.Attributes.GeneralParameterAttributesAnalyzer|86.5%|70.3%|
|BenchmarkDotNet.Analyzers.Attributes.ParamsAllValuesAttributeAnalyzer|90.7%|79.4%|
|BenchmarkDotNet.Analyzers.Attributes.ParamsAttributeAnalyzer|96.7%|89.2%|
|BenchmarkDotNet.Analyzers.BenchmarkRunner.RunAnalyzer|94%|87.1%|
|BenchmarkDotNet.Analyzers.General.BenchmarkClassAnalyzer|98.1%|97.8%|

</details>
<details><summary>BenchmarkDotNet.Annotations - 19%</summary>

|**Name**|**Line**|**Branch**|
|:---|---:|---:|
|**BenchmarkDotNet.Annotations**|**19%**|**87.5%**|
|BenchmarkDotNet.Attributes.ArgumentsAttribute|75%|100%|
|BenchmarkDotNet.Attributes.ArgumentsSourceAttribute|100%||
|BenchmarkDotNet.Attributes.BenchmarkAttribute|100%||
|BenchmarkDotNet.Attributes.BenchmarkCategoryAttribute|66.6%||
|BenchmarkDotNet.Attributes.GenericTypeArgumentsAttribute|100%||
|BenchmarkDotNet.Attributes.ParamsAttribute|100%|100%|
|BenchmarkDotNet.Attributes.ParamsSourceAttribute|100%||
|BenchmarkDotNet.Attributes.PriorityAttribute|100%||
|BenchmarkDotNet.Attributes.TargetedAttribute|75%|75%|
|JetBrains.Annotations.AspAttributeRoutingAttribute|0%||
|JetBrains.Annotations.AspChildControlTypeAttribute|0%||
|JetBrains.Annotations.AspMinimalApiDeclarationAttribute|0%||
|JetBrains.Annotations.AspMvcActionAttribute|0%||
|JetBrains.Annotations.AspMvcAreaAttribute|0%||
|JetBrains.Annotations.AspMvcAreaMasterLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcAreaPartialViewLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcAreaViewComponentViewLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcAreaViewLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcControllerAttribute|0%||
|JetBrains.Annotations.AspMvcMasterLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcPartialViewLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcViewComponentViewLocationFormatAttribute|0%||
|JetBrains.Annotations.AspMvcViewLocationFormatAttribute|0%||
|JetBrains.Annotations.AspRequiredAttributeAttribute|0%||
|JetBrains.Annotations.AspRouteConventionAttribute|0%||
|JetBrains.Annotations.AspTypePropertyAttribute|0%||
|JetBrains.Annotations.AssertionConditionAttribute|0%||
|JetBrains.Annotations.BaseTypeRequiredAttribute|0%||
|JetBrains.Annotations.CodeTemplateAttribute|0%||
|JetBrains.Annotations.CollectionAccessAttribute|0%||
|JetBrains.Annotations.ContractAnnotationAttribute|0%||
|JetBrains.Annotations.HtmlAttributeValueAttribute|0%||
|JetBrains.Annotations.HtmlElementAttributesAttribute|0%||
|JetBrains.Annotations.InstantHandleAttribute|0%||
|JetBrains.Annotations.LanguageInjectionAttribute|0%||
|JetBrains.Annotations.LocalizationRequiredAttribute|0%||
|JetBrains.Annotations.MacroAttribute|0%||
|JetBrains.Annotations.MeansImplicitUseAttribute|0%||
|JetBrains.Annotations.MustUseReturnValueAttribute|0%||
|JetBrains.Annotations.NotifyPropertyChangedInvocatorAttribute|0%||
|JetBrains.Annotations.PathReferenceAttribute|0%||
|JetBrains.Annotations.PublicAPIAttribute|0%||
|JetBrains.Annotations.RazorDirectiveAttribute|0%||
|JetBrains.Annotations.RazorImportNamespaceAttribute|0%||
|JetBrains.Annotations.RazorInjectionAttribute|0%||
|JetBrains.Annotations.RazorPageBaseTypeAttribute|0%||
|JetBrains.Annotations.RequireStaticDelegateAttribute|0%||
|JetBrains.Annotations.RouteParameterConstraintAttribute|0%||
|JetBrains.Annotations.StringFormatMethodAttribute|0%||
|JetBrains.Annotations.TestSubjectAttribute|0%||
|JetBrains.Annotations.UriStringAttribute|0%||
|JetBrains.Annotations.UsedImplicitlyAttribute|0%||
|JetBrains.Annotations.ValueProviderAttribute|0%||
|JetBrains.Annotations.ValueRangeAttribute|0%||

</details>
<details><summary>BenchmarkDotNet.Diagnostics.dotMemory - 20%</summary>

|**Name**|**Line**|**Branch**|
|:---|---:|---:|
|**BenchmarkDotNet.Diagnostics.dotMemory**|**20%**|**10%**|
|BenchmarkDotNet.Diagnostics.dotMemory.DotMemoryDiagnoser|13.8%|10%|
|BenchmarkDotNet.Diagnostics.dotMemory.DotMemoryDiagnoserAttribute|44.4%||

</details>
<details><summary>BenchmarkDotNet.Diagnostics.dotTrace - 18.7%</summary>

|**Name**|**Line**|**Branch**|
|:---|---:|---:|
|**BenchmarkDotNet.Diagnostics.dotTrace**|**18.7%**|**10%**|
|BenchmarkDotNet.Diagnostics.dotTrace.DotTraceDiagnoser|12.8%|10%|
|BenchmarkDotNet.Diagnostics.dotTrace.DotTraceDiagnoserAttribute|44.4%||

</details>
<details><summary>BenchmarkDotNet.Diagnostics.Windows - 9.3%</summary>

|**Name**|**Line**|**Branch**|
|:---|---:|---:|
|**BenchmarkDotNet.Diagnostics.Windows**|**9.3%**|**4.1%**|
|BenchmarkDotNet.Diagnostics.Windows.ConcurrencyVisualizerProfiler|33%|0%|
|BenchmarkDotNet.Diagnostics.Windows.Configs.ConcurrencyVisualizerProfilerAt<br/>tribute|0%||
|BenchmarkDotNet.Diagnostics.Windows.Configs.EtwProfilerAttribute|0%||
|BenchmarkDotNet.Diagnostics.Windows.Configs.InliningDiagnoserAttribute|0%||
|BenchmarkDotNet.Diagnostics.Windows.Configs.JitStatsDiagnoserAttribute|0%||
|BenchmarkDotNet.Diagnostics.Windows.Configs.NativeMemoryProfilerAttribute|0%||
|BenchmarkDotNet.Diagnostics.Windows.Configs.TailCallDiagnoserAttribute|0%||
|BenchmarkDotNet.Diagnostics.Windows.EtwDiagnoser<TStats>|7.1%|0%|
|BenchmarkDotNet.Diagnostics.Windows.EtwProfiler|14.7%|5.8%|
|BenchmarkDotNet.Diagnostics.Windows.EtwProfilerConfig|78.2%|100%|
|BenchmarkDotNet.Diagnostics.Windows.HardwareCounters|0%|0%|
|BenchmarkDotNet.Diagnostics.Windows.HeapSession|0%||
|BenchmarkDotNet.Diagnostics.Windows.InliningDiagnoser|4.6%|0%|
|BenchmarkDotNet.Diagnostics.Windows.JitDiagnoser<TStats>|0%|0%|
|BenchmarkDotNet.Diagnostics.Windows.JitDiagnoser<TStats>|0%|0%|
|BenchmarkDotNet.Diagnostics.Windows.JitStatsDiagnoser|0%|0%|
|BenchmarkDotNet.Diagnostics.Windows.JitStatsDiagnoser.JitAllocatedMemoryDes<br/>criptor|0%||
|BenchmarkDotNet.Diagnostics.Windows.JitStatsDiagnoser.MethodsJittedDescript<br/>or|0%||
|BenchmarkDotNet.Diagnostics.Windows.JitStatsDiagnoser.MethodsTieredDescript<br/>or|0%||
|BenchmarkDotNet.Diagnostics.Windows.KernelSession|0%|0%|
|BenchmarkDotNet.Diagnostics.Windows.NativeMemoryProfiler|30.4%|0%|
|BenchmarkDotNet.Diagnostics.Windows.Session|0%|0%|
|BenchmarkDotNet.Diagnostics.Windows.TailCallDiagnoser|5%|0%|
|BenchmarkDotNet.Diagnostics.Windows.Tracing.BenchmarkEvent|0%|0%|
|BenchmarkDotNet.Diagnostics.Windows.Tracing.EngineEventLogParser|0%|0%|
|BenchmarkDotNet.Diagnostics.Windows.Tracing.IterationData|0%|0%|
|BenchmarkDotNet.Diagnostics.Windows.Tracing.IterationEvent|0%|0%|
|BenchmarkDotNet.Diagnostics.Windows.Tracing.NativeMemoryLogParser|0%|0%|
|BenchmarkDotNet.Diagnostics.Windows.Tracing.ProcessMetrics|0%|0%|
|BenchmarkDotNet.Diagnostics.Windows.Tracing.TraceLogParser|0%|0%|
|BenchmarkDotNet.Diagnostics.Windows.UserSession|0%|0%|

</details>
