### PR TITLE
chore: Remove unused wasm-tools installation

### DIFF
--- a/build/BenchmarkDotNet.Build/Program.cs
+++ b/build/BenchmarkDotNet.Build/Program.cs
@@ -86,7 +86,6 @@ public class InstallWasmToolsWorkload : FrostingTask<BuildContext>, IHelpProvide
     public override void Run(BuildContext context)
     {
         context.BuildRunner.InstallWorkload("wasm-tools-net8");
-        context.BuildRunner.InstallWorkload("wasm-tools");
     }
 
     public HelpInfo GetHelp()


### PR DESCRIPTION
This PR remove `wasm-tools` workload installation from CI tests.

Because it seems not be used by CI tests (Currently there is no Wasm tests that targeting .NET 10)
And it takes minutes to install workload.
