### PR TITLE
chore: Add ThreadingDiagnoserTests with InProcessToolchain

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
@@ -9,14 +9,10 @@ using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Tests.Loggers;
 using BenchmarkDotNet.Toolchains;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using BenchmarkDotNet.Toolchains.NativeAot;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using BenchmarkDotNet.Detectors;
 using BenchmarkDotNet.IntegrationTests.Xunit;
-using BenchmarkDotNet.Portability;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -30,6 +26,8 @@ namespace BenchmarkDotNet.IntegrationTests
 
         public static IEnumerable<object[]> GetToolchains()
         {
+            yield return new object[] { InProcessEmitToolchain.Default };
+
             yield return new object[] { Job.Default.GetToolchain() };
 
             if (!ContinuousIntegration.IsGitHubActionsOnWindows() // no native dependencies
@@ -37,8 +35,6 @@ namespace BenchmarkDotNet.IntegrationTests
             {
                 yield return new object[] { NativeAotToolchain.Net80 };
             }
-            // TODO: Support InProcessEmitToolchain.Instance
-            // yield return new object[] { InProcessEmitToolchain.Instance };
         }
 
         [Theory, MemberData(nameof(GetToolchains), DisableDiscoveryEnumeration = true)]


### PR DESCRIPTION
Currently, ThreadingDiagnoserTests with InProcessEmitToolchain is commented out with following commit.
https://github.com/dotnet/BenchmarkDotNet/commit/852bb8cd9c2ac2530866dc53723c5f2ce3d411fa

This PR enable these tests that use InProcessToolin.
Because it seems works without problem on latest codebase (As far as I've tested)

By this changes, it can implement skip long-running tests on **Draft PR** (#3088) (Currently, it takes about 4 minutes)
 
