### PR TITLE
[Feat] Add common tool directories to IgnoredDirectoryNames in CsProjGenerator

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -395,6 +395,10 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         {
             ".git",
             ".vs",
+            ".vscode",
+            ".claude",
+            ".github",
+            ".gitlab",
             "bin",
             "obj",
         };


### PR DESCRIPTION
## Problem

AI tools like Claude use worktree features that create directories like `.claude/worktrees` inside the project folder. BenchmarkDotNet picks these up and throws an exception because it finds duplicate project files.

## Fix

Added common tool/CI directories to the default `IgnoredDirectoryNames` set in `CsProjGenerator.Helpers`:
- `.vscode`
- `.claude`
- `.github`
- `.gitlab`

These are now excluded by default, matching the existing behavior for `.git`, `.vs`, `bin`, and `obj`.

Closes #3110