### PR TITLE
chore: Fix xunit tests that failed to deserialize theory's member data

### DIFF
--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -77,7 +77,7 @@ namespace BenchmarkDotNet.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Exporters))]
+        [MemberData(nameof(Exporters), DisableDiscoveryEnumeration = true)]
         public void ExportersAreParsedCorrectly(string exporter, IExporter[] expectedExporters)
         {
             var config = ConfigParser.Parse(["--exporters", exporter], new OutputLogger(Output)).config;


### PR DESCRIPTION
This PR intended to fix warning for `MemberData` when non-deserialize type is passed as argument.