### PR TITLE
deps: Update Microsoft.Diagnostics.Traching.TraceEvent package version

### DIFF
--- a/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -9,7 +9,6 @@
     <PackageId>BenchmarkDotNet.Samples</PackageId>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
-    <NoWarn>$(NoWarn);CA1018;CA5351;CA1825</NoWarn>
     <!-- Disable entry point generation as this project has it's own entry point -->
     <GenerateProgramFile>false</GenerateProgramFile>
     <!-- Disable parallel tests between TargetFrameworks -->
@@ -19,8 +18,8 @@
     <Reference Include="System.Reflection" />
   </ItemGroup>
   <PropertyGroup>
-    <!-- Use 8.0.0 as baseline package for IntroNuGet -->
-    <SihVersion Condition="'$(SihVersion)' == ''">8.0.0</SihVersion>
+    <!-- Use 10.0.0 as baseline package for IntroNuGet -->
+    <SihVersion Condition="'$(SihVersion)' == ''">10.0.0</SihVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IO.Hashing" Version="[$(SihVersion)]" />

--- a/samples/BenchmarkDotNet.Samples/IntroNuGet.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroNuGet.cs
@@ -17,8 +17,8 @@ namespace BenchmarkDotNet.Samples
         // Setup your csproj like this:
         /*
         <PropertyGroup>
-          <!-- Use 8.0.0 as default package version if not specified -->
-          <SihVersion Condition="'$(SihVersion)' == ''">8.0.0</SciVersion>
+          <!-- Use 10.0.0 as default package version if not specified -->
+          <SihVersion Condition="'$(SihVersion)' == ''">10.0.0</SciVersion>
         </PropertyGroup>
         <ItemGroup>
           <PackageReference Include="System.IO.Hashing" Version="$(SihVersion)" />
@@ -30,9 +30,9 @@ namespace BenchmarkDotNet.Samples
             public Config()
             {
                 string[] targetVersions = [
-                    "8.0.0",
-                    "9.0.0",
                     "10.0.0",
+                    "10.0.5",
+                    "10.0.9",
                 ];
 
                 foreach (var version in targetVersions)

--- a/src/BenchmarkDotNet.Diagnostics.Windows/BenchmarkDotNet.Diagnostics.Windows.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/BenchmarkDotNet.Diagnostics.Windows.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.3" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.4" PrivateAssets="contentfiles;analyzers" />
   </ItemGroup>
   <Import Project="..\..\build\common.targets" />
 </Project>

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Iced" Version="1.21.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="4.0.726401" />
     <PackageReference Include="Perfolizer" Version="[0.6.6]" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.3" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.4" PrivateAssets="contentfiles;analyzers" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="System.Management" Version="10.0.9" />


### PR DESCRIPTION
This PR update `Microsoft.Diagnostics.Tracing.TraceEvent` package version from `3.2.3` to `3.2.4`.
https://github.com/microsoft/perfview/releases/tag/v3.2.4

#### Other Changes
- Remove unused `<NoWarn>` setting from `BenchmarkDotNet.Samples.csproj`
- Modify `IntroNuGet.cs` sample to compare `System.IO.Hashing` 10.0.x versions.  
   > It's required because `Microsoft.Diagnostics.Tracing.TraceEvent` `3.2.4` implicitly depends on `System.IO.Hashing`  `9.0.8`.  and  It cause MSB3277 warnings.