### PR TITLE
chore: Fix CodeFixer tests error that occurred on windows

### DIFF
--- a/tests/BenchmarkDotNet.Analyzers.Tests/CodeFixTests/AsyncBenchmarkCodeFixProviderTests.cs
+++ b/tests/BenchmarkDotNet.Analyzers.Tests/CodeFixTests/AsyncBenchmarkCodeFixProviderTests.cs
@@ -24,7 +24,7 @@ public class AsyncBenchmarkCodeFixProviderTests : CodeFixTestFixture<AsyncBenchm
                     await Task.Delay(100);
                 }
             }
-            """;
+            """.ReplaceLineEndings();
 
         var fixedCode = /* lang=c#-test */ """
             using BenchmarkDotNet.Attributes;
@@ -42,7 +42,7 @@ public class AsyncBenchmarkCodeFixProviderTests : CodeFixTestFixture<AsyncBenchm
                     await Task.Delay(100);
                 }
             }
-            """;
+            """.ReplaceLineEndings();
 
         TestCode = testCode;
         FixedCode = fixedCode;
@@ -67,7 +67,7 @@ public class AsyncBenchmarkCodeFixProviderTests : CodeFixTestFixture<AsyncBenchm
                     await Task.Delay(100);
                 }
             }
-            """;
+            """.ReplaceLineEndings();
 
         var fixedCode = /* lang=c#-test */ """
             using BenchmarkDotNet.Attributes;
@@ -85,7 +85,7 @@ public class AsyncBenchmarkCodeFixProviderTests : CodeFixTestFixture<AsyncBenchm
                     await Task.Delay(100);
                 }
             }
-            """;
+            """.ReplaceLineEndings();
 
         TestCode = testCode;
         FixedCode = fixedCode;
@@ -113,7 +113,7 @@ public class AsyncBenchmarkCodeFixProviderTests : CodeFixTestFixture<AsyncBenchm
                     await Task.Delay(Size);
                 }
             }
-            """;
+            """.ReplaceLineEndings();
 
         var fixedCode = /* lang=c#-test */ """
             using BenchmarkDotNet.Attributes;
@@ -134,7 +134,7 @@ public class AsyncBenchmarkCodeFixProviderTests : CodeFixTestFixture<AsyncBenchm
                     await Task.Delay(Size);
                 }
             }
-            """;
+            """.ReplaceLineEndings();
 
         TestCode = testCode;
         FixedCode = fixedCode;
@@ -165,7 +165,7 @@ public class AsyncBenchmarkCodeFixProviderTests : CodeFixTestFixture<AsyncBenchm
                     await Task.Delay(200);
                 }
             }
-            """;
+            """.ReplaceLineEndings();
 
         var fixedCode = /* lang=c#-test */ """
             using BenchmarkDotNet.Attributes;
@@ -189,7 +189,7 @@ public class AsyncBenchmarkCodeFixProviderTests : CodeFixTestFixture<AsyncBenchm
                     await Task.Delay(200);
                 }
             }
-            """;
+            """.ReplaceLineEndings();
 
         TestCode = testCode;
         FixedCode = fixedCode;

--- a/tests/BenchmarkDotNet.Analyzers.Tests/StringExtensions.cs
+++ b/tests/BenchmarkDotNet.Analyzers.Tests/StringExtensions.cs
@@ -1,0 +1,19 @@
+#if NETFRAMEWORK
+namespace BenchmarkDotNet.Analyzers.Tests;
+
+internal static class StringExtensions
+{
+    public static string ReplaceLineEndings(this string input)
+        => ReplaceLineEndings(input, Environment.NewLine);
+
+    private static string ReplaceLineEndings(this string text, string replacementText)
+    {
+        text = text.Replace("\r\n", "\n");
+
+        if (replacementText != "\n")
+            text = text.Replace("\n", replacementText);
+
+        return text;
+    }
+}
+#endif


### PR DESCRIPTION
This PR fix errors that occurred by CRLF/LF differences on windows environment.

Currently `AsyncBenchmarkCodeFixProviderTests` failed when following conditions are met.
1. Running tests on Windows environment. 
2. git `autocrlf` config is disabled. (Source code is checked out as `LF`)

As far as I've confirmed, there is no setting to ignore line endings on `Microsoft.CodeAnalysis.Testing` library side.
So manually normalize expected/actual values with `ReplaceLineEndings` API.
https://github.com/dotnet/roslyn-sdk/issues/983

