### PR TITLE
chore: Fix duplicated test cases and add unit tests on windows CI

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -28,6 +28,12 @@ jobs:
       - name: Run task 'build'
         shell: cmd
         run: ./build.cmd build
+      - name: Run task 'unit-tests'
+        shell: cmd
+        run: ./build.cmd unit-tests -e
+      - name: Run task 'analyzer-tests'
+        shell: cmd
+        run: ./build.cmd analyzer-tests -e
       - name: Run task 'in-tests-core'
         shell: cmd
         run: ./build.cmd in-tests-core -e

--- a/tests/BenchmarkDotNet.Analyzers.Tests/AnalyzerTests/Attributes/ArgumentsAttributeAnalyzerTests.cs
+++ b/tests/BenchmarkDotNet.Analyzers.Tests/AnalyzerTests/Attributes/ArgumentsAttributeAnalyzerTests.cs
@@ -245,7 +245,7 @@ public class ArgumentsAttributeAnalyzerTests
 
         public static TheoryData<string> ArgumentsAttributeUsages()
         {
-            return [.. GenerateData()];
+            return [.. GenerateData().Distinct()];
 
             static IEnumerable<string> GenerateData()
             {


### PR DESCRIPTION
This PR contains following changes

1. Resolve `Skipping test case with duplicate ID` on `BenchmarkDotNet.Analyzers.Tests`  (4 test cases)
2. Add unit tests / analyzer tests on Windows CI. 
