### PR TITLE
chore: Separate solution file for sample projects

### DIFF
--- a/BenchmarkDotNet.slnx
+++ b/BenchmarkDotNet.slnx
@@ -3,11 +3,14 @@
     <File Path="build/common.props" />
     <File Path="build/common.targets" />
   </Folder>
+  <!-- These projects are temporarily commented out. It's enabled TestAdapter is migrated to MTP based implementation. https://github.com/dotnet/BenchmarkDotNet/issues/2803 -->
+  <!--
   <Folder Name="/samples/">
     <File Path="samples/Directory.Build.props" />
     <Project Path="samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj" />
     <Project Path="samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj" DefaultStartup="true" />
   </Folder>
+  -->
   <Folder Name="/src/">
     <Project Path="src/BenchmarkDotNet.Analyzers/BenchmarkDotNet.Analyzers.csproj" />
     <Project Path="src/BenchmarkDotNet.Annotations/BenchmarkDotNet.Annotations.csproj" />

--- a/samples/BenchmarkDotNet.Samples.slnx
+++ b/samples/BenchmarkDotNet.Samples.slnx
@@ -1,0 +1,24 @@
+<Solution>
+  <Folder Name="/build/">
+    <File Path="../build/common.props" />
+    <File Path="../build/common.targets" />
+  </Folder>
+  <Folder Name="/samples/">
+    <File Path="Directory.Build.props" />
+    <Project Path="BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj" />
+    <Project Path="BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj" DefaultStartup="true" />
+  </Folder>
+  <Folder Name="/src/">
+    <Project Path="../src/BenchmarkDotNet.Analyzers/BenchmarkDotNet.Analyzers.csproj" />
+    <Project Path="../src/BenchmarkDotNet.Annotations/BenchmarkDotNet.Annotations.csproj" />
+    <Project Path="../src/BenchmarkDotNet.Diagnostics.dotMemory/BenchmarkDotNet.Diagnostics.dotMemory.csproj" />
+    <Project Path="../src/BenchmarkDotNet.Diagnostics.dotTrace/BenchmarkDotNet.Diagnostics.dotTrace.csproj" />
+    <Project Path="../src/BenchmarkDotNet.Diagnostics.Windows/BenchmarkDotNet.Diagnostics.Windows.csproj" />
+    <Project Path="../src/BenchmarkDotNet.Disassembler/BenchmarkDotNet.Disassembler.csproj" />
+    <Project Path="../src/BenchmarkDotNet.Exporters.Plotting/BenchmarkDotNet.Exporters.Plotting.csproj" />
+    <Project Path="../src/BenchmarkDotNet.TestAdapter/BenchmarkDotNet.TestAdapter.csproj" />
+    <Project Path="../src/BenchmarkDotNet.Weaver/BenchmarkDotNet.Weaver.csproj" />
+    <Project Path="../src/BenchmarkDotNet/BenchmarkDotNet.csproj" />
+  </Folder>
+</Solution>
+

--- a/samples/BenchmarkDotNet.Samples/Properties/launchSettings.json
+++ b/samples/BenchmarkDotNet.Samples/Properties/launchSettings.json
@@ -20,7 +20,7 @@
     },
     "--list": {
       "commandName": "Project",
-      "commandLineArgs": "--list"
+      "commandLineArgs": "--list Flat"
     },
     "--info": {
       "commandName": "Project",


### PR DESCRIPTION
This PR contains following changes.

1. Temporary comment out samples projects from root solution file.
2. Add `samples/BenchmarkDotNet.Samples.slnx` solution file instead.
3. Fix wrong `launchSettings.json` settings.

**Background**
Currently VS TestAdapter and test projects both using VSTest based dependencies.

When replacing TestAdapter to use MTP(Microsoft.Testing.Platform) based implementation (#2803)
Both VSTest/MTP based projects are mixed and it seems Test Explorer unstable state.
And `dotnet test` failed when both VSTest/MTP based project mixed in solution.

So it need to separate solution files until TestAdapter/Tests are migrated to use MTP.