### PR TITLE
[docs] Fix filter example rendering

### DIFF
--- a/docs/articles/configs/filters.md
+++ b/docs/articles/configs/filters.md
@@ -10,16 +10,16 @@ In this case, you can *filter* some of them with the help of *filters*.
 
 Predefined filters:
 
-| Filter Type         | Filters benchmarks by       | Console argument   | Console example                  |
-|---------------------|-----------------------------|--------------------|----------------------------------|
-| GlobFilter          | Provided glob pattern       | `filter`           | --filter *Serializer*.ToStream   |
-| AttributesFilter    | Provided attribute names    | `attribute`        | --attribute STAThread            |
-| AllCategoriesFilter | All Provided category names | `categories`       | --allCategories Priority1 CoreFX |
-| AnyCategoriesFilter | Any provided category names | `anycategories`    | --anyCategories Json Xml         |
-| SimpleFilter        | Provided lambda predicate   | -                  |                                  |
-| NameFilter          | Provided lambda predicate   | -                  |                                  |
-| UnionFilter         | Logical AND                 | -                  |                                  |
-| DisjunctionFilter   | Logical OR                  | -                  |                                  |
+| Filter Type         | Filters benchmarks by       | Console argument   | Console example                    |
+|---------------------|-----------------------------|--------------------|------------------------------------|
+| GlobFilter          | Provided glob pattern       | `filter`           | `--filter *Serializer*.ToStream`   |
+| AttributesFilter    | Provided attribute names    | `attribute`        | `--attribute STAThread`            |
+| AllCategoriesFilter | All Provided category names | `categories`       | `--allCategories Priority1 CoreFX` |
+| AnyCategoriesFilter | Any provided category names | `anycategories`    | `--anyCategories Json Xml`         |
+| SimpleFilter        | Provided lambda predicate   | -                  |                                    |
+| NameFilter          | Provided lambda predicate   | -                  |                                    |
+| UnionFilter         | Logical AND                 | -                  |                                    |
+| DisjunctionFilter   | Logical OR                  | -                  |                                    |
 
 ---
 


### PR DESCRIPTION
Wrap in backticks so the markdown renders correctly.

Otherwise you get examples with italics instead of globs:

<img width="130" height="31" alt="image" src="https://github.com/user-attachments/assets/ada64d3c-c346-423f-a830-c1519996b664" />
