### PR TITLE
chore: Add unit test for CpuDetector

### DIFF
--- a/tests/BenchmarkDotNet.Tests/Detectors/Cpu/CpuDetectorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Detectors/Cpu/CpuDetectorTests.cs
@@ -1,0 +1,27 @@
+using AwesomeAssertions;
+using BenchmarkDotNet.Detectors;
+using Perfolizer.Helpers;
+using Perfolizer.Models;
+
+namespace BenchmarkDotNet.Tests.Detectors.Cpu;
+
+public class CpuDetectorTests(ITestOutputHelper Output)
+{
+    [Fact]
+    public void DetectCpuInfo()
+    {
+        // Act
+        CpuInfo? cpuInfo = CpuDetector.Cpu;
+
+        // Assert
+        cpuInfo.Should().NotBeNull();
+        Output.WriteLine(cpuInfo.ToFullBrandName());
+        if (cpuInfo.MaxFrequencyHz == null || cpuInfo.NominalFrequencyHz == null)
+            return;
+
+        cpuInfo.MaxFrequencyHz.Should().BeGreaterThanOrEqualTo(cpuInfo.NominalFrequencyHz.Value);
+
+        Output.WriteLine($"MaxFrequencyHz: {cpuInfo.MaxFrequencyHz}");
+        Output.WriteLine($"NominalFrequencyHz: {cpuInfo.NominalFrequencyHz}");
+    }
+}


### PR DESCRIPTION
This PR add unit test for CpuDetector and output raw values to `ITestOutputHelper`.

By this unit test. It can verify CPU info mismatch issue that occurred on Windows environment.
https://github.com/dotnet/BenchmarkDotNet/issues/859#issuecomment-4414842406
