### PR TITLE
Extend OpenMetrics exporter to include allocations

### DIFF
--- a/src/BenchmarkDotNet/Exporters/OpenMetrics/OpenMetricsExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/OpenMetrics/OpenMetricsExporter.cs
@@ -1,3 +1,4 @@
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Helpers;
@@ -29,20 +30,24 @@ public class OpenMetricsExporter : ExporterBase
             var gcStats = report.GcStats;
             var descriptor = benchmark.Descriptor;
             var parameters = benchmark.Parameters;
+            bool hasMemoryDiagnoser = benchmark.Config.HasMemoryDiagnoser();
+            long? allocatedBytesPerOperation = hasMemoryDiagnoser
+                ? gcStats.GetBytesAllocatedPerOperation(benchmark)
+                : null;
 
             var stats = report.ResultStatistics;
             var metrics = report.Metrics;
             if (stats == null)
                 continue;
 
-            AddCommonMetrics(metricsSet, descriptor, parameters, stats, gcStats);
-            AddAdditionalMetrics(metricsSet, metrics, descriptor, parameters);
+            AddCommonMetrics(metricsSet, descriptor, parameters, stats, gcStats, allocatedBytesPerOperation);
+            AddAdditionalMetrics(metricsSet, metrics, descriptor, parameters, skipAllocatedMemoryMetric: allocatedBytesPerOperation.HasValue);
         }
 
         await WriteMetricsAsync(writer, metricsSet, cancellationToken).ConfigureAwait(false);
     }
 
-    private static void AddCommonMetrics(HashSet<OpenMetric> metricsSet, Descriptor descriptor, ParameterInstances parameters, Statistics stats, GcStats gcStats)
+    private static void AddCommonMetrics(HashSet<OpenMetric> metricsSet, Descriptor descriptor, ParameterInstances parameters, Statistics stats, GcStats gcStats, long? allocatedBytesPerOperation)
     {
         metricsSet.AddRange([
             // Mean
@@ -127,9 +132,21 @@ public class OpenMetricsExporter : ExporterBase
                 parameters,
                 stats.Percentiles.P95)
         ]);
+
+        if (allocatedBytesPerOperation.HasValue)
+        {
+            metricsSet.Add(OpenMetric.FromStatistics(
+                $"{MetricPrefix}allocated_bytes",
+                "Allocated managed memory per single benchmark operation.",
+                "gauge",
+                "bytes",
+                descriptor,
+                parameters,
+                allocatedBytesPerOperation.Value));
+        }
     }
 
-    private static void AddAdditionalMetrics(HashSet<OpenMetric> metricsSet, IReadOnlyDictionary<string, Metric> metrics, Descriptor descriptor, ParameterInstances parameters)
+    private static void AddAdditionalMetrics(HashSet<OpenMetric> metricsSet, IReadOnlyDictionary<string, Metric> metrics, Descriptor descriptor, ParameterInstances parameters, bool skipAllocatedMemoryMetric)
     {
         var reservedMetricNames = new HashSet<string>
         {
@@ -141,11 +158,15 @@ public class OpenMetricsExporter : ExporterBase
             $"{MetricPrefix}gc_gen2_collections_total",
             $"{MetricPrefix}gc_total_operations_total",
             $"{MetricPrefix}p90_nanoseconds",
-            $"{MetricPrefix}p95_nanoseconds"
+            $"{MetricPrefix}p95_nanoseconds",
+            $"{MetricPrefix}allocated_bytes"
         };
 
         foreach (var metric in metrics)
         {
+            if (skipAllocatedMemoryMetric && metric.Value.Descriptor is AllocatedMemoryMetricDescriptor)
+                continue;
+
             string metricName = SanitizeMetricName(metric.Key);
             string fullMetricName = $"{MetricPrefix}{metricName}";
 

--- a/src/BenchmarkDotNet/Exporters/OpenMetrics/OpenMetricsExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/OpenMetrics/OpenMetricsExporter.cs
@@ -31,9 +31,13 @@ public class OpenMetricsExporter : ExporterBase
             var descriptor = benchmark.Descriptor;
             var parameters = benchmark.Parameters;
             bool hasMemoryDiagnoser = benchmark.Config.HasMemoryDiagnoser();
-            long? allocatedBytesPerOperation = hasMemoryDiagnoser
+            double? allocatedBytesPerOperation = hasMemoryDiagnoser
                 ? gcStats.GetBytesAllocatedPerOperation(benchmark)
                 : null;
+            if (hasMemoryDiagnoser && !allocatedBytesPerOperation.HasValue)
+            {
+                allocatedBytesPerOperation = double.NaN;
+            }
 
             var stats = report.ResultStatistics;
             var metrics = report.Metrics;
@@ -41,13 +45,13 @@ public class OpenMetricsExporter : ExporterBase
                 continue;
 
             AddCommonMetrics(metricsSet, descriptor, parameters, stats, gcStats, allocatedBytesPerOperation);
-            AddAdditionalMetrics(metricsSet, metrics, descriptor, parameters, skipAllocatedMemoryMetric: allocatedBytesPerOperation.HasValue);
+            AddAdditionalMetrics(metricsSet, metrics, descriptor, parameters, skipAllocatedMemoryMetric: hasMemoryDiagnoser, reserveAllocatedBytesMetricName: hasMemoryDiagnoser);
         }
 
         await WriteMetricsAsync(writer, metricsSet, cancellationToken).ConfigureAwait(false);
     }
 
-    private static void AddCommonMetrics(HashSet<OpenMetric> metricsSet, Descriptor descriptor, ParameterInstances parameters, Statistics stats, GcStats gcStats, long? allocatedBytesPerOperation)
+    private static void AddCommonMetrics(HashSet<OpenMetric> metricsSet, Descriptor descriptor, ParameterInstances parameters, Statistics stats, GcStats gcStats, double? allocatedBytesPerOperation)
     {
         metricsSet.AddRange([
             // Mean
@@ -146,7 +150,7 @@ public class OpenMetricsExporter : ExporterBase
         }
     }
 
-    private static void AddAdditionalMetrics(HashSet<OpenMetric> metricsSet, IReadOnlyDictionary<string, Metric> metrics, Descriptor descriptor, ParameterInstances parameters, bool skipAllocatedMemoryMetric)
+    private static void AddAdditionalMetrics(HashSet<OpenMetric> metricsSet, IReadOnlyDictionary<string, Metric> metrics, Descriptor descriptor, ParameterInstances parameters, bool skipAllocatedMemoryMetric, bool reserveAllocatedBytesMetricName)
     {
         var reservedMetricNames = new HashSet<string>
         {
@@ -158,9 +162,13 @@ public class OpenMetricsExporter : ExporterBase
             $"{MetricPrefix}gc_gen2_collections_total",
             $"{MetricPrefix}gc_total_operations_total",
             $"{MetricPrefix}p90_nanoseconds",
-            $"{MetricPrefix}p95_nanoseconds",
-            $"{MetricPrefix}allocated_bytes"
+            $"{MetricPrefix}p95_nanoseconds"
         };
+
+        if (reserveAllocatedBytesMetricName)
+        {
+            reservedMetricNames.Add($"{MetricPrefix}allocated_bytes");
+        }
 
         foreach (var metric in metrics)
         {

--- a/src/BenchmarkDotNet/Exporters/OpenMetrics/OpenMetricsExporter.cs
+++ b/src/BenchmarkDotNet/Exporters/OpenMetrics/OpenMetricsExporter.cs
@@ -45,7 +45,7 @@ public class OpenMetricsExporter : ExporterBase
                 continue;
 
             AddCommonMetrics(metricsSet, descriptor, parameters, stats, gcStats, allocatedBytesPerOperation);
-            AddAdditionalMetrics(metricsSet, metrics, descriptor, parameters, skipAllocatedMemoryMetric: hasMemoryDiagnoser, reserveAllocatedBytesMetricName: hasMemoryDiagnoser);
+            AddAdditionalMetrics(metricsSet, metrics, descriptor, parameters, skipAllocatedMemoryMetric: hasMemoryDiagnoser, reserveMemoryMetricNames: hasMemoryDiagnoser);
         }
 
         await WriteMetricsAsync(writer, metricsSet, cancellationToken).ConfigureAwait(false);
@@ -81,42 +81,6 @@ public class OpenMetricsExporter : ExporterBase
                 descriptor,
                 parameters,
                 stats.StandardDeviation),
-            // GC Stats Gen0 - these are counters, not gauges
-            OpenMetric.FromStatistics(
-                $"{MetricPrefix}gc_gen0_collections_total",
-                "Total number of Gen 0 garbage collections during the benchmark execution.",
-                "counter",
-                "",
-                descriptor,
-                parameters,
-                gcStats.Gen0Collections),
-            // GC Stats Gen1
-            OpenMetric.FromStatistics(
-                $"{MetricPrefix}gc_gen1_collections_total",
-                "Total number of Gen 1 garbage collections during the benchmark execution.",
-                "counter",
-                "",
-                descriptor,
-                parameters,
-                gcStats.Gen1Collections),
-            // GC Stats Gen2
-            OpenMetric.FromStatistics(
-                $"{MetricPrefix}gc_gen2_collections_total",
-                "Total number of Gen 2 garbage collections during the benchmark execution.",
-                "counter",
-                "",
-                descriptor,
-                parameters,
-                gcStats.Gen2Collections),
-            // Total GC Operations
-            OpenMetric.FromStatistics(
-                $"{MetricPrefix}gc_total_operations_total",
-                "Total number of garbage collection operations during the benchmark execution.",
-                "counter",
-                "",
-                descriptor,
-                parameters,
-                gcStats.TotalOperations),
             // P90 - in nanoseconds
             OpenMetric.FromStatistics(
                 $"{MetricPrefix}p90_nanoseconds",
@@ -139,6 +103,46 @@ public class OpenMetricsExporter : ExporterBase
 
         if (allocatedBytesPerOperation.HasValue)
         {
+            // GC Stats Gen0 - these are counters, not gauges
+            metricsSet.Add(OpenMetric.FromStatistics(
+                $"{MetricPrefix}gc_gen0_collections_total",
+                "Total number of Gen 0 garbage collections during the benchmark execution.",
+                "counter",
+                "",
+                descriptor,
+                parameters,
+                gcStats.Gen0Collections));
+
+            // GC Stats Gen1
+            metricsSet.Add(OpenMetric.FromStatistics(
+                $"{MetricPrefix}gc_gen1_collections_total",
+                "Total number of Gen 1 garbage collections during the benchmark execution.",
+                "counter",
+                "",
+                descriptor,
+                parameters,
+                gcStats.Gen1Collections));
+
+            // GC Stats Gen2
+            metricsSet.Add(OpenMetric.FromStatistics(
+                $"{MetricPrefix}gc_gen2_collections_total",
+                "Total number of Gen 2 garbage collections during the benchmark execution.",
+                "counter",
+                "",
+                descriptor,
+                parameters,
+                gcStats.Gen2Collections));
+
+            // Total GC Operations
+            metricsSet.Add(OpenMetric.FromStatistics(
+                $"{MetricPrefix}gc_total_operations_total",
+                "Total number of garbage collection operations during the benchmark execution.",
+                "counter",
+                "",
+                descriptor,
+                parameters,
+                gcStats.TotalOperations));
+
             metricsSet.Add(OpenMetric.FromStatistics(
                 $"{MetricPrefix}allocated_bytes",
                 "Allocated managed memory per single benchmark operation.",
@@ -150,23 +154,23 @@ public class OpenMetricsExporter : ExporterBase
         }
     }
 
-    private static void AddAdditionalMetrics(HashSet<OpenMetric> metricsSet, IReadOnlyDictionary<string, Metric> metrics, Descriptor descriptor, ParameterInstances parameters, bool skipAllocatedMemoryMetric, bool reserveAllocatedBytesMetricName)
+    private static void AddAdditionalMetrics(HashSet<OpenMetric> metricsSet, IReadOnlyDictionary<string, Metric> metrics, Descriptor descriptor, ParameterInstances parameters, bool skipAllocatedMemoryMetric, bool reserveMemoryMetricNames)
     {
         var reservedMetricNames = new HashSet<string>
         {
             $"{MetricPrefix}execution_time_nanoseconds",
             $"{MetricPrefix}error_nanoseconds",
             $"{MetricPrefix}stddev_nanoseconds",
-            $"{MetricPrefix}gc_gen0_collections_total",
-            $"{MetricPrefix}gc_gen1_collections_total",
-            $"{MetricPrefix}gc_gen2_collections_total",
-            $"{MetricPrefix}gc_total_operations_total",
             $"{MetricPrefix}p90_nanoseconds",
             $"{MetricPrefix}p95_nanoseconds"
         };
 
-        if (reserveAllocatedBytesMetricName)
+        if (reserveMemoryMetricNames)
         {
+            reservedMetricNames.Add($"{MetricPrefix}gc_gen0_collections_total");
+            reservedMetricNames.Add($"{MetricPrefix}gc_gen1_collections_total");
+            reservedMetricNames.Add($"{MetricPrefix}gc_gen2_collections_total");
+            reservedMetricNames.Add($"{MetricPrefix}gc_total_operations_total");
             reservedMetricNames.Add($"{MetricPrefix}allocated_bytes");
         }
 
@@ -275,7 +279,6 @@ public class OpenMetricsExporter : ExporterBase
             return new OpenMetric(fullMetricName, help, type, "", labels, metric.Value.Value);
         }
 
-        private static readonly Dictionary<string, string> NormalizedLabelKeyCache = [];
         private static string NormalizeLabelKey(string key)
         {
             string normalized = new(key

--- a/tests/BenchmarkDotNet.Tests/Exporters/OpenMetricsExporterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Exporters/OpenMetricsExporterTests.cs
@@ -1,4 +1,5 @@
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Exporters;
@@ -278,6 +279,50 @@ namespace BenchmarkDotNet.Tests.Exporters
             }
 
             return;
+        }
+
+        [Fact]
+        public async Task MemoryDiagnoser_ExportsAllocatedBytesPerOperation()
+        {
+            var config = new ManualConfig().AddDiagnoser(MemoryDiagnoser.Default);
+            var summary = new Summary(
+                "MemoryDiagnoserSummary",
+                [
+                    new BenchmarkReport(
+                        success: true,
+                        benchmarkCase: new BenchmarkCase(
+                            new Descriptor(MockFactory.MockType, MockFactory.MockMethodInfo),
+                            Job.Dry,
+                            new ParameterInstances([]),
+                            ImmutableConfigBuilder.Create(config)),
+                        null!,
+                        null!,
+                        [
+                            new ExecuteResult(
+                                [
+                                    new Measurement(0, IterationMode.Workload, IterationStage.Result, 4, 4, 40)
+                                ],
+                                GcStats.Parse("// GC: 1 2 3 65536 4"))
+                        ],
+                        [
+                            new Metric(AllocatedMemoryMetricDescriptor.Instance, 16384),
+                            new(new FakeMetricDescriptor("label", "label"), 42.0)
+                        ])
+                ],
+                HostEnvironmentInfo.GetCurrent(),
+                "",
+                "",
+                TimeSpan.Zero,
+                CultureInfo.InvariantCulture,
+                [],
+                []);
+
+            var logger = new AccumulationLogger();
+
+            await ((ExporterBase)OpenMetricsExporter.Default).ExportToLogAsync(summary, logger, CancellationToken.None);
+
+            var settings = VerifyHelper.Create();
+            await Verifier.Verify(logger.GetLog(), settings);
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/Exporters/OpenMetricsExporterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Exporters/OpenMetricsExporterTests.cs
@@ -324,5 +324,90 @@ namespace BenchmarkDotNet.Tests.Exporters
             var settings = VerifyHelper.Create();
             await Verifier.Verify(logger.GetLog(), settings);
         }
+
+        [Fact]
+        public async Task MemoryDiagnoser_WithoutAllocationData_ExportsAllocatedBytesAsNaN()
+        {
+            var config = new ManualConfig().AddDiagnoser(MemoryDiagnoser.Default);
+            var summary = new Summary(
+                "MemoryDiagnoserNoAllocationDataSummary",
+                [
+                    new BenchmarkReport(
+                        success: true,
+                        benchmarkCase: new BenchmarkCase(
+                            new Descriptor(MockFactory.MockType, MockFactory.MockMethodInfo),
+                            Job.Dry,
+                            new ParameterInstances([]),
+                            ImmutableConfigBuilder.Create(config)),
+                        null!,
+                        null!,
+                        [
+                            new ExecuteResult(
+                                [
+                                    new Measurement(0, IterationMode.Workload, IterationStage.Result, 1, 1, 10)
+                                ],
+                                GcStats.Empty)
+                        ],
+                        [
+                            new Metric(AllocatedMemoryMetricDescriptor.Instance, double.NaN)
+                        ])
+                ],
+                HostEnvironmentInfo.GetCurrent(),
+                "",
+                "",
+                TimeSpan.Zero,
+                CultureInfo.InvariantCulture,
+                [],
+                []);
+
+            var logger = new AccumulationLogger();
+
+            await ((ExporterBase)OpenMetricsExporter.Default).ExportToLogAsync(summary, logger, CancellationToken.None);
+
+            var log = logger.GetLog();
+            Assert.Contains("# HELP benchmark_allocated_bytes Allocated managed memory per single benchmark operation.", log);
+            Assert.Contains("benchmark_allocated_bytes{method=\"Foo\", type=\"MockBenchmarkClass\"} NaN", log);
+        }
+
+        [Fact]
+        public async Task WithoutMemoryDiagnoser_CustomAllocatedBytesMetricIsNotSuppressed()
+        {
+            var summary = new Summary(
+                "CustomAllocatedBytesMetricSummary",
+                [
+                    new BenchmarkReport(
+                        success: true,
+                        benchmarkCase: new BenchmarkCase(
+                            new Descriptor(MockFactory.MockType, MockFactory.MockMethodInfo),
+                            Job.Dry,
+                            new ParameterInstances([]),
+                            ImmutableConfigBuilder.Create(new ManualConfig())),
+                        null!,
+                        null!,
+                        [
+                            new ExecuteResult([
+                                new Measurement(0, IterationMode.Workload, IterationStage.Result, 1, 1, 10)
+                            ])
+                        ],
+                        [
+                            new(new FakeMetricDescriptor("allocated_bytes", "allocated bytes"), 42.0)
+                        ])
+                ],
+                HostEnvironmentInfo.GetCurrent(),
+                "",
+                "",
+                TimeSpan.Zero,
+                CultureInfo.InvariantCulture,
+                [],
+                []);
+
+            var logger = new AccumulationLogger();
+
+            await ((ExporterBase)OpenMetricsExporter.Default).ExportToLogAsync(summary, logger, CancellationToken.None);
+
+            var log = logger.GetLog();
+            Assert.Contains("# HELP benchmark_allocated_bytes Additional metric allocated_bytes", log);
+            Assert.Contains("benchmark_allocated_bytes{method=\"Foo\", type=\"MockBenchmarkClass\"} 42", log);
+        }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_Invariant.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_Invariant.verified.txt
@@ -596,6 +596,11 @@ MarkdownExporter-stackoverflow
 ############################################
 OpenMetricsExporter
 ############################################
+# HELP benchmark_allocated_bytes Allocated managed memory per single benchmark operation.
+# TYPE benchmark_allocated_bytes gauge
+# UNIT benchmark_allocated_bytes bytes
+benchmark_allocated_bytes{method="Foo", type="MockBenchmarkClass"} NaN
+benchmark_allocated_bytes{method="Bar", type="MockBenchmarkClass"} NaN
 # HELP benchmark_cachemisses Additional metric CacheMisses
 # TYPE benchmark_cachemisses gauge
 benchmark_cachemisses{method="Foo", type="MockBenchmarkClass"} 7

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_en-US.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_en-US.verified.txt
@@ -596,6 +596,11 @@ MarkdownExporter-stackoverflow
 ############################################
 OpenMetricsExporter
 ############################################
+# HELP benchmark_allocated_bytes Allocated managed memory per single benchmark operation.
+# TYPE benchmark_allocated_bytes gauge
+# UNIT benchmark_allocated_bytes bytes
+benchmark_allocated_bytes{method="Foo", type="MockBenchmarkClass"} NaN
+benchmark_allocated_bytes{method="Bar", type="MockBenchmarkClass"} NaN
 # HELP benchmark_cachemisses Additional metric CacheMisses
 # TYPE benchmark_cachemisses gauge
 benchmark_cachemisses{method="Foo", type="MockBenchmarkClass"} 7

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_ru-RU.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/CommonExporterVerifyTests.Exporters_ru-RU.verified.txt
@@ -596,6 +596,11 @@ MarkdownExporter-stackoverflow
 ############################################
 OpenMetricsExporter
 ############################################
+# HELP benchmark_allocated_bytes Allocated managed memory per single benchmark operation.
+# TYPE benchmark_allocated_bytes gauge
+# UNIT benchmark_allocated_bytes bytes
+benchmark_allocated_bytes{method="Foo", type="MockBenchmarkClass"} NaN
+benchmark_allocated_bytes{method="Bar", type="MockBenchmarkClass"} NaN
 # HELP benchmark_cachemisses Additional metric CacheMisses
 # TYPE benchmark_cachemisses gauge
 benchmark_cachemisses{method="Foo", type="MockBenchmarkClass"} 7

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/OpenMetricsExporterTests.LabelsAreEscapedCorrectly.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/OpenMetricsExporterTests.LabelsAreEscapedCorrectly.verified.txt
@@ -6,18 +6,6 @@ benchmark_error_nanoseconds{method="Foo", type="MockBenchmarkClass"} 0
 # TYPE benchmark_execution_time_nanoseconds gauge
 # UNIT benchmark_execution_time_nanoseconds nanoseconds
 benchmark_execution_time_nanoseconds{method="Foo", type="MockBenchmarkClass"} 0.1
-# HELP benchmark_gc_gen0_collections_total Total number of Gen 0 garbage collections during the benchmark execution.
-# TYPE benchmark_gc_gen0_collections_total counter
-benchmark_gc_gen0_collections_total{method="Foo", type="MockBenchmarkClass"} 0
-# HELP benchmark_gc_gen1_collections_total Total number of Gen 1 garbage collections during the benchmark execution.
-# TYPE benchmark_gc_gen1_collections_total counter
-benchmark_gc_gen1_collections_total{method="Foo", type="MockBenchmarkClass"} 0
-# HELP benchmark_gc_gen2_collections_total Total number of Gen 2 garbage collections during the benchmark execution.
-# TYPE benchmark_gc_gen2_collections_total counter
-benchmark_gc_gen2_collections_total{method="Foo", type="MockBenchmarkClass"} 0
-# HELP benchmark_gc_total_operations_total Total number of garbage collection operations during the benchmark execution.
-# TYPE benchmark_gc_total_operations_total counter
-benchmark_gc_total_operations_total{method="Foo", type="MockBenchmarkClass"} 0
 # HELP benchmark_label_with_dash Additional metric label_with-dash
 # TYPE benchmark_label_with_dash gauge
 benchmark_label_with_dash{method="Foo", type="MockBenchmarkClass"} 84

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/OpenMetricsExporterTests.MemoryDiagnoser_ExportsAllocatedBytesPerOperation.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/OpenMetricsExporterTests.MemoryDiagnoser_ExportsAllocatedBytesPerOperation.verified.txt
@@ -1,0 +1,40 @@
+﻿# HELP benchmark_allocated_bytes Allocated managed memory per single benchmark operation.
+# TYPE benchmark_allocated_bytes gauge
+# UNIT benchmark_allocated_bytes bytes
+benchmark_allocated_bytes{method="Foo", type="MockBenchmarkClass"} 16384
+# HELP benchmark_error_nanoseconds Standard error of the mean execution time in nanoseconds.
+# TYPE benchmark_error_nanoseconds gauge
+# UNIT benchmark_error_nanoseconds nanoseconds
+benchmark_error_nanoseconds{method="Foo", type="MockBenchmarkClass"} 0
+# HELP benchmark_execution_time_nanoseconds Mean execution time in nanoseconds.
+# TYPE benchmark_execution_time_nanoseconds gauge
+# UNIT benchmark_execution_time_nanoseconds nanoseconds
+benchmark_execution_time_nanoseconds{method="Foo", type="MockBenchmarkClass"} 10
+# HELP benchmark_gc_gen0_collections_total Total number of Gen 0 garbage collections during the benchmark execution.
+# TYPE benchmark_gc_gen0_collections_total counter
+benchmark_gc_gen0_collections_total{method="Foo", type="MockBenchmarkClass"} 1
+# HELP benchmark_gc_gen1_collections_total Total number of Gen 1 garbage collections during the benchmark execution.
+# TYPE benchmark_gc_gen1_collections_total counter
+benchmark_gc_gen1_collections_total{method="Foo", type="MockBenchmarkClass"} 2
+# HELP benchmark_gc_gen2_collections_total Total number of Gen 2 garbage collections during the benchmark execution.
+# TYPE benchmark_gc_gen2_collections_total counter
+benchmark_gc_gen2_collections_total{method="Foo", type="MockBenchmarkClass"} 3
+# HELP benchmark_gc_total_operations_total Total number of garbage collection operations during the benchmark execution.
+# TYPE benchmark_gc_total_operations_total counter
+benchmark_gc_total_operations_total{method="Foo", type="MockBenchmarkClass"} 4
+# HELP benchmark_label Additional metric label
+# TYPE benchmark_label gauge
+benchmark_label{method="Foo", type="MockBenchmarkClass"} 42
+# HELP benchmark_p90_nanoseconds 90th percentile execution time in nanoseconds.
+# TYPE benchmark_p90_nanoseconds gauge
+# UNIT benchmark_p90_nanoseconds nanoseconds
+benchmark_p90_nanoseconds{method="Foo", type="MockBenchmarkClass"} 10
+# HELP benchmark_p95_nanoseconds 95th percentile execution time in nanoseconds.
+# TYPE benchmark_p95_nanoseconds gauge
+# UNIT benchmark_p95_nanoseconds nanoseconds
+benchmark_p95_nanoseconds{method="Foo", type="MockBenchmarkClass"} 10
+# HELP benchmark_stddev_nanoseconds Standard deviation of execution time in nanoseconds.
+# TYPE benchmark_stddev_nanoseconds gauge
+# UNIT benchmark_stddev_nanoseconds nanoseconds
+benchmark_stddev_nanoseconds{method="Foo", type="MockBenchmarkClass"} 0
+# EOF

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/OpenMetricsExporterTests.ParametrizedBenchmarks_LabelExpansion.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/OpenMetricsExporterTests.ParametrizedBenchmarks_LabelExpansion.verified.txt
@@ -10,26 +10,6 @@ benchmark_error_nanoseconds{method="Foo", param1="value3", param2="value3", para
 benchmark_execution_time_nanoseconds{method="Foo", param1="value1", param2="value1", param3="value1", type="MockBenchmarkClass"} 0.1
 benchmark_execution_time_nanoseconds{method="Foo", param1="value2", param2="value2", param3="value2", type="MockBenchmarkClass"} 0.1
 benchmark_execution_time_nanoseconds{method="Foo", param1="value3", param2="value3", param3="value3", type="MockBenchmarkClass"} 0.1
-# HELP benchmark_gc_gen0_collections_total Total number of Gen 0 garbage collections during the benchmark execution.
-# TYPE benchmark_gc_gen0_collections_total counter
-benchmark_gc_gen0_collections_total{method="Foo", param1="value1", param2="value1", param3="value1", type="MockBenchmarkClass"} 0
-benchmark_gc_gen0_collections_total{method="Foo", param1="value2", param2="value2", param3="value2", type="MockBenchmarkClass"} 0
-benchmark_gc_gen0_collections_total{method="Foo", param1="value3", param2="value3", param3="value3", type="MockBenchmarkClass"} 0
-# HELP benchmark_gc_gen1_collections_total Total number of Gen 1 garbage collections during the benchmark execution.
-# TYPE benchmark_gc_gen1_collections_total counter
-benchmark_gc_gen1_collections_total{method="Foo", param1="value1", param2="value1", param3="value1", type="MockBenchmarkClass"} 0
-benchmark_gc_gen1_collections_total{method="Foo", param1="value2", param2="value2", param3="value2", type="MockBenchmarkClass"} 0
-benchmark_gc_gen1_collections_total{method="Foo", param1="value3", param2="value3", param3="value3", type="MockBenchmarkClass"} 0
-# HELP benchmark_gc_gen2_collections_total Total number of Gen 2 garbage collections during the benchmark execution.
-# TYPE benchmark_gc_gen2_collections_total counter
-benchmark_gc_gen2_collections_total{method="Foo", param1="value1", param2="value1", param3="value1", type="MockBenchmarkClass"} 0
-benchmark_gc_gen2_collections_total{method="Foo", param1="value2", param2="value2", param3="value2", type="MockBenchmarkClass"} 0
-benchmark_gc_gen2_collections_total{method="Foo", param1="value3", param2="value3", param3="value3", type="MockBenchmarkClass"} 0
-# HELP benchmark_gc_total_operations_total Total number of garbage collection operations during the benchmark execution.
-# TYPE benchmark_gc_total_operations_total counter
-benchmark_gc_total_operations_total{method="Foo", param1="value1", param2="value1", param3="value1", type="MockBenchmarkClass"} 0
-benchmark_gc_total_operations_total{method="Foo", param1="value2", param2="value2", param3="value2", type="MockBenchmarkClass"} 0
-benchmark_gc_total_operations_total{method="Foo", param1="value3", param2="value3", param3="value3", type="MockBenchmarkClass"} 0
 # HELP benchmark_label Additional metric label
 # TYPE benchmark_label gauge
 benchmark_label{method="Foo", param1="value1", param2="value1", param3="value1", type="MockBenchmarkClass"} 42

--- a/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/OpenMetricsExporterTests.SingleBenchmark_ProducesHelpAndTypeOnce.verified.txt
+++ b/tests/BenchmarkDotNet.Tests/Exporters/VerifiedFiles/OpenMetricsExporterTests.SingleBenchmark_ProducesHelpAndTypeOnce.verified.txt
@@ -10,26 +10,6 @@ benchmark_error_nanoseconds{method="Foo", param1="value3", type="MockBenchmarkCl
 benchmark_execution_time_nanoseconds{method="Foo", param1="value1", type="MockBenchmarkClass"} 0.1
 benchmark_execution_time_nanoseconds{method="Foo", param1="value2", type="MockBenchmarkClass"} 0.1
 benchmark_execution_time_nanoseconds{method="Foo", param1="value3", type="MockBenchmarkClass"} 0.1
-# HELP benchmark_gc_gen0_collections_total Total number of Gen 0 garbage collections during the benchmark execution.
-# TYPE benchmark_gc_gen0_collections_total counter
-benchmark_gc_gen0_collections_total{method="Foo", param1="value1", type="MockBenchmarkClass"} 0
-benchmark_gc_gen0_collections_total{method="Foo", param1="value2", type="MockBenchmarkClass"} 0
-benchmark_gc_gen0_collections_total{method="Foo", param1="value3", type="MockBenchmarkClass"} 0
-# HELP benchmark_gc_gen1_collections_total Total number of Gen 1 garbage collections during the benchmark execution.
-# TYPE benchmark_gc_gen1_collections_total counter
-benchmark_gc_gen1_collections_total{method="Foo", param1="value1", type="MockBenchmarkClass"} 0
-benchmark_gc_gen1_collections_total{method="Foo", param1="value2", type="MockBenchmarkClass"} 0
-benchmark_gc_gen1_collections_total{method="Foo", param1="value3", type="MockBenchmarkClass"} 0
-# HELP benchmark_gc_gen2_collections_total Total number of Gen 2 garbage collections during the benchmark execution.
-# TYPE benchmark_gc_gen2_collections_total counter
-benchmark_gc_gen2_collections_total{method="Foo", param1="value1", type="MockBenchmarkClass"} 0
-benchmark_gc_gen2_collections_total{method="Foo", param1="value2", type="MockBenchmarkClass"} 0
-benchmark_gc_gen2_collections_total{method="Foo", param1="value3", type="MockBenchmarkClass"} 0
-# HELP benchmark_gc_total_operations_total Total number of garbage collection operations during the benchmark execution.
-# TYPE benchmark_gc_total_operations_total counter
-benchmark_gc_total_operations_total{method="Foo", param1="value1", type="MockBenchmarkClass"} 0
-benchmark_gc_total_operations_total{method="Foo", param1="value2", type="MockBenchmarkClass"} 0
-benchmark_gc_total_operations_total{method="Foo", param1="value3", type="MockBenchmarkClass"} 0
 # HELP benchmark_label Additional metric label
 # TYPE benchmark_label gauge
 benchmark_label{method="Foo", param1="value1", type="MockBenchmarkClass"} 42


### PR DESCRIPTION
- Extend the OpenMetrics exporter to include a gauge for allocated bytes if the memory diagnoser is enabled.
- Only emit GC metrics if the memory diagnoser is enabled.
