### PR TITLE
fix: InProcess command line option behaviors

### DIFF
--- a/src/BenchmarkDotNet/Attributes/Jobs/InProcessAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/Jobs/InProcessAttribute.cs
@@ -19,7 +19,10 @@ public class InProcessAttribute(
     bool executeOnSeparateThread = true)
     : JobConfigBaseAttribute(GetJob(toolchainType, executeOnSeparateThread))
 {
-    internal static Job GetJob(InProcessToolchainType toolchainType, bool executeOnSeparateThread)
+    private static Job GetJob(InProcessToolchainType toolchainType, bool executeOnSeparateThread)
+        => GetJob(Job.Default, toolchainType, executeOnSeparateThread);
+
+    internal static Job GetJob(Job baseJob, InProcessToolchainType toolchainType, bool executeOnSeparateThread)
     {
         if (toolchainType == InProcessToolchainType.Auto)
         {
@@ -27,8 +30,9 @@ public class InProcessAttribute(
                 ? InProcessToolchainType.NoEmit
                 : InProcessToolchainType.Emit;
         }
+
         return toolchainType == InProcessToolchainType.Emit
-            ? Job.Default.WithToolchain(new InProcessEmitToolchain(new() { ExecuteOnSeparateThread = executeOnSeparateThread }))
-            : Job.Default.WithToolchain(new InProcessNoEmitToolchain(new() { ExecuteOnSeparateThread = executeOnSeparateThread }));
+            ? baseJob.WithToolchain(new InProcessEmitToolchain(new() { ExecuteOnSeparateThread = executeOnSeparateThread }))
+            : baseJob.WithToolchain(new InProcessNoEmitToolchain(new() { ExecuteOnSeparateThread = executeOnSeparateThread }));
     }
 }

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -469,7 +469,7 @@ namespace BenchmarkDotNet.ConsoleArguments
         {
             if (options.RunInProcess)
             {
-                yield return Attributes.InProcessAttribute.GetJob(Attributes.InProcessToolchainType.Auto, true);
+                yield return Attributes.InProcessAttribute.GetJob(baseJob, Attributes.InProcessToolchainType.Auto, true);
             }
             else if (options.ClrVersion.IsNotBlank())
             {

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Globalization;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Reflection;
+using AwesomeAssertions;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.ConsoleArguments;
@@ -20,7 +19,7 @@ using BenchmarkDotNet.Toolchains;
 using BenchmarkDotNet.Toolchains.CoreRun;
 using BenchmarkDotNet.Toolchains.CsProj;
 using BenchmarkDotNet.Toolchains.DotNetCli;
-using BenchmarkDotNet.Toolchains.MonoWasm;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using BenchmarkDotNet.Toolchains.NativeAot;
 using Perfolizer.Horology;
 using Xunit;
@@ -113,6 +112,18 @@ namespace BenchmarkDotNet.Tests
             var job = configEasy.GetJobs().Single();
 
             Assert.Equal(RunStrategy.ColdStart, job.Run.RunStrategy);
+        }
+
+        [Fact]
+        public void UserCanChooseInProcessAndStrategyMonitoring()
+        {
+            var configEasy = ConfigParser.Parse(["--inProcess", "--strategy", "Monitoring"], new OutputLogger(Output)).config;
+
+            Assert.NotNull(configEasy);
+            var job = configEasy.GetJobs().Single();
+
+            job.GetToolchain().Should().BeOfType<InProcessEmitToolchain>();
+            job.Run.RunStrategy.Should().Be(RunStrategy.Monitoring);
         }
 
         [FactEnvSpecific(


### PR DESCRIPTION
This PR intended to fix `--inProcess` command line option behaviors.

Currently, when `--inProcess` argument is contained as argument.
ConfigParser create job based on `Job.Default`. and remaining `baseConfig` setting seems silently ignored.

This PR modify code to use `baseJob` settings when creating InProcess toolchain job.
