### PR TITLE
chore: Re-enable shared compilation feature

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -16,7 +16,6 @@
     <CLSCompliant>true</CLSCompliant>
     <ComVisible>false</ComVisible>
 
-    <UseSharedCompilation>false</UseSharedCompilation>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <SuppressNETCoreSdkPreviewMessage>True</SuppressNETCoreSdkPreviewMessage>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>


### PR DESCRIPTION
This PR re-enable `UseSharedCompilation` setting(Use shared `VBCSCompiler.exe` process) for faster **local** build.

This setting is introduced by #719.
Though,  currently it seems not be required because there are no shared `obj`/`bin` content between BenchmarkDotNet projects.

And when building AutoGenerated project. following settings are passed explicitly.
So these build is not expected be affected. 
https://github.com/dotnet/BenchmarkDotNet/blob/bc899f3c8c218f7c829a69e3643ef51ab2682e2a/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs#L213