### PR TITLE
chore: Add logics to set JobId when using InProcessAttribute

### DIFF
--- a/src/BenchmarkDotNet/Attributes/Jobs/InProcessAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/Jobs/InProcessAttribute.cs
@@ -1,8 +1,10 @@
-using System;
+using BenchmarkDotNet.Characteristics;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Portability;
+using BenchmarkDotNet.Toolchains;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+using System;
 
 namespace BenchmarkDotNet.Attributes;
 
@@ -31,8 +33,17 @@ public class InProcessAttribute(
                 : InProcessToolchainType.Emit;
         }
 
-        return toolchainType == InProcessToolchainType.Emit
-            ? baseJob.WithToolchain(new InProcessEmitToolchain(new() { ExecuteOnSeparateThread = executeOnSeparateThread }))
-            : baseJob.WithToolchain(new InProcessNoEmitToolchain(new() { ExecuteOnSeparateThread = executeOnSeparateThread }));
+        IToolchain toolchain = toolchainType switch
+        {
+            InProcessToolchainType.Emit => new InProcessEmitToolchain(new() { ExecuteOnSeparateThread = executeOnSeparateThread }),
+            InProcessToolchainType.NoEmit => new InProcessNoEmitToolchain(new() { ExecuteOnSeparateThread = executeOnSeparateThread }),
+            _ => throw new ArgumentOutOfRangeException(nameof(toolchainType))
+        };
+
+        var job = baseJob.WithToolchain(toolchain);
+        if (!job.HasValue(CharacteristicObject.IdCharacteristic))
+            job = job.WithId("InProcess");
+
+        return job.Freeze();
     }
 }

--- a/tests/BenchmarkDotNet.Tests/Jobs/JobIdTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Jobs/JobIdTests.cs
@@ -1,0 +1,31 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using System.Linq;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests.Jobs;
+
+public class JobIdTests
+{
+    [Theory]
+    [MemberData(nameof(GetTheoryData), DisableDiscoveryEnumeration = true)]
+    public void AutoGenerateJobId(string expectedId, Job job)
+    {
+        // Act
+        var result = job.ResolvedId;
+
+        // Assert
+        Assert.Equal(expectedId, result);
+    }
+
+    public static TheoryData<string, Job> GetTheoryData() => new()
+    {
+        {"InProcess", Job.InProcess },
+
+        // If baseJob don't have id. Set "InProcess".
+        {"InProcess", InProcessAttribute.GetJob(Job.Default, InProcessToolchainType.Auto, true) },
+
+        // If baseJob has exisiting id, it should not be overwritten.
+        {"Dry", InProcessAttribute.GetJob(Job.Dry, InProcessToolchainType.Auto, true) },
+    };
+}


### PR DESCRIPTION
Currently, auto-generated JobID (e,g, `Job-JWQWGO`) is shown when following condition met.
1. Using `[InProcess]` attribute or `--inProcess` cli option.
2. `Default` config is used as base config.

This PR modifies this behavior by assigning an ID that is the same as 'Job.InProcess'.
