### PR TITLE
chore: Migrate Cake.Git package to Cake.Frosting.Git

### DIFF
--- a/build/BenchmarkDotNet.Build/BenchmarkDotNet.Build.csproj
+++ b/build/BenchmarkDotNet.Build/BenchmarkDotNet.Build.csproj
@@ -7,9 +7,9 @@
     <NoWarn>$(NoWarn);CA2007</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="6.2.0" />
     <PackageReference Include="Cake.FileHelpers" Version="9.0.0" />
-    <PackageReference Include="Cake.Git" Version="5.0.1" />
+    <PackageReference Include="Cake.Frosting" Version="6.2.0" />
+    <PackageReference Include="Cake.Frosting.Git" Version="5.0.1" />
     <PackageReference Include="Docfx.App" Version="2.78.5" />
     <PackageReference Include="Octokit" Version="14.0.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR replace `Cake.Git` to `Cake.Frosting.Git` package
to avoid following warning on `dotnet build`.

> warning MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. PE image does not have metadata. PE image does not have metadata.

See: `https://github.com/cake-contrib/Cake_Git/issues/137`
