### PR TITLE
chore: Cleanup run-tests workflow

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up v8
         run: |
           npm install jsvu -g
-          jsvu --os=win64 --engines=v8
+          jsvu --os=default --engines=v8
           Add-Content -Path $env:GITHUB_PATH -Value "$env:USERPROFILE\.jsvu\bin"
       - name: Install wasm-tools workload
         run: ./build.cmd install-wasm-tools
@@ -85,7 +85,7 @@ jobs:
       - name: Set up v8
         run: |
           npm install jsvu -g
-          jsvu --os=win64 --engines=v8
+          jsvu --os=default --engines=v8
           Add-Content -Path $env:GITHUB_PATH -Value "$env:USERPROFILE\.jsvu\bin"
       - name: Install wasm-tools workload
         run: ./build.cmd install-wasm-tools
@@ -138,7 +138,7 @@ jobs:
         with:
           node-version: "24"
       - name: Set up v8
-        run: npm install jsvu -g && jsvu --os=linux64 --engines=v8 && echo "$HOME/.jsvu/bin" >> $GITHUB_PATH
+        run: npm install jsvu -g && jsvu --os=default --engines=v8 && echo "$HOME/.jsvu/bin" >> $GITHUB_PATH
       - name: Install wasm-tools workload
         run: ./build.cmd install-wasm-tools
       # Build and Test
@@ -173,10 +173,8 @@ jobs:
       matrix:
         os:
           - runs-on: 'macos-latest'
-            jsvu-os: 'mac64arm'
             arch: 'arm64'
           - runs-on: 'macos-15-intel'
-            jsvu-os: 'mac64'
             arch: 'x64'
     steps:
       - uses: actions/checkout@v6
@@ -185,7 +183,7 @@ jobs:
         with:
           node-version: "24"
       - name: Set up v8
-        run: npm install jsvu -g && jsvu --os=${{ matrix.os.jsvu-os }} --engines=v8 && echo "$HOME/.jsvu/bin" >> $GITHUB_PATH
+        run: npm install jsvu -g && jsvu --os=default --engines=v8 && echo "$HOME/.jsvu/bin" >> $GITHUB_PATH
       - name: Install wasm-tools workload
         run: ./build.cmd install-wasm-tools
       # Build and Test

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -126,13 +126,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       # Set up the environment
-      - name: Set up Clang
-        uses: egor-tensin/setup-clang@471a6f8ef1d449dba8e1a51780e7f943572a3f99 # v2.1
-        with:
-          version: latest
-          platform: x64
-      - name: Set up zlib-static
-        run: sudo apt-get install -y libkrb5-dev
       - name: Set up node
         uses: actions/setup-node@v6
         with:
@@ -215,13 +208,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Clang
-        uses: egor-tensin/setup-clang@471a6f8ef1d449dba8e1a51780e7f943572a3f99 # v2.1
-        with:
-          version: latest
-          platform: x64
-      - name: Set up zlib-static
-        run: sudo apt-get install -y libkrb5-dev
       - name: Run task 'pack'
         run: ./build.cmd pack
 


### PR DESCRIPTION
This PR contains following changes.

**1. Modify jsvu `os` parameter to `default`**
Modify `--os` parameter value to use `default` (guess from environment)
As far as I've confirmed, it works without problem with `default` setting . (It can be confirmed by CI logs)

**2. Remove unused tools installation steps**
Remove following tools installation  steps from CI.
- `clang`
- `libkrb5-dev`

These package are listed as Mono prerequisite.
But it seems not be used on CI.
https://benchmarkdotnet.org/articles/configs/toolchains.html?q=libkrb5-dev#wasm


#### TODO:
Following tasks is expected to be on another PR.

**1. Separate `WasmTests` related tool installations to shared actions**
These tool installation can be shared between jobs and `run-tests-selected.yaml`.
And `wasm-tools` workload installation takes about 7 minitus (on `macos-latest`)
So it's better to skip tool installation when it's not needed (On `win-arm64`/`linux-arm64` and wasm related tests are not executed)

**2. Add skip v8 install steps 
Currently,  `jsvu --os=linux64 --engines=v8` command is **silently** failed on `ubuntu-24.04-arm`.
And it seems x64 version is installed on `windows-11-arm`.

On these environment, WasmTests skip tests with following message,
> JSVU does not support ARM on Windows or Linux

So it's better to skip tools installations.