### PR TITLE
chore: Remove extra space that is added by AppendArgument

### DIFF
--- a/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/StringAndTextExtensions.cs
@@ -128,9 +128,11 @@ namespace BenchmarkDotNet.Extensions
             {
                 return stringBuilder;
             }
-            argument = " " + argument.Trim();
-            stringBuilder.Append(argument);
 
+            if (stringBuilder.Length != 0)
+                stringBuilder.Append(' ');
+
+            stringBuilder.Append(argument.Trim());
             return stringBuilder;
         }
 

--- a/tests/BenchmarkDotNet.Tests/StringExtensionsTests.cs
+++ b/tests/BenchmarkDotNet.Tests/StringExtensionsTests.cs
@@ -1,3 +1,4 @@
+using AwesomeAssertions;
 using BenchmarkDotNet.Extensions;
 using System.Text;
 
@@ -33,6 +34,9 @@ namespace BenchmarkDotNet.Tests
         [InlineData(null, "")]
         [InlineData("", "")]
         [InlineData(" ", "")]
+        [InlineData("--test", "--test")]
+        [InlineData(" --test", "--test")]
+        [InlineData("--test ", "--test")]
         [InlineData("-n win-x64", "-n win-x64")]
         [InlineData(" -n win-x64", "-n win-x64")]
         [InlineData("-n win-x64 ", "-n win-x64")]
@@ -40,12 +44,46 @@ namespace BenchmarkDotNet.Tests
         [InlineData(" a ", "a")]
         [InlineData("        a        ", "a")]
         [InlineData("   \r\n  a   \r\n", "a")]
-        public void AppendArgumentMakesSureOneSpaceBeforeStringArgument(string? input, string expectedOutput)
+        public void AppendArgumentWithEmptyStringBuilder(string? input, string expectedOutput)
         {
+            // Arrange
             var stringBuilder = new StringBuilder();
+
+            // Act
             var result = stringBuilder.AppendArgument(input).ToString();
 
-            Assert.Equal(expectedOutput, result);
+            // Assert
+            result.Should().Be(expectedOutput);
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData(" ", "")]
+        [InlineData("--test", "--test")]
+        [InlineData(" --test", "--test")]
+        [InlineData(" --test ", "--test")]
+        [InlineData("-n win-x64", "-n win-x64")]
+        [InlineData(" -n win-x64", "-n win-x64")]
+        [InlineData("-n win-x64 ", "-n win-x64")]
+        [InlineData(" -n Win-x64 ", "-n Win-x64")]
+        [InlineData(" a ", "a")]
+        [InlineData("        a        ", "a")]
+        [InlineData("   \r\n  a   \r\n", "a")]
+        public void AppendArgumentMultipleTimes(string? input, string expectedOutput)
+        {
+            // Arrange
+            var stringBuilder = new StringBuilder();
+            stringBuilder.AppendArgument("--firstArg");
+
+            // Act
+            var result = stringBuilder.AppendArgument(input).ToString();
+
+            // Assert
+            if (expectedOutput.IsBlank())
+                result.Should().Be($"--firstArg");
+            else
+                result.Should().Be($"--firstArg {expectedOutput}");
         }
 
         [Theory]

--- a/tests/BenchmarkDotNet.Tests/StringExtensionsTests.cs
+++ b/tests/BenchmarkDotNet.Tests/StringExtensionsTests.cs
@@ -93,7 +93,7 @@ namespace BenchmarkDotNet.Tests
         [InlineData("http://test.com/ ", "http://test.com/")]
         [InlineData(" http://test.com/ ", "http://test.com/")]
         [InlineData("\r\n  http://test.com/  \r\n", "http://test.com/")]
-        public void AppendArgumentMakesSureOneSpaceBeforeObjectArgument(string? input, string expectedOutput)
+        public void AppendArgumentWithObjectArgument(string? input, string expectedOutput)
         {
             Uri? uri = input != null ? new Uri(input) : null; // Use Uri for our object type since that is what is used in code
             var stringBuilder = new StringBuilder();

--- a/tests/BenchmarkDotNet.Tests/StringExtensionsTests.cs
+++ b/tests/BenchmarkDotNet.Tests/StringExtensionsTests.cs
@@ -33,13 +33,13 @@ namespace BenchmarkDotNet.Tests
         [InlineData(null, "")]
         [InlineData("", "")]
         [InlineData(" ", "")]
-        [InlineData("-n win-x64", " -n win-x64")]
-        [InlineData(" -n win-x64", " -n win-x64")]
-        [InlineData("-n win-x64 ", " -n win-x64")]
-        [InlineData(" -n Win-x64 ", " -n Win-x64")]
-        [InlineData(" a ", " a")]
-        [InlineData("        a        ", " a")]
-        [InlineData("   \r\n  a   \r\n", " a")]
+        [InlineData("-n win-x64", "-n win-x64")]
+        [InlineData(" -n win-x64", "-n win-x64")]
+        [InlineData("-n win-x64 ", "-n win-x64")]
+        [InlineData(" -n Win-x64 ", "-n Win-x64")]
+        [InlineData(" a ", "a")]
+        [InlineData("        a        ", "a")]
+        [InlineData("   \r\n  a   \r\n", "a")]
         public void AppendArgumentMakesSureOneSpaceBeforeStringArgument(string? input, string expectedOutput)
         {
             var stringBuilder = new StringBuilder();
@@ -50,11 +50,11 @@ namespace BenchmarkDotNet.Tests
 
         [Theory]
         [InlineData(null, "")]
-        [InlineData("http://test.com/", " http://test.com/")]
-        [InlineData(" http://test.com/", " http://test.com/")]
-        [InlineData("http://test.com/ ", " http://test.com/")]
-        [InlineData(" http://test.com/ ", " http://test.com/")]
-        [InlineData("\r\n  http://test.com/  \r\n", " http://test.com/")]
+        [InlineData("http://test.com/", "http://test.com/")]
+        [InlineData(" http://test.com/", "http://test.com/")]
+        [InlineData("http://test.com/ ", "http://test.com/")]
+        [InlineData(" http://test.com/ ", "http://test.com/")]
+        [InlineData("\r\n  http://test.com/  \r\n", "http://test.com/")]
         public void AppendArgumentMakesSureOneSpaceBeforeObjectArgument(string? input, string expectedOutput)
         {
             Uri? uri = input != null ? new Uri(input) : null; // Use Uri for our object type since that is what is used in code


### PR DESCRIPTION
This PR modify `AppendArgument` extension method for StringBuilder.

This extension method is used by [DotNetCliCommand.cs](https://github.com/dotnet/BenchmarkDotNet/blob/50f9429f3295dc9362cb0aa5cd89e87f93194670/src/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliCommand.cs#L151-L152)
And it add extra space between `dotnet` and sub command (e.g. `dotnet  restore`)

This PR remove extra space to make it easier to grep from logs.
