### PR TITLE
Fix PathTooLongException for benchmarks with long parameters

### DIFF
--- a/src/BenchmarkDotNet/Helpers/ArtifactFileNameHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/ArtifactFileNameHelper.cs
@@ -1,13 +1,12 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using BenchmarkDotNet.Detectors;
+﻿using BenchmarkDotNet.Detectors;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Extensions;
-using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains;
+using System;
+using System.IO;
+using System.Linq;
 
 namespace BenchmarkDotNet.Helpers
 {
@@ -15,6 +14,7 @@ namespace BenchmarkDotNet.Helpers
     {
         private const int WindowsOldPathLimit = 260;
         private const int CommonSenseLimit = 1024; // for benchmarks that use args like "new string('a', 200_000)"
+        private const int MaxFileNameLength = 255;
 
         internal static string GetTraceFilePath(DiagnoserActionParameters details, DateTime creationTime, string fileExtension)
         {
@@ -25,13 +25,15 @@ namespace BenchmarkDotNet.Helpers
         {
             string nameNoLimit = GetFilePathNoLimits(details, subfolder, creationTime, fileExtension);
 
+            string fileNameOnly = Path.GetFileName(nameNoLimit);
+
             // long paths can be enabled on Windows but it does not mean that everything is going to work fine..
             // so we always use 260 as limit on Windows
             int limit = OsDetector.IsWindows()
                 ? WindowsOldPathLimit - reserve
                 : CommonSenseLimit;
 
-            if (nameNoLimit.Length <= limit)
+            if (nameNoLimit.Length <= limit && fileNameOnly.Length <= MaxFileNameLength)
             {
                 return nameNoLimit;
             }


### PR DESCRIPTION
Fixes #2093

### Description
This PR addresses the `PathTooLongException` that occurs on Linux/macOS when a benchmark has very long parameter values. 

**The Root Cause:**
Previously, `ArtifactFileNameHelper` only checked if the *total* path length exceeded the `CommonSenseLimit` (1024 characters). However, on Linux/macOS, while the total path can be long, the individual **file name component** has a strict OS limit of 255 characters. If the parameters are extremely long, the total path might still be under 1024, but the file name itself exceeds 255 characters, causing the OS to throw an exception.

**The Fix:**
I introduced a `MaxFileNameLength` constant (255) and updated the validation in `GetFilePath` to check both the total path length and the individual file name length:
```csharp
string fileNameOnly = Path.GetFileName(nameNoLimit);
if (nameNoLimit.Length <= limit && fileNameOnly.Length <= MaxFileNameLength)