### PR TITLE
chore: Add AppHost validation to DisassemblyDiagniser  on macos environment

### DIFF
--- a/src/BenchmarkDotNet/Detectors/AppHostDetector.cs
+++ b/src/BenchmarkDotNet/Detectors/AppHostDetector.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Extensions;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace BenchmarkDotNet.Detectors;
+
+internal static class AppHostDetector
+{
+    public static bool HasAppHost()
+    {
+        var entryAssembly = Assembly.GetEntryAssembly();
+
+        // Check NativeAOT
+        if (entryAssembly == null)
+            return false;
+
+        using var process = Process.GetCurrentProcess();
+        var processName = process.ProcessName;
+
+        // Check executed with `dotnet run`
+        if (processName.Equals("dotnet", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        // Check Single-file executable (AppHost is bundled)
+        if (entryAssembly.Location.IsBlank())
+            return true;
+
+        // Check entry assembly extension.
+        if (entryAssembly.Location.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Return false for unknown environment
+        return false;
+    }
+}

--- a/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
+++ b/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
@@ -1,4 +1,4 @@
-﻿using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Analysers;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Detectors;
 using BenchmarkDotNet.Disassemblers;
@@ -100,7 +100,7 @@ namespace BenchmarkDotNet.Diagnosers
                     );
                     break;
                 case HostSignal.SeparateLogic when ShouldUseMonoDisassembler(benchmark):
-                    var result = await monoDisassembler.Disassemble(benchmark, (MonoRuntime) benchmark.Job.Environment.Runtime!, cancellationToken).ConfigureAwait(false);
+                    var result = await monoDisassembler.Disassemble(benchmark, (MonoRuntime)benchmark.Job.Environment.Runtime!, cancellationToken).ConfigureAwait(false);
                     results.Add(benchmark, result);
                     break;
             }
@@ -173,6 +173,16 @@ namespace BenchmarkDotNet.Diagnosers
                 else if (!ShouldUseMonoDisassembler(benchmark))
                 {
                     yield return new ValidationError(true, $"Only Windows and Linux are supported in DisassemblyDiagnoser without Mono. Current OS is {System.Runtime.InteropServices.RuntimeInformation.OSDescription}");
+                }
+
+                var isInProcess = benchmark.Job.Infrastructure.TryGetToolchain(out toolchain) && toolchain.IsInProcess;
+                if (isInProcess && OsDetector.IsMacOS() && AppHostDetector.HasAppHost())
+                {
+                    // On macos environment, WriteDump API is used and it cause freeze when using AppHost with InProcessToolchain.
+                    // https://github.com/dotnet/BenchmarkDotNet/issues/3076
+                    var errorMessage = "DisassemblyDiagnoser is not supported on macos environment that using AppHost and InProcessToolchain. "
+                                     + "Disable AppHost with '<UseAppHost>false</UseAppHost>' or use another toolchain";
+                    yield return new ValidationError(true, errorMessage);
                 }
             }
         }


### PR DESCRIPTION
This PR add AppHost validation to DisassemblyDiagniser  on macos environment.

As commented on #3076.
Currently DisassemblyDiagniser  cause freeze when following conditions met.
1. Running on macos(x86/arm64).
2. Using InProcessDiagnoser and using AppHost

By this PR it can avoid unintended benchmark freeze problem.