### PR TITLE
chore: Re-enable flaky test(UserCanSpecifyCustomBuildConfiguration) for .NET Framework

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/CustomBuildConfigurationTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/CustomBuildConfigurationTests.cs
@@ -16,13 +16,13 @@ namespace BenchmarkDotNet.IntegrationTests
         {
         }
 
-        [FactEnvSpecific("Flaky, see https://github.com/dotnet/BenchmarkDotNet/issues/2376", EnvRequirement.NonFullFramework)]
+        [FactEnvSpecific(EnvRequirement.NonGitHubDraftPR)]
         public void UserCanSpecifyCustomBuildConfiguration()
         {
             var jobWithCustomConfiguration = Job.Dry.WithCustomBuildConfiguration("CUSTOM");
 
             var config = CreateSimpleConfig(job: jobWithCustomConfiguration);
-            config = ((ManualConfig)config).WithBuildTimeout(TimeSpan.FromSeconds(240));
+            config = ((ManualConfig)config).WithBuildTimeout(TimeSpan.FromSeconds(360));
 
             var report = CanExecute<CustomBuildConfiguration>(config);
 


### PR DESCRIPTION
This PR intended to fix #2376

#### What's changed in this PR
1. Remove `NonFullFramework` env requirement.
2. Increase build timeout to `360s` (When I've tested before. `240` timeout is not enough on .NET Framework)
3. Add `NonGitHubDraftPR` env requirement (#3088)
