### PR TITLE
deps: Update CI relating package versions

### DIFF
--- a/.github/workflows/generate-coverage-report.yaml
+++ b/.github/workflows/generate-coverage-report.yaml
@@ -56,7 +56,7 @@ jobs:
         run: dotnet coverage shutdown bdn_coverage --timeout 60000
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.os }}
           path: "**/*.cobertura.xml"
@@ -92,7 +92,7 @@ jobs:
         run: dotnet coverage shutdown bdn_coverage --timeout 60000
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-windows-netfx
           path: "**/*.cobertura.xml"
@@ -106,12 +106,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           path: coverage
 
       - name: Upload raw coverage data
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage
@@ -158,7 +158,7 @@ jobs:
           Write-Output $markdown >> $env:GITHUB_STEP_SUMMARY
 
       - name: Upload HTML report files
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage_report
           path: coverage_report

--- a/.github/workflows/generate-gh-pages.yaml
+++ b/.github/workflows/generate-gh-pages.yaml
@@ -37,7 +37,7 @@ jobs:
       run: ./build.cmd docs-build
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: site
         path: docs/_site
@@ -54,7 +54,7 @@ jobs:
         ref: docs-stable
 
     - name: Download Artifacts
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v8
       with:
         name: site
         path: site

--- a/.github/workflows/publish-nightly.yaml
+++ b/.github/workflows/publish-nightly.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Pack
         run: ./build.cmd pack /p:VersionSuffix=nightly.$DATE.$GITHUB_RUN_NUMBER /p:WeaverVersionSuffix=\"\"
       - name: Upload nupkg to artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: nupkgs
           path: "**/*.*nupkg"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
       run: ./build.cmd pack --stable /p:WeaverVersionSuffix=\"\"
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nupkgs
         path: artifacts/*.nupkg

--- a/.github/workflows/run-tests-selected.yaml
+++ b/.github/workflows/run-tests-selected.yaml
@@ -102,7 +102,7 @@ jobs:
 
       # Upload artifact files that are located at `$(GITHUB_WORKSPACE)/artifacts` directory
       - name: Upload test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: results

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -51,7 +51,7 @@ jobs:
         run: ./build.cmd in-tests-core -e
       # Report test results with unique name
       - name: Report tests results
-        uses: dorny/test-reporter@fe45e9537387dac839af0d33ba56eed8e24189e8 # v2.3.0
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: always()
         with:
           name: test-windows-core-${{ matrix.os }}
@@ -59,7 +59,7 @@ jobs:
           reporter: dotnet-trx
       # Upload Artifacts with Unique Name
       - name: Upload test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-windows-core-trx-${{ github.run_id }}-${{ matrix.os }}
@@ -104,7 +104,7 @@ jobs:
         run: ./build.cmd in-tests-full -e
       # Report test results with unique name
       - name: Report tests results
-        uses: dorny/test-reporter@fe45e9537387dac839af0d33ba56eed8e24189e8 # v2.3.0
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: always()
         with:
           name: test-windows-full-${{ matrix.os }}
@@ -112,7 +112,7 @@ jobs:
           reporter: dotnet-trx
       # Upload Artifacts with Unique Name
       - name: Upload test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-windows-full-trx-${{ github.run_id }}-${{ matrix.os }}
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@v6
       # Set up the environment
       - name: Set up Clang
-        uses: egor-tensin/setup-clang@ef434b41eb33a70396fb336b1bae39c76d740c3d # v1.4
+        uses: egor-tensin/setup-clang@471a6f8ef1d449dba8e1a51780e7f943572a3f99 # v2.1
         with:
           version: latest
           platform: x64
@@ -152,7 +152,7 @@ jobs:
         run: ./build.cmd in-tests-core -e
       # Report test results with unique name
       - name: Report tests results
-        uses: dorny/test-reporter@fe45e9537387dac839af0d33ba56eed8e24189e8 # v2.3.0
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: always()
         with:
           name: test-linux-${{ matrix.os }}
@@ -160,7 +160,7 @@ jobs:
           reporter: dotnet-trx
       # Upload Artifacts with Unique Name
       - name: Upload test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-linux-trx-${{ github.run_id }}-${{ matrix.os }}
@@ -199,7 +199,7 @@ jobs:
         run: ./build.cmd in-tests-core -e
       # Report test results with unique name
       - name: Report tests results
-        uses: dorny/test-reporter@fe45e9537387dac839af0d33ba56eed8e24189e8 # v2.3.0
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: always()
         with:
           name: test-macos(${{ matrix.os.arch }})
@@ -207,7 +207,7 @@ jobs:
           reporter: dotnet-trx
       # Upload Artifacts with Unique Name
       - name: Upload test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-macos(${{ matrix.os.arch }})-trx-${{ github.run_id }}
@@ -218,7 +218,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Clang
-        uses: egor-tensin/setup-clang@v1
+        uses: egor-tensin/setup-clang@471a6f8ef1d449dba8e1a51780e7f943572a3f99 # v2.1
         with:
           version: latest
           platform: x64
@@ -236,7 +236,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install cSpell
-        run: npm install -g cspell@9.0.2
+        run: npm install -g cspell@9.7.0
       - name: Copy cSpell config
         run: cp ./build/cSpell.json ./cSpell.json
       - name: Run cSpell


### PR DESCRIPTION
This PR update `dorny/test-reporter` package version to 3.0.0 to suppress Node v20 relating warnings.

**Other Changes**
- Update `actions/upload-artifact`/`actions/download-artifact` versions.
- Update `egor-tensin/setup-clang` package version and enable version pinning.
- Update `cspell` version
