### PR TITLE
chore: Enable MosCpuDetector on .NET runtime

### DIFF
--- a/src/BenchmarkDotNet/Detectors/Cpu/Windows/MosCpuDetector.cs
+++ b/src/BenchmarkDotNet/Detectors/Cpu/Windows/MosCpuDetector.cs
@@ -10,9 +10,7 @@ namespace BenchmarkDotNet.Detectors.Cpu.Windows;
 internal class MosCpuDetector : ICpuDetector
 {
     [SupportedOSPlatform("windows")]
-    public bool IsApplicable() => OsDetector.IsWindows() &&
-                                  RuntimeInformation.IsFullFramework &&
-                                  !RuntimeInformation.IsMono;
+    public bool IsApplicable() => OsDetector.IsWindows() && !RuntimeInformation.IsMono;
 
     [SupportedOSPlatform("windows")]
     public CpuInfo? Detect()


### PR DESCRIPTION
This PR remove `RuntimeInformation.IsFullFramework` condition from MosCpuDetector.

As far as I've tested.
It works on both `x64`/`arm64` environment and run faster than `PowershellWmiCpuDetector` (It call external process)
