### PR TITLE
chore: Downgrade node.js version to 22

### DIFF
--- a/.github/actions/setup-additional-tools/action.yaml
+++ b/.github/actions/setup-additional-tools/action.yaml
@@ -11,7 +11,7 @@ runs:
     - name: Set up node
       uses: actions/setup-node@v6
       with:
-        node-version: "24.15.0" # Temporary workaround for https://github.com/dotnet/BenchmarkDotNet/issues/3154
+        node-version: "22" # Temporary workaround for https://github.com/dotnet/BenchmarkDotNet/issues/3154
 
     - name: Set up v8
       shell: bash


### PR DESCRIPTION
On recent GitHub Actions runner images.
`Setup Additional Tools` failed.

It seems cached Node.js version `24.16.0` is used and explicitly specified `24.15.0` version seems ignored in some cases.

This PR downgrade Node.js version to `22.x` temporary.
Because Node 22 is not affected by #3154. and it can receive security updates. 
