### PR TITLE
Fix RPlotExporter (#3094)

### DIFF
--- a/src/BenchmarkDotNet/Templates/BuildPlots.R
+++ b/src/BenchmarkDotNet/Templates/BuildPlots.R
@@ -75,7 +75,7 @@ for (file in files) {
   }
 
   resultStats <- result %>%
-    group_by_(.dots = c("Target_Method", "Job_Id")) %>%
+    group_by(Target_Method, Job_Id) %>%
     summarise(se = std.error(Measurement_Value), Value = mean(Measurement_Value))
 
   benchmarkBoxplot <- ggplot(result, aes(x=Target_Method, y=Measurement_Value, fill=Job_Id)) +


### PR DESCRIPTION
Fixes #3094 

Even though the plots are now generated, when using this feature for the first time after installing R and running the benchmark, `ggplot2` could not be installed, so I had to install it manually from another mirror. After that, it works just fine.