### PR TITLE
chore: Modify PowerShellLocator and related tests

### DIFF
--- a/src/BenchmarkDotNet/Detectors/Cpu/Windows/PowershellWmiCpuDetector.cs
+++ b/src/BenchmarkDotNet/Detectors/Cpu/Windows/PowershellWmiCpuDetector.cs
@@ -23,8 +23,14 @@ internal class PowershellWmiCpuDetector : ICpuDetector
                                $"{WmiCpuInfoKeyNames.NumberOfLogicalProcessors}, " +
                                $"{WmiCpuInfoKeyNames.MaxClockSpeed}";
 
-        string? output = ProcessHelper.RunAndReadOutput(PowerShellLocator.LocateOnWindows() ?? "PowerShell",
-            $"Get-CimInstance Win32_Processor -Property {argList} | Format-List {argList}");
+        var exePath = PowerShellLocator.LocateOnWindows() ?? "powershell";
+        var command = $"Get-CimInstance Win32_Processor -Property {argList} | Format-List {argList}";
+        var envVars = new Dictionary<string, string>
+        {
+            ["TERM"] = "dumb" // Suppress outputting ANSI escape sequences.
+        };
+
+        string? output = ProcessHelper.RunAndReadOutput(exePath, $"-Command \"{command}\"", environmentVariables: envVars);
 
         if (output.IsBlank())
             return null;

--- a/src/BenchmarkDotNet/Helpers/PowerShellLocator.cs
+++ b/src/BenchmarkDotNet/Helpers/PowerShellLocator.cs
@@ -1,4 +1,5 @@
 using BenchmarkDotNet.Detectors;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 
@@ -7,70 +8,71 @@ namespace BenchmarkDotNet.Helpers;
 /// <summary>
 /// Locates PowerShell on a system, currently only supports on Windows.
 /// </summary>
-internal class PowerShellLocator
+[SupportedOSPlatform("windows")]
+internal static class PowerShellLocator
 {
-    private static readonly string WindowsPowershellPath =
-        $"{Environment.SystemDirectory}{Path.DirectorySeparatorChar}WindowsPowerShell{Path.DirectorySeparatorChar}" +
-        $"v1.0{Path.DirectorySeparatorChar}powershell.exe";
+    private const string FallbackCommand = "powershell";
 
-    [SupportedOSPlatform("windows")]
-    internal static string? LocateOnWindows()
+    private static readonly string WindowsPowerShellPath =
+        Path.Combine(
+            Environment.SystemDirectory,
+            "WindowsPowerShell",
+            "v1.0",
+            "powershell.exe");
+
+    private static readonly Lazy<string> CachedExePath = new(LocateOnWindowsCore);
+
+    internal static string LocateOnWindows()
+        => CachedExePath.Value;
+
+    private static string LocateOnWindowsCore()
     {
-        if (OsDetector.IsWindows() == false)
-            return null;
-
-        string powershellPath;
+        if (!OsDetector.IsWindows())
+            throw new PlatformNotSupportedException();
 
         try
         {
-            string programFiles = Environment.Is64BitOperatingSystem
-                ? Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)
-                : Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+            // Try to find PowerShell Core (`pwsh.exe`)
+            if (TryLocatePwshExe(out var pwshExePath))
+                return pwshExePath;
 
-            string powershell7PlusPath = $"{programFiles}{Path.DirectorySeparatorChar}Powershell{Path.DirectorySeparatorChar}";
-
-            bool checkForPowershell7Plus = true;
-
-            if (Directory.Exists(powershell7PlusPath))
-            {
-                string[] subDirectories = Directory.EnumerateDirectories(powershell7PlusPath, "*", SearchOption.AllDirectories)
-                    .ToArray();
-
-                //Use the highest number string directory for PowerShell so that we get the newest major PowerShell version
-                // Example version directories are 6, 7, and in the future 8.
-                string? subDirectory = subDirectories.Where(x => Regex.IsMatch(x, "[0-9]"))
-                    .Select(x => x)
-                    .OrderByDescending(x => x)
-                    .FirstOrDefault();
-
-                if (subDirectory is not null)
-                {
-                    powershell7PlusPath = $"{subDirectory}{Path.DirectorySeparatorChar}pwsh.exe";
-                }
-                else
-                {
-                    checkForPowershell7Plus = false;
-                }
-            }
-
-            // Optimistically, use Cross-platform new PowerShell when available but fallback to Windows PowerShell if not available.
-            if (checkForPowershell7Plus)
-            {
-                powershellPath = File.Exists(powershell7PlusPath) ? powershell7PlusPath : WindowsPowershellPath;
-            }
-            else
-            {
-                powershellPath = WindowsPowershellPath;
-            }
-
-            if (File.Exists(powershellPath) == false)
-                powershellPath = "PowerShell";
+            // Try to find Windows PowerShell (`powershell.exe)
+            if (File.Exists(WindowsPowerShellPath))
+                return WindowsPowerShellPath;
         }
         catch
         {
-            powershellPath = "PowerShell";
+            // ignored
         }
 
-        return powershellPath;
+        // Fallback to `powershell` command, which should be available in PATH.
+        return FallbackCommand;
+    }
+
+    private static bool TryLocatePwshExe([NotNullWhen(true)] out string? pwshExePath)
+    {
+        pwshExePath = null;
+
+        string programFiles = Environment.Is64BitOperatingSystem
+            ? Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)
+            : Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+
+        string root = Path.Combine(programFiles, "PowerShell");
+
+        if (!Directory.Exists(root))
+            return false;
+
+        // Find latest version of PowerShell Core install directory.(e.g. `C:\Program Files\PowerShell\7`)
+        var latestVersionDirectory = Directory
+            .EnumerateDirectories(root, "*", SearchOption.TopDirectoryOnly)
+            .Where(path => Regex.IsMatch(Path.GetFileName(path), @"^\d+$"))
+            .OrderByDescending(path => int.Parse(Path.GetFileName(path)))
+            .FirstOrDefault();
+
+        if (latestVersionDirectory is null)
+            return false;
+
+        pwshExePath = Path.Combine(latestVersionDirectory, "pwsh.exe");
+        return File.Exists(pwshExePath);
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/Detectors/CpuDetectorTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/Detectors/CpuDetectorTests.cs
@@ -15,6 +15,8 @@ public class CpuDetectorTests(ITestOutputHelper Output)
 
         // Assert
         cpuInfo.Should().NotBeNull();
+        cpuInfo.ToFullBrandName().Should().NotBe("Unknown processor");
+
         Output.WriteLine(cpuInfo.ToFullBrandName());
         if (cpuInfo.MaxFrequencyHz == null || cpuInfo.NominalFrequencyHz == null)
             return;

--- a/tests/BenchmarkDotNet.IntegrationTests/Helpers/PowerShellLocatorTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/Helpers/PowerShellLocatorTests.cs
@@ -1,0 +1,34 @@
+using AwesomeAssertions;
+using BenchmarkDotNet.Helpers;
+using BenchmarkDotNet.Tests.XUnit;
+using System.Runtime.Versioning;
+
+namespace BenchmarkDotNet.IntegrationTests.Helpers;
+
+public class PowerShellLocatorTests
+{
+    [SupportedOSPlatform("windows")]
+    [FactEnvSpecific(EnvRequirement.WindowsOnly)]
+    public void LocateExeOnWindows()
+    {
+        // Act
+        var exePath = PowerShellLocator.LocateOnWindows();
+
+        // Assert
+        exePath.Should().NotBeEmpty();
+        var exeName = Path.GetFileName(exePath);
+
+        // On GitHub Actions, PowerShell Core is installed by default.
+        if (ContinuousIntegration.IsGitHubActionsOnWindows())
+        {
+            exeName.Should().Be("pwsh.exe");
+        }
+        else
+        {
+            exeName.Should().BeOneOf(
+                "powershell.exe", // Windows PowerShell
+                "pwsh.exe",       // PowerShell Core
+                "powershell");    // Fallback command, which will be resolved via PATH.
+        }
+    }
+}


### PR DESCRIPTION
This PR fix #3132.
By this changes, BenchmarkDotNet use `pwsh.exe` when available on Windows environment.

#### What's changed in this PR

1. Change fallback command name from `PowerShell` to `powershell` (lower-case)
2. Add explicit `-Command` argument to support `pwsh.exe`
3. Add `TERM=dumb` environment variable to suppress ANSI escape sequence for coloring on `pwsh.exe`.
4. Modify `EnumerateDirectories` option and regex to enumerate installation directory.
5. Add lazy caching for PowerShellLocator result.
6. Add additional assertion to `CpuDetectorTests.cs` to detect CpuDetector powershell command silently failed.
7. Add `PowerShellLocatorTests.cs`