### PR TITLE
chore: Add setting to skip long running tests on draft PR

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,8 +3,12 @@ run-name: Run tests / ${{ github.event.head_commit.message }}
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
   workflow_dispatch:
+
+env:
+  IS_DRAFT_PR: ${{ github.event.pull_request.draft }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
@@ -24,6 +28,7 @@ jobs:
       - uses: ./.github/actions/add-windowsdefender-exclusions
       # Setup additional tools
       - name: Setup additional tools for Wasm/NativeAot tests
+        if: ${{ github.event.pull_request.draft != true }}
         uses: ./.github/actions/setup-additional-tools
       # Build and Test
       - name: Run task 'build'
@@ -66,6 +71,7 @@ jobs:
       - uses: ./.github/actions/add-windowsdefender-exclusions
       # Setup additional tools
       - name: Setup additional tools for Wasm/NativeAot tests
+        if: ${{ github.event.pull_request.draft != true }}
         uses: ./.github/actions/setup-additional-tools
       # Build and Test
       - name: Run task 'build'
@@ -105,6 +111,7 @@ jobs:
       - uses: actions/checkout@v6
       # Setup additional tools
       - name: Setup additional tools for Wasm/NativeAot tests
+        if: ${{ github.event.pull_request.draft != true }}
         uses: ./.github/actions/setup-additional-tools
       # Build and Test
       - name: Run task 'build'
@@ -145,6 +152,7 @@ jobs:
       - uses: actions/checkout@v6
       # Setup additional tools
       - name: Setup additional tools for Wasm/NativeAot tests
+        if: ${{ github.event.pull_request.draft != true }}
         uses: ./.github/actions/setup-additional-tools
       # Build and Test
       - name: Run task 'build'

--- a/tests/BenchmarkDotNet.IntegrationTests/ArgumentsTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ArgumentsTests.cs
@@ -11,11 +11,14 @@ namespace BenchmarkDotNet.IntegrationTests
     public class ArgumentsTests : BenchmarkTestExecutor
     {
         public static IEnumerable<object[]> GetToolchains()
-            =>
-                [
-                    [Job.Default.GetToolchain()],
-                    [InProcessEmitToolchain.Default],
-                ];
+        {
+            yield return [InProcessEmitToolchain.Default];
+
+            if (ContinuousIntegration.IsGitHubDraftPR())
+                yield break;
+
+            yield return [Job.Default.GetToolchain()];
+        }
 
         public ArgumentsTests(ITestOutputHelper output) : base(output) { }
 

--- a/tests/BenchmarkDotNet.IntegrationTests/CancellationTokenTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/CancellationTokenTests.cs
@@ -52,7 +52,7 @@ public class CancellationTokenTests(ITestOutputHelper output) : BenchmarkTestExe
         CanExecute<BenchmarkWithCancellationToken>(config);
     }
 
-    [TheoryEnvSpecific("JSVU does not support ARM on Windows or Linux", EnvRequirement.NonWindowsArm, EnvRequirement.NonLinuxArm)]
+    [TheoryEnvSpecific("JSVU does not support ARM on Windows or Linux", EnvRequirement.NonWindowsArm, EnvRequirement.NonLinuxArm, EnvRequirement.NonGitHubDraftPR)]
     [InlineData("v8")]
     [InlineData("node")]
     public void BenchmarkWithCancellationTokenProperty_ReceivesToken_Wasm(string javaScriptEngine)
@@ -116,7 +116,7 @@ public class CancellationTokenTests(ITestOutputHelper output) : BenchmarkTestExe
     }
 
     [Theory]
-    [InlineDataEnvSpecific("v8", "JSVU does not support ARM on Windows or Linux", [EnvRequirement.NonWindowsArm, EnvRequirement.NonLinuxArm])]
+    [InlineDataEnvSpecific("v8", "JSVU does not support ARM on Windows or Linux", [EnvRequirement.NonWindowsArm, EnvRequirement.NonLinuxArm, EnvRequirement.NonGitHubDraftPR])]
     [InlineData("node")]
     public async Task RunWithCancellationTokenIsCancelled_Wasm(string javaScriptEngine)
     {

--- a/tests/BenchmarkDotNet.IntegrationTests/ContinuousIntegration.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ContinuousIntegration.cs
@@ -1,4 +1,6 @@
 using BenchmarkDotNet.Detectors;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Tests.XUnit;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
@@ -10,5 +12,8 @@ namespace BenchmarkDotNet.IntegrationTests
             => OsDetector.IsWindows() && IsGitHubActions();
 
         internal static bool IsLocalRun() => !IsGitHubActions();
+
+        internal static bool IsGitHubDraftPR()
+           => EnvRequirementChecker.GetSkip(EnvRequirement.NonGitHubDraftPR).IsNotBlank();
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
@@ -25,6 +25,9 @@ namespace BenchmarkDotNet.IntegrationTests
         {
             yield return [JitInfo.GetCurrentJit(), RuntimeInformation.GetCurrentPlatform(), InProcessEmitToolchain.Default]; // InProcess
 
+            if (ContinuousIntegration.IsGitHubDraftPR())
+                yield break;
+
             if (RuntimeInformation.IsFullFramework)
             {
                 yield return [Jit.LegacyJit, Platform.X86, CsProjClassicNetToolchain.Net472]; // 32bit LegacyJit for desktop .NET

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -32,12 +32,14 @@ namespace BenchmarkDotNet.IntegrationTests
 
         public static IEnumerable<object[]> GetToolchains()
         {
-            yield return new object[] { Job.Default.GetToolchain() };
             // InProcessEmit reports flaky allocations in current .Net 8.
             if (!RuntimeInformation.IsNetCore)
-            {
                 yield return new object[] { InProcessEmitToolchain.Default };
-            }
+
+            if (ContinuousIntegration.IsGitHubDraftPR())
+                yield break;
+
+            yield return new object[] { Job.Default.GetToolchain() };
         }
 
         public class AccurateAllocations
@@ -68,7 +70,7 @@ namespace BenchmarkDotNet.IntegrationTests
             });
         }
 
-        [FactEnvSpecific("We don't want to test NativeAOT twice (for .NET Framework 4.6.2 and .NET 8.0)", EnvRequirement.DotNetCoreOnly)]
+        [FactEnvSpecific("We don't want to test NativeAOT twice (for .NET Framework 4.6.2 and .NET 8.0)", [EnvRequirement.DotNetCoreOnly, EnvRequirement.NonGitHubDraftPR])]
         public void MemoryDiagnoserSupportsNativeAOT()
         {
             if (OsDetector.IsMacOS())
@@ -77,13 +79,13 @@ namespace BenchmarkDotNet.IntegrationTests
             MemoryDiagnoserIsAccurate(NativeAotToolchain.Net80);
         }
 
-        [FactEnvSpecific("We don't want to test MonoVM twice (for .NET Framework 4.6.2 and .NET 8.0), and it's not supported on Windows+Arm", [EnvRequirement.DotNetCoreOnly, EnvRequirement.NonWindowsArm])]
+        [FactEnvSpecific("We don't want to test MonoVM twice (for .NET Framework 4.6.2 and .NET 8.0), and it's not supported on Windows+Arm", [EnvRequirement.DotNetCoreOnly, EnvRequirement.NonWindowsArm, EnvRequirement.NonGitHubDraftPR])]
         public void MemoryDiagnoserSupportsModernMono()
         {
             MemoryDiagnoserIsAccurate(MonoToolchain.Mono80);
         }
 
-        [TheoryEnvSpecific("JSVU does not support ARM on Windows or Linux", EnvRequirement.NonWindowsArm, EnvRequirement.NonLinuxArm)]
+        [TheoryEnvSpecific("JSVU does not support ARM on Windows or Linux", [EnvRequirement.NonWindowsArm, EnvRequirement.NonLinuxArm, EnvRequirement.NonGitHubDraftPR])]
         [InlineData(MonoAotCompilerMode.mini)]
         // BUG: https://github.com/dotnet/BenchmarkDotNet/issues/3036
         [InlineData(MonoAotCompilerMode.wasm, Skip = "AOT is broken")]

--- a/tests/BenchmarkDotNet.IntegrationTests/MonoTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MonoTests.cs
@@ -12,7 +12,7 @@ namespace BenchmarkDotNet.IntegrationTests
     {
         public MonoTests(ITestOutputHelper output) : base(output) { }
 
-        [FactEnvSpecific("UseMonoRuntime option is available in .NET Core only starting from .NET 6, and it's not supported on Windows+Arm", [EnvRequirement.DotNetCoreOnly, EnvRequirement.NonWindowsArm])]
+        [FactEnvSpecific("UseMonoRuntime option is available in .NET Core only starting from .NET 6, and it's not supported on Windows+Arm", [EnvRequirement.DotNetCoreOnly, EnvRequirement.NonWindowsArm, EnvRequirement.NonGitHubDraftPR])]
         public void Mono80IsSupported()
         {
             var logger = new OutputLogger(Output);

--- a/tests/BenchmarkDotNet.IntegrationTests/NativeAotTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/NativeAotTests.cs
@@ -33,7 +33,7 @@ namespace BenchmarkDotNet.IntegrationTests
                     .WithEnvironmentVariable(NativeAotBenchmark.EnvVarKey, IsAvx2Supported().ToString().ToLower()));
         }
 
-        [FactEnvSpecific("It's impossible to reliably detect the version of NativeAOT if the process is not a .NET Core or NativeAOT process", EnvRequirement.DotNetCoreOnly)]
+        [FactEnvSpecific("It's impossible to reliably detect the version of NativeAOT if the process is not a .NET Core or NativeAOT process", EnvRequirement.DotNetCoreOnly, EnvRequirement.NonGitHubDraftPR)]
         public void LatestNativeAotVersionIsSupported()
         {
             if (!GetShouldRunTest())
@@ -52,7 +52,7 @@ namespace BenchmarkDotNet.IntegrationTests
             }
         }
 
-        [FactEnvSpecific("It's impossible to reliably detect the version of NativeAOT if the process is not a .NET Core or NativeAOT process", EnvRequirement.DotNetCoreOnly)]
+        [FactEnvSpecific("It's impossible to reliably detect the version of NativeAOT if the process is not a .NET Core or NativeAOT process", EnvRequirement.DotNetCoreOnly, EnvRequirement.NonGitHubDraftPR)]
         public void NativeAotSupportsInProcessDiagnosers()
         {
             if (!GetShouldRunTest())

--- a/tests/BenchmarkDotNet.IntegrationTests/ParamSourceTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ParamSourceTests.cs
@@ -14,11 +14,14 @@ namespace BenchmarkDotNet.IntegrationTests
         public ParamSourceTests(ITestOutputHelper output) : base(output) { }
 
         public static IEnumerable<object[]> GetToolchains()
-            =>
-                [
-                    [Job.Default.GetToolchain()],
-                    [InProcessEmitToolchain.Default],
-                ];
+        {
+            yield return [InProcessEmitToolchain.Default];
+
+            if (ContinuousIntegration.IsGitHubDraftPR())
+                yield break;
+
+            yield return [Job.Default.GetToolchain()];
+        }
 
         [Fact]
         public void ParamSourceCanHandleStringWithSurrogates()

--- a/tests/BenchmarkDotNet.IntegrationTests/R2RTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/R2RTests.cs
@@ -54,7 +54,7 @@ namespace BenchmarkDotNet.IntegrationTests
 #endif
         }
 
-        [FactEnvSpecific("R2R requires .NET Core runtime", EnvRequirement.DotNetCoreOnly)]
+        [FactEnvSpecific("R2R requires .NET Core runtime", EnvRequirement.DotNetCoreOnly, EnvRequirement.NonGitHubDraftPR)]
         public void R2RToolchainCanExecuteBenchmarks()
         {
             try

--- a/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ThreadingDiagnoserTests.cs
@@ -13,6 +13,7 @@ using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using BenchmarkDotNet.Toolchains.NativeAot;
 using BenchmarkDotNet.Detectors;
 using BenchmarkDotNet.IntegrationTests.Xunit;
+using BenchmarkDotNet.Tests.XUnit;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
@@ -26,6 +27,9 @@ namespace BenchmarkDotNet.IntegrationTests
         {
             yield return new object[] { InProcessEmitToolchain.Default };
 
+            if (ContinuousIntegration.IsGitHubDraftPR())
+                yield break;
+
             yield return new object[] { Job.Default.GetToolchain() };
 
             if (!ContinuousIntegration.IsGitHubActionsOnWindows() // no native dependencies
@@ -35,7 +39,8 @@ namespace BenchmarkDotNet.IntegrationTests
             }
         }
 
-        [Theory, MemberData(nameof(GetToolchains), DisableDiscoveryEnumeration = true)]
+        [TheoryEnvSpecific(EnvRequirement.NonGitHubDraftPR)]
+        [MemberData(nameof(GetToolchains), DisableDiscoveryEnumeration = true)]
         public void CompletedWorkItemCountIsAccurate(IToolchain toolchain)
         {
             var config = CreateConfig(toolchain);
@@ -76,7 +81,8 @@ namespace BenchmarkDotNet.IntegrationTests
             public void DoNothing() { }
         }
 
-        [Theory, MemberData(nameof(GetToolchains), DisableDiscoveryEnumeration = true)]
+        [TheoryEnvSpecific(EnvRequirement.NonGitHubDraftPR)]
+        [MemberData(nameof(GetToolchains), DisableDiscoveryEnumeration = true)]
         public void LockContentionCountIsAccurate(IToolchain toolchain)
         {
             var config = CreateConfig(toolchain);

--- a/tests/BenchmarkDotNet.IntegrationTests/WasmTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/WasmTests.cs
@@ -23,7 +23,7 @@ namespace BenchmarkDotNet.IntegrationTests
     {
         private const string V8SkipReason = "JSVU does not support ARM on Windows or Linux";
 
-        [Theory]
+        [TheoryEnvSpecific(EnvRequirement.NonGitHubDraftPR)]
         [InlineDataEnvSpecific([MonoAotCompilerMode.mini, "v8"], V8SkipReason, [EnvRequirement.NonWindowsArm, EnvRequirement.NonLinuxArm])]
         [InlineData(MonoAotCompilerMode.mini, "node")]
         // BUG: https://github.com/dotnet/BenchmarkDotNet/issues/3036
@@ -34,7 +34,7 @@ namespace BenchmarkDotNet.IntegrationTests
             CanExecute<WasmBenchmark>(GetConfig(aotCompilerMode, javaScriptEngine));
         }
 
-        [Theory]
+        [TheoryEnvSpecific(EnvRequirement.NonGitHubDraftPR)]
         [InlineDataEnvSpecific([MonoAotCompilerMode.mini, "v8"], V8SkipReason, [EnvRequirement.NonWindowsArm, EnvRequirement.NonLinuxArm])]
         [InlineData(MonoAotCompilerMode.mini, "node")]
         // BUG: https://github.com/dotnet/BenchmarkDotNet/issues/3036
@@ -58,7 +58,7 @@ namespace BenchmarkDotNet.IntegrationTests
             }
         }
 
-        [Theory]
+        [TheoryEnvSpecific(EnvRequirement.NonGitHubDraftPR)]
         [InlineDataEnvSpecific(["v8", "custom-main-v8.mjs", WasmIpcType.FileStdOut], V8SkipReason, [EnvRequirement.NonWindowsArm, EnvRequirement.NonLinuxArm])]
         [InlineData("node", "custom-main-node.mjs", WasmIpcType.WebSocket)]
         public void WasmSupportsCustomMainJs(string javaScriptEngine, string customMainJs, WasmIpcType ipcType)

--- a/tests/BenchmarkDotNet.Tests/Shared/XUnit/EnvRequirement.cs
+++ b/tests/BenchmarkDotNet.Tests/Shared/XUnit/EnvRequirement.cs
@@ -10,5 +10,6 @@ public enum EnvRequirement
     FullFrameworkOnly,
     NonFullFramework,
     DotNetCoreOnly,
-    NeedsPrivilegedProcess
+    NeedsPrivilegedProcess,
+    NonGitHubDraftPR,
 }

--- a/tests/BenchmarkDotNet.Tests/Shared/XUnit/EnvRequirementChecker.cs
+++ b/tests/BenchmarkDotNet.Tests/Shared/XUnit/EnvRequirementChecker.cs
@@ -1,4 +1,5 @@
 using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Extensions;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using BdnRuntimeInformation = BenchmarkDotNet.Portability.RuntimeInformation;
@@ -20,6 +21,7 @@ public static class EnvRequirementChecker
         EnvRequirement.NonFullFramework => !BdnRuntimeInformation.IsFullFramework ? null : "Non-Full .NET Framework test",
         EnvRequirement.DotNetCoreOnly => BdnRuntimeInformation.IsNetCore ? null : ".NET/.NET Core-only test",
         EnvRequirement.NeedsPrivilegedProcess => IsPrivilegedProcess() ? null : "Needs authorization to perform security-relevant functions",
+        EnvRequirement.NonGitHubDraftPR => !IsGitHubDraftPR() ? null : "GitHub draft PR",
         _ => throw new ArgumentOutOfRangeException(nameof(requirement), requirement, "Unknown value")
     };
 
@@ -35,4 +37,11 @@ public static class EnvRequirementChecker
 
     private static bool IsArm()
         => BdnRuntimeInformation.GetCurrentPlatform() is Platform.Arm64 or Platform.Arm or Platform.Armv6;
+
+    /// <summary>
+    /// Check current test is running on GitHub Actions and PR is a draft PR.
+    /// </summary>
+    private static bool IsGitHubDraftPR()
+        => Environment.GetEnvironmentVariable("GITHUB_ACTION").IsNotBlank()
+        && Environment.GetEnvironmentVariable("IS_DRAFT_PR") == "true"; // `IS_DRAFT_PR` is set by CI workflow
 }


### PR DESCRIPTION
This PR intended to fix some part of #3088

#### What's changed in this PR

**1. Modify `run-tests.yaml` workflow**

- Add `ready_for_review` trigger on pull request event (Other values are default settings when `types` is omitted)
- Add `IS_DRAFT_PR` environment variable to detect draft PR
- Add setting to skip `setup-additional-tools` actions on draft PR 

**2. Add settings to skip tests on draft PR**
To skip Fact/Theory tests on draft PR.
I've added `EnvRequirement.NonGitHubDraftPR` and related logics.

**3. Add code to skip long-run tests on draft PR**

- ArgumentsTests.cs
- CancellationTokenTests.cs
- DisassemblyDiagnoserTests.cs
- MemoryDiagnoserTests.cs
- MonoTests.cs
- NativeAotTests.cs
- R2RTests.cs
- ThreadingDiagnoserTests.cs
- WasmTests.cs


