### PR TITLE
deps: Update AsmResolver.DotNet version

### DIFF
--- a/src/BenchmarkDotNet.Weaver/BenchmarkDotNet.Weaver.csproj
+++ b/src/BenchmarkDotNet.Weaver/BenchmarkDotNet.Weaver.csproj
@@ -20,7 +20,7 @@ then run `build.cmd pack-weaver`.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsmResolver.DotNet" Version="6.0.0-beta.6" PrivateAssets="all" />
+    <PackageReference Include="AsmResolver.DotNet" Version="6.0.0-rc.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Framework" Version="18.0.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.0.2" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
This PR update AsmResolver.DotNet package version to `6.0.0-rc.1`

By this changes.
Build issue on VisualStudio is expected to be fixed. (https://github.com/dotnet/BenchmarkDotNet/pull/3024#issuecomment-3956676718)