### PR TITLE
deps: Update Perfolizer package version to `0.7.1`

### DIFF
--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -28,10 +28,10 @@
     <PackageReference Include="Gee.External.Capstone" Version="2.3.0" />
     <PackageReference Include="Iced" Version="1.21.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="4.0.726401" />
-    <PackageReference Include="Perfolizer" Version="[0.6.6]" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.3" PrivateAssets="contentfiles;analyzers" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Perfolizer" Version="[0.7.1]" />
     <PackageReference Include="System.Management" Version="10.0.8" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />
     <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.8" />


### PR DESCRIPTION
This PR update `Perfolizer` package dependency to latest version.

Currently, this package version is specified explicitly.
So if there are any known issues on updating `Perfolizer` version, Please close this PR.

As far as I've confirmed, there is following comment.
https://github.com/dotnet/BenchmarkDotNet/issues/3056#issuecomment-4113773740
