### PR TITLE
chore: modify NativeAotToolchain related settings

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -108,9 +108,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             // Skip creating NuGet.config file if clear tag is not specified, and feeds only contain a default nuget.org feed.
             if (!useNuGetClearTag && Feeds.Count == 1)
             {
-                var feed = Feeds.First();
-                if (feed.Key == NativeAotNuGetFeed
-                 && feed.Value == "https://api.nuget.org/v3/index.json")
+                if (Feeds.TryGetValue(NativeAotNuGetFeed, out var value) && value == "https://api.nuget.org/v3/index.json")
                     return;
             }
 

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -105,6 +105,15 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             if (!Feeds.Any())
                 return;
 
+            // Skip creating NuGet.config file if clear tag is not specified, and feeds only contain a default nuget.org feed.
+            if (!useNuGetClearTag && Feeds.Count == 1)
+            {
+                var feed = Feeds.First();
+                if (feed.Key == NativeAotNuGetFeed
+                 && feed.Value == "https://api.nuget.org/v3/index.json")
+                    return;
+            }
+
             string content = $"""
                 <?xml version="1.0" encoding="utf-8"?>
                 <configuration>

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/NativeAotToolchain.cs
@@ -24,7 +24,7 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             .ToToolchain();
 
         /// <summary>
-        /// compiled as net8.0, targets latest NativeAOT build from the NuGet.org feed: "https://api.nuget.org/v3/index.json"
+        /// compiled as net8.0, targets latest NativeAOT build from the NuGet.org feed
         /// </summary>
         public static readonly IToolchain Net80 = CreateBuilder()
             .UseNuGet("", "https://api.nuget.org/v3/index.json")
@@ -32,15 +32,15 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
             .ToToolchain();
 
         /// <summary>
-        /// compiled as net9.0, targets latest NativeAOT build from the .NET 9 feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json
+        /// compiled as net9.0, targets latest NativeAOT build from the NuGet.org feed
         /// </summary>
         public static readonly IToolchain Net90 = CreateBuilder()
-            .UseNuGet("", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json")
+            .UseNuGet("", "https://api.nuget.org/v3/index.json")
             .TargetFrameworkMoniker("net9.0")
             .ToToolchain();
 
         /// <summary>
-        /// compiled as net10.0, targets latest NativeAOT build from the .NET 10 feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json
+        /// compiled as net10.0, targets latest NativeAOT build from the NuGet.org feed
         /// </summary>
         public static readonly IToolchain Net10_0 = CreateBuilder()
             .UseNuGet("", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json")


### PR DESCRIPTION
This PR contains following changes

**1. Skip creating `NuGet.config` file when custom settings are not contained**
This change is intended to resolve some part of issue #2610.
When using default NuGet feed only, There is no need for packageSourceMapping for `nativeAotNuGetFeed`.

Note: Currently NativeAotToolchain may create following keys on NuGet.config's packageSources.
- `nativeAotNuGetFeed`
- `local`
- `dotnet11`

**2. Modify `NativeAotNuGetFeed` to use default nuget feed**
It's same changes as #2221.

Modify code to use default NuGet feed for `net8.0`/`net9.0`/`net10.0` tfms.
Only preview version tfm need to reference developer feed.
