### PR TITLE
Add OpenMetrics to --exporters

### DIFF
--- a/docs/articles/guides/console-args.md
+++ b/docs/articles/guides/console-args.md
@@ -257,7 +257,7 @@ dotnet run -c Release -- --filter * --runtimes net6.0 net8.0 --statisticalTest 5
 
 * `-j`, `--job`               (Default: Default) Dry/Short/Medium/Long or Default
 * `-r`, `--runtimes`          Full target framework moniker for .NET Core and .NET. For Mono just 'Mono'. For NativeAOT please append target runtime version (example: 'nativeaot7.0'). First one will be marked as baseline!
-* `-e`, `--exporters`         GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML
+* `-e`, `--exporters`         GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML/CSVMeasurements/Markdown/Atlassian/Plain/BriefJSON/FullJSON/Asciidoc/BriefXML/FullXML/OpenMetrics
 * `-m`, `--memory`            (Default: false) Prints memory statistics
 * `-t`, `--threading`         (Default: false) Prints threading statistics
 * `--exceptions`              (Default: false) Prints exception statistics

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -26,7 +26,7 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option('r', "runtimes", Required = false, HelpText = "Full target framework moniker for .NET Core and .NET. For Mono just 'Mono'. For NativeAOT please append target runtime version (example: 'nativeaot7.0'). First one will be marked as baseline!")]
         public IEnumerable<string> Runtimes { get; set; } = [];
 
-        [Option('e', "exporters", Required = false, HelpText = "GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML")]
+        [Option('e', "exporters", Required = false, HelpText = "GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML/CSVMeasurements/Markdown/Atlassian/Plain/BriefJSON/FullJSON/Asciidoc/BriefXML/FullXML/OpenMetrics")]
         public IEnumerable<string> Exporters { get; set; } = [];
 
         [Option('m', "memory", Required = false, Default = false, HelpText = "Prints memory statistics")]

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -71,7 +71,8 @@ namespace BenchmarkDotNet.ConsoleArguments
                 { "asciidoc", new[] { AsciiDocExporter.Default } },
                 { "xml", new[] { XmlExporter.Default } },
                 { "briefxml", new[] { XmlExporter.Brief } },
-                { "fullxml", new[] { XmlExporter.Full } }
+                { "fullxml", new[] { XmlExporter.Full } },
+                { "openmetrics", new[] { Exporters.OpenMetrics.OpenMetricsExporter.Default } }
             };
 
         public static (bool isSuccess, IConfig? config, CommandLineOptions? options) Parse(string[] args, ILogger logger, IConfig? globalConfig = null)

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -7,6 +7,9 @@ using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Exporters.Csv;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Exporters.OpenMetrics;
+using BenchmarkDotNet.Exporters.Xml;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Portability;
@@ -27,6 +30,26 @@ namespace BenchmarkDotNet.Tests
     public class ConfigParserTests
     {
         public ITestOutputHelper Output { get; }
+        public static TheoryData<string, IExporter[]> Exporters => new()
+        {
+            { "csv", [CsvExporter.Default] },
+            { "csvmeasurements", [CsvMeasurementsExporter.Default] },
+            { "html", [HtmlExporter.Default] },
+            { "markdown", [MarkdownExporter.Default] },
+            { "atlassian", [MarkdownExporter.Atlassian] },
+            { "stackoverflow", [MarkdownExporter.StackOverflow] },
+            { "github", [MarkdownExporter.GitHub] },
+            { "plain", [PlainExporter.Default] },
+            { "rplot", [CsvMeasurementsExporter.Default, RPlotExporter.Default] },
+            { "json", [JsonExporter.Default] },
+            { "briefjson", [JsonExporter.Brief] },
+            { "fulljson", [JsonExporter.Full] },
+            { "asciidoc", [AsciiDocExporter.Default] },
+            { "xml", [XmlExporter.Default] },
+            { "briefxml", [XmlExporter.Brief] },
+            { "fullxml", [XmlExporter.Full] },
+            { "openmetrics", [OpenMetricsExporter.Default] }
+        };
 
         public ConfigParserTests(ITestOutputHelper output) => Output = output;
 
@@ -51,6 +74,16 @@ namespace BenchmarkDotNet.Tests
             Assert.Empty(config.GetDiagnosers());
             Assert.Empty(config.GetAnalysers());
             Assert.Empty(config.GetLoggers());
+        }
+
+        [Theory]
+        [MemberData(nameof(Exporters))]
+        public void ExportersAreParsedCorrectly(string exporter, IExporter[] expectedExporters)
+        {
+            var config = ConfigParser.Parse(["--exporters", exporter], new OutputLogger(Output)).config;
+
+            Assert.NotNull(config);
+            Assert.Equal(expectedExporters, config.GetExporters().ToArray());
         }
 
         [Fact]


### PR DESCRIPTION
Allow the OpenMetrics exporter to be specified through `--exporters`.
