### PR TITLE
chore: include README in NuGet package

### DIFF
--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -7,6 +7,7 @@
     <NoWarn>$(NoWarn);1701;1702;1705;1591;3005;NU1702;CS3001;CS3003</NoWarn>
     <AssemblyName>BenchmarkDotNet</AssemblyName>
     <PackageId>BenchmarkDotNet</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <RootNamespace>BenchmarkDotNet</RootNamespace>
     <!-- needed for docfx xref resolver -->
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
@@ -16,6 +17,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="BenchmarkDotNet.targets" Pack="true" PackagePath="buildTransitive" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />


### PR DESCRIPTION
Fixes #2519\n\nAdds NuGet package readme metadata and packs the repo root README.md into the BenchmarkDotNet NuGet package so NuGet.org can display it.\n\nValidation:\n- dotnet pack src/BenchmarkDotNet/BenchmarkDotNet.csproj -c Release\n- verified the produced .nuspec contains <readme>README.md</readme> and the .nupkg includes README.md