### PR TITLE
chore: Move dotMemory/dotTrace tests to IntegrationTests.ManualRunning project

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/BenchmarkDotNet.IntegrationTests.ManualRunning.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/BenchmarkDotNet.IntegrationTests.ManualRunning.csproj
@@ -32,6 +32,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />
     <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.Windows\BenchmarkDotNet.Diagnostics.Windows.csproj" />
+    <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.dotTrace\BenchmarkDotNet.Diagnostics.dotTrace.csproj" />
+    <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.dotMemory\BenchmarkDotNet.Diagnostics.dotMemory.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/DotTraceTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/DotTraceTests.cs
@@ -5,21 +5,21 @@ using System.Linq;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Detectors;
-using BenchmarkDotNet.Diagnostics.dotMemory;
+using BenchmarkDotNet.Diagnostics.dotTrace;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace BenchmarkDotNet.IntegrationTests
+namespace BenchmarkDotNet.IntegrationTests.ManualRunning
 {
-    public class DotMemoryTests : BenchmarkTestExecutor
+    public class DotTraceTests : BenchmarkTestExecutor
     {
-        public DotMemoryTests(ITestOutputHelper output) : base(output) { }
+        public DotTraceTests(ITestOutputHelper output) : base(output) { }
 
         [Fact]
-        public void DotMemorySmokeTest()
+        public void DotTraceSmokeTest()
         {
             if (!OsDetector.IsWindows() && RuntimeInformation.IsMono)
             {
@@ -30,8 +30,7 @@ namespace BenchmarkDotNet.IntegrationTests
             var config = new ManualConfig().AddJob(
             [
                 Job.Dry.WithId("ExternalProcess"),
-                // TODO: Add InProcessEmitToolchain job when flaky test issue is resolved https://github.com/dotnet/BenchmarkDotNet/issues/2950
-                //Job.Dry.WithToolchain(InProcessEmitToolchain.Default).WithId("InProcess"),
+                Job.Dry.WithToolchain(InProcessEmitToolchain.Default).WithId("InProcess")
             ]
             );
             string snapshotDirectory = Path.Combine(Directory.GetCurrentDirectory(), "BenchmarkDotNet.Artifacts", "snapshots");
@@ -43,7 +42,7 @@ namespace BenchmarkDotNet.IntegrationTests
             Output.WriteLine("---------------------------------------------");
             Output.WriteLine("SnapshotDirectory:" + snapshotDirectory);
             var snapshots = Directory.EnumerateFiles(snapshotDirectory)
-                .Where(filePath => Path.GetExtension(filePath).Equals(".dmw", StringComparison.OrdinalIgnoreCase))
+                .Where(filePath => Path.GetExtension(filePath).Equals(".dtp", StringComparison.OrdinalIgnoreCase))
                 .Select(Path.GetFileName!)
                 .OrderBy(fileName => fileName)
                 .ToList();
@@ -51,27 +50,18 @@ namespace BenchmarkDotNet.IntegrationTests
             foreach (var snapshot in snapshots)
                 Output.WriteLine("* " + snapshot);
 
-            Assert.Equal(2, snapshots.Count);
-            // Assert.Equal(4, snapshots.Count);
+            Assert.Single(snapshots);
+            // Assert.Equal(2, snapshots.Count);
         }
 
-        [DotMemoryDiagnoser]
+        [DotTraceDiagnoser]
         public class Benchmarks
         {
             [Benchmark]
-            public int Foo0()
+            public int Foo()
             {
                 var list = new List<object>();
-                for (int i = 0; i < 1000; i++)
-                    list.Add(new object());
-                return list.Count;
-            }
-
-            [Benchmark]
-            public int Foo1()
-            {
-                var list = new List<object>();
-                for (int i = 0; i < 1000; i++)
+                for (int i = 0; i < 1000000; i++)
                     list.Add(new object());
                 return list.Count;
             }

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
@@ -30,8 +30,6 @@
     <ProjectReference Include="..\BenchmarkDotNet.IntegrationTests.Static\BenchmarkDotNet.IntegrationTests.Static.csproj" />
     <ProjectReference Include="..\BenchmarkDotNet.Tests\BenchmarkDotNet.Tests.csproj" />
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />
-    <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.dotTrace\BenchmarkDotNet.Diagnostics.dotTrace.csproj" />
-    <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.dotMemory\BenchmarkDotNet.Diagnostics.dotMemory.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />


### PR DESCRIPTION
This PR is temporary workaround for flaky test issue of dotMemory/dotTrace (https://github.com/dotnet/BenchmarkDotNet/issues/2950)

**What's changed in this PR**
- Move flaky tests to `BenchmarkDotNet.IntegrationTests.ManualRunning` project.
- Re-enable tests that use InProcessEmitToolchain.

Currently these flaky tests need to be manually tested.
In future, It need to be executed on CI that can be easy retry in case of failure.