### PR TITLE
Fix freeze when Ctrl+C is pressed multiple times (#3181)

### DIFF
--- a/src/BenchmarkDotNet/Helpers/CtrlCCanceler.cs
+++ b/src/BenchmarkDotNet/Helpers/CtrlCCanceler.cs
@@ -12,6 +12,7 @@ namespace BenchmarkDotNet.Helpers
         {
             this.logger = logger;
             this.cts = cts;
+            DisposeAtProcessTermination.EnsureCancelKeyPressKeepAlive();
             Console.CancelKeyPress += OnCancelKeyPress;
         }
 

--- a/src/BenchmarkDotNet/Helpers/DisposeAtProcessTermination.cs
+++ b/src/BenchmarkDotNet/Helpers/DisposeAtProcessTermination.cs
@@ -31,11 +31,29 @@ namespace BenchmarkDotNet.Helpers
         internal static readonly bool ConsoleSupportsCancelKeyPress =
             !(OsDetector.IsAndroid() || OsDetector.IsIOS() || OsDetector.IsTvOS() || Portability.RuntimeInformation.IsWasm);
 
+        private static int cancelKeyPressKeepAliveRegistered;
+
+        private int disposed;
+
+        // #3181
+        // Called by every site that subscribes to Console.CancelKeyPress and later unsubscribes, before subscribing.
+        // It installs a single no-op handler that is never removed, so the CancelKeyPress handler count can never
+        // drop to zero. Removing the last handler calls SetConsoleCtrlHandler(..., Add: false), which deadlocks
+        // in Windows when the user presses ctrl+c multiple times rapidly before the first event execution completed.
+        internal static void EnsureCancelKeyPressKeepAlive()
+        {
+            if (ConsoleSupportsCancelKeyPress && Interlocked.Exchange(ref cancelKeyPressKeepAliveRegistered, 1) == 0)
+            {
+                Console.CancelKeyPress += static (_, _) => { };
+            }
+        }
+
         protected DisposeAtProcessTermination()
         {
             AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
             if (ConsoleSupportsCancelKeyPress)
             {
+                EnsureCancelKeyPressKeepAlive();
                 Console.CancelKeyPress += OnCancelKeyPress;
             }
 
@@ -43,12 +61,19 @@ namespace BenchmarkDotNet.Helpers
             // as we are subscribed to static events, it would never be called.
         }
 
+        // Ensures the disposal logic runs at most once. The same instance can be disposed both explicitly
+        // (using/await using) and via the OnCancelKeyPress / OnProcessExit handlers when a run is aborted.
+        // Without this guard, subclasses would run their cleanup twice - e.g. WakeLockSentinel would call
+        // PowerClearRequest on an already-disposed SafeHandle and throw ObjectDisposedException.
+        protected bool MarkDisposed()
+            => Interlocked.Exchange(ref disposed, 1) == 0;
+
         /// <summary>
         /// Called when the user presses Ctrl-C or Ctrl-Break.
         /// </summary>
         private void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs e)
         {
-            if (!e.Cancel)
+            if (!e.Cancel && MarkDisposed())
             {
                 Dispose(true);
             }
@@ -58,10 +83,20 @@ namespace BenchmarkDotNet.Helpers
         /// Called when the user clicks on the X in the upper right corner to close the Benchmark's Window.
         /// </summary>
         private void OnProcessExit(object? sender, EventArgs e)
-            => Dispose(true);
+        {
+            if (MarkDisposed())
+            {
+                Dispose(true);
+            }
+        }
 
         public void Dispose()
-            => Dispose(false);
+        {
+            if (MarkDisposed())
+            {
+                Dispose(false);
+            }
+        }
 
         protected virtual void Dispose(bool exiting)
         {

--- a/src/BenchmarkDotNet/Helpers/ProcessCleanupHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/ProcessCleanupHelper.cs
@@ -53,6 +53,13 @@ namespace BenchmarkDotNet.Helpers
 
         public async ValueTask DisposeAsync()
         {
+            // DisposeAsync bypasses the base Dispose() entry point, so honor the same run-once guard to avoid
+            // racing the OnCancelKeyPress / OnProcessExit handlers when a run is aborted.
+            if (!MarkDisposed())
+            {
+                return;
+            }
+
             try
             {
                 if (!process.HasExited)


### PR DESCRIPTION
Fixes #3181.

## Problem

Pressing <kbd>Ctrl</kbd>+<kbd>C</kbd> repeatedly during a run (e.g. while waiting for `dotnet restore`) freezes `BenchmarkRunner.Run`/`RunAsync` on Windows, right after:

> Cancelling benchmark run... press ctrl+c again to force abort.

The process never makes progress and the second press can't force-abort it. It reproduced 100% on Windows when mashing Ctrl+C, but not with `BenchmarkSwitcher` and not on Linux.

## Root cause

BenchmarkDotNet subscribes to / unsubscribes from `Console.CancelKeyPress` in several places during a run — `CtrlCCanceler` and every `DisposeAtProcessTermination` instance (per-command `ProcessCleanupHelper`, `WakeLockSentinel`, `TaskbarProgress`, `ConsoleTitler`, …). On modern .NET, removing the **last** `CancelKeyPress` handler calls `SetConsoleCtrlHandler(..., Add: false)`, which **deadlocks in the OS** while console control events are being dispatched — exactly the situation when the user mashes Ctrl+C. Once it's wedged, no handler can run, so the "press again to force abort" path is dead too.

A dump of the frozen process showed the hang at `CtrlCCanceler.Dispose()` / `WakeLockSentinel.Dispose()` → `Console.remove_CancelKeyPress` → `PosixSignalRegistration.Unregister()`, blocked indefinitely (even after signals stopped).

`BenchmarkSwitcher` was unaffected because `UserInteraction` keeps a **permanent** `CancelKeyPress` subscription, so the underlying registration was never torn down mid-run — which is essentially the fix.

## Fix

- **Keep-alive pin.** `DisposeAtProcessTermination.EnsureCancelKeyPressKeepAlive()` installs a single no-op `Console.CancelKeyPress` handler that is never removed, so the handler count can never drop to zero. Every site that hooks `CancelKeyPress` and later unsubscribes calls it **before** subscribing (`DisposeAtProcessTermination`'s ctor and `CtrlCCanceler`'s ctor), so the deadlocking `SetConsoleCtrlHandler(remove)` is never reached during a run. Each hook site is therefore safe on its own rather than relying on another type having been constructed first.
- **Dispose-once guard.** `DisposeAtProcessTermination` now runs its disposal at most once (`MarkDisposed`). Previously the abort handlers (`OnCancelKeyPress`/`OnProcessExit` → `Dispose(true)`) and the normal `using`/`await using` teardown could both run, e.g. `WakeLockSentinel` calling `PowerClearRequest` on an already-disposed `SafeHandle` and throwing `ObjectDisposedException` (also observed in the dump).

## Verification

Reproduced with real console control events: a parent launches a child running the actual `BenchmarkRunner.Run<T>` in a new process group, then sends repeated `CTRL_BREAK` events during the restore/build window (same `Console.CancelKeyPress` code path as Ctrl+C), and detects a hang via `WaitForSingleObject`.

- Before: 100% freeze.
- After: no freeze across repeated runs and timings, the second press force-aborts, no `ObjectDisposedException`; single Ctrl+C still cancels gracefully and a normal run completes unchanged.