### PR TITLE
Handle `OperationCanceledException` from ctrl+c

### DIFF
--- a/src/BenchmarkDotNet/Helpers/ExceptionHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/ExceptionHelper.cs
@@ -7,14 +7,12 @@ namespace BenchmarkDotNet.Helpers
     public static class ExceptionHelper
     {
         public static bool IsProperCancelation(Exception ex, CancellationToken cancellationToken)
-        {
-            if (!cancellationToken.IsCancellationRequested)
-            {
-                return false;
-            }
-            return ex is OperationCanceledException ||
-                (ex is TargetInvocationException && ex.InnerException is OperationCanceledException);
-        }
+            => cancellationToken.IsCancellationRequested && IsCancelation(ex);
+
+        // On .NET Framework an Exception thrown from a reflection-invoked method is wrapped in a TargetInvocationException.
+        internal static bool IsCancelation(Exception ex) =>
+            ex is OperationCanceledException ||
+            (ex is TargetInvocationException && ex.InnerException is OperationCanceledException);
 
         public static bool IsOom(Exception ex) =>
             ex is OutOfMemoryException ||

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -35,6 +35,22 @@ namespace BenchmarkDotNet.Running
 
         internal static async ValueTask<Summary[]> Run(BenchmarkRunInfo[] benchmarkRunInfos, CancellationToken cancellationToken)
         {
+            try
+            {
+                return await RunCore(benchmarkRunInfos, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e) when (!cancellationToken.IsCancellationRequested && ExceptionHelper.IsCancelation(e))
+            {
+                // The run was cancelled via Ctrl+C (CtrlCCanceler cancels an internal linked token, so the
+                // caller-provided token is not cancellation-requested here). CtrlCCanceler already logged the
+                // cancellation, so we just swallow the exception instead of letting it bubble up as an unhandled
+                // exception with a full stack trace. When the caller's own token is cancelled, we let it propagate.
+                return [];
+            }
+        }
+
+        private static async ValueTask<Summary[]> RunCore(BenchmarkRunInfo[] benchmarkRunInfos, CancellationToken cancellationToken)
+        {
             using var taskbarProgress = new TaskbarProgress(TaskbarProgressState.Indeterminate);
 
             var resolver = DefaultResolver;

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -45,7 +45,7 @@ namespace BenchmarkDotNet.Running
                 // caller-provided token is not cancellation-requested here). CtrlCCanceler already logged the
                 // cancellation, so we just swallow the exception instead of letting it bubble up as an unhandled
                 // exception with a full stack trace. When the caller's own token is cancelled, we let it propagate.
-                return [];
+                return [Summary.ValidationFailed("Canceled via ctrl+c", string.Empty, string.Empty)];
             }
         }
 


### PR DESCRIPTION
Secondary part of #3181.