### PR TITLE
Docs: update VSTest TestAdapter version

### DIFF
--- a/docs/articles/features/vstest.md
+++ b/docs/articles/features/vstest.md
@@ -72,10 +72,10 @@ In addition, we can still make use of this boolean output to indicate
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
-	  <ItemGroup>
-	    <PackageReference Include="BenchmarkDotNet.TestAdapter" Version="0.16.0" />
-	    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-	  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet.TestAdapter" Version="0.16.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+  </ItemGroup>
 
 </Project>
 ```


### PR DESCRIPTION
Fixes #2979

- Update `BenchmarkDotNet.TestAdapter` version in `docs/articles/features/vstest.md` to the latest stable on NuGet (0.15.8).
- Make the Rider/ReSharper VSTest note less version-specific.

Note: the issue suggested 0.16.0, but it does not appear to be published on NuGet at the moment.
