### PR TITLE
chore: Fix duplicated analyzer tests test cases

### DIFF
--- a/tests/BenchmarkDotNet.Analyzers.Tests/AnalyzerTests/Attributes/ArgumentsAttributeAnalyzerTests.cs
+++ b/tests/BenchmarkDotNet.Analyzers.Tests/AnalyzerTests/Attributes/ArgumentsAttributeAnalyzerTests.cs
@@ -353,13 +353,17 @@ public class ArgumentsAttributeAnalyzerTests
                 "\"value\", 100, false"
             ];
 
+            HashSet<string> hashSet = new();
+
             foreach (var attributeUsageBase in attributeUsagesBase)
             {
                 foreach (var nameColonUsage in nameColonUsages)
                 {
                     foreach (var priorityNamedParameterUsage in priorityNamedParameterUsages)
                     {
-                        yield return string.Join("\n    ", valueLists.Select((vv, i) => $"[{{|#{i}:{string.Format(attributeUsageBase, nameColonUsage, vv, priorityNamedParameterUsage)}|}}]"));
+                        var value = string.Join("\n    ", valueLists.Select((vv, i) => $"[{{|#{i}:{string.Format(attributeUsageBase, nameColonUsage, vv, priorityNamedParameterUsage)}|}}]"));
+                        if (hashSet.Add(value))
+                            yield return value;
                     }
                 }
             }


### PR DESCRIPTION
This PR intended to fix following **duplicated** TheoryData skip message.

>  Skipping test case with duplicate ID '...' 

```
2026-05-24T23:17:20.3535760Z [xUnit.net 00:00:01.61] BenchmarkDotNet.Analyzers.Tests: Skipping test case with duplicate ID 'a236bf49521839c2a615160a2672f2d3a87a84cc' ('BenchmarkDotNet.Analyzers.Tests.AnalyzerTests.Attributes.ArgumentsAttributeAnalyzerTests+MustHaveMatchingValueCount.Having_a_mismatching_value_count_should_trigger_diagnostic(argumentsAttributeUsage: "[{|#0:Arguments(42, \"test\")|}]\n    [{|#1:Argume"···)' and 'BenchmarkDotNet.Analyzers.Tests.AnalyzerTests.Attributes.ArgumentsAttributeAnalyzerTests+MustHaveMatchingValueCount.Having_a_mismatching_value_count_should_trigger_diagnostic(argumentsAttributeUsage: "[{|#0:Arguments(42, \"test\")|}]\n    [{|#1:Argume"···)')
2026-05-24T23:17:20.3543310Z [xUnit.net 00:00:01.61] BenchmarkDotNet.Analyzers.Tests: Skipping test case with duplicate ID '14214bbc1a6821bd6731f3bc88d50390c5327d51' ('BenchmarkDotNet.Analyzers.Tests.AnalyzerTests.Attributes.ArgumentsAttributeAnalyzerTests+MustHaveMatchingValueCount.Having_a_mismatching_value_count_should_trigger_diagnostic(argumentsAttributeUsage: "[{|#0:Arguments(42, \"test\", Priority = 1)|}]\n  "···)' and 'BenchmarkDotNet.Analyzers.Tests.AnalyzerTests.Attributes.ArgumentsAttributeAnalyzerTests+MustHaveMatchingValueCount.Having_a_mismatching_value_count_should_trigger_diagnostic(argumentsAttributeUsage: "[{|#0:Arguments(42, \"test\", Priority = 1)|}]\n  "···)')
```