### PR TITLE
Update JIT stage timing heuristic

### DIFF
--- a/docs/articles/guides/console-args.md
+++ b/docs/articles/guides/console-args.md
@@ -313,6 +313,7 @@ dotnet run -c Release -- --filter * --runtimes net6.0 net8.0 --statisticalTest 5
 * `--maxWidth`                Max parameter column width, the default is 20.
 * `--envVars`                 Colon separated environment variables (key:value)
 * `--memoryRandomization`     Specifies whether Engine should allocate some random-sized memory between iterations. It makes [GlobalCleanup] and [GlobalSetup] methods to be executed after every iteration.
+* `--jitTieringMode`          (Default: Auto) Controls the behavior of the JIT stage when tiering is enabled. Auto/Force/Skip.
 * `--wasmEngine`              (Default: v8) Specifies the executable (in PATH) or full path to a java script engine used to run the benchmarks, used by Wasm toolchain.
 * `--wasmArgs`                (Default: --expose_wasm) Arguments for the javascript engine used by Wasm toolchain.
 * `--customRuntimePack`       Path to a custom runtime pack. Only used for wasm/MonoAotLLVM currently.

--- a/src/BenchmarkDotNet/Attributes/Mutators/JitTieringAttribute.cs
+++ b/src/BenchmarkDotNet/Attributes/Mutators/JitTieringAttribute.cs
@@ -1,0 +1,9 @@
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+
+namespace BenchmarkDotNet.Attributes;
+
+/// <inheritdoc cref="RunMode.JitTieringMode"/>
+public class JitTieringAttribute(JitTieringMode mode) : JobMutatorConfigBaseAttribute(Job.Default.WithJitTieringMode(mode))
+{
+}

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -198,6 +198,9 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option("memoryRandomization", Required = false, HelpText = "Specifies whether Engine should allocate some random-sized memory between iterations. It makes [GlobalCleanup] and [GlobalSetup] methods to be executed after every iteration.")]
         public bool MemoryRandomization { get; set; }
 
+        [Option("jitTieringMode", Required = false, Default = JitTieringMode.Auto, HelpText = "Controls the behavior of the JIT stage when tiering is enabled. Auto/Force/Skip.")]
+        public JitTieringMode JitTieringMode { get; set; }
+
         [Option("wasmEngine", Required = false, HelpText = "Specifies the executable (in PATH) or full path to a java script engine used to run the benchmarks, used by Wasm toolchain.", Default = "v8")]
         public string? WasmJavaScriptEngine { get; set; } = "v8";
 

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -455,6 +455,8 @@ namespace BenchmarkDotNet.ConsoleArguments
                 baseJob = baseJob.RunOncePerIteration();
             if (options.MemoryRandomization)
                 baseJob = baseJob.WithMemoryRandomization();
+            if (options.JitTieringMode != Engines.JitTieringMode.Auto)
+                baseJob = baseJob.WithJitTieringMode(options.JitTieringMode);
             if (options.NoForcedGCs)
                 baseJob = baseJob.WithGcForce(false);
             if (options.EvaluateOverhead is bool evaluateOverhead)

--- a/src/BenchmarkDotNet/Engines/EngineJitStage.cs
+++ b/src/BenchmarkDotNet/Engines/EngineJitStage.cs
@@ -74,8 +74,9 @@ internal sealed class EngineJitStage : EngineStage
         }
         yield return GetWorkloadIterationData(userInvokeCount);
 
-        // If the jit is not tiered, we're done.
-        if (!JitInfo.IsTiered)
+        JitTieringMode jitTieringMode = parameters.TargetJob.ResolveValue(RunMode.JitTieringModeCharacteristic, parameters.Resolver);
+        // If the jit is not tiered, or the user wants to skip, we're done.
+        if (!JitInfo.IsTiered || jitTieringMode == JitTieringMode.Skip)
         {
             yield break;
         }
@@ -90,9 +91,11 @@ internal sealed class EngineJitStage : EngineStage
         // it agrees. Same cutoff value that pilot stage uses.
         // We do not bail out immediately if the first iteration is long-running because it could
         // be due to cctors or other lazy initialization that won't be hit in steady-state. #2004
+        // JitTieringMode.Force opts out of this heuristic and always promotes through every tier.
         TimeInterval iterationTime = parameters.TargetJob.ResolveValue(RunMode.IterationTimeCharacteristic, parameters.Resolver);
         long remainingCalls = JitInfo.TieredCallCountThreshold;
-        if (iterationTime.Nanoseconds / (lastMeasurement.Nanoseconds / (double)userInvokeCount) < 1.5)
+        if (jitTieringMode == JitTieringMode.Auto
+            && iterationTime.Nanoseconds / (lastMeasurement.Nanoseconds / (double)userInvokeCount) < 1.5)
         {
             ++iterationIndex;
             yield return GetWorkloadIterationData(userInvokeCount);

--- a/src/BenchmarkDotNet/Engines/EngineJitStage.cs
+++ b/src/BenchmarkDotNet/Engines/EngineJitStage.cs
@@ -11,9 +11,6 @@ namespace BenchmarkDotNet.Engines;
 // the following stages (Pilot and Warmup) will likely take it the rest of the way. Long-running benchmarks may never fully reach tier1.
 internal sealed class EngineJitStage : EngineStage
 {
-    // It is not worth spending a long time in jit stage for macro-benchmarks.
-    private static readonly TimeInterval MaxTieringTime = TimeInterval.FromSeconds(10);
-
     // Jit call counting delay is only for when the app starts up. We don't need to wait for every benchmark if multiple benchmarks are ran in-process.
     private static TimeSpan s_tieredDelay = JitInfo.TieredDelay;
 
@@ -88,49 +85,40 @@ internal sealed class EngineJitStage : EngineStage
         // Don't make the next jit stage wait if it's ran in the same process.
         s_tieredDelay = TimeSpan.Zero;
 
-        // Attempt to promote methods to tier1, but don't spend too much time in jit stage.
-        StartedClock startedClock = parameters.TargetJob.ResolveValue(InfrastructureMode.ClockCharacteristic, parameters.Resolver)!.Start();
-
-        int remainingTiers = JitInfo.MaxTierPromotions;
-        long lastInvokeCount = userInvokeCount;
-        while (remainingTiers > 0)
+        // If the first iteration suggests a long-running benchmark (a single invocation already
+        // takes ~2/3 of IterationTime or more), run one confirmation iteration and bail out if
+        // it agrees. Same cutoff value that pilot stage uses.
+        // We do not bail out immediately if the first iteration is long-running because it could
+        // be due to cctors or other lazy initialization that won't be hit in steady-state. #2004
+        TimeInterval iterationTime = parameters.TargetJob.ResolveValue(RunMode.IterationTimeCharacteristic, parameters.Resolver);
+        long remainingCalls = JitInfo.TieredCallCountThreshold;
+        if (iterationTime.Nanoseconds / (lastMeasurement.Nanoseconds / (double)userInvokeCount) < 1.5)
         {
-            --remainingTiers;
-            long remainingCalls = JitInfo.TieredCallCountThreshold;
+            ++iterationIndex;
+            yield return GetWorkloadIterationData(userInvokeCount);
+            if (iterationTime.Nanoseconds / (lastMeasurement.Nanoseconds / (double)userInvokeCount) < 1.5)
+            {
+                didStopEarly = true;
+                yield break;
+            }
+            remainingCalls -= userInvokeCount;
+        }
+
+        // Promote methods to tier1.
+        for (int remainingTiers = JitInfo.MaxTierPromotions; remainingTiers > 0; --remainingTiers)
+        {
             while (remainingCalls > 0)
             {
-                long invokeCount;
-                if (hasUserInvocationCount)
-                {
-                    invokeCount = userInvokeCount;
-                }
-                else
-                {
-                    // If we can run a batch of calls within the time limit (based on the last measurement), do that instead of multiple single-invocation iterations.
-                    // For long-running benchmarks where even a small batch wouldn't fit, fall back to one invocation per iteration.
-                    var remainingTimeLimit = MaxTieringTime.ToNanoseconds() - startedClock.GetElapsed().GetNanoseconds();
-                    var lastMeasurementSingleInvocationTime = lastMeasurement.Nanoseconds / lastInvokeCount;
-                    long allowedCallsWithinTimeLimit = (long)Math.Floor(remainingTimeLimit / lastMeasurementSingleInvocationTime);
-                    invokeCount = allowedCallsWithinTimeLimit > 0
-                        ? Math.Min(remainingCalls, allowedCallsWithinTimeLimit)
-                        : 1;
-                }
-                lastInvokeCount = invokeCount;
-
+                // Run the whole tier's call budget in a single iteration unless the user pinned InvocationCount.
+                long invokeCount = hasUserInvocationCount ? userInvokeCount : remainingCalls;
                 remainingCalls -= invokeCount;
                 ++iterationIndex;
                 // The generated __Overhead method is aggressively optimized, so we don't need to run it again.
                 yield return GetWorkloadIterationData(invokeCount);
-
-                if ((remainingTiers > 0 || remainingCalls > 0)
-                    && startedClock.GetElapsed().GetTimeValue() >= MaxTieringTime)
-                {
-                    didStopEarly = true;
-                    yield break;
-                }
             }
 
             Engine.SleepIfPositive(JitInfo.BackgroundCompilationDelay);
+            remainingCalls = JitInfo.TieredCallCountThreshold;
         }
 
         // Empirical evidence shows that the first call after the method is tiered up may take longer,

--- a/src/BenchmarkDotNet/Engines/EngineResolver.cs
+++ b/src/BenchmarkDotNet/Engines/EngineResolver.cs
@@ -33,6 +33,7 @@ namespace BenchmarkDotNet.Engines
             Register(AccuracyMode.MinInvokeCountCharacteristic, () => 4);
             Register(AccuracyMode.EvaluateOverheadCharacteristic, () => false);
             Register(RunMode.MemoryRandomizationCharacteristic, () => false);
+            Register(RunMode.JitTieringModeCharacteristic, () => JitTieringMode.Auto);
             Register(AccuracyMode.OutlierModeCharacteristic, job =>
             {
                 // if Memory Randomization was enabled and the benchmark is truly multimodal

--- a/src/BenchmarkDotNet/Engines/JitTieringMode.cs
+++ b/src/BenchmarkDotNet/Engines/JitTieringMode.cs
@@ -1,0 +1,25 @@
+namespace BenchmarkDotNet.Engines;
+
+/// <summary>
+/// Controls the behavior of the JIT stage when tiering is enabled.
+/// </summary>
+public enum JitTieringMode
+{
+    /// <summary>
+    /// Default.
+    /// If the benchmark is long-running, tiering is skipped and the benchmark method is left at the tier following the initial invoke (usually tier0).
+    /// Otherwise, the JIT stage attempts to force the benchmark method and its callees to be promoted to their final tier by calling it repeatedly before measurements begin.
+    /// </summary>
+    Auto,
+
+    /// <summary>
+    /// Forces the JIT stage to attempt to force the benchmark method and its callees to be promoted to their final tier by calling it repeatedly before measurements begin.
+    /// Useful when you want the most stable tier1 measurements even for longer-running benchmarks.
+    /// </summary>
+    Force,
+
+    /// <summary>
+    /// Forces the JIT stage to skip tier promotion entirely, leaving the benchmark method at the tier following the initial invoke (usually tier0).
+    /// </summary>
+    Skip
+}

--- a/src/BenchmarkDotNet/Jobs/JobExtensions.cs
+++ b/src/BenchmarkDotNet/Jobs/JobExtensions.cs
@@ -199,6 +199,9 @@ namespace BenchmarkDotNet.Jobs
         /// </summary>
         public static Job WithMemoryRandomization(this Job job, bool enable = true) => job.WithCore(j => j.Run.MemoryRandomization = enable);
 
+        /// <inheritdoc cref="RunMode.JitTieringMode"/>
+        public static Job WithJitTieringMode(this Job job, JitTieringMode mode) => job.WithCore(j => j.Run.JitTieringMode = mode);
+
         // Infrastructure
         public static Job WithToolchain(this Job job, IToolchain toolchain) => job.WithCore(j => j.Infrastructure.Toolchain = toolchain);
 

--- a/src/BenchmarkDotNet/Jobs/RunMode.cs
+++ b/src/BenchmarkDotNet/Jobs/RunMode.cs
@@ -25,6 +25,7 @@ namespace BenchmarkDotNet.Jobs
         public static readonly Characteristic<int> MinWarmupIterationCountCharacteristic = CreateCharacteristic<int>(nameof(MinWarmupIterationCount));
         public static readonly Characteristic<int> MaxWarmupIterationCountCharacteristic = CreateCharacteristic<int>(nameof(MaxWarmupIterationCount));
         public static readonly Characteristic<bool> MemoryRandomizationCharacteristic = CreateCharacteristic<bool>(nameof(MemoryRandomization));
+        public static readonly Characteristic<JitTieringMode> JitTieringModeCharacteristic = CreateCharacteristic<JitTieringMode>(nameof(JitTieringMode));
 
         public static readonly RunMode Dry = new RunMode(nameof(Dry))
         {
@@ -188,6 +189,20 @@ namespace BenchmarkDotNet.Jobs
         {
             get => MemoryRandomizationCharacteristic[this];
             set => MemoryRandomizationCharacteristic[this] = value;
+        }
+
+        /// <summary>
+        /// Controls the behavior of the JIT stage when tiering is enabled.
+        /// <list type="bullet">
+        /// <item><see cref="JitTieringMode.Auto"/> (default): Promote through every tier for short-running benchmarks only.</item>
+        /// <item><see cref="JitTieringMode.Force"/>: Always promote through every tier, regardless of invocation time.</item>
+        /// <item><see cref="JitTieringMode.Skip"/>: Skip tier promotion entirely.</item>
+        /// </list>
+        /// </summary>
+        public JitTieringMode JitTieringMode
+        {
+            get => JitTieringModeCharacteristic[this];
+            set => JitTieringModeCharacteristic[this] = value;
         }
 
         internal BdnExecution ToPerfonar() => new()

--- a/tests/BenchmarkDotNet.Tests/Engine/EnumerateStagesTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Engine/EnumerateStagesTests.cs
@@ -2,6 +2,7 @@ using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Tests.XUnit;
 using JetBrains.Annotations;
 using Perfolizer.Horology;
 
@@ -229,6 +230,80 @@ namespace BenchmarkDotNet.Tests.Engine
             // pinned InvocationCount=1, matching JitInfo.MaxTierPromotions * TieredCallCountThreshold)
             // + one stabilization iteration. Just assert it ran the full tiering loop rather than bailing.
             Assert.True(jitWorkloadCount > 2, $"Expected the tiering loop to run after confirmation disagreed, got {jitWorkloadCount} jitting iterations.");
+        }
+
+        [FactEnvSpecific("Requires tiered JIT", EnvRequirement.DotNetCoreOnly)]
+        public void ForceJitTieringModeRunsFullTieringLoopEvenForLongRunningBenchmarks()
+        {
+            // Tier-promotion loop is skipped entirely on non-tiered runtimes, so there is nothing to force.
+            if (!JitInfo.IsTiered) return;
+
+            // A benchmark whose single invocation far exceeds IterationTime would normally trip the
+            // long-running heuristic and bail (see LongRunningBenchmarksExitJitStageEarly).
+            // JitTieringMode.Force opts out of that heuristic and always promotes through every tier.
+            var slowMeasurement = TimeInterval.FromSeconds(4); // ~8x default IterationTime of 500ms
+            var job = Job.Default.WithInvocationCount(1).WithUnrollFactor(1).WithJitTieringMode(JitTieringMode.Force);
+            var engineParameters = CreateEngineParameters(job);
+
+            int jitWorkloadCount = 0;
+            bool didStopEarly = false;
+            foreach (var stage in EngineStage.EnumerateStages(engineParameters))
+            {
+                var stageMeasurements = stage.GetMeasurementList();
+                while (stage.GetShouldRunIteration(stageMeasurements, out var iterationData))
+                {
+                    if (stage is EngineJitStage && iterationData.mode == IterationMode.Workload)
+                    {
+                        jitWorkloadCount++;
+                    }
+                    stageMeasurements.Add(new Measurement(0, iterationData.mode, iterationData.stage, iterationData.index, iterationData.invokeCount, slowMeasurement.Nanoseconds));
+                }
+
+                if (stage is EngineJitStage jitStage)
+                {
+                    didStopEarly = jitStage.didStopEarly;
+                    break;
+                }
+            }
+
+            Assert.False(didStopEarly, "Force mode should never bail out of the JIT stage early.");
+            Assert.True(jitWorkloadCount > 2, $"Expected the full tiering loop to run under Force mode, got {jitWorkloadCount} jitting iterations.");
+        }
+
+        [Fact]
+        public void SkipJitTieringModeSkipsTierPromotion()
+        {
+            // JitTieringMode.Skip runs only the initial workload iteration and leaves tier promotion to the
+            // following Pilot/Warmup stages (as on non-tiered runtimes). Unlike the long-running bail-out,
+            // it does not flag the benchmark as long-running, so the Pilot stage still runs normally.
+            var fastMeasurement = TimeInterval.FromMicroseconds(1); // would normally run the full tiering loop
+            var job = Job.Default.WithInvocationCount(1).WithUnrollFactor(1).WithJitTieringMode(JitTieringMode.Skip);
+            var engineParameters = CreateEngineParameters(job);
+
+            int jitWorkloadCount = 0;
+            bool didStopEarly = false;
+            foreach (var stage in EngineStage.EnumerateStages(engineParameters))
+            {
+                var stageMeasurements = stage.GetMeasurementList();
+                while (stage.GetShouldRunIteration(stageMeasurements, out var iterationData))
+                {
+                    if (stage is EngineJitStage && iterationData.mode == IterationMode.Workload)
+                    {
+                        jitWorkloadCount++;
+                    }
+                    stageMeasurements.Add(new Measurement(0, iterationData.mode, iterationData.stage, iterationData.index, iterationData.invokeCount, fastMeasurement.Nanoseconds));
+                }
+
+                if (stage is EngineJitStage jitStage)
+                {
+                    didStopEarly = jitStage.didStopEarly;
+                    break;
+                }
+            }
+
+            // Only the single pre-loop workload iteration runs; the tier-promotion loop is skipped.
+            Assert.Equal(1, jitWorkloadCount);
+            Assert.False(didStopEarly, "Skip mode should not flag the benchmark as long-running.");
         }
 
         [Fact]

--- a/tests/BenchmarkDotNet.Tests/Engine/EnumerateStagesTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Engine/EnumerateStagesTests.cs
@@ -1,5 +1,6 @@
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Reports;
 using JetBrains.Annotations;
 using Perfolizer.Horology;
@@ -161,6 +162,73 @@ namespace BenchmarkDotNet.Tests.Engine
                     stageMeasurements.Add(measurement);
                 }
             }
+        }
+
+        [Fact]
+        public void LongRunningBenchmarksExitJitStageEarly()
+        {
+            // #3114: a benchmark whose single invocation exceeds IterationTime shouldn't drag
+            // the JIT stage through the full tier-promotion loop. The pre-loop iteration
+            // absorbs cctors/lazy-init; a confirmation iteration trips the long-running
+            // heuristic and bails.
+            var slowMeasurement = TimeInterval.FromSeconds(4); // ~8x default IterationTime of 500ms
+            var job = Job.Default.WithInvocationCount(1).WithUnrollFactor(1);
+            var engineParameters = CreateEngineParameters(job);
+
+            int jitWorkloadCount = 0;
+            foreach (var stage in EngineStage.EnumerateStages(engineParameters))
+            {
+                var stageMeasurements = stage.GetMeasurementList();
+                while (stage.GetShouldRunIteration(stageMeasurements, out var iterationData))
+                {
+                    if (stage is EngineJitStage && iterationData.mode == IterationMode.Workload)
+                    {
+                        jitWorkloadCount++;
+                    }
+                    var measurement = new Measurement(0, iterationData.mode, iterationData.stage, iterationData.index, iterationData.invokeCount, slowMeasurement.Nanoseconds);
+                    stageMeasurements.Add(measurement);
+                }
+
+                if (stage is EngineJitStage) break;
+            }
+
+            // Non-tiered runtimes yield exactly one iteration; tiered runtimes yield two
+            // (the pre-loop one, then a single confirmation before bailing).
+            Assert.Equal(JitInfo.IsTiered ? 2 : 1, jitWorkloadCount);
+        }
+
+        [Fact]
+        public void SlowFirstIterationButFastSteadyStateDoesNotExitJitStageEarly()
+        {
+            // If only the first iteration looks long-running (e.g. expensive cctor / lazy init),
+            // the confirmation iteration disagrees and the tiering loop continues as before.
+            if (!JitInfo.IsTiered) return; // Tier-promotion loop is skipped entirely on non-tiered runtimes.
+
+            var slowFirst = TimeInterval.FromSeconds(4).Nanoseconds;
+            var fastRest = TimeInterval.FromMicroseconds(1).Nanoseconds;
+            var engineParameters = CreateEngineParameters(Job.Default.WithInvocationCount(1).WithUnrollFactor(1));
+
+            int jitWorkloadCount = 0;
+            foreach (var stage in EngineStage.EnumerateStages(engineParameters))
+            {
+                var stageMeasurements = stage.GetMeasurementList();
+                while (stage.GetShouldRunIteration(stageMeasurements, out var iterationData))
+                {
+                    if (stage is EngineJitStage && iterationData.mode == IterationMode.Workload)
+                    {
+                        jitWorkloadCount++;
+                    }
+                    var ns = jitWorkloadCount == 1 && stage is EngineJitStage ? slowFirst : fastRest;
+                    stageMeasurements.Add(new Measurement(0, iterationData.mode, iterationData.stage, iterationData.index, iterationData.invokeCount, ns));
+                }
+
+                if (stage is EngineJitStage) break;
+            }
+
+            // Pre-loop iter + confirmation + full tiering loop (one yield per tier since the user
+            // pinned InvocationCount=1, matching JitInfo.MaxTierPromotions * TieredCallCountThreshold)
+            // + one stabilization iteration. Just assert it ran the full tiering loop rather than bailing.
+            Assert.True(jitWorkloadCount > 2, $"Expected the tiering loop to run after confirmation disagreed, got {jitWorkloadCount} jitting iterations.");
         }
 
         [Fact]


### PR DESCRIPTION
Bails out after the second invocation if it detects a long-running benchmark using the same calculation as the pilot stage, instead of continuing invokes for 10 seconds.

Fixes #3114 