### PR TITLE
chore: Modify external PowerShell/Pwsh invoke logics

### DIFF
--- a/src/BenchmarkDotNet/Detectors/Cpu/Windows/PowershellWmiCpuDetector.cs
+++ b/src/BenchmarkDotNet/Detectors/Cpu/Windows/PowershellWmiCpuDetector.cs
@@ -23,14 +23,9 @@ internal class PowershellWmiCpuDetector : ICpuDetector
                                $"{WmiCpuInfoKeyNames.NumberOfLogicalProcessors}, " +
                                $"{WmiCpuInfoKeyNames.MaxClockSpeed}";
 
-        var exePath = PowerShellLocator.LocateOnWindows() ?? "powershell";
         var command = $"Get-CimInstance Win32_Processor -Property {argList} | Format-List {argList}";
-        var envVars = new Dictionary<string, string>
-        {
-            ["TERM"] = "dumb" // Suppress outputting ANSI escape sequences.
-        };
 
-        string? output = ProcessHelper.RunAndReadOutput(exePath, $"-Command \"{command}\"", environmentVariables: envVars);
+        string? output = ProcessHelper.RunPowerShellCommandAndReadOutput(command);
 
         if (output.IsBlank())
             return null;

--- a/src/BenchmarkDotNet/Helpers/ProcessHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/ProcessHelper.cs
@@ -1,9 +1,12 @@
 using BenchmarkDotNet.Detectors;
-using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Loggers;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+
+#if NETSTANDARD
+using BenchmarkDotNet.Extensions;
+#endif
 
 namespace BenchmarkDotNet.Helpers
 {
@@ -81,6 +84,59 @@ namespace BenchmarkDotNet.Helpers
             var output = includeErrors ? outputReader.GetOutputAndErrorLines() : outputReader.GetOutputLines();
 
             return (process.ExitCode, output);
+        }
+
+        /// <summary>
+        /// Run powershell/pwsh command and return the console output.
+        /// In the case of any exception, null will be returned.
+        /// </summary>
+        internal static string? RunPowerShellCommandAndReadOutput(string command, ILogger? logger = null, Dictionary<string, string>? environmentVariables = null)
+        {
+            string fileName = OsDetector.IsWindows()
+                ? PowerShellLocator.LocateOnWindows() ?? "powershell"
+                : "pwsh";
+
+            var arguments = $"""
+                -NoProfile -Command "$ErrorActionPreference='Stop';{command}"
+                """;
+
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                WorkingDirectory = "",
+                Arguments = arguments,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+            };
+
+            environmentVariables ??= [];
+
+            // Suppress outputting ANSI escape sequences.
+            if (!environmentVariables.ContainsKey("TERM"))
+                environmentVariables.Add("TERM", "dumb");
+
+            foreach (var variable in environmentVariables)
+                processStartInfo.Environment.Add(variable.Key, variable.Value);
+
+            using var process = new Process { StartInfo = processStartInfo };
+            using (new ProcessCleanupHelper(process, logger ?? NullLogger.Instance))
+            {
+                try
+                {
+                    process.Start();
+                }
+                catch (Exception)
+                {
+                    if (XUnitHelper.IsIntegrationTest.Value)
+                        throw;
+
+                    return null;
+                }
+                string output = process.StandardOutput.ReadToEnd();
+                process.WaitForExit();
+                return output;
+            }
         }
 
         internal static bool TestCommandExists(string commandName, string arguments = "--version")

--- a/tests/BenchmarkDotNet.IntegrationTests/Environments/HostEnvironmentTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/Environments/HostEnvironmentTests.cs
@@ -1,0 +1,31 @@
+using AwesomeAssertions;
+using BenchmarkDotNet.Environments;
+
+namespace BenchmarkDotNet.IntegrationTests;
+
+public class HostEnvironmentTests
+{
+    [Fact]
+    public void ValidateLazyInitializedValues()
+    {
+        var info = HostEnvironmentInfo.GetCurrent();
+
+        // Gets lazy initialized values
+        var os = info.Os.Value;
+        var cpu = info.Cpu.Value;
+        var physicalMemory = info.PhysicalMemory;
+        var vmHypervisor = info.VirtualMachineHypervisor.Value;
+        var antivirusProduct = info.AntivirusProducts.Value;
+        var dotnetSdkVersion = info.DotNetSdkVersion.Value;
+
+        // Assert
+        os.Should().NotBeNull();
+        cpu.Should().NotBeNull();
+        physicalMemory.Should().NotBeNull();
+        antivirusProduct.Should().NotBeNull();
+        dotnetSdkVersion.Should().NotBeNullOrEmpty();
+
+        if (ContinuousIntegration.IsGitHubActionsOnWindows())
+            vmHypervisor.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
This PR modify PowerShell/Pwsh relating logics

#### What's changed in this PR
**1. ProcessHelper.cs**
Add `RunPowerShellCommandAndReadOutput` helper method to invoke powershell/pwsh command.
And add following code.
- Add `-NoProfile` argument for faster launch
- Add `$ErrorActionPreference='Stop'` statement to throw exception on error.
- Set `TERM=dumb` environment variable by default to suppress ANSI escape sequence
- Add throw logics when running on `IntegrationTests` to avoid exception is silently ignored.

**2. PowershellWmiCpuDetector.cs**
Modify powershell invoke code to use helper method.

**3. HostEnvironmentTests.cs**
Add tests to validate values that are lazy-initialized.