### PR TITLE
chore: Add test skip condition when running CI on draft PR

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkSwitcherTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkSwitcherTest.cs
@@ -283,7 +283,7 @@ namespace BenchmarkDotNet.IntegrationTests
             Assert.True(results.All(r => r.BenchmarksCases.All(bc => bc.Job == Job.Dry)));
         }
 
-        [Fact]
+        [FactEnvSpecific(EnvRequirement.NonGitHubDraftPR)]
         public void JobNotDefinedButStillBenchmarkIsExecuted()
         {
             var types = new[] { typeof(JustBenchmark) };

--- a/tests/BenchmarkDotNet.IntegrationTests/CancellationTokenTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/CancellationTokenTests.cs
@@ -115,7 +115,7 @@ public class CancellationTokenTests(ITestOutputHelper output) : BenchmarkTestExe
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await BenchmarkRunner.RunAsync<SimpleBenchmark>(config, cancellationToken: cts.Token));
     }
 
-    [Theory]
+    [TheoryEnvSpecific(EnvRequirement.NonGitHubDraftPR)]
     [InlineDataEnvSpecific("v8", "JSVU does not support ARM on Windows or Linux", [EnvRequirement.NonWindowsArm, EnvRequirement.NonLinuxArm, EnvRequirement.NonGitHubDraftPR])]
     [InlineData("node")]
     public async Task RunWithCancellationTokenIsCancelled_Wasm(string javaScriptEngine)

--- a/tests/BenchmarkDotNet.IntegrationTests/EngineTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/EngineTests.cs
@@ -3,6 +3,7 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Tests.XUnit;
 using BenchmarkDotNet.Toolchains;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
@@ -79,9 +80,9 @@ namespace BenchmarkDotNet.IntegrationTests
             Job.Default.GetToolchain()
         ];
 
-        // #1120
-        [Theory]
-        [MemberData(nameof(GetToolchains))]
+        // https://github.com/dotnet/BenchmarkDotNet/issues/1120
+        [TheoryEnvSpecific(EnvRequirement.NonGitHubDraftPR)]
+        [MemberData(nameof(GetToolchains), DisableDiscoveryEnumeration = true)]
         public void BenchmarkIsInvokedWithSameStack(IToolchain toolchain)
         {
             CanExecute<StackBench>(DefaultConfig.Instance

--- a/tests/BenchmarkDotNet.IntegrationTests/InProcessDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/InProcessDiagnoserTests.cs
@@ -4,6 +4,7 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.IntegrationTests.Diagnosers;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Tests.Loggers;
+using BenchmarkDotNet.Tests.XUnit;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 using RunMode = BenchmarkDotNet.Diagnosers.RunMode;
@@ -114,7 +115,7 @@ public class InProcessDiagnoserTests(ITestOutputHelper output) : BenchmarkTestEx
             .AddJob(job);
     }
 
-    [Theory]
+    [TheoryEnvSpecific(EnvRequirement.NonGitHubDraftPR)]
     [MemberData(nameof(GetTestCombinations))]
     public void MultipleInProcessDiagnosersWork(RunMode[] runModes, ToolchainType toolchain)
     {

--- a/tests/BenchmarkDotNet.IntegrationTests/RunStrategyTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/RunStrategyTests.cs
@@ -4,6 +4,7 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Tests.Loggers;
+using BenchmarkDotNet.Tests.XUnit;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
@@ -11,7 +12,7 @@ namespace BenchmarkDotNet.IntegrationTests
     {
         public RunStrategyTests(ITestOutputHelper output) : base(output) { }
 
-        [Fact]
+        [FactEnvSpecific(EnvRequirement.NonGitHubDraftPR)]
         public void RunStrategiesAreSupported()
         {
             var config = ManualConfig.CreateEmpty()


### PR DESCRIPTION
This PR intended to reduce CI execution time on draft PR (#3088)
By adding skip condition for tests that takes over 30 seconds (on `macos(x64)`).

**Other Changes**
Add `DisableDiscoveryEnumeration=true` setting for test data that can't serialize/deserialize and modify comment.