### PR TITLE
Fix missing ReferencePaths parameter in Annotations.targets

### DIFF
--- a/src/BenchmarkDotNet.Annotations/buildTransitive/netstandard2.0/BenchmarkDotNet.Annotations.targets
+++ b/src/BenchmarkDotNet.Annotations/buildTransitive/netstandard2.0/BenchmarkDotNet.Annotations.targets
@@ -9,6 +9,6 @@
   <UsingTask TaskName="BenchmarkDotNet.Weaver.WeaveAssemblyTask" AssemblyFile="$(MSBuildThisFileDirectory)..\..\tasks\netstandard2.0\BenchmarkDotNet.Weaver.dll" />
 
   <Target Name="WeaveAssemblies" AfterTargets="AfterBuild" >
-    <WeaveAssemblyTask TargetAssembly="$(TargetDir)$(TargetFileName)" />
+    <WeaveAssemblyTask TargetAssembly="$(TargetDir)$(TargetFileName)" ReferencePaths="@(ReferencePath)" />
   </Target>
 </Project>


### PR DESCRIPTION
Fix for an error we are hitting with latest nightly BDN. Summary from Copilot:

When the BenchmarkDotNet.Annotations NuGet package is built in "FullPack" mode (nightly builds), the Weaver task DLLs are bundled directly into the Annotations package and invoked via BenchmarkDotNet.Annotations.targets. This targets file calls WeaveAssemblyTask but was not passing the required ReferencePaths parameter, resulting in: `error MSB4044: The "WeaveAssemblyTask" task was not given a value for the required parameter "ReferencePaths".` This broke any project consuming the nightly package (e.g., dotnet-runtime-perf microbenchmark runs).

The standalone BenchmarkDotNet.Weaver.targets already passes ReferencePaths="@(ReferencePath)" correctly — the Annotations targets file was simply missing it. This PR adds the same parameter to align the two targets files.

I am not sure if this is the correct fix as I just let Copilot have a go at it, but in this test run it fixed the issue: https://dev.azure.com/dnceng/internal/_build/results?buildId=2912906&view=results (at least for wasm wasm, the rest are still running).

<details><summary>Here is a copy of the full error we were hitting:</summary>
```
--------------------------------------------
Building .NET micro benchmarks for 'net11.0'
--------------------------------------------
$ pushd "/home/helixbot/work/AC9A08E1/w/A1F90890/e/performance/src/benchmarks/micro"
$ dotnet build /home/helixbot/work/AC9A08E1/w/A1F90890/e/performance/src/benchmarks/micro/MicroBenchmarks.csproj --configuration Release --framework net11.0 --no-restore
/p:NuGetPackageRoot=/home/helixbot/work/AC9A08E1/w/A1F90890/e/performance/artifacts/packages /p:RestorePackagesPath=/home/helixbot/work/AC9A08E1/w/A1F90890/e/performance/artifacts/packages /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 --output
/home/helixbot/work/AC9A08E1/w/A1F90890/e/performance/artifacts/bin/for-running/MicroBenchmarks /p:BuildingForWasm=true
  Reporting -> /home/helixbot/work/AC9A08E1/w/A1F90890/e/performance/artifacts/bin/for-running/MicroBenchmarks/Reporting.dll
  BenchmarkDotNet.Extensions -> /home/helixbot/work/AC9A08E1/w/A1F90890/e/performance/artifacts/bin/for-running/MicroBenchmarks/BenchmarkDotNet.Extensions.dll
/home/helixbot/work/AC9A08E1/w/A1F90890/e/performance/artifacts/packages/benchmarkdotnet.annotations/0.16.0-nightly.20260225.450/buildTransitive/netstandard2.0/BenchmarkDotNet.Annotations.targets(12,5): error MSB4044: The
"WeaveAssemblyTask" task was not given a value for the required parameter "ReferencePaths". [/home/helixbot/work/AC9A08E1/w/A1F90890/e/performance/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj]
/home/helixbot/work/AC9A08E1/p/dotnet/sdk/11.0.100-preview.2.26117.101/Microsoft.Common.CurrentVersion.targets(2151,5): error MSB4181: The "MSBuild" task returned false but did not log an error.
[/home/helixbot/work/AC9A08E1/w/A1F90890/e/performance/src/benchmarks/micro/MicroBenchmarks.csproj::TargetFramework=net11.0]
Build FAILED.
/home/helixbot/work/AC9A08E1/w/A1F90890/e/performance/artifacts/packages/benchmarkdotnet.annotations/0.16.0-nightly.20260225.450/buildTransitive/netstandard2.0/BenchmarkDotNet.Annotations.targets(12,5): error MSB4044: The
"WeaveAssemblyTask" task was not given a value for the required parameter "ReferencePaths". [/home/helixbot/work/AC9A08E1/w/A1F90890/e/performance/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj]
/home/helixbot/work/AC9A08E1/p/dotnet/sdk/11.0.100-preview.2.26117.101/Microsoft.Common.CurrentVersion.targets(2151,5): error MSB4181: The "MSBuild" task returned false but did not log an error.
[/home/helixbot/work/AC9A08E1/w/A1F90890/e/performance/src/benchmarks/micro/MicroBenchmarks.csproj::TargetFramework=net11.0]
    0 Warning(s)
    2 Error(s)
Time Elapsed 00:00:03.04
$ popd
Process exited with status 1
```
</details>