### PR TITLE
chore: Add setting to remove unused files from bin directory on local build

### DIFF
--- a/BenchmarkDotNet.slnx
+++ b/BenchmarkDotNet.slnx
@@ -5,6 +5,7 @@
   </Folder>
   <Folder Name="/samples/">
     <File Path="samples/Directory.Build.props" />
+    <File Path="samples/Directory.Build.targets" />
     <Project Path="samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj" />
     <Project Path="samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj" DefaultStartup="true" />
   </Folder>
@@ -28,6 +29,7 @@
   </Folder>
   <Folder Name="/tests/">
     <File Path="tests/Directory.Build.props" />
+    <File Path="tests/Directory.Build.targets" />
     <Project Path="tests/BenchmarkDotNet.Analyzers.Tests/BenchmarkDotNet.Analyzers.Tests.csproj" />
     <Project Path="tests/BenchmarkDotNet.Exporters.Plotting.Tests/BenchmarkDotNet.Exporters.Plotting.Tests.csproj" />
     <Project Path="tests/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly.csproj" />

--- a/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -40,5 +40,6 @@
     <!-- Enables analyzers for this project (this is required since ProjectReference is not transitive). -->
     <ProjectReference Include="..\..\src\BenchmarkDotNet.Analyzers\BenchmarkDotNet.Analyzers.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
+
   <Import Project="..\..\build\common.targets" />
 </Project>

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Manually import `BenchmarkDotNet.targets` for build that using ProjectReference -->
+  <Import Project="$(MSBuildThisFileDirectory)..\src\BenchmarkDotNet\BenchmarkDotNet.targets" />
+</Project>

--- a/src/BenchmarkDotNet/BenchmarkDotNet.targets
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.targets
@@ -1,10 +1,10 @@
-﻿<Project>
+<Project>
 
   <PropertyGroup>
     <!-- If the RuntimeIdentifier is explicitly specified. Use the specified target platform. -->
     <BenchmarkDotNetTargetPlatform>$(RuntimeIdentifier)</BenchmarkDotNetTargetPlatform>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(BenchmarkDotNetTargetPlatform)' == ''">
     <!-- If RuntimeIdentifier is not specified Use current build platform -->
     <!-- List of runtimes supported by Gee.External.Capstone: https://github.com/9ee1/Capstone.NET/tree/master/Gee.External.Capstone/runtimes -->
@@ -18,7 +18,7 @@
     <BenchmarkDotNetTargetPlatform Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">$(BenchmarkDotNetTargetPlatform)-arm64</BenchmarkDotNetTargetPlatform>
   </PropertyGroup>
 
-  <Target Name="FilterBenchmarkDotNetPackageAssets" AfterTargets="ResolvePackageAssets">
+  <Target Name="BdnFilterPackageAssets" AfterTargets="ResolvePackageAssets">
     <!-- Remove `runtimes/{RuntimeIdentifier}` files that is not matched to target platform. -->
     <ItemGroup Condition="'$(BenchmarkDotNetTargetPlatform)' != '' AND $(BenchmarkDotNetTargetPlatform) != 'all'">
       <RuntimeTargetsCopyLocalItems Remove="@(RuntimeTargetsCopyLocalItems)"
@@ -27,8 +27,21 @@
 
     <!-- Remove unnecessary satellite assemblies. -->
     <ItemGroup>
-      <ResourceCopyLocalItems Remove="@(ResourceCopyLocalItems)"
-                              Condition="'%(ResourceCopyLocalItems.NuGetPackageId)' == 'Microsoft.CodeAnalysis.Common' OR '%(ResourceCopyLocalItems.NuGetPackageId)' == 'Microsoft.CodeAnalysis.CSharp'"/>
+      <ResourceCopyLocalItems
+        Remove="@(ResourceCopyLocalItems)"
+        Condition="'%(ResourceCopyLocalItems.NuGetPackageId)' == 'Microsoft.CodeAnalysis.Common'
+                   OR
+                   '%(ResourceCopyLocalItems.NuGetPackageId)' == 'Microsoft.CodeAnalysis.CSharp'
+                   OR
+                   '%(ResourceCopyLocalItems.NuGetPackageId)' == 'Microsoft.TestPlatform.AdapterUtilities'
+                   OR
+                   '%(ResourceCopyLocalItems.NuGetPackageId)' == 'Microsoft.TestPlatform.ObjectModel'
+                   OR
+                   '%(ResourceCopyLocalItems.NuGetPackageId)' == 'Microsoft.TestPlatform.TestHost'
+                   OR
+                   '%(ResourceCopyLocalItems.NuGetPackageId)' == 'Microsoft.TestPlatform.TranslationLayer'
+                  "/>
     </ItemGroup>
   </Target>
+
 </Project>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Manually import `BenchmarkDotNet.targets` for build that using ProjectReference -->
+  <Import Project="$(MSBuildThisFileDirectory)..\src\BenchmarkDotNet\BenchmarkDotNet.targets" />
+</Project>


### PR DESCRIPTION
This PR is the successor to #2737.

On existing implementation,
Custom targets is executed only when using NuGet package (PackageReference).
And it's not works on local build (`ProjectReference`)

By this PR changes,
`BdnFilterPackageAssets` target is executed on **local** build also.

### 1. What's changed in this PR

**1.1.Add `Directory.Build.targets` file under `samples`/`tests` directory.**
By this change custom target is loaded on **local** build.

**1.2.Modify `BenchmarkDotNet/BenchmarkDotNet.targets` file**

- Rename custom target name to use `Bdn` prefix. (To improve searchability in the `binlog`)
- Add additional conditions to filter satellite assembly resources.
- Apply code formatter.

### 2. Tasks that are not covered in this PR

**1. Remove non `arm64` platform native dependencies**
Currently Capstone's native dependencies are used for `arm64` platform only.
So it can remove native dependencies.

**2. Remove unused files that generated on temp build directory.**
Autogenerated project don't use `BenchmarkDotNet.targets`.
So custom target is not executed on CsProjGenerator relating toolchain currently.