### PR TITLE
Revert "chore: Modify mono toolchain behavior and remove mono90 or la…

### DIFF
--- a/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
+++ b/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
@@ -213,6 +213,21 @@ namespace BenchmarkDotNet.Jobs
         Mono80,
 
         /// <summary>
+        /// .NET 9 using MonoVM (not CLR which is the default)
+        /// </summary>
+        Mono90,
+
+        /// <summary>
+        /// .NET 10 using MonoVM (not CLR which is the default)
+        /// </summary>
+        Mono10_0,
+
+        /// <summary>
+        /// .NET 11 using MonoVM (not CLR which is the default)
+        /// </summary>
+        Mono11_0,
+
+        /// <summary>
         /// .NET 8 CLR with composite ReadyToRun compilation
         /// </summary>
         R2R80,

--- a/src/BenchmarkDotNet.Diagnostics.dotMemory/DotMemoryDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.dotMemory/DotMemoryDiagnoser.cs
@@ -113,6 +113,9 @@ public class DotMemoryDiagnoser(Uri? nugetUrl = null, string? downloadTo = null)
             case RuntimeMoniker.Mono60:
             case RuntimeMoniker.Mono70:
             case RuntimeMoniker.Mono80:
+            case RuntimeMoniker.Mono90:
+            case RuntimeMoniker.Mono10_0:
+            case RuntimeMoniker.Mono11_0:
                 return false;
             case RuntimeMoniker.NetCoreApp20:
             case RuntimeMoniker.NetCoreApp21:

--- a/src/BenchmarkDotNet.Diagnostics.dotTrace/DotTraceDiagnoser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.dotTrace/DotTraceDiagnoser.cs
@@ -116,6 +116,9 @@ public class DotTraceDiagnoser(Uri? nugetUrl = null, string? downloadTo = null) 
             case RuntimeMoniker.Mono60:
             case RuntimeMoniker.Mono70:
             case RuntimeMoniker.Mono80:
+            case RuntimeMoniker.Mono90:
+            case RuntimeMoniker.Mono10_0:
+            case RuntimeMoniker.Mono11_0:
                 return false;
             case RuntimeMoniker.NetCoreApp20:
             case RuntimeMoniker.NetCoreApp21:

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -639,6 +639,15 @@ namespace BenchmarkDotNet.ConsoleArguments
                 case RuntimeMoniker.Mono80:
                     return MakeMonoJob(baseJob, options, MonoRuntime.Mono80);
 
+                case RuntimeMoniker.Mono90:
+                    return MakeMonoJob(baseJob, options, MonoRuntime.Mono90);
+
+                case RuntimeMoniker.Mono10_0:
+                    return MakeMonoJob(baseJob, options, MonoRuntime.Mono10_0);
+
+                case RuntimeMoniker.Mono11_0:
+                    return MakeMonoJob(baseJob, options, MonoRuntime.Mono11_0);
+
                 case RuntimeMoniker.R2R80:
                 case RuntimeMoniker.R2R90:
                 case RuntimeMoniker.R2R10_0:

--- a/src/BenchmarkDotNet/Environments/Runtimes/MonoRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/MonoRuntime.cs
@@ -8,6 +8,9 @@ namespace BenchmarkDotNet.Environments
         public static readonly MonoRuntime Mono60 = new("Mono with .NET 6.0", RuntimeMoniker.Mono60, "net6.0", isDotNetBuiltIn: true);
         public static readonly MonoRuntime Mono70 = new("Mono with .NET 7.0", RuntimeMoniker.Mono70, "net7.0", isDotNetBuiltIn: true);
         public static readonly MonoRuntime Mono80 = new("Mono with .NET 8.0", RuntimeMoniker.Mono80, "net8.0", isDotNetBuiltIn: true);
+        public static readonly MonoRuntime Mono90 = new("Mono with .NET 9.0", RuntimeMoniker.Mono90, "net9.0", isDotNetBuiltIn: true);
+        public static readonly MonoRuntime Mono10_0 = new("Mono with .NET 10.0", RuntimeMoniker.Mono10_0, "net10.0", isDotNetBuiltIn: true);
+        public static readonly MonoRuntime Mono11_0 = new("Mono with .NET 11.0", RuntimeMoniker.Mono11_0, "net11.0", isDotNetBuiltIn: true);
 
         public string CustomPath { get; } = "";
 

--- a/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
@@ -67,6 +67,12 @@ namespace BenchmarkDotNet.Extensions
                     return MonoRuntime.Mono70;
                 case RuntimeMoniker.Mono80:
                     return MonoRuntime.Mono80;
+                case RuntimeMoniker.Mono90:
+                    return MonoRuntime.Mono90;
+                case RuntimeMoniker.Mono10_0:
+                    return MonoRuntime.Mono10_0;
+                case RuntimeMoniker.Mono11_0:
+                    return MonoRuntime.Mono11_0;
                 case RuntimeMoniker.R2R80:
                     return R2RRuntime.Net80;
                 case RuntimeMoniker.R2R90:
@@ -110,6 +116,9 @@ namespace BenchmarkDotNet.Extensions
             RuntimeMoniker.Mono60 => new Version(6, 0),
             RuntimeMoniker.Mono70 => new Version(7, 0),
             RuntimeMoniker.Mono80 => new Version(8, 0),
+            RuntimeMoniker.Mono90 => new Version(9, 0),
+            RuntimeMoniker.Mono10_0 => new Version(10, 0),
+            RuntimeMoniker.Mono11_0 => new Version(11, 0),
             RuntimeMoniker.WasmNet80 => new Version(8, 0),
             RuntimeMoniker.WasmNet90 => new Version(9, 0),
             RuntimeMoniker.WasmNet10_0 => new Version(10, 0),

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -191,13 +191,6 @@ namespace BenchmarkDotNet.Toolchains.CsProj
                 ));
             }
             
-             // Mono80IsSupported test fails when BenchmarkDotNet is restored for net9.0 if we don't remove the ProjectReference.
-            // We still need to preserve the ProjectReference in every other case for disassembly, though.
-            if (XUnitHelper.IsIntegrationTest.Value && this is MonoGenerator)
-            {
-                projectElement.RemoveChild(projectElement.SelectSingleNode("ItemGroup/ProjectReference")!.ParentNode!);
-            }
-            
             using var projectStream = File.Create(artifactsPaths.ProjectFilePath);
 #if NETSTANDARD2_0
             doc.Save(projectStream, SaveOptions.None);

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -190,7 +190,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
                 // TODO: Add Aliases here for extern alias #2289
                 ));
             }
-            
+
             using var projectStream = File.Create(artifactsPaths.ProjectFilePath);
 #if NETSTANDARD2_0
             doc.Save(projectStream, SaveOptions.None);

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -190,7 +190,14 @@ namespace BenchmarkDotNet.Toolchains.CsProj
                 // TODO: Add Aliases here for extern alias #2289
                 ));
             }
-
+            
+             // Mono80IsSupported test fails when BenchmarkDotNet is restored for net9.0 if we don't remove the ProjectReference.
+            // We still need to preserve the ProjectReference in every other case for disassembly, though.
+            if (XUnitHelper.IsIntegrationTest.Value && this is MonoGenerator)
+            {
+                projectElement.RemoveChild(projectElement.SelectSingleNode("ItemGroup/ProjectReference")!.ParentNode!);
+            }
+            
             using var projectStream = File.Create(artifactsPaths.ProjectFilePath);
 #if NETSTANDARD2_0
             doc.Save(projectStream, SaveOptions.None);

--- a/src/BenchmarkDotNet/Toolchains/Mono/MonoGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/Mono/MonoGenerator.cs
@@ -12,8 +12,16 @@ namespace BenchmarkDotNet.Toolchains.Mono
 
         protected override string GetRuntimeSettings(GcMode gcMode, IResolver resolver)
         {
-            // Workaround for 'Found multiple publish output files with the same relative path' error
-            return base.GetRuntimeSettings(gcMode, resolver) + "<PropertyGroup><ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles></PropertyGroup>";
+            // Workaround for following issues.
+            // 1. 'Found multiple publish output files with the same relative path' error
+            // 2. NU1102 error occurs when passing /p:UseMonoRuntime=true to the dotnet cli with projects containing .NET 9.0 or higher. #3000
+            return base.GetRuntimeSettings(gcMode, resolver) +
+                """
+                  <PropertyGroup>
+                    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+                    <UseMonoRuntime>true</UseMonoRuntime>
+                  </PropertyGroup>
+                """;
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/Mono/MonoGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/Mono/MonoGenerator.cs
@@ -12,18 +12,8 @@ namespace BenchmarkDotNet.Toolchains.Mono
 
         protected override string GetRuntimeSettings(GcMode gcMode, IResolver resolver)
         {
-            // Workaround for following issues.
-            // 1. 'Found multiple publish output files with the same relative path' error
-            // 2. NU1102 error occurs when running 'dotnet publish' on projects that contain .NET 9.0 or higher. https://github.com/dotnet/BenchmarkDotNet/issues/3000
-            return base.GetRuntimeSettings(gcMode, resolver) +
-                """
-                  <PropertyGroup>
-                    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-                  </PropertyGroup>
-                  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0'">
-                    <UseMonoRuntime>true</UseMonoRuntime>
-                  </PropertyGroup>
-                """;
+            // Workaround for 'Found multiple publish output files with the same relative path' error
+            return base.GetRuntimeSettings(gcMode, resolver) + "<PropertyGroup><ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles></PropertyGroup>";
         }
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/Mono/MonoPublisher.cs
+++ b/src/BenchmarkDotNet/Toolchains/Mono/MonoPublisher.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.DotNetCli;
@@ -29,6 +31,6 @@ public class MonoPublisher(string tfm, string customDotNetCliPath) : DotNetCliPu
     {
         var runtimeIdentifier = CustomDotNetCliToolchainBuilder.GetPortableRuntimeIdentifier();
         // /p:RuntimeIdentifiers is set explicitly here because --self-contained requires it, see https://github.com/dotnet/sdk/issues/10566
-        return $"--self-contained -r {runtimeIdentifier} /p:RuntimeIdentifiers={runtimeIdentifier}";
+        return $"--self-contained -r {runtimeIdentifier} /p:UseMonoRuntime=true /p:RuntimeIdentifiers={runtimeIdentifier}";
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/Mono/MonoPublisher.cs
+++ b/src/BenchmarkDotNet/Toolchains/Mono/MonoPublisher.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.DotNetCli;
@@ -31,6 +29,6 @@ public class MonoPublisher(string tfm, string customDotNetCliPath) : DotNetCliPu
     {
         var runtimeIdentifier = CustomDotNetCliToolchainBuilder.GetPortableRuntimeIdentifier();
         // /p:RuntimeIdentifiers is set explicitly here because --self-contained requires it, see https://github.com/dotnet/sdk/issues/10566
-        return $"--self-contained -r {runtimeIdentifier} /p:UseMonoRuntime=true /p:RuntimeIdentifiers={runtimeIdentifier}";
+        return $"--self-contained -r {runtimeIdentifier} /p:RuntimeIdentifiers={runtimeIdentifier}";
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/Mono/MonoToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/Mono/MonoToolchain.cs
@@ -10,6 +10,9 @@ namespace BenchmarkDotNet.Toolchains.Mono
         [PublicAPI] public static readonly IToolchain Mono60 = From(new NetCoreAppSettings("net6.0", "mono60"));
         [PublicAPI] public static readonly IToolchain Mono70 = From(new NetCoreAppSettings("net7.0", "mono70"));
         [PublicAPI] public static readonly IToolchain Mono80 = From(new NetCoreAppSettings("net8.0", "mono80"));
+        [PublicAPI] public static readonly IToolchain Mono90 = From(new NetCoreAppSettings("net9.0", "mono90"));
+        [PublicAPI] public static readonly IToolchain Mono10_0 = From(new NetCoreAppSettings("net10.0", "mono10_0"));
+        [PublicAPI] public static readonly IToolchain Mono11_0 = From(new NetCoreAppSettings("net11.0", "mono11_0"));
 
         private MonoToolchain(string name, IGenerator generator, IBuilder builder, IExecutor executor, string customDotNetCliPath)
             : base(name, generator, builder, executor, customDotNetCliPath)

--- a/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
@@ -76,7 +76,7 @@ namespace BenchmarkDotNet.Toolchains
                                 RuntimeMoniker.Mono90 => GetToolchain(RuntimeMoniker.Net90),
                                 RuntimeMoniker.Mono10_0 => GetToolchain(RuntimeMoniker.Net10_0),
                                 RuntimeMoniker.Mono11_0 => GetToolchain(RuntimeMoniker.Net11_0),
-                                _ => CsProjCoreToolchain.From(new NetCoreAppSettings(mono.MsBuildMoniker, null, mono.Name))
+                                _ => CsProjCoreToolchain.From(new NetCoreAppSettings(mono.MsBuildMoniker, mono.Name))
                             };
                         }
                         else

--- a/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
@@ -73,7 +73,10 @@ namespace BenchmarkDotNet.Toolchains
                                 RuntimeMoniker.Mono60 => GetToolchain(RuntimeMoniker.Net60),
                                 RuntimeMoniker.Mono70 => GetToolchain(RuntimeMoniker.Net70),
                                 RuntimeMoniker.Mono80 => GetToolchain(RuntimeMoniker.Net80),
-                                _ => CsProjCoreToolchain.From(new NetCoreAppSettings(mono.MsBuildMoniker, mono.Name))
+                                RuntimeMoniker.Mono90 => GetToolchain(RuntimeMoniker.Net90),
+                                RuntimeMoniker.Mono10_0 => GetToolchain(RuntimeMoniker.Net10_0),
+                                RuntimeMoniker.Mono11_0 => GetToolchain(RuntimeMoniker.Net11_0),
+                                _ => CsProjCoreToolchain.From(new NetCoreAppSettings(mono.MsBuildMoniker, null, mono.Name))
                             };
                         }
                         else
@@ -197,6 +200,15 @@ namespace BenchmarkDotNet.Toolchains
 
                 case RuntimeMoniker.Mono80:
                     return MonoToolchain.Mono80;
+
+                case RuntimeMoniker.Mono90:
+                    return MonoToolchain.Mono90;
+
+                case RuntimeMoniker.Mono10_0:
+                    return MonoToolchain.Mono10_0;
+
+                case RuntimeMoniker.Mono11_0:
+                    return MonoToolchain.Mono11_0;
 
                 case RuntimeMoniker.R2R80:
                     return R2RToolchain.R2R80;


### PR DESCRIPTION
reverts #3004 

Mono is still used in community supported architecture's i.e s390x and ppc64le and corresponding nupkg's are still published for these architectures 

This reverts commit 96e5d7b7ae0f4c495e54721d523779ecb2cb3094.

fixes #3172 
