### PR TITLE
chore: Remove unneeded project reference from auto-generated project

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -191,6 +191,9 @@ namespace BenchmarkDotNet.Toolchains.CsProj
                 ));
             }
 
+            // Remove ProjectReference node of benchmark project after gathered dll references are added.
+            doc.Root.Descendants("ProjectReference").Single().Remove();
+
             using var projectStream = File.Create(artifactsPaths.ProjectFilePath);
 #if NETSTANDARD2_0
             doc.Save(projectStream, SaveOptions.None);


### PR DESCRIPTION
This PR remove `ProjectReference` of benchmark project from `BenchmarkDotNet.Autogenerated.csproj`

CsProjGenerator gather referenced dlls of benchmark project.
Then add referenced dlls as `<Reference Include="..." />` node.

So original `<ProjectReference Include="..." />` node is not expected to be used when building `BenchmarkDotNet.Autogenerated.csproj`

**Test**
This code path is not used when running IntegrationTest project or when using non Release custom configuration.
https://github.com/dotnet/BenchmarkDotNet/blob/bcdcc98407faf392179fb76ee96a187ca7b1e591/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs#L57

So I've confirmed behavior by using generated `binlog`.
After this PR content is merged. Reference project evaluation stage is skipped on local build.
