### PR TITLE
chore: Remove WarmupCount setting from Dry job

### DIFF
--- a/src/BenchmarkDotNet/Jobs/RunMode.cs
+++ b/src/BenchmarkDotNet/Jobs/RunMode.cs
@@ -29,9 +29,8 @@ namespace BenchmarkDotNet.Jobs
         public static readonly RunMode Dry = new RunMode(nameof(Dry))
         {
             LaunchCount = 1,
-            WarmupCount = 1,
             IterationCount = 1,
-            RunStrategy = RunStrategy.ColdStart,
+            RunStrategy = RunStrategy.ColdStart, // WarmupStage is not invoked when using RunStrategy.ColdStart.
             UnrollFactor = 1
         }.Freeze();
 


### PR DESCRIPTION
This PR remove `WarmupCount = 1` setting from `Dry` job.

**Background**
Currently, following content is shown when running benchmark with `Job.Dry`.

> Dry(IterationCount=1, LaunchCount=1, RunStrategy=ColdStart, UnrollFactor=1, WarmupCount=1)

But when using `RunStrategy.ColdStart`, warmup stage is skipped.
So no need to set `WarmupCount` setting.
https://github.com/dotnet/BenchmarkDotNet/blob/54dbe140fc7e7900f29f6cefb7e4e6d09e65eaf9/src/BenchmarkDotNet/Engines/EngineStage.cs#L26


