### PR TITLE
Improve console contrast: add 256-color ANSI support with improved 16-color fallback

### DIFF
--- a/src/BenchmarkDotNet/Loggers/ConsoleLogger.cs
+++ b/src/BenchmarkDotNet/Loggers/ConsoleLogger.cs
@@ -1,4 +1,4 @@
-﻿using BenchmarkDotNet.Detectors;
+using BenchmarkDotNet.Detectors;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Helpers;
 using BenchmarkDotNet.Portability;
@@ -21,15 +21,15 @@ namespace BenchmarkDotNet.Loggers
             return !(OsDetector.IsAndroid() || OsDetector.IsIOS() || RuntimeInformation.IsWasm || OsDetector.IsTvOS());
         });
 
-        private static readonly Lazy<bool> ConsoleSupports256Colors = new (() =>
+        private static readonly Lazy<bool> ConsoleSupports256Colors = new(() =>
         {
-            
+
             var colorTerm = Environment.GetEnvironmentVariable("COLORTERM");
-            if ( colorTerm == "truecolor" || colorTerm=="24bit")
+            if (colorTerm == "truecolor" || colorTerm == "24bit")
                 return true;
 
             var term = Environment.GetEnvironmentVariable("TERM");
-            return term!=null && term.Contains("256color");
+            return term != null && term.Contains("256color");
         });
 
         private readonly bool unicodeSupport;
@@ -67,7 +67,7 @@ namespace BenchmarkDotNet.Loggers
 
             if (ConsoleSupports256Colors.Value)
             {
-                var colorIndex=Get256Color(logKind);
+                var colorIndex = Get256Color(logKind);
                 Console.Write($"\x1b[38;5;{colorIndex}m");
                 write(text);
                 Console.Write("\x1b[0m");
@@ -91,40 +91,41 @@ namespace BenchmarkDotNet.Loggers
         }
 
         private ConsoleColor GetColor(LogKind logKind) =>
-            colorScheme.ContainsKey(logKind) ? colorScheme[logKind] : DefaultColor;
+            colorScheme.TryGetValue(logKind, out ConsoleColor value) ? value : DefaultColor;
 
         private static int Get256Color(LogKind logKind)
         {
             var scheme = Create256ColorScheme();
-            return scheme.ContainsKey(logKind) ? scheme[logKind] :252;
+            return scheme.TryGetValue(logKind, out int value) ? value : 252;
         }
-        private static Dictionary<LogKind, ConsoleColor> CreateColorfulScheme() =>
-    new Dictionary<LogKind, ConsoleColor>
-    {
-        { LogKind.Default, ConsoleColor.Gray },
-        { LogKind.Help, ConsoleColor.Cyan },
-        { LogKind.Header, ConsoleColor.Magenta },
-        { LogKind.Result, ConsoleColor.Blue },
-        { LogKind.Statistic, ConsoleColor.DarkCyan },
-        { LogKind.Info, ConsoleColor.DarkGray },
-        { LogKind.Error, ConsoleColor.Red },
-        { LogKind.Warning, ConsoleColor.DarkYellow },
-        { LogKind.Hint, ConsoleColor.DarkMagenta }
-    };
 
-private static Dictionary<LogKind, int> Create256ColorScheme() =>
-    new Dictionary<LogKind, int>
-    {
-        { LogKind.Default,   244 },  // mid gray - readable on both
-        { LogKind.Help,      36  },  // teal-green
-        { LogKind.Header,    127 },  // mid magenta
-        { LogKind.Result,    33  },  // mid blue
-        { LogKind.Statistic, 30  },  // darker teal - distinct from Result and Help
-        { LogKind.Info,      130 },  // dark orange/brown - distinct from Warning
-        { LogKind.Error,     160 },  // darker red - visible on white without blinding
-        { LogKind.Warning,   166 },  // orange - distinct from Info
-        { LogKind.Hint,      98  }   // muted purple - distinct from Header
-    };
+        private static Dictionary<LogKind, ConsoleColor> CreateColorfulScheme() =>
+            new()
+            {
+                { LogKind.Default, ConsoleColor.Gray },
+                { LogKind.Help, ConsoleColor.Cyan },
+                { LogKind.Header, ConsoleColor.Magenta },
+                { LogKind.Result, ConsoleColor.Blue },
+                { LogKind.Statistic, ConsoleColor.DarkCyan },
+                { LogKind.Info, ConsoleColor.DarkGray },
+                { LogKind.Error, ConsoleColor.Red },
+                { LogKind.Warning, ConsoleColor.DarkYellow },
+                { LogKind.Hint, ConsoleColor.DarkMagenta }
+            };
+
+        private static Dictionary<LogKind, int> Create256ColorScheme() =>
+            new()
+            {
+                { LogKind.Default,   244 },  // mid gray - readable on both
+                { LogKind.Help,      36  },  // teal-green
+                { LogKind.Header,    127 },  // mid magenta
+                { LogKind.Result,    33  },  // mid blue
+                { LogKind.Statistic, 30  },  // darker teal - distinct from Result and Help
+                { LogKind.Info,      130 },  // dark orange/brown - distinct from Warning
+                { LogKind.Error,     160 },  // darker red - visible on white without blinding
+                { LogKind.Warning,   166 },  // orange - distinct from Info
+                { LogKind.Hint,      98  }   // muted purple - distinct from Header
+            };
 
         [PublicAPI]
         public static Dictionary<LogKind, ConsoleColor> CreateGrayScheme()

--- a/src/BenchmarkDotNet/Loggers/ConsoleLogger.cs
+++ b/src/BenchmarkDotNet/Loggers/ConsoleLogger.cs
@@ -21,6 +21,17 @@ namespace BenchmarkDotNet.Loggers
             return !(OsDetector.IsAndroid() || OsDetector.IsIOS() || RuntimeInformation.IsWasm || OsDetector.IsTvOS());
         });
 
+        private static readonly Lazy<bool> ConsoleSupports256Colors = new (() =>
+        {
+            
+            var colorTerm = Environment.GetEnvironmentVariable("COLORTERM");
+            if ( colorTerm == "truecolor" || colorTerm=="24bit")
+                return true;
+
+            var term = Environment.GetEnvironmentVariable("TERM");
+            return term!=null && term.Contains("256color");
+        });
+
         private readonly bool unicodeSupport;
         private readonly Dictionary<LogKind, ConsoleColor> colorScheme;
 
@@ -54,6 +65,15 @@ namespace BenchmarkDotNet.Loggers
                 return;
             }
 
+            if (ConsoleSupports256Colors.Value)
+            {
+                var colorIndex=Get256Color(logKind);
+                Console.Write($"\x1b[38;5;{colorIndex}m");
+                write(text);
+                Console.Write("\x1b[0m");
+                return;
+            }
+
             var colorBefore = Console.ForegroundColor;
 
             try
@@ -73,19 +93,38 @@ namespace BenchmarkDotNet.Loggers
         private ConsoleColor GetColor(LogKind logKind) =>
             colorScheme.ContainsKey(logKind) ? colorScheme[logKind] : DefaultColor;
 
+        private static int Get256Color(LogKind logKind)
+        {
+            var scheme = Create256ColorScheme();
+            return scheme.ContainsKey(logKind) ? scheme[logKind] :252;
+        }
         private static Dictionary<LogKind, ConsoleColor> CreateColorfulScheme() =>
-            new Dictionary<LogKind, ConsoleColor>
-            {
-                { LogKind.Default, ConsoleColor.Gray },
-                { LogKind.Help, ConsoleColor.DarkGreen },
-                { LogKind.Header, ConsoleColor.Magenta },
-                { LogKind.Result, ConsoleColor.DarkCyan },
-                { LogKind.Statistic, ConsoleColor.Cyan },
-                { LogKind.Info, ConsoleColor.DarkYellow },
-                { LogKind.Error, ConsoleColor.Red },
-                { LogKind.Warning, ConsoleColor.Yellow },
-                { LogKind.Hint, ConsoleColor.DarkCyan }
-            };
+    new Dictionary<LogKind, ConsoleColor>
+    {
+        { LogKind.Default, ConsoleColor.Gray },
+        { LogKind.Help, ConsoleColor.Cyan },
+        { LogKind.Header, ConsoleColor.Magenta },
+        { LogKind.Result, ConsoleColor.Blue },
+        { LogKind.Statistic, ConsoleColor.DarkCyan },
+        { LogKind.Info, ConsoleColor.DarkGray },
+        { LogKind.Error, ConsoleColor.Red },
+        { LogKind.Warning, ConsoleColor.DarkYellow },
+        { LogKind.Hint, ConsoleColor.DarkMagenta }
+    };
+
+private static Dictionary<LogKind, int> Create256ColorScheme() =>
+    new Dictionary<LogKind, int>
+    {
+        { LogKind.Default,   244 },  // mid gray - readable on both
+        { LogKind.Help,      36  },  // teal-green
+        { LogKind.Header,    127 },  // mid magenta
+        { LogKind.Result,    33  },  // mid blue
+        { LogKind.Statistic, 30  },  // darker teal - distinct from Result and Help
+        { LogKind.Info,      130 },  // dark orange/brown - distinct from Warning
+        { LogKind.Error,     160 },  // darker red - visible on white without blinding
+        { LogKind.Warning,   166 },  // orange - distinct from Info
+        { LogKind.Hint,      98  }   // muted purple - distinct from Header
+    };
 
         [PublicAPI]
         public static Dictionary<LogKind, ConsoleColor> CreateGrayScheme()


### PR DESCRIPTION
Fixes #1336 
//What this does

Addresses the poor contrast of DarkGreen, DarkCyan and DarkYellow log colors on dark terminals, following @AndreyAkinshin 's suggestion in the issue to go beyond the 16-color palette. 

//Changes

-Detects 256-color terminal support via "COLORTERM=truecolor" / "24bit" or "TERM=*256color"
-When supported, writes ANSI escape codes directly instead of using "Console.ForegroundColor"
-Each "LogKind" maps to a specific palette index chosen for readability on light and dark backgrounds

-Improved the 16-color fallback 
-Replaces unreadable Dark colors with readable equivalents
-All 9 LogKind values remain visually distinct