### PR TITLE
chore: Update macos(x64) CI image to `macos-26-intel` and increase build timeout

### DIFF
--- a/.github/workflows/run-tests-selected.yaml
+++ b/.github/workflows/run-tests-selected.yaml
@@ -15,7 +15,7 @@ on:
           - macos-latest
           - windows-11-arm
           - ubuntu-24.04-arm
-          - macos-15-intel
+          - macos-26-intel
       project:
         type: string
         description: Specify test project path

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -139,7 +139,7 @@ jobs:
         os:
           - runs-on: 'macos-latest'
             arch: 'arm64'
-          - runs-on: 'macos-15-intel'
+          - runs-on: 'macos-26-intel'
             arch: 'x64'
     steps:
       - uses: actions/checkout@v6

--- a/docs/articles/contributing/running-tests.md
+++ b/docs/articles/contributing/running-tests.md
@@ -53,7 +53,7 @@ Following parameters need to specified to invoke workflow with `gh workflow run`
 
 | name                          | default                                  | description
 |-------------------------------|------------------------------------------|---------------------
-| `runs_on`                     | `ubuntu-latest`                          | GitHub Actions runner image name (`windows-latest` `windows-11-arm` `ubuntu-latest` `macos-latest` `macos-15-intel`)
+| `runs_on`                     | `ubuntu-latest`                          | GitHub Actions runner image name (`windows-latest` `windows-11-arm` `ubuntu-latest` `macos-latest` `macos-26-intel`)
 | `project`                     | `tests/BenchmarkDotNet.IntegrationTests` | Specify path of project directory
 | `framework`                   | `net8.0`                                 | Target Framework (e.g. `net8.0`, `net472`)
 | `filter`                      | `BenchmarkDotNet`                        | Test filter text (It's used for `dotnet test --filter`) Use default value when running all tests

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -417,7 +417,7 @@ namespace BenchmarkDotNet.IntegrationTests
                         new EnvironmentVariable("COMPlus_TieredCompilation", "0")
                     )
                     : job)
-                .WithBuildTimeout(TimeSpan.FromSeconds(240)) // Increase timeout for `MemoryDiagnoserSupportsModernMono` test on macos(x64)
+                .WithBuildTimeout(TimeSpan.FromSeconds(480)) // Increase timeout for `MemoryDiagnoserSupportsModernMono` test on macos(x64)
                 .AddColumnProvider(DefaultColumnProviders.Instance)
                 .AddDiagnoser(MemoryDiagnoser.Default)
                 .AddLogger(toolchain.IsInProcess ? ConsoleLogger.Default : new OutputLogger(output)); // we can't use OutputLogger for the InProcess toolchains because it allocates memory on the same thread

--- a/tests/BenchmarkDotNet.IntegrationTests/WasmTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/WasmTests.cs
@@ -81,7 +81,7 @@ namespace BenchmarkDotNet.IntegrationTests
                 .AddJob(Job.Dry
                     .WithRuntime(new WasmRuntime(dotnetVersion, RuntimeMoniker.WasmNet80, "wasm", aotCompilerMode == MonoAotCompilerMode.wasm, javaScriptEngine, mainJsTemplate: mainJsTemplate, ipcType: ipcType))
                     .WithToolchain(WasmToolchain.From(netCoreAppSettings)))
-                .WithBuildTimeout(TimeSpan.FromSeconds(240))
+                .WithBuildTimeout(TimeSpan.FromSeconds(480)) // Increase timeout for `WasmSupportsInProcessDiagnosers` test on macos(x64)
                 .WithOption(ConfigOptions.LogBuildOutput, true)
                 .WithOption(ConfigOptions.GenerateMSBuildBinLog, false);
         }


### PR DESCRIPTION
This PR contains following changes

#### 1. Migrate `macos(x64)` CI image from `macos-15-intel` to `macos-26-intel`
`macos-26-intel` is expected to be last version that support `Intel Mac`

#### 2. Increase build timeout value that randomly failed on macos(x64) image
Sometimes `macos(x64)`  takes over 3h and randomly failed with build timeout error.
So I've increased build timeout for failed tests.

#### Other Notes
CI on `macos(x64)` is about 2x slower than other images and takes over 2h-3h to complete.
It might be better to skip some integration tests that takes long times to execute.