### PR TITLE
chore: Fix regression of PowershellWmiCpuDetector

### DIFF
--- a/src/BenchmarkDotNet/Detectors/Cpu/Windows/CpuInfoParser.cs
+++ b/src/BenchmarkDotNet/Detectors/Cpu/Windows/CpuInfoParser.cs
@@ -5,17 +5,27 @@ using Perfolizer.Models;
 
 namespace BenchmarkDotNet.Detectors.Cpu.Windows;
 
-internal static class WmiCpuInfoParser
+internal static class CpuInfoParser
 {
+    /// <summary>
+    /// Parses Get-CimInstance output and returns <see cref="CpuInfo"/>
+    /// </summary>
+    internal static CpuInfo ParseCimOutput(string cimOutput)
+    {
+        var processorSections = SectionsHelper.ParseSectionsForPowershellWmi(cimOutput, ':');
+        return ParseCore(processorSections);
+    }
+
     /// <summary>
     /// Parses wmic output and returns <see cref="CpuInfo"/>
     /// </summary>
-    /// <param name="wmiOutput">
-    /// Output of `wmic cpu get Name, NumberOfCores, NumberOfLogicalProcessors /Format:List`
-    /// or
-    /// Output of `Get-CimInstance Win32_Processor -Property Name, NumberOfCores, NumberOfLogicalProcessors`
-    /// </param>
-    internal static CpuInfo Parse(string wmiOutput)
+    internal static CpuInfo ParseWmicOutput(string wmicOutput)
+    {
+        var processorSections = SectionsHelper.ParseSections(wmicOutput, '=');
+        return ParseCore(processorSections);
+    }
+
+    private static CpuInfo ParseCore(List<Dictionary<string, string>> processors)
     {
         HashSet<string> processorModelNames = [];
         int physicalCoreCount = 0;
@@ -24,7 +34,6 @@ internal static class WmiCpuInfoParser
         double maxFrequency = 0.0;
         double nominalFrequency = 0.0;
 
-        List<Dictionary<string, string>> processors = SectionsHelper.ParseSections(wmiOutput, '=');
         foreach (var processor in processors)
         {
             if (processor.TryGetValue(WmiCpuInfoKeyNames.NumberOfCores, out var numberOfCoresValue) &&

--- a/src/BenchmarkDotNet/Detectors/Cpu/Windows/PowershellWmiCpuDetector.cs
+++ b/src/BenchmarkDotNet/Detectors/Cpu/Windows/PowershellWmiCpuDetector.cs
@@ -6,7 +6,7 @@ using System.Runtime.Versioning;
 namespace BenchmarkDotNet.Detectors.Cpu.Windows;
 
 /// <summary>
-/// CPU information from output of the `Get-CimInstance Win32_Processor -Property Name, NumberOfCores, NumberOfLogicalProcessors` command.
+/// CPU information from output of the `Get-CimInstance Win32_Processor -Property Name, NumberOfCores, NumberOfLogicalProcessors, MaxClockSpeed` command.
 /// Windows only.
 /// </summary>
 internal class PowershellWmiCpuDetector : ICpuDetector
@@ -24,11 +24,11 @@ internal class PowershellWmiCpuDetector : ICpuDetector
                                $"{WmiCpuInfoKeyNames.MaxClockSpeed}";
 
         string? output = ProcessHelper.RunAndReadOutput(PowerShellLocator.LocateOnWindows() ?? "PowerShell",
-            "Get-CimInstance Win32_Processor -Property " + argList);
+            $"Get-CimInstance Win32_Processor -Property {argList} | Format-List {argList}");
 
         if (output.IsBlank())
             return null;
 
-        return WmiCpuInfoParser.Parse(output);
+        return CpuInfoParser.ParseCimOutput(output);
     }
 }

--- a/src/BenchmarkDotNet/Detectors/Cpu/Windows/WmicCpuDetector.cs
+++ b/src/BenchmarkDotNet/Detectors/Cpu/Windows/WmicCpuDetector.cs
@@ -5,7 +5,7 @@ using Perfolizer.Models;
 namespace BenchmarkDotNet.Detectors.Cpu.Windows;
 
 /// <summary>
-/// CPU information from output of the `wmic cpu get Name, NumberOfCores, NumberOfLogicalProcessors /Format:List` command.
+/// CPU information from output of the `wmic cpu get Name, NumberOfCores, NumberOfLogicalProcessors, MaxClockSpeed /Format:List` command.
 /// Windows only.
 /// </summary>
 /// <remarks>
@@ -34,6 +34,6 @@ internal class WmicCpuDetector : ICpuDetector
         if (wmicOutput.IsBlank())
             return null;
 
-        return WmiCpuInfoParser.Parse(wmicOutput);
+        return CpuInfoParser.ParseWmicOutput(wmicOutput);
     }
 }

--- a/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
+++ b/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
@@ -58,7 +58,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Detectors\" />
     <Folder Include="Perfonar\VerifiedFiles\" />
   </ItemGroup>
   <Import Project="..\..\build\common.targets" />

--- a/tests/BenchmarkDotNet.Tests/Detectors/Cpu/CpuInfoParserTests_Cim.cs
+++ b/tests/BenchmarkDotNet.Tests/Detectors/Cpu/CpuInfoParserTests_Cim.cs
@@ -1,0 +1,119 @@
+using BenchmarkDotNet.Detectors.Cpu.Windows;
+using Perfolizer.Models;
+
+namespace BenchmarkDotNet.Tests.Detectors.Cpu;
+
+public class CimCpuInfoParserTests_Cim(ITestOutputHelper output)
+{
+    private ITestOutputHelper Output { get; } = output;
+
+
+    [Fact]
+    public void EmptyTest()
+    {
+        CpuInfo? actual = CpuInfoParser.ParseCimOutput(string.Empty);
+        CpuInfo expected = new CpuInfo();
+        Output.AssertEqual(expected, actual);
+    }
+
+
+    [Fact]
+    public void MalformedTest()
+    {
+        CpuInfo? actual = CpuInfoParser.ParseCimOutput("malformedkey=malformedvalue\n\nmalformedkey2=malformedvalue2");
+        CpuInfo expected = new CpuInfo();
+        Output.AssertEqual(expected, actual);
+    }
+
+    [Fact]
+    public void RealTwoProcessorEightCoresTest()
+    {
+        const string cpuInfo =
+            """
+            MaxClockSpeed:2400
+            Name:Intel(R) Xeon(R) CPU E5-2630 v3
+            NumberOfCores:8
+            NumberOfLogicalProcessors:16
+                            
+                          
+            MaxClockSpeed:2400
+            Name:Intel(R) Xeon(R) CPU E5-2630 v3
+            NumberOfCores:8
+            NumberOfLogicalProcessors:16
+            
+            """;
+        CpuInfo? actual = CpuInfoParser.ParseCimOutput(cpuInfo);
+
+        CpuInfo expected = new CpuInfo
+        {
+            ProcessorName = "Intel(R) Xeon(R) CPU E5-2630 v3",
+            PhysicalProcessorCount = 2,
+            PhysicalCoreCount = 16,
+            LogicalCoreCount = 32,
+            NominalFrequencyHz = 2_400_000_000,
+            MaxFrequencyHz = 2_400_000_000,
+        };
+
+        Output.AssertEqual(expected, actual);
+    }
+
+    [Fact]
+    public void RealTwoProcessorEightCoresWithWmicBugTest()
+    {
+        const string cpuInfo =
+            "\r\r\n" +
+            "\r\r\n" +
+            "MaxClockSpeed:3111\r\r\n" +
+            "Name:Intel(R) Xeon(R) CPU E5-2687W 0\r\r\n" +
+            "NumberOfCores:8\r\r\n" +
+            "NumberOfLogicalProcessors:16\r\r\n" +
+            "\r\r\n" +
+            "\r\r\n" +
+            "MaxClockSpeed:3111\r\r\n" +
+            "Name:Intel(R) Xeon(R) CPU E5-2687W 0\r\r\n" +
+            "NumberOfCores:8\r\r\n" +
+            "NumberOfLogicalProcessors:16\r\r\n" +
+            "\r\r\n" +
+            "\r\r\n" +
+            "\r\r\n";
+
+        CpuInfo? actual = CpuInfoParser.ParseCimOutput(cpuInfo);
+
+        CpuInfo expected = new CpuInfo
+        {
+            ProcessorName = "Intel(R) Xeon(R) CPU E5-2687W 0",
+            PhysicalProcessorCount = 2,
+            PhysicalCoreCount = 16,
+            LogicalCoreCount = 32,
+            NominalFrequencyHz = 3_111_000_000,
+            MaxFrequencyHz = 3_111_000_000,
+        };
+
+        Output.AssertEqual(expected, actual);
+    }
+
+    [Fact]
+    public void RealOneProcessorFourCoresTest()
+    {
+        const string cpuInfo = """
+
+            MaxClockSpeed:2500
+            Name:Intel(R) Core(TM) i7-4710MQ
+            NumberOfCores:4
+            NumberOfLogicalProcessors:8
+            """;
+
+        CpuInfo? actual = CpuInfoParser.ParseCimOutput(cpuInfo);
+        CpuInfo expected = new CpuInfo
+        {
+            ProcessorName = "Intel(R) Core(TM) i7-4710MQ",
+            PhysicalProcessorCount = 1,
+            PhysicalCoreCount = 4,
+            LogicalCoreCount = 8,
+            NominalFrequencyHz = 2_500_000_000,
+            MaxFrequencyHz = 2_500_000_000,
+        };
+
+        Output.AssertEqual(expected, actual);
+    }
+}

--- a/tests/BenchmarkDotNet.Tests/Detectors/Cpu/CpuInfoParserTests_Wmic.cs
+++ b/tests/BenchmarkDotNet.Tests/Detectors/Cpu/CpuInfoParserTests_Wmic.cs
@@ -4,14 +4,14 @@ using Perfolizer.Models;
 namespace BenchmarkDotNet.Tests.Detectors.Cpu;
 
 // ReSharper disable StringLiteralTypo
-public class WmiCpuInfoParserTests(ITestOutputHelper output)
+public class WmiCpuInfoParserTests_Wmic(ITestOutputHelper output)
 {
     private ITestOutputHelper Output { get; } = output;
 
     [Fact]
     public void EmptyTest()
     {
-        var actual = WmiCpuInfoParser.Parse(string.Empty);
+        var actual = CpuInfoParser.ParseWmicOutput(string.Empty);
         var expected = new CpuInfo();
         Output.AssertEqual(expected, actual);
     }
@@ -19,7 +19,7 @@ public class WmiCpuInfoParserTests(ITestOutputHelper output)
     [Fact]
     public void MalformedTest()
     {
-        var actual = WmiCpuInfoParser.Parse("malformedkey=malformedvalue\n\nmalformedkey2=malformedvalue2");
+        var actual = CpuInfoParser.ParseWmicOutput("malformedkey=malformedvalue\n\nmalformedkey2=malformedvalue2");
         var expected = new CpuInfo();
         Output.AssertEqual(expected, actual);
     }
@@ -41,7 +41,7 @@ public class WmiCpuInfoParserTests(ITestOutputHelper output)
             NumberOfLogicalProcessors=16
 
             """;
-        var actual = WmiCpuInfoParser.Parse(cpuInfo);
+        var actual = CpuInfoParser.ParseWmicOutput(cpuInfo);
         var expected = new CpuInfo
         {
             ProcessorName = "Intel(R) Xeon(R) CPU E5-2630 v3 @ 2.40GHz",
@@ -73,7 +73,7 @@ public class WmiCpuInfoParserTests(ITestOutputHelper output)
             "\r\r\n" +
             "\r\r\n" +
             "\r\r\n";
-        var actual = WmiCpuInfoParser.Parse(cpuInfo);
+        var actual = CpuInfoParser.ParseWmicOutput(cpuInfo);
         var expected = new CpuInfo
         {
             ProcessorName = "Intel(R) Xeon(R) CPU E5-2687W 0 @ 3.10GHz",
@@ -98,7 +98,7 @@ public class WmiCpuInfoParserTests(ITestOutputHelper output)
 
             """;
 
-        var actual = WmiCpuInfoParser.Parse(cpuInfo);
+        var actual = CpuInfoParser.ParseWmicOutput(cpuInfo);
         var expected = new CpuInfo
         {
             ProcessorName = "Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz",


### PR DESCRIPTION
This PR fix regression that introduced by #3122

That PR merge of Wmic/Cim command output parse logics.
But these changes are wrong and  it cause `Unknown processor` on `wmic.exe` is not installed environment.

### What's changed in this PR

**1. `CpuInfoParser.cs`**

- Rename `WmiCpuInfoParser` to `CpuInfoParser`
- Separate core parser logics to `ParseCore`
- Add `ParseCimOutput`/`ParseWmicOutput` and rename caller method names.

**2. `PowershellWmiCpuDetector`**
- Add `Format-List {argList}` to filter properties and ensure output is **list** format

**3. `CpuInfoParserTests_Cim.cs`/`CpuInfoParserTests_Wmic.cs`**
- Revert `PowershellWmiCpuInfoParserTests.cs‎` test contents and rename file.
