### PR TITLE
chore: Modify run-tests-workflow and samples project

### DIFF
--- a/.github/workflows/run-tests-selected.yaml
+++ b/.github/workflows/run-tests-selected.yaml
@@ -17,7 +17,7 @@ on:
           - ubuntu-24.04-arm
           - macos-15-intel
       project:
-        type: string
+        type: choice
         description: Specify test project path
         required: true
         default: tests/BenchmarkDotNet.IntegrationTests
@@ -25,6 +25,8 @@ on:
           - tests/BenchmarkDotNet.Tests
           - tests/BenchmarkDotNet.IntegrationTests
           - tests/BenchmarkDotNet.IntegrationTests.ManualRunning
+          - tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks
+          - samples/BenchmarkDotNet.Samples
       framework:
         type: choice
         description: Specify target framework
@@ -32,6 +34,10 @@ on:
         options:
           - net8.0
           - net472
+          # Following target framework is used for `MultipleFrameworks` tests
+          - net10.0
+          - net462
+          - net48
       filter:
         type: string
         description: Test filter text (It's used for `dotnet test --filter`) Use default value when running all tests
@@ -101,3 +107,4 @@ jobs:
           if-no-files-found: ignore
           path: |
             artifacts/**/*
+            **/BenchmarkDotNet.Artifacts/**

--- a/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
+++ b/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <GenerateProgramFile>false</GenerateProgramFile>
     <!-- Disable parallel tests between TargetFrameworks -->
     <TestTfmsInParallel>false</TestTfmsInParallel>

--- a/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.Samples</AssemblyTitle>
-    <TargetFrameworks>net8.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.Samples</AssemblyName>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
This PR contains following changes to execute `Samples` benchmarks on CI .

**1. Modify `run-selected-tests` workflow**
- Change `project` input type from `text` to `choice`
- Add `project` input options
- Add `framework` input options
- Modify `upload-artifact` parameter to include files under `BenchmarkDotNet.Artifacts`

**2. Modify samples projects target framework to net472**

Note: Currently `BenchmarkDotNet.Samples.FSharp` project failed to run when using `dotnet test` command. So this project is excluded from `project` input options

