### PR TITLE
deps: Update ClrMD version to 4.x

### DIFF
--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="deniszykov.WebSocketListener" Version="4.2.19" />
     <PackageReference Include="Gee.External.Capstone" Version="2.3.0" />
     <PackageReference Include="Iced" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="3.1.512801" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="4.0.722401" />
     <PackageReference Include="Perfolizer" Version="[0.6.6]" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.30" PrivateAssets="contentfiles;analyzers" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />

--- a/src/BenchmarkDotNet/Disassemblers/ClrMdDisassembler.cs
+++ b/src/BenchmarkDotNet/Disassemblers/ClrMdDisassembler.cs
@@ -1,9 +1,8 @@
-﻿using BenchmarkDotNet.Detectors;
+using BenchmarkDotNet.Detectors;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Portability;
-using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Runtime;
 using System.Text.RegularExpressions;
 
@@ -58,24 +57,9 @@ namespace BenchmarkDotNet.Disassemblers
             }
             if (OsDetector.IsMacOS())
             {
-                // ClrMD does not support CreateSnapshotAndAttach on MacOS, and AttachToProcess is unreliable, so we have to create a dump file and load it.
-                string dumpPath = Path.GetTempFileName();
-                try
-                {
-                    try
-                    {
-                        new DiagnosticsClient(processId).WriteDump(DumpType.Full, dumpPath, logDumpGeneration: false);
-                    }
-                    catch (ServerErrorException sxe)
-                    {
-                        throw new ArgumentException($"Unable to create a snapshot of process {processId:x}.", sxe);
-                    }
-                    return DataTarget.LoadDump(dumpPath);
-                }
-                finally
-                {
-                    File.Delete(dumpPath);
-                }
+                // On macOS it need to use CreateSnapshotAndAttach API instead of AttachToProcess.
+                // https://github.com/microsoft/clrmd/issues/1034
+                return DataTarget.CreateSnapshotAndAttach(processId);
             }
             throw new NotSupportedException($"{System.Runtime.InteropServices.RuntimeInformation.OSDescription} is not supported");
         }
@@ -85,8 +69,6 @@ namespace BenchmarkDotNet.Disassemblers
             using var dataTarget = Attach(args.ProcessId);
 
             var runtime = dataTarget.ClrVersions.Single().CreateRuntime();
-
-            ConfigureSymbols(dataTarget);
 
             var state = new State(runtime, args.TargetFrameworkMoniker);
 
@@ -118,12 +100,6 @@ namespace BenchmarkDotNet.Disassemblers
                 AddressToNameMapping = state.AddressToNameMapping,
                 PointerSize = (uint)IntPtr.Size
             };
-        }
-
-        private static void ConfigureSymbols(DataTarget dataTarget)
-        {
-            // code copied from https://github.com/Microsoft/clrmd/issues/34#issuecomment-161926535
-            dataTarget.SetSymbolPath("http://msdl.microsoft.com/download/symbols");
         }
 
         private static void FilterAndEnqueue(State state, ClrMdArgs args)


### PR DESCRIPTION
**1. Update ClrMD version to 4.x**

**2. Update existing code based on migration guide**
https://github.com/microsoft/clrmd/blob/main/doc/Migrating4.md

**3. Remove temporary workaround code for macOS**
ClrMD v4 add CreateSnapshotAndAttach support for macos. 
https://github.com/microsoft/clrmd/blob/main/doc/Migrating4.md#macos-createsnapshotandattach-support

**4. Enable disassembler tests on windows-arm**
It seems be fixed by https://github.com/microsoft/clrmd/issues/1050

But on following environment, It throw `DLLNotFoundException` that relating capstone.
1. Running on Windows(arm64)
2. Running on .NET Framework
3. Using Platform=Arm64

So ` [TheoryEnvSpecific("Not supported on Windows+Arm", EnvRequirement.NonWindowsArm)]` setting is remained as is.

**Stacktrace**
```
// ! InProcessEmitExecutor, exception: System.DllNotFoundException: Unable to load DLL 'capstone': The specified module could not be found. (Exception from HRESULT: 0x8007007E)
   at Gee.External.Capstone.NativeCapstoneImport.CreateDisassembler(DisassembleArchitecture disassembleArchitecture, NativeDisassembleMode disassembleMode, IntPtr& pDisassembler)
   at Gee.External.Capstone.NativeCapstone.CreateDisassembler(DisassembleArchitecture disassembleArchitecture, NativeDisassembleMode disassembleMode)
   at Gee.External.Capstone.CapstoneDisassembler`8..ctor(DisassembleArchitecture disassembleArchitecture, TDisassembleMode disassembleMode)
   at BenchmarkDotNet.Disassemblers.Arm64Disassembler.<Decode>d__2.MoveNext() in /_/src/BenchmarkDotNet/Disassemblers/Arm64Disassembler.cs:line 199
   at System.Collections.Generic.List`1.InsertRange(Int32 index, IEnumerable`1 collection)
   at BenchmarkDotNet.Disassemblers.ClrMdDisassembler.DisassembleMethod(MethodInfo methodInfo, State state, ClrMdArgs args, DisassemblySyntax syntax, SourceCodeProvider sourceCodeProvider) in /_/src/BenchmarkDotNet/Disassemblers/ClrMdDisassembler.cs:line 199
   at BenchmarkDotNet.Disassemblers.ClrMdDisassembler.Disassemble(ClrMdArgs args, State state) in /_/src/BenchmarkDotNet/Disassemblers/ClrMdDisassembler.cs:line 161
   at BenchmarkDotNet.Disassemblers.ClrMdDisassembler.AttachAndDisassemble(ClrMdArgs args) in /_/src/BenchmarkDotNet/Disassemblers/ClrMdDisassembler.cs:line 101
   at BenchmarkDotNet.Diagnosers.DisassemblyDiagnoser.<HandleAsync>d__23.MoveNext() in /_/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs:line 98
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at BenchmarkDotNet.Diagnosers.CompositeDiagnoser.<HandleAsync>d__9.MoveNext() in /_/src/BenchmarkDotNet/Diagnosers/CompositeDiagnoser.cs:line 39
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at BenchmarkDotNet.Toolchains.InProcess.Emit.InProcessEmitRunner.<Run>d__0.MoveNext() in /_/src/BenchmarkDotNet/Toolchains/InProcess/Emit/InProcessEmitRunner.cs:line 52
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at BenchmarkDotNet.Toolchains.InProcess.Emit.InProcessEmitExecutor.<ExecuteCore>d__3.MoveNext() in /_/src/BenchmarkDotNet/Toolchains/InProcess/Emit/InProcessEmitExecutor.cs:line 78
```
