### PR TITLE
chore: Change behavior when auto-generated project failed to build

### DIFF
--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -276,9 +276,19 @@ namespace BenchmarkDotNet.Running
                         if (!benchmark.Job.GetToolchain().IsInProcess)
                         {
                             logger.WriteLine();
-                            logger.WriteLineError("// BenchmarkDotNet has failed to build the auto-generated boilerplate code.");
-                            logger.WriteLineError($"// It can be found in {buildResult.ArtifactsPaths.BuildArtifactsDirectoryPath}");
-                            logger.WriteLineError("// Please follow the troubleshooting guide: https://benchmarkdotnet.org/articles/guides/troubleshooting.html");
+                            logger.WriteLineError($"// BenchmarkDotNet has failed to build the auto-generated boilerplate code.");
+
+                            if (config.Options.IsSet(ConfigOptions.KeepBenchmarkFiles))
+                            {
+                                logger.WriteLineError($"// It can be found in {buildResult.ArtifactsPaths.BuildArtifactsDirectoryPath}");
+                            }
+                            else
+                            {
+                                artifactsToCleanup.AddRange(buildResult.ArtifactsToCleanup);
+                                logger.WriteLineError($"// Re-run benchmark with --keepFiles option to confirm auto-generated project files.");
+                            }
+
+                            logger.WriteLineError($"// Please follow the troubleshooting guide: https://benchmarkdotnet.org/articles/guides/troubleshooting.html");
                         }
 
                         if (config.Options.IsSet(ConfigOptions.StopOnFirstError) || allBuildsHaveFailed)


### PR DESCRIPTION
Currently, BenchmarkDotNet preserve auto-generated project directory when restore/build/publish operation failed.
(Regardless `--keepFiles` option exists or not)

This PR change this behavior to preserve temporary directory only when `--keepFiles` option exists.

**Background**
Auto-generated project directory can be reused between benchmark runs. (e.g. `Dry-1`)

And when previous build files are exists on temporary directory.
It seems DllGatherer output unexpected references and that cause errors.

To prevent inconsistent behaviors, This PR change behavior to preserve files only when when `--keepFiles` option specified.

Relating comment: https://github.com/dotnet/BenchmarkDotNet/pull/3020#issuecomment-3954942479
