### PR TITLE
chore: add setting to skip long running tests on draft PR

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/InProcessDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/InProcessDiagnoserTests.cs
@@ -65,6 +65,10 @@ public class InProcessDiagnoserTests(ITestOutputHelper output) : BenchmarkTestEx
 
                     bool ShouldSkip()
                     {
+                        // Skip out-of-process when running tests on GitHub Draft PR.
+                        if (ContinuousIntegration.IsGitHubDraftPR() && toolchain == ToolchainType.Default)
+                            return true;
+
                         // Default toolchain is much slower than in-process toolchains, so to prevent CI from taking too much time, we skip combinations with duplicate run modes.
                         if (toolchain != ToolchainType.Default || runModes.Length != 3)
                             return false;


### PR DESCRIPTION
This is a follow-up PR of #3121

Currently `InProcessDiagnoserTests` takes about `456s` (on `macos(x64)`).
To reduce CI test times, add setting to exclude default toolchain when running tests on DraftPR.