### PR TITLE
chore: Remove duplicated tests on CI

### DIFF
--- a/build/BenchmarkDotNet.Build/Helpers/Utils.cs
+++ b/build/BenchmarkDotNet.Build/Helpers/Utils.cs
@@ -1,9 +1,10 @@
+using Cake.Common;
+using Cake.Common.Tools.DotNet;
+using Octokit;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-using Cake.Common.Tools.DotNet;
-using Octokit;
 
 namespace BenchmarkDotNet.Build.Helpers;
 
@@ -57,5 +58,28 @@ public static class Utils
 
         var oldValue = match.Groups[1].Value;
         return content.Replace(oldValue, newValue);
+    }
+
+    public static string[] GetTargetFrameworks(BuildContext context)
+    {
+        var jobName = context.Environment.GetEnvironmentVariable("GITHUB_JOB");
+
+        switch (jobName)
+        {
+            case "test-windows-core":
+                return ["net8.0"];
+
+            case "test-windows-full":
+                return ["net472"];
+
+            case "test-linux":
+            case "test-macos":
+                return ["net8.0"];
+
+            default:
+                return context.IsRunningOnWindows()
+                    ? ["net472", "net8.0"]
+                    : ["net8.0"];
+        }
     }
 }

--- a/build/BenchmarkDotNet.Build/Runners/UnitTestRunner.cs
+++ b/build/BenchmarkDotNet.Build/Runners/UnitTestRunner.cs
@@ -1,5 +1,4 @@
 using BenchmarkDotNet.Build.Helpers;
-using Cake.Common;
 using Cake.Common.Diagnostics;
 using Cake.Common.Tools.DotNet;
 using Cake.Common.Tools.DotNet.Test;
@@ -70,14 +69,14 @@ public class UnitTestRunner(BuildContext context)
 
     public void RunUnitTests()
     {
-        string[] targetFrameworks = context.IsRunningOnWindows() ? ["net472", "net8.0"] : ["net8.0"];
+        string[] targetFrameworks = Utils.GetTargetFrameworks(context);
         foreach (var targetFramework in targetFrameworks)
             RunUnitTests(targetFramework);
     }
 
     public void RunAnalyzerTests()
     {
-        string[] targetFrameworks = context.IsRunningOnWindows() ? ["net472", "net8.0"] : ["net8.0"];
+        string[] targetFrameworks = Utils.GetTargetFrameworks(context);
         foreach (var targetFramework in targetFrameworks)
             RunTests(AnalyzerTestsProjectFile, "analyzer", targetFramework);
     }


### PR DESCRIPTION
This PR add setting to skip duplicated tests on CI to avoid unnecessary test reports are generated.

- On `test-windows-core` job, run only net8.0 tests.
- On `test-windows-full` job, run net472 tests.
- On other environment, keep existing behaviors.
