### PR TITLE
chore: Drop outdated TFMs from dotMemory/dotTrace projects

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.dotMemory/BenchmarkDotNet.Diagnostics.dotMemory.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.dotMemory/BenchmarkDotNet.Diagnostics.dotMemory.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\build\common.props" />
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net6.0;net462;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;net462</TargetFrameworks>
         <NoWarn>$(NoWarn);1591</NoWarn>
         <AssemblyTitle>BenchmarkDotNet.Diagnostics.dotMemory</AssemblyTitle>
         <AssemblyName>BenchmarkDotNet.Diagnostics.dotMemory</AssemblyName>

--- a/src/BenchmarkDotNet.Diagnostics.dotTrace/BenchmarkDotNet.Diagnostics.dotTrace.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.dotTrace/BenchmarkDotNet.Diagnostics.dotTrace.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\build\common.props" />
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net6.0;net462;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;net462</TargetFrameworks>
         <NoWarn>$(NoWarn);1591</NoWarn>
         <AssemblyTitle>BenchmarkDotNet.Diagnostics.dotTrace</AssemblyTitle>
         <AssemblyName>BenchmarkDotNet.Diagnostics.dotTrace</AssemblyName>


### PR DESCRIPTION
This PR intended to fix #2947

Drop `netcoreapp3.1`/`net6.0` TFMs supports from dotMemory/dotTrace projects based on following comment.
https://github.com/dotnet/BenchmarkDotNet/issues/2947#issuecomment-3877167953 