### PR TITLE
Defer BenchmarkDotNetSynchronizationContext install past discovery

### DIFF
--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs
@@ -16,51 +16,42 @@ namespace BenchmarkDotNet.Running
     {
         [PublicAPI]
         public static Summary Run<T>(IConfig? config = null, string[]? args = null)
-        {
-            using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync<T>(config, args));
-        }
+            => ExecuteSynchronously(RunAsync<T>(config, args));
 
         [PublicAPI]
         public static Summary Run(Type type, IConfig? config = null, string[]? args = null)
-        {
-            using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(type, config, args));
-        }
+            => ExecuteSynchronously(RunAsync(type, config, args));
 
         [PublicAPI]
         public static Summary[] Run(Type[] types, IConfig? config = null, string[]? args = null)
-        {
-            using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(types, config, args));
-        }
+            => ExecuteSynchronously(RunAsync(types, config, args));
 
         [PublicAPI]
         public static Summary Run(Type type, MethodInfo[] methods, IConfig? config = null)
-        {
-            using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(type, methods, config));
-        }
+            => ExecuteSynchronously(RunAsync(type, methods, config));
 
         [PublicAPI]
         public static Summary[] Run(Assembly assembly, IConfig? config = null, string[]? args = null)
-        {
-            using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(assembly, config, args));
-        }
+            => ExecuteSynchronously(RunAsync(assembly, config, args));
 
         [PublicAPI]
         public static Summary Run(BenchmarkRunInfo benchmarkRunInfo)
-        {
-            using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(benchmarkRunInfo));
-        }
+            => ExecuteSynchronously(RunAsync(benchmarkRunInfo));
 
         [PublicAPI]
         public static Summary[] Run(BenchmarkRunInfo[] benchmarkRunInfos)
+            => ExecuteSynchronously(RunAsync(benchmarkRunInfos));
+
+        // See BenchmarkSwitcher.ExecuteSynchronously: defer installing BenchmarkSynchronizationContext
+        // until after the async pipeline has started, so synchronous discovery / early-exit paths
+        // are not pumped under the single-threaded BDN context (avoids deadlocks when a user
+        // [ParamsSource]/[ArgumentsSource] evaluator does sync-over-async).
+        private static T ExecuteSynchronously<T>(ValueTask<T> task)
         {
+            if (task.IsCompleted)
+                return task.GetAwaiter().GetResult();
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(benchmarkRunInfos));
+            return context.ExecuteUntilComplete(task);
         }
 
         [PublicAPI]

--- a/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
@@ -53,26 +53,32 @@ namespace BenchmarkDotNet.Running
         /// </summary>
         [PublicAPI]
         public IEnumerable<Summary> RunAll(IConfig? config = null, string[]? args = null)
-        {
-            using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAllAsync(config, args));
-        }
+            => ExecuteSynchronously(RunAllAsync(config, args));
 
         /// <summary>
         /// Run all available benchmarks and join them to a single summary
         /// </summary>
         [PublicAPI]
         public Summary RunAllJoined(IConfig? config = null, string[]? args = null)
-        {
-            using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAllJoinedAsync(config, args));
-        }
+            => ExecuteSynchronously(RunAllJoinedAsync(config, args));
 
         [PublicAPI]
         public IEnumerable<Summary> Run(string[]? args = null, IConfig? config = null)
+            => ExecuteSynchronously(RunAsync(args, config));
+
+        // Bridges sync entrypoints to the async pipeline. The BenchmarkSynchronizationContext is installed
+        // ONLY when the returned task is not already completed (i.e., we have actual benchmark execution to pump).
+        // Discovery, --list, --info, --help, no-benchmarks, and other early-exit paths complete synchronously
+        // inside the async pipeline and bypass the context entirely. This avoids deadlocks when a user
+        // [ParamsSource]/[ArgumentsSource] evaluator does sync-over-async during discovery, since the BDN
+        // SynchronizationContext is single-threaded and discovery would otherwise block waiting for a
+        // continuation that can never run.
+        private static T ExecuteSynchronously<T>(ValueTask<T> task)
         {
+            if (task.IsCompleted)
+                return task.GetAwaiter().GetResult();
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(args, config));
+            return context.ExecuteUntilComplete(task);
         }
 
         /// <summary>


### PR DESCRIPTION
Below is Copilot's analysis of another issue that we are hitting with moving forward to the BDN that contains the async refactor. If this is us using `ParamsSource` and `ArgumentsSource` wrong, I am happy to make the changes in our code, but I was not sure what the right solution was.

The sync entrypoints BenchmarkSwitcher.Run/RunAll/RunAllJoined and BenchmarkRunner.Run<T> overloads were installing
BenchmarkDotNetSynchronizationContext (a single-threaded post/pump context) before benchmark discovery. Discovery evaluates user [ParamsSource]/[ArgumentsSource] members. If any of them perform sync-over-async work (e.g. someTask.GetAwaiter().GetResult()), the async continuation captures the BDN ctx and is queued; the pump thread is blocked inside .GetResult(); classic single-threaded deadlock.

Repro in dotnet/performance:
    SslStreamTests.GetTls13Support() does HandshakeAsync(...).GetAwaiter().GetResult()
    inside a [ArgumentsSource(nameof(TlsProtocols))] code path. With
    BDN 0.16.0 (post Async Refactor 4229d4fc), `--list flat` hangs
    forever. Pre-Refactor sync Run() did not install the SyncCtx and
    the same code worked for years.

Fix: defer SyncCtx install. Sync entrypoints now route through a tiny ExecuteSynchronously<T>(ValueTask<T>) helper that:
  - returns immediately if the task is already completed (covers --list/--info/--help/no-benchmarks early exits)
  - otherwise installs the BDN ctx and pumps until completion (preserves SyncCtx semantics for execution awaits)

Internal awaits use ConfigureAwait(false) so nothing is actually posted to the BDN ctx in modern code; the SyncCtx is essentially decorative during the pump.