### PR TITLE
chore: Reduce CI execution time by changing some tests to use InProcessToolchain

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/AsyncBenchmarksTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/AsyncBenchmarksTests.cs
@@ -46,7 +46,8 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void TaskReturningMethodsAreAwaited()
         {
-            var summary = CanExecute<TaskDelayMethods>();
+            var config = new SingleRunInProcessConfig(Output);
+            var summary = CanExecute<TaskDelayMethods>(config);
 
             foreach (var report in summary.Reports)
                 foreach (var measurement in report.AllMeasurements)

--- a/tests/BenchmarkDotNet.IntegrationTests/AttributesTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/AttributesTests.cs
@@ -9,7 +9,9 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void AttributesAreNotSealed()
         {
-            CanExecute<ConsumingCustomAttributes>();
+            var config = new SingleRunInProcessConfig(Output);
+
+            CanExecute<ConsumingCustomAttributes>(config);
         }
 
         public class ConsumingCustomAttributes

--- a/tests/BenchmarkDotNet.IntegrationTests/BaselineRatioColumnTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/BaselineRatioColumnTest.cs
@@ -14,9 +14,11 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void ColumnsWithBaselineGetsRatio()
         {
+            var config = new SingleRunInProcessConfig(Output);
+
             // This is the common way to run benchmarks,
             // BenchmarkTestExecutor.CanExecute(..) calls BenchmarkRunner.Run(..) under the hood
-            var summary = CanExecute<BaselineRatioColumnBenchmarks>();
+            var summary = CanExecute<BaselineRatioColumnBenchmarks>(config);
 
             var table = summary.Table;
             var headerRow = table.FullHeader;
@@ -59,7 +61,7 @@ namespace BenchmarkDotNet.IntegrationTests
         public void Test()
         {
             var testExporter = new TestExporter();
-            var config = CreateSimpleConfig().AddExporter(testExporter);
+            var config = new SingleRunInProcessConfig(Output).AddExporter(testExporter);
 
             CanExecute<BaselineRatioResultExtenderNoBaseline>(config);
 
@@ -97,7 +99,9 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void OnlyOneMethodCanBeBaseline()
         {
-            var summary = CanExecute<BaselineRatioResultExtenderError>(fullValidation: false);
+            var config = new SingleRunInProcessConfig(Output);
+
+            var summary = CanExecute<BaselineRatioResultExtenderError>(config, fullValidation: false);
 
             // You can't have more than 1 method in a class with [Benchmark(Baseline = true)]
             Assert.True(summary.HasCriticalValidationErrors);
@@ -122,7 +126,9 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void ColumnsWithBaselineGetsRatio()
         {
-            var summary = CanExecute<BaselineRatioColumnWithLongParams>(fullValidation: false);
+            var config = new SingleRunInProcessConfig(Output);
+
+            var summary = CanExecute<BaselineRatioColumnWithLongParams>(config, fullValidation: false);
 
             // Ensure that Params attribute values will not affect Baseline property
             Assert.False(summary.HasCriticalValidationErrors);

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkSwitcherTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkSwitcherTest.cs
@@ -20,13 +20,19 @@ namespace BenchmarkDotNet.IntegrationTests
 
         public BenchmarkSwitcherTest(ITestOutputHelper output) => Output = output;
 
+        private IConfig GetRunInProcessConfig()
+            => new SingleRunInProcessConfig(Output);
+
+        private IConfig GetRunOutOfProcessConfig()
+           => new SingleRunOutOfProcessConfig(Output);
+
         [FactEnvSpecific(
             "When CommandLineParser wants to display help, it tries to get the Title of the Entry Assembly which is an xunit runner, which has no Title and fails..",
             EnvRequirement.DotNetCoreOnly)]
         public void WhenInvalidCommandLineArgumentIsPassedAnErrorMessageIsDisplayedAndNoBenchmarksAreExecuted()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
+            var config = GetRunInProcessConfig();
+            var logger = config.GetOutputLogger();
 
             var summaries = BenchmarkSwitcher
                 .FromTypes([])
@@ -39,8 +45,8 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void WhenUserAsksForInfoAnInfoIsDisplayedAndNoBenchmarksAreExecuted()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
+            var config = GetRunInProcessConfig();
+            var logger = config.GetOutputLogger();
 
             var summaries = BenchmarkSwitcher
                 .FromTypes([])
@@ -53,8 +59,8 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void WhenInvalidTypeIsProvidedAnErrorMessageIsDisplayedAndNoBenchmarksAreExecuted()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
+            var config = GetRunInProcessConfig();
+            var logger = config.GetOutputLogger();
 
             var summaries = BenchmarkSwitcher
                 .FromTypes([typeof(ClassC)])
@@ -67,8 +73,8 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void WhenNoTypesAreProvidedAnErrorMessageIsDisplayedAndNoBenchmarksAreExecuted()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
+            var config = GetRunInProcessConfig();
+            var logger = config.GetOutputLogger();
 
             var summaries = BenchmarkSwitcher
                 .FromTypes([])
@@ -81,8 +87,8 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void WhenFilterReturnsNothingAnErrorMessageIsDisplayedAndNoBenchmarksAreExecuted()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
+            var config = GetRunInProcessConfig();
+            var logger = config.GetOutputLogger();
 
             const string filter = "WRONG";
             var summaries = BenchmarkSwitcher
@@ -96,8 +102,8 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void WhenUserAsksToPrintAListWePrintIt()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
+            var config = GetRunInProcessConfig();
+            var logger = config.GetOutputLogger();
 
             var summaries = BenchmarkSwitcher
                 .FromTypes([typeof(ClassA)])
@@ -111,8 +117,8 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void WhenUserAsksToPrintAListAndProvidesAFilterWePrintFilteredList()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
+            var config = GetRunInProcessConfig();
+            var logger = config.GetOutputLogger();
 
             var summaries = BenchmarkSwitcher
                 .FromTypes([typeof(ClassA)])
@@ -127,8 +133,7 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void WhenDisableLogFileWeDontWriteToFile()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger).WithOptions(ConfigOptions.DisableLogFile).AddJob(Job.Dry);
+            var config = GetRunInProcessConfig().WithOptions(ConfigOptions.DisableLogFile);
 
             string? logFilePath = null;
             try
@@ -153,8 +158,7 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void EnsureLogFileIsWritten()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger).AddJob(Job.Dry);
+            var config = GetRunInProcessConfig();
 
             string? logFilePath = null;
             try
@@ -179,12 +183,11 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void WhenUserDoesNotProvideFilterOrCategoriesViaCommandLineWeAskToChooseBenchmark()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
+            var config = GetRunInProcessConfig();
             var userInteractionMock = new UserInteractionMock(returnValue: []);
 
             var summaries = new BenchmarkSwitcher(userInteractionMock)
-                .With([typeof(WithDryAttributeAndCategory)])
+                .With([typeof(WithCategory)])
                 .Run([], config);
 
             Assert.Empty(summaries); // summaries is empty because the returnValue configured for mock returns 0 types
@@ -196,9 +199,8 @@ namespace BenchmarkDotNet.IntegrationTests
         [InlineData("--anyCategories")]
         public void WhenUserProvidesCategoriesWithoutFiltersWeDontAskToChooseBenchmarkJustRunGivenCategories(string categoriesConsoleLineArgument)
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
-            var types = new[] { typeof(WithDryAttributeAndCategory) };
+            var config = GetRunInProcessConfig();
+            var types = new[] { typeof(WithCategory) };
             var userInteractionMock = new UserInteractionMock(returnValue: types);
 
             var summaries = new BenchmarkSwitcher(userInteractionMock)
@@ -214,9 +216,8 @@ namespace BenchmarkDotNet.IntegrationTests
         [InlineData("--anyCategories")]
         public void WhenUserProvidesCategoriesWithFiltersWeDontAskToChooseBenchmarkJustUseCombinedFilterAndRunTheBenchmarks(string categoriesConsoleLineArgument)
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
-            var types = new[] { typeof(WithDryAttributeAndCategory) };
+            var config = GetRunInProcessConfig();
+            var types = new[] { typeof(WithCategory) };
             var userInteractionMock = new UserInteractionMock(returnValue: types);
 
             var summaries = new BenchmarkSwitcher(userInteractionMock)
@@ -230,8 +231,7 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void ValidCommandLineArgumentsAreProperlyHandled()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
+            var config = GetRunOutOfProcessConfig();
 
             // Don't cover every combination, just pick a complex scenario and check
             // it works end-to-end, i.e. "method=Method1" and "class=ClassB"
@@ -253,7 +253,7 @@ namespace BenchmarkDotNet.IntegrationTests
             var types = new[] { typeof(ClassB) };
             var switcher = new BenchmarkSwitcher(types);
             MockExporter mockExporter = new MockExporter();
-            var configWithJobDefined = ManualConfig.CreateEmpty().AddExporter(mockExporter).AddJob(Job.Dry);
+            var configWithJobDefined = GetRunInProcessConfig().AddExporter(mockExporter);
 
             var results = switcher.Run(["--filter", "*Method3"], configWithJobDefined);
 
@@ -262,7 +262,7 @@ namespace BenchmarkDotNet.IntegrationTests
             Assert.Single(results);
             Assert.Single(results.SelectMany(r => r.BenchmarksCases));
             Assert.Single(results.SelectMany(r => r.BenchmarksCases.Select(bc => bc.Job)));
-            Assert.True(results.All(r => r.BenchmarksCases.All(bc => bc.Job == Job.Dry)));
+            Assert.True(results.All(r => r.BenchmarksCases.All(bc => bc.Job.Id == "Dry")));
         }
 
         [Fact]
@@ -271,7 +271,7 @@ namespace BenchmarkDotNet.IntegrationTests
             var types = new[] { typeof(WithDryAttributeAndCategory) };
             var switcher = new BenchmarkSwitcher(types);
             MockExporter mockExporter = new MockExporter();
-            var configWithoutJobDefined = ManualConfig.CreateEmpty().AddExporter(mockExporter);
+            var configWithoutJobDefined = GetRunOutOfProcessConfig().AddExporter(mockExporter);
 
             var results = switcher.Run(["--filter", "*WithDryAttribute*"], configWithoutJobDefined);
 
@@ -289,7 +289,7 @@ namespace BenchmarkDotNet.IntegrationTests
             var types = new[] { typeof(JustBenchmark) };
             var switcher = new BenchmarkSwitcher(types);
             MockExporter mockExporter = new MockExporter();
-            var configWithoutJobDefined = ManualConfig.CreateEmpty().AddExporter(mockExporter);
+            var configWithoutJobDefined = GetRunOutOfProcessConfig().AddExporter(mockExporter);
 
             var results = switcher.Run(["--filter", "*"], configWithoutJobDefined);
 
@@ -304,8 +304,8 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void WhenUserCreatesStaticBenchmarkMethodWeDisplayAnError_FromTypes()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
+            var config = GetRunInProcessConfig();
+            var logger = config.GetOutputLogger();
 
             var summariesForType = BenchmarkSwitcher
                 .FromTypes([typeof(Static.BenchmarkClassWithStaticMethodsOnly)])
@@ -318,8 +318,8 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void WhenUserCreatesStaticBenchmarkMethodWeDisplayAnError_FromAssembly()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
+            var config = GetRunInProcessConfig();
+            var logger = config.GetOutputLogger();
 
             var summariesForAssembly = BenchmarkSwitcher
                 .FromAssembly(typeof(Static.BenchmarkClassWithStaticMethodsOnly).Assembly)
@@ -332,16 +332,15 @@ namespace BenchmarkDotNet.IntegrationTests
         [FactEnvSpecific("For some reason this test is flaky on Full Framework", EnvRequirement.DotNetCoreOnly)]
         public void WhenUserAddTheResumeAttributeAndRunTheBenchmarks()
         {
-            var logger = new OutputLogger(Output);
-            var config = ManualConfig.CreateEmpty().AddLogger(logger);
+            var config = GetRunOutOfProcessConfig().AddJob(Job.Dry);
 
-            var types = new[] { typeof(WithDryAttributeAndCategory) };
+            var types = new[] { typeof(WithCategory) };
             var switcher = new BenchmarkSwitcher(types);
 
             // the first run should execute all benchmarks
-            Assert.Single(switcher.Run(["--filter", "*WithDryAttributeAndCategory*"], config));
+            Assert.Single(switcher.Run(["--filter", "*WithCategory*"], config));
             // resuming after succesfull run should run nothing
-            Assert.Empty(switcher.Run(["--resume", "--filter", "*WithDryAttributeAndCategory*"], config));
+            Assert.Empty(switcher.Run(["--resume", "--filter", "*WithCategory*"], config));
         }
 
         private class UserInteractionMock : IUserInteraction
@@ -369,6 +368,12 @@ namespace BenchmarkDotNet.IntegrationTests
         {
             return $"No [Benchmark] attribute found on '{type.Name}' benchmark case.";
         }
+    }
+
+    file static class ExtensionMethods
+    {
+        public static OutputLogger GetOutputLogger(this IConfig config)
+            => (OutputLogger)config.GetLoggers().Single();
     }
 }
 
@@ -400,6 +405,13 @@ namespace BenchmarkDotNet.IntegrationTests
         public void Method1() { }
         public void Method2() { }
         public void Method3() { }
+    }
+
+    [BenchmarkCategory(BenchmarkSwitcherTest.TestCategory)]
+    public class WithCategory
+    {
+        [Benchmark]
+        public void Method() { }
     }
 
     [DryJob]

--- a/tests/BenchmarkDotNet.IntegrationTests/Helpers/CaptureConsoleHelper.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/Helpers/CaptureConsoleHelper.cs
@@ -1,0 +1,27 @@
+using System.Text;
+
+namespace BenchmarkDotNet.IntegrationTests;
+
+internal class CaptureConsoleHelper : IDisposable
+{
+    private readonly TextWriter originalOut;
+    private readonly StringWriter writer = new(new StringBuilder());
+
+    public CaptureConsoleHelper()
+    {
+        originalOut = Console.Out;
+        Console.SetOut(writer);
+    }
+
+    public void Dispose()
+    {
+        Console.SetOut(originalOut);
+        writer.Dispose();
+    }
+
+    public string CapturedText
+       => writer.ToString();
+
+    public IReadOnlyList<string> CapturedLines
+        => CapturedText.Split(["\r\n", "\n"], StringSplitOptions.None);
+}

--- a/tests/BenchmarkDotNet.IntegrationTests/ParamsTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ParamsTests.cs
@@ -1,4 +1,6 @@
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Toolchains;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
@@ -6,11 +8,36 @@ namespace BenchmarkDotNet.IntegrationTests
     {
         public ParamsTests(ITestOutputHelper output) : base(output) { }
 
+        private IConfig? GetConfig()
+            => new SingleRunInProcessConfig(Output); // Use `null` when running test with out-of-process toolchain.
+
+        private IReadOnlyList<string> Execute<T>()
+        {
+            var config = GetConfig();
+
+            bool isInProcess = config == null
+                ? false
+                : config.GetJobs().Single().GetToolchain().IsInProcess;
+
+            if (isInProcess)
+            {
+                // When using inprocess toolchain, Report don't contains StandardOutput.
+                using var captureConsoleHelper = new CaptureConsoleHelper();
+                CanExecute<T>(config);
+                return captureConsoleHelper.CapturedLines; // CapturedLines contains benchmark execution logs also.
+            }
+            else
+            {
+                // Use following code when running test with out-of-process.
+                var summary = CanExecute<T>();
+                return GetCombinedStandardOutput(summary);
+            }
+        }
+
         [Fact]
         public void ParamsSupportPropertyWithPublicSetter()
         {
-            var summary = CanExecute<ParamsTestProperty>();
-            var standardOutput = GetCombinedStandardOutput(summary);
+            var standardOutput = Execute<ParamsTestProperty>();
 
             foreach (var param in new[] { 1, 2 })
                 Assert.Contains($"// ### New Parameter {param} ###", standardOutput);
@@ -30,8 +57,7 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void ParamsSupportPublicFields()
         {
-            var summary = CanExecute<ParamsTestField>();
-            var standardOutput = GetCombinedStandardOutput(summary);
+            var standardOutput = Execute<ParamsTestField>();
 
             foreach (var param in new[] { 1, 2 })
                 Assert.Contains($"// ### New Parameter {param} ###", standardOutput);
@@ -54,7 +80,10 @@ namespace BenchmarkDotNet.IntegrationTests
         }
 
         [Fact]
-        public void NestedEnumsAsParamsAreSupported() => CanExecute<NestedEnumsAsParams>();
+        public void NestedEnumsAsParamsAreSupported()
+        {
+            Execute<NestedEnumsAsParams>();
+        }
 
         public class NestedEnumsAsParams
         {
@@ -66,7 +95,8 @@ namespace BenchmarkDotNet.IntegrationTests
         }
 
         [Fact]
-        public void CharactersAsParamsAreSupported() => CanExecute<CharactersAsParams>();
+        public void CharactersAsParamsAreSupported()
+            => Execute<CharactersAsParams>();
 
         public class CharactersAsParams
         {
@@ -78,7 +108,8 @@ namespace BenchmarkDotNet.IntegrationTests
         }
 
         [Fact]
-        public void NullableTypesAsParamsAreSupported() => CanExecute<NullableTypesAsParams>();
+        public void NullableTypesAsParamsAreSupported()
+            => Execute<NullableTypesAsParams>();
 
         public class NullableTypesAsParams
         {
@@ -93,7 +124,8 @@ namespace BenchmarkDotNet.IntegrationTests
         }
 
         [Fact]
-        public void InvalidFileNamesInParamsAreSupported() => CanExecute<InvalidFileNamesInParams>();
+        public void InvalidFileNamesInParamsAreSupported()
+            => Execute<InvalidFileNamesInParams>();
 
         public class InvalidFileNamesInParams
         {
@@ -105,7 +137,8 @@ namespace BenchmarkDotNet.IntegrationTests
         }
 
         [Fact]
-        public void SpecialCharactersInStringAreSupported() => CanExecute<CompileSpecialCharactersInString>();
+        public void SpecialCharactersInStringAreSupported()
+            => Execute<CompileSpecialCharactersInString>();
 
         public class CompileSpecialCharactersInString
         {
@@ -140,7 +173,8 @@ namespace BenchmarkDotNet.IntegrationTests
         }
 
         [Fact]
-        public void SpecialCharactersInCharAreSupported() => CanExecute<CompileSpecialCharactersInChar>();
+        public void SpecialCharactersInCharAreSupported()
+            => Execute<CompileSpecialCharactersInChar>();
 
         public class CompileSpecialCharactersInChar
         {
@@ -156,7 +190,8 @@ namespace BenchmarkDotNet.IntegrationTests
         }
 
         [Fact]
-        public void ParamsMustBeEscapedProperly() => CanExecute<NeedEscaping>();
+        public void ParamsMustBeEscapedProperly()
+            => Execute<NeedEscaping>();
 
         public class NeedEscaping
         {
@@ -175,7 +210,8 @@ namespace BenchmarkDotNet.IntegrationTests
         }
 
         [Fact]
-        public void ArrayCanBeUsedAsParameter() => CanExecute<WithArray>();
+        public void ArrayCanBeUsedAsParameter()
+            => Execute<WithArray>();
 
         public class WithArray
         {
@@ -195,7 +231,8 @@ namespace BenchmarkDotNet.IntegrationTests
         }
 
         [Fact]
-        public void StaticFieldsAndPropertiesCanBeParams() => CanExecute<WithStaticParams>();
+        public void StaticFieldsAndPropertiesCanBeParams()
+            => Execute<WithStaticParams>();
 
         public class WithStaticParams
         {
@@ -219,8 +256,7 @@ namespace BenchmarkDotNet.IntegrationTests
         [Fact]
         public void ParamsSupportRequiredProperty()
         {
-            var summary = CanExecute<ParamsTestRequiredProperty>();
-            var standardOutput = GetCombinedStandardOutput(summary);
+            var standardOutput = Execute<ParamsTestRequiredProperty>();
 
             foreach (var param in new[] { "a", "b" })
             {

--- a/tests/BenchmarkDotNet.IntegrationTests/Shared/TestConfigs.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/Shared/TestConfigs.cs
@@ -1,6 +1,10 @@
+using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Tests.Loggers;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
@@ -42,6 +46,31 @@ namespace BenchmarkDotNet.IntegrationTests
         {
             // Diagnosers need enough runs to collects the statistics!
             AddJob(new Job { Run = { LaunchCount = 1, WarmupCount = 1, IterationCount = 50 } });
+        }
+    }
+
+    public class SingleRunInProcessConfig : ManualConfig
+    {
+        public SingleRunInProcessConfig(ITestOutputHelper? output = null, bool addDryJob = true)
+        {
+            AddAnalyser(DefaultConfig.Instance.GetAnalysers().ToArray());
+            AddColumnProvider(DefaultColumnProviders.Instance);
+            AddLogger(output != null ? new OutputLogger(output) : ConsoleLogger.Default);
+
+            var job = Job.Dry
+                         .WithStrategy(RunStrategy.Monitoring)
+                         .WithToolchain(InProcessEmitToolchain.Default);
+            AddJob(job);
+        }
+    }
+
+    public class SingleRunOutOfProcessConfig : ManualConfig
+    {
+        public SingleRunOutOfProcessConfig(ITestOutputHelper? output = null)
+        {
+            AddAnalyser(DefaultConfig.Instance.GetAnalysers().ToArray());
+            AddColumnProvider(DefaultColumnProviders.Instance);
+            AddLogger(output != null ? new OutputLogger(output) : ConsoleLogger.Default);
         }
     }
 }


### PR DESCRIPTION
This PR intended to reduce CI execution time by using `InProcessToolchain` when possible.

### What's changed in this PR

**1. Add shared configs to `TestConfigs.cs`**
Add following test configs that used for faster test execution.
- SingleRunInProcessConfig
- SingleRunOutOfProcessConfig

**2. Add `Helpers/CaptureConsoleHelper.cs`**
This helper class is used to capture console logs that are outputted by benchmark.

It's required because `StandardOutput` is not recorded to Summary/Report instance. when running benchmark with `InProcessToolchain`.

As a side effect, captured log contains benchmark execution logs also.
Though, It's not affects test results when assert contents line by line.

**3. Modify some test code to use `InProcessToolchain`**

Modify following tests to use `SingleRunInProcessConfig` when possible
- AsyncBenchmarksTests
- AttributesTests
- BaselineRatioColumnTest
- BenchmarkSwitcherTest (Partially)
- ParamsTests

**4. Modify some test code to use `SingleRunOutOfProcessConfig`**
Some `BenchmarkSwitcherTest` tests can't convert to use `InProcessToolchain` by following reason.
- Test that using `[DryJob]` attribute. 
- Test that pass `--job` command line argument.
- Test that using `--resume` option (It seems not works because InProcessToolchain don't output logs for resume) 

So these test need to use `SingleRunOutOfProcessConfig` instead. (It's basically same behavior as original code)