### PR TITLE
fix: StaticFieldsAndPropertiesCanBeParams+InProcessEmitToolchain test issue

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/InProcess/Emit/Implementation/Runnable/RunnableReflectionHelpers.cs
+++ b/src/BenchmarkDotNet/Toolchains/InProcess/Emit/Implementation/Runnable/RunnableReflectionHelpers.cs
@@ -11,7 +11,7 @@ namespace BenchmarkDotNet.Toolchains.InProcess.Emit.Implementation
         public const BindingFlags BindingFlagsNonPublicInstance = BindingFlags.NonPublic | BindingFlags.Instance;
         public const BindingFlags BindingFlagsPublicInstance = BindingFlags.Public | BindingFlags.Instance;
         public const BindingFlags BindingFlagsPublicStatic = BindingFlags.Public | BindingFlags.Static;
-        public const BindingFlags BindingFlagsAllStatic = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+        public const BindingFlags BindingFlagsAllStatic = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.FlattenHierarchy;
         public const BindingFlags BindingFlagsAllInstance = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
         private static object? TryChangeType(object? value, Type targetType)


### PR DESCRIPTION
This PR intended to fix #3118

**What's changed in this PR**

Add `BindingFlags.FlattenHierarchy` to reflection logics on `RunnableReflectionHelpers.SetParameter`.

Currently, it failed to resolve *inherited static* property/field on following lines.
https://github.com/dotnet/BenchmarkDotNet/blob/4cb07038f9f623479fa61d883ba2fe7585548266/src/BenchmarkDotNet/Toolchains/InProcess/Emit/Implementation/Runnable/RunnableReflectionHelpers.cs#L79-L86

By this change, It can resolve **inherited static** property/field.
https://learn.microsoft.com/en-us/dotnet/api/system.reflection.bindingflags?view=net-8.0#fields

### Test
Currently, test behavior is confirmed local environment.
I'll modify `ParamsTests` to use `InProcessToolchain` on another PR (Reduce CI execution time).