### PR TITLE
chore: Fix v8 installation silently failed issue on CI

### DIFF
--- a/.github/actions/setup-additional-tools/action.yaml
+++ b/.github/actions/setup-additional-tools/action.yaml
@@ -11,16 +11,24 @@ runs:
     - name: Set up node
       uses: actions/setup-node@v6
       with:
-        node-version: "24"
+        node-version: "24.15.0" # Temporary workaround for https://github.com/dotnet/BenchmarkDotNet/issues/3154
 
     - name: Set up v8
+      shell: bash
+      run: npx jsvu --os=default --engines=v8
+
+    - name: Add `GITHUB_PATH` environment variable
       shell: pwsh
       run: |
-        npm install jsvu -g
-        jsvu --os=default --engines=v8
-        
         $jsvuDir = Join-Path $HOME '.jsvu/bin'
         Add-Content -Path $env:GITHUB_PATH -Value $jsvuDir
+
+    - name: Add `GITHUB_PATH` environment variable and verify command exists
+      shell: pwsh
+      run: |
+        if (-not (Get-Command v8 -ErrorAction SilentlyContinue)) {
+            throw "v8 command is not found."
+        }
 
     - name: Install wasm-tools workload
       shell: bash


### PR DESCRIPTION
This PR intended to fix #3154 by explicitly install Node.js `v24.15.0`.

#### Other Changes
1. Replace `npm install` command to `npx` command.
2. Move `jsvu` command execution on separated `bash` step.   
  (Because `pwsh` require `$PSNativeCommandUseErrorActionPreference` setting to handle native command exit code)
4. Add command exists check logics to avoid silent exit issue on early CI stage. 
