### PR TITLE
chore: Disable CpuDetectorTests max frequency assertion

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\BenchmarkDotNet.Tests\Shared\**\*.cs" Link="Shared\%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="..\BenchmarkDotNet.Tests\Shared\**\*.cs" Link="Shared\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/tests/BenchmarkDotNet.IntegrationTests/Detectors/CpuDetectorTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/Detectors/CpuDetectorTests.cs
@@ -3,7 +3,7 @@ using BenchmarkDotNet.Detectors;
 using Perfolizer.Helpers;
 using Perfolizer.Models;
 
-namespace BenchmarkDotNet.Tests.Detectors.Cpu;
+namespace BenchmarkDotNet.IntegrationTests.Detectors.Cpu;
 
 public class CpuDetectorTests(ITestOutputHelper Output)
 {
@@ -19,9 +19,11 @@ public class CpuDetectorTests(ITestOutputHelper Output)
         if (cpuInfo.MaxFrequencyHz == null || cpuInfo.NominalFrequencyHz == null)
             return;
 
-        cpuInfo.MaxFrequencyHz.Should().BeGreaterThanOrEqualTo(cpuInfo.NominalFrequencyHz.Value);
-
         Output.WriteLine($"MaxFrequencyHz: {cpuInfo.MaxFrequencyHz}");
         Output.WriteLine($"NominalFrequencyHz: {cpuInfo.NominalFrequencyHz}");
+
+        // On some environment, it failed following assertion.
+        // https://github.com/dotnet/BenchmarkDotNet/pull/3131#issuecomment-4455965694
+        // cpuInfo.MaxFrequencyHz.Should().BeGreaterThanOrEqualTo(cpuInfo.NominalFrequencyHz.Value);
     }
 }


### PR DESCRIPTION
This PR temporary disable CPU frequency compare assertion. (See: #3131)
Because it failed to get Turbo Boosted clocks on some CPU environment (`Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz`)

**Other Changes**
- Move `CpuDetectorTests` to IntegrationTests project. Because it takes seconds on first execution.
- Add `AwesomeAssertions` package to IntegrationTests project.
