### PR TITLE
Fix perf test failures WASM mono & coreclr

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -222,6 +222,9 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option("wasmCoreCLR", Required = false, Default = false, HelpText = "Use CoreCLR runtime pack (Microsoft.NETCore.App.Runtime.browser-wasm) instead of the Mono runtime pack for WASM benchmarks.")]
         public bool WasmCoreCLR { get; set; }
 
+        [Option("wasmProcessTimeout", Required = false, Default = 10, HelpText = "Maximum time in minutes to wait for a single WASM benchmark process to finish before force killing it.")]
+        public int WasmProcessTimeoutMinutes { get; set; }
+
         [Option("noForcedGCs", Required = false, HelpText = "Specifying would not forcefully induce any GCs.")]
         public bool NoForcedGCs { get; set; }
 

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -706,7 +706,8 @@ namespace BenchmarkDotNet.ConsoleArguments
                 aot: wasmAot,
                 wasmDataDir: options.WasmDataDirectory?.FullName ?? "",
                 moniker: moniker,
-                isMonoRuntime: !options.WasmCoreCLR);
+                isMonoRuntime: !options.WasmCoreCLR,
+                processTimeoutMinutes: options.WasmProcessTimeoutMinutes);
 
             var toolChain = WasmToolchain.From(new NetCoreAppSettings(
                 targetFrameworkMoniker: wasmRuntime.MsBuildMoniker,

--- a/src/BenchmarkDotNet/Environments/Runtimes/WasmRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/WasmRuntime.cs
@@ -27,6 +27,11 @@ namespace BenchmarkDotNet.Environments
         public bool IsMonoRuntime { get; }
 
         /// <summary>
+        /// Maximum time in minutes to wait for a single benchmark process to finish before force killing it. Default is 10 minutes.
+        /// </summary>
+        public int ProcessTimeoutMinutes { get; }
+
+        /// <summary>
         /// creates new instance of WasmRuntime
         /// </summary>
         /// <param name="javaScriptEngine">Full path to a java script engine used to run the benchmarks. "v8" by default</param>
@@ -37,6 +42,7 @@ namespace BenchmarkDotNet.Environments
         /// <param name="wasmDataDir">Specifies a wasm data directory surfaced as $(WasmDataDir) for the project</param>
         /// <param name="moniker">Runtime moniker</param>
         /// <param name="isMonoRuntime">When true (default), use Mono runtime pack; when false, use CoreCLR runtime pack.</param>
+        /// <param name="processTimeoutMinutes">Maximum time in minutes to wait for a single benchmark process to finish. Default is 10.</param>
         public WasmRuntime(
             string msBuildMoniker = "net8.0",
             string displayName = "Wasm",
@@ -45,7 +51,8 @@ namespace BenchmarkDotNet.Environments
             bool aot = false,
             string wasmDataDir = "",
             RuntimeMoniker moniker = RuntimeMoniker.WasmNet80,
-            bool isMonoRuntime = true)
+            bool isMonoRuntime = true,
+            int processTimeoutMinutes = 10)
             : base(moniker, msBuildMoniker, displayName)
         {
             if (javaScriptEngine.IsNotBlank() && javaScriptEngine != "v8" && !File.Exists(javaScriptEngine))
@@ -56,6 +63,7 @@ namespace BenchmarkDotNet.Environments
             Aot = aot;
             WasmDataDir = wasmDataDir;
             IsMonoRuntime = isMonoRuntime;
+            ProcessTimeoutMinutes = processTimeoutMinutes;
         }
 
         public override bool Equals(object? obj)

--- a/src/BenchmarkDotNet/Templates/benchmark-main.mjs
+++ b/src/BenchmarkDotNet/Templates/benchmark-main.mjs
@@ -1,9 +1,27 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+const ENVIRONMENT_IS_NODE = typeof process == "object" && typeof process.versions == "object" && typeof process.versions.node == "string";
+const ENVIRONMENT_IS_WEB_WORKER = typeof importScripts == "function";
+const ENVIRONMENT_IS_WEB = typeof window == "object" || (ENVIRONMENT_IS_WEB_WORKER && !ENVIRONMENT_IS_NODE);
+
+if (!ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WEB && typeof globalThis.crypto === 'undefined') {
+    // **NOTE** this is a simple insecure polyfill for JS shells (like v8/d8) that lack Web Crypto API.
+    // /dev/random doesn't work on js shells, so define our own.
+    globalThis.crypto = {
+        getRandomValues: function (buffer) {
+            for (let i = 0; i < buffer.length; i++)
+                buffer[i] = (Math.random() * 256) | 0;
+        }
+    }
+}
+
 import { dotnet } from './_framework/dotnet.js'
+
+// Get command line arguments: Node.js uses process.argv, v8 uses arguments/scriptArgs
+const args = typeof process !== 'undefined' ? process.argv.slice(2) : (typeof arguments !== 'undefined' ? [...arguments] : (typeof scriptArgs !== 'undefined' ? scriptArgs : []));
 
 await dotnet
     .withDiagnosticTracing(false)
-    .withApplicationArguments(...arguments)
+    .withApplicationArguments(...args)
     .run()

--- a/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmExecutor.cs
+++ b/src/BenchmarkDotNet/Toolchains/MonoWasm/WasmExecutor.cs
@@ -89,9 +89,11 @@ namespace BenchmarkDotNet.Toolchains.MonoWasm
                 process.TrySetAffinity(benchmarkCase.Job.Environment.Affinity, logger);
             }
 
-            if (!process.WaitForExit(milliseconds: (int)TimeSpan.FromMinutes(10).TotalMilliseconds))
+            WasmRuntime wasmRuntime = (WasmRuntime)benchmarkCase.GetRuntime();
+            int timeoutMinutes = wasmRuntime.ProcessTimeoutMinutes;
+            if (!process.WaitForExit(milliseconds: (int)TimeSpan.FromMinutes(timeoutMinutes).TotalMilliseconds))
             {
-                logger.WriteLineInfo("// The benchmarking process did not finish within 10 minutes, it's going to get force killed now.");
+                logger.WriteLineInfo($"// The benchmarking process did not finish within {timeoutMinutes} minutes, it's going to get force killed now.");
 
                 processOutputReader.CancelRead();
                 consoleExitHandler.KillProcessTree();


### PR DESCRIPTION
- Changing from `test-main.mjs` to BDN-based `bechmark-main.mjs` in https://github.com/dotnet/BenchmarkDotNet/pull/2998 did not port the polyfill https://github.com/dotnet/runtime/blob/85b9bc521939ab950171921e021508d5f267f51b/src/mono/browser/test-main.mjs#L50 to `bechmark-main.mjs`, causing
```
[2026/02/24 18:15:05][INFO] MONO_WASM: This engine doesn't support crypto.getRandomValues. Please use a modern version or provide polyfill for 'globalThis.crypto.getRandomValues'.
[2026/02/24 18:15:05][INFO] System.Reflection.TargetInvocationException: Arg_TargetInvocationException
[2026/02/24 18:15:05][INFO]  ---> System.TypeInitializationException: TypeInitialization_Type, System.ComponentModel.TypeDescriptor
[2026/02/24 18:15:05][INFO]  ---> System.Security.Cryptography.CryptographicException: Arg_CryptographyException
[2026/02/24 18:15:05][INFO]    at Interop.GetCryptographicallySecureRandomBytes(Byte* buffer, Int32 length)
[2026/02/24 18:15:05][INFO]    at System.Guid.NewGuid()
[2026/02/24 18:15:05][INFO]    at System.ComponentModel.TypeDescriptor..cctor()
[2026/02/24 18:15:05][INFO]    Exception_EndOfInnerExceptionStack
```

- Mono interpreter and coreCLR tests were hitting timeouts. BDN does not have a way to manipulate test run timeouts, this PR introduces a param for it.

```
[2026/02/24 17:49:36][INFO] // The benchmarking process did not finish within 10 minutes, it's going to get force killed now.
[2026/02/24 17:49:36][INFO] 
[2026/02/24 17:49:36][INFO] 
[2026/02/24 17:49:36][INFO] #
[2026/02/24 17:49:36][INFO] # Fatal error in , line 0
[2026/02/24 17:49:36][INFO] # d8: Received SIGTERM signal (likely due to a TIMEOUT)
```

cc @timcassell 