### PR TITLE
feat: Add API to set custom `DefaultConfig.Instance`

### DIFF
--- a/src/BenchmarkDotNet/Configs/DefaultConfig.cs
+++ b/src/BenchmarkDotNet/Configs/DefaultConfig.cs
@@ -35,7 +35,7 @@ namespace BenchmarkDotNet.Configs
         {
         }
 
-        public static void SetDefault(IConfig? config)
+        public static void SetCustomConfig(ImmutableConfig? config)
         {
             customDefaultConfig = config;
         }


### PR DESCRIPTION
This PR add `DefaultConfig.SetDefault(config)` API to customize **default global config**.

**Background**
BenchmarkDotNet use `DefaultConfig.Instance` when **global** config is not passed to `BenchmarkRunner`/`BenchmarkSwitcher`.

On normarl use case, It can specify **global** config by using `Main` entry point.
But when running benchmark via `TestAdaper`, It can't use `Main` entry point (and `launchsettings.json`)
So. it need to customize config via assembly-level ConfigAttribute.
https://benchmarkdotnet.org/articles/features/vstest.html?q=testadapter#setting-a-default-configuration

This PR add `DefaultConfig.SetDefault(config)` API.
By this change, it can use custom config by TestAdapter, (Settings are loaded from `.runsettings`/`testconfig.json`)
