### PR TITLE
chore: Update GitHub Actions package dependencies

### DIFF
--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -31,7 +31,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push changelog
-      uses: JamesIves/github-pages-deploy-action@9d877eea73427180ae43cf98e8914934fe157a1a # v4.7.6
+      uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
       with:
         branch: docs-changelog
         folder: docs/_changelog

--- a/.github/workflows/generate-gh-pages.yaml
+++ b/.github/workflows/generate-gh-pages.yaml
@@ -63,7 +63,7 @@ jobs:
       run: tree $GITHUB_WORKSPACE
 
     - name: Deploy documentation
-      uses: JamesIves/github-pages-deploy-action@9d877eea73427180ae43cf98e8914934fe157a1a # v4.7.6
+      uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
       with:
         branch: gh-pages
         folder: site

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,14 +83,14 @@ jobs:
     # --- Release ---
 
     - name: Push git changes
-      uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # v1.0.0
+      uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: master
         tags: true
 
     - name: Release
-      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
       with:
         name: BenchmarkDotNet v${{ steps.version.outputs.VERSION }}
         tag_name: v${{ steps.version.outputs.VERSION }}
@@ -128,7 +128,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push changelog
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
       with:
         branch: docs-changelog
         folder: docs/_changelog
@@ -140,7 +140,7 @@ jobs:
       run: ./build.cmd docs-build
 
     - name: Deploy documentation
-      uses: JamesIves/github-pages-deploy-action@9d877eea73427180ae43cf98e8914934fe157a1a # v4.7.6
+      uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
       with:
         branch: gh-pages
         folder: docs/_site


### PR DESCRIPTION
This PR update following GitHub Action's package dependencies to avoid Node.js 20 relating warnings.
1. `JamesIves/github-pages-deploy-action`
2. `ad-m/github-push-action`
3. `softprops/action-gh-release`

As far as I've confirmed ReleaseNote/CommitHistory,
There is no breaking changes, and safe to use latest versions.
