### PR TITLE
deps: Update GitHub Actions dependency versions

### DIFF
--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -15,12 +15,12 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         ref: master
 
     - name: Checkout changelog
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         ref: docs-changelog
         path: docs/_changelog

--- a/.github/workflows/generate-coverage-report.yaml
+++ b/.github/workflows/generate-coverage-report.yaml
@@ -25,7 +25,7 @@ jobs:
         # https://github.com/microsoft/codecoverage/blob/main/docs/supported-os.md
         os: [windows-latest, ubuntu-latest, macos-26-intel, windows-11-arm]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Ensure DOTNET_ROOT environment variable set on macOS
       - uses: actions/setup-dotnet@v5
@@ -72,7 +72,7 @@ jobs:
       run:
         shell: pwsh
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup additional tools for Wasm/NativeAot tests
         if: ${{ github.event.inputs.skip_integration_tests == 'false'}}
@@ -113,7 +113,7 @@ jobs:
       run:
         shell: pwsh
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/generate-gh-pages.yaml
+++ b/.github/workflows/generate-gh-pages.yaml
@@ -15,12 +15,12 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         ref: docs-stable
 
     - name: Checkout changelog
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         ref: docs-changelog
         path: docs/_changelog

--- a/.github/workflows/publish-nightly.yaml
+++ b/.github/workflows/publish-nightly.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'dotnet/BenchmarkDotNet' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set date
         run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
       - name: Pack

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,10 @@ jobs:
     # --- Init ---
 
     - name: Checkout sources
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Checkout changelog
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         ref: docs-changelog
         path: docs/_changelog
@@ -68,7 +68,7 @@ jobs:
       run: ./build.cmd version-increment
 
     - name: Commit changes
-      uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
+      uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
       with:
         message: "Set next BenchmarkDotNet version: ${{ steps.version.outputs.VERSION }} and update released analyzer rules"
         author_name: GitHub Actions
@@ -99,7 +99,7 @@ jobs:
         discussion_category_name: Announcements
 
     - name: Close old milestone
-      uses: Akkjon/close-milestone@v2.2.0
+      uses: Akkjon/close-milestone@2dd67f0346a3cb6159a33c7467ae5fbd17e5affc # v2.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       # Checkout
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       # Add Windows Defender Exclusions
       - uses: ./.github/actions/add-windowsdefender-exclusions
       # Setup additional tools
@@ -66,7 +66,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       # Checkout
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       # Add Windows Defender Exclusions
       - uses: ./.github/actions/add-windowsdefender-exclusions
       # Setup additional tools
@@ -108,7 +108,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       # Setup additional tools
       - name: Setup additional tools for Wasm/NativeAot tests
         if: ${{ github.event.pull_request.draft != true }}
@@ -149,7 +149,7 @@ jobs:
           - runs-on: 'macos-26-intel'
             arch: 'x64'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       # Setup additional tools
       - name: Setup additional tools for Wasm/NativeAot tests
         if: ${{ github.event.pull_request.draft != true }}
@@ -182,14 +182,14 @@ jobs:
   test-pack:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run task 'pack'
         run: ./build.cmd pack
 
   spellcheck-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         name: Setup node
         with:


### PR DESCRIPTION
This PR contains following changes.
1. Update `actions/checkout` version to `v7`
2. Update `EndBug/add-and-commit` to `v10.0.0`
3. Enable version pinning on `Akkjon/close-milestone`
