### PR TITLE
Remove dependency to `Microsoft.DotNet.PlatformAbstractions`.

### DIFF
--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="4.0.726401" />
     <PackageReference Include="Perfolizer" Version="[0.6.6]" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.4" PrivateAssets="contentfiles;analyzers" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="System.Management" Version="10.0.9" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />

--- a/src/BenchmarkDotNet/Detectors/OsDetector.cs
+++ b/src/BenchmarkDotNet/Detectors/OsDetector.cs
@@ -5,7 +5,6 @@ using Perfolizer.Models;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using static System.Runtime.InteropServices.RuntimeInformation;
-using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 
 namespace BenchmarkDotNet.Detectors;
 
@@ -53,8 +52,8 @@ public class OsDetector
             }
         }
 
-        string operatingSystem = RuntimeEnvironment.OperatingSystem;
-        string operatingSystemVersion = RuntimeEnvironment.OperatingSystemVersion;
+        string operatingSystem = OSDescription;
+        string operatingSystemVersion = Environment.OSVersion.ToString();
         if (IsWindows())
         {
             int? ubr = GetWindowsUbr();

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/CustomDotNetCliToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/CustomDotNetCliToolchainBuilder.cs
@@ -1,12 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using BenchmarkDotNet.Detectors;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Extensions;
-using BenchmarkDotNet.Portability;
 using JetBrains.Annotations;
-#if NETSTANDARD
-using Microsoft.DotNet.PlatformAbstractions;
-#endif
 
 namespace BenchmarkDotNet.Toolchains.DotNetCli
 {
@@ -64,7 +61,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         {
             if (targetFrameworkMoniker.IsNotBlank())
                 return targetFrameworkMoniker;
-            if (!RuntimeInformation.IsNetCore)
+            if (!Portability.RuntimeInformation.IsNetCore)
                 throw new NotSupportedException("You must specify the target framework moniker in explicit way using builder.TargetFrameworkMoniker(tfm) method");
 
             return CoreRuntime.GetCurrentVersion().MsBuildMoniker;
@@ -130,12 +127,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             // the values taken from https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#macos-rids
             string osPart = OsDetector.IsWindows() ? "win" : (OsDetector.IsMacOS() ? "osx" : "linux");
 
-            string architecture =
-#if NETSTANDARD
-                RuntimeEnvironment.RuntimeArchitecture;
-#else
-                System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-#endif
+            string architecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
 
             return $"{osPart}-{architecture}";
         }


### PR DESCRIPTION
`Microsoft.DotNet.PlatformAbstractions` is a package that [no longer receives updates since .NET 5](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/platformabstractions-package-removed). This PR removes this dependency from BenchmarkDotNet, and replaces its usage with built-in APIs.