### PR TITLE
Add ReadyToRun flag to restore step

### DIFF
--- a/src/BenchmarkDotNet/Templates/R2RCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/R2RCsProj.txt
@@ -58,7 +58,8 @@
 
   <!-- The purpose of this project is to publish the app with r2r composite using a custom runtime pack and a custom crossgen2, built locally -->
 
-  <Target Name="TrickRuntimePackLocation" AfterTargets="ProcessFrameworkReferences">
+  <Target Name="TrickRuntimePackLocation" AfterTargets="ProcessFrameworkReferences"
+          Condition="'$RUNTIMEPACK$' != '' And '$CROSSGEN2PACK$' != ''">
     <ItemGroup>
       <RuntimePack>
         <PackageDirectory>$RUNTIMEPACK$</PackageDirectory>

--- a/src/BenchmarkDotNet/Toolchains/R2R/R2RToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/R2R/R2RToolchain.cs
@@ -26,17 +26,11 @@ namespace BenchmarkDotNet.Toolchains.R2R
 
         [PublicAPI]
         public static new IToolchain From(NetCoreAppSettings settings)
-        {
-            // .NET requires PublishReadyToRun to be passed during restore
-            // so that the correct R2R crossgen2 packages are resolved (see https://github.com/dotnet/sdk/issues/20701).
-            string extraArguments = "/p:PublishReadyToRun=true";
-
-            return new R2RToolchain(settings.Name,
+            => new R2RToolchain(settings.Name,
                 new R2RGenerator(settings.TargetFrameworkMoniker, settings.CustomDotNetCliPath, settings.PackagesPath, settings.CustomRuntimePack, settings.AOTCompilerPath),
-                new DotNetCliPublisher(settings.TargetFrameworkMoniker, settings.CustomDotNetCliPath, extraArguments),
+                new DotNetCliPublisher(settings.TargetFrameworkMoniker, settings.CustomDotNetCliPath),
                 new Executor(),
                 settings.CustomDotNetCliPath);
-        }
 
         public override IEnumerable<ValidationError> Validate(BenchmarkCase benchmarkCase, IResolver resolver)
         {


### PR DESCRIPTION
When BDN is run with the `--no-restore` option we need to pass this parameter as part of the restore step or crossgen fails in the publish step.