### PR TITLE
chore: Increase timeout seconds of R2R test

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/R2RTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/R2RTests.cs
@@ -26,7 +26,7 @@ namespace BenchmarkDotNet.IntegrationTests
                 .AddJob(Job.Dry
                     .WithRuntime(GetCurrentR2RRuntime())
                     .WithToolchain(toolchain))
-                .WithBuildTimeout(TimeSpan.FromSeconds(240));
+                .WithBuildTimeout(TimeSpan.FromSeconds(360));
         }
 
         private static string GetTargetFrameworkMoniker()


### PR DESCRIPTION
This PR increase R2RTests timeout value from `240s` to `360s`.

Currently R2RTests `dotnet publish` command takes about 175 seconds on succeeded.

But there is cases, it take times and exceed build timeout on `macos(x64)`
https://github.com/dotnet/BenchmarkDotNet/actions/runs/24426573098


