### PR TITLE
chore: Modify setup-additional-tools action to print node.js version

### DIFF
--- a/.github/actions/setup-additional-tools/action.yaml
+++ b/.github/actions/setup-additional-tools/action.yaml
@@ -13,6 +13,10 @@ runs:
       with:
         node-version: "22" # Temporary workaround for https://github.com/dotnet/BenchmarkDotNet/issues/3154
 
+    - name: Print Node.js version
+      shell: bash
+      run: node --version
+
     - name: Set up v8
       shell: bash
       run: npx jsvu --os=default --engines=v8


### PR DESCRIPTION
This PR add `node --version` command to print actual Node.js version.

**Background**
On GitHub Actions,
It seems some conditions that **explicitly** installed node.js is not used.
And cached version of Node.js is used instead.

But it can't confirmed by existing logs.
Log: https://github.com/dotnet/BenchmarkDotNet/actions/runs/27997008028/job/82861211406

Related Issue: `https://github.com/actions/setup-node/issues/1556`
