### PR TITLE
chore: Avoid exception thrown on output redirected environment

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -747,6 +747,9 @@ namespace BenchmarkDotNet.ConsoleArguments
 
         private static int GetMaximumDisplayWidth()
         {
+            if (Console.IsOutputRedirected)
+                return MinimumDisplayWidth;
+
             try
             {
                 return Console.WindowWidth;


### PR DESCRIPTION
This PR modify `ConfigParser.cs` to avoid exception thrown on some environment.

When `Console.IsOutputRedirected` is enabled (e.g. Running benchmark from Test Explorer).
IOException is thrown and caught by try-catch blocks.

This behavior affects VS `Break When Thrown` setting enabled environment.
So it's desirable to avoid throwing exception.
