### PR TITLE
feat: Add cleanup logic for workdirectory before build projects

### DIFF
--- a/src/BenchmarkDotNet/Helpers/FileCleanupHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/FileCleanupHelper.cs
@@ -1,0 +1,91 @@
+namespace BenchmarkDotNet.Helpers;
+
+internal static class FileCleanupHelper
+{
+    public static void Cleanup(string path)
+    {
+        if (File.Exists(path))
+        {
+            CleanupFile(new FileInfo(path));
+            return;
+        }
+
+        if (Directory.Exists(path))
+        {
+            CleanupDirectory(new DirectoryInfo(path));
+        }
+    }
+
+    private static void CleanupFile(FileInfo fileInfo)
+    {
+        TryExecute(() =>
+        {
+            File.SetAttributes(fileInfo.FullName, FileAttributes.Normal);
+            File.Delete(fileInfo.FullName);
+        });
+    }
+
+    private static void CleanupDirectory(DirectoryInfo directoryInfo)
+    {
+        // Delete files
+        foreach (var file in EnumerateFiles(directoryInfo))
+        {
+            CleanupFile(file);
+        }
+
+        // Delete sub directories
+        foreach (var subDirectory in EnumerateSubDirectories(directoryInfo))
+        {
+            CleanupDirectory(subDirectory);
+        }
+
+        // Delete directory
+        TryExecute(() => directoryInfo.Delete(recursive: false));
+    }
+
+    private static void TryExecute(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch
+        {
+            // Ignore exceptions for access denied, in use, etc.
+        }
+    }
+
+#if NETSTANDARD2_0
+    private static IEnumerable<FileInfo> EnumerateFiles(DirectoryInfo directory)
+        => TryExecute(() => directory.EnumerateFiles("*", SearchOption.TopDirectoryOnly), []);
+
+    private static IEnumerable<DirectoryInfo> EnumerateSubDirectories(DirectoryInfo directory)
+        => TryExecute(() => directory.EnumerateDirectories(), []);
+
+    private static T TryExecute<T>(Func<T> func, T fallback)
+    {
+        try
+        {
+            return func();
+        }
+        catch
+        {
+            // Ignore exceptions for access denied, in use, etc.
+            return fallback;
+        }
+    }
+#else
+    private static readonly EnumerationOptions EnumerationOptions = new()
+    {
+        RecurseSubdirectories = false,
+        IgnoreInaccessible = true,
+        AttributesToSkip = FileAttributes.ReparsePoint
+    };
+
+    private static IEnumerable<FileInfo> EnumerateFiles(DirectoryInfo directory)
+        => directory.EnumerateFiles("*", EnumerationOptions);
+
+    private static IEnumerable<DirectoryInfo> EnumerateSubDirectories(DirectoryInfo currentDir)
+        => currentDir.EnumerateDirectories("*", EnumerationOptions);
+#endif
+}

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -808,22 +808,7 @@ namespace BenchmarkDotNet.Running
         {
             foreach (string path in artifactsToCleanup)
             {
-                try
-                {
-                    if (Directory.Exists(path))
-                    {
-                        Directory.Delete(path, recursive: true);
-                    }
-                    else if (File.Exists(path))
-                    {
-                        File.Delete(path);
-                    }
-                }
-                catch (Exception)
-                {
-                    // sth is locking our auto-generated files
-                    // there is very little we can do about it
-                }
+                FileCleanupHelper.Cleanup(path);
             }
         }
 

--- a/src/BenchmarkDotNet/Toolchains/GeneratorBase.cs
+++ b/src/BenchmarkDotNet/Toolchains/GeneratorBase.cs
@@ -27,6 +27,10 @@ namespace BenchmarkDotNet.Toolchains
             {
                 artifactsPaths = GetArtifactsPaths(buildPartition, rootArtifactsFolderPath);
 
+                // Cleanup artifact files/directories before generating project files.
+                foreach (var path in GetArtifactsToCleanup(artifactsPaths))
+                    FileCleanupHelper.Cleanup(path);
+
                 // There is no async file copy API, so we just do it synchronously. We are likely on a ThreadPool thread here anyway if this generator is ran in parallel.
                 CopyAllRequiredFiles(artifactsPaths);
 


### PR DESCRIPTION
This PR intended to fix #3174

#### What's changed in this PR

1. Add `FileCleanupHelper` helper class
2. Modify `GeneratorBase.cs` and add cleanup logics for files/directories that returned by `GetArtifactsToCleanup`
3. Modify `BenchmarkRunnerClean.cs` logics to support following scenario.
3.1  Delete file that have `ReadOnly` attribute (on Windows)
3.2. Continue processing when exception occurred.