### PR TITLE
fix: Fix OsDetector logics on windows

### DIFF
--- a/src/BenchmarkDotNet/Detectors/OsDetector.cs
+++ b/src/BenchmarkDotNet/Detectors/OsDetector.cs
@@ -1,10 +1,12 @@
-using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Helpers;
 using Microsoft.Win32;
 using Perfolizer.Models;
-using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using static System.Runtime.InteropServices.RuntimeInformation;
+using System.Runtime.InteropServices;
+
+#if NETSTANDARD
+using BenchmarkDotNet.Extensions;
+#endif
 
 namespace BenchmarkDotNet.Detectors;
 
@@ -52,14 +54,21 @@ public class OsDetector
             }
         }
 
-        string operatingSystem = OSDescription;
-        string operatingSystemVersion = Environment.OSVersion.ToString();
         if (IsWindows())
         {
+            var osVersion = RuntimeInformation.OSDescription.Split(' ').LastOrDefault() ?? ""; // `Microsoft Windows 10.0.26200`
             int? ubr = GetWindowsUbr();
-            if (ubr != null)
-                operatingSystemVersion += $".{ubr}";
+            return new OsInfo
+            {
+                Name = "Windows",
+                Version = ubr == null
+                    ? osVersion
+                    : $"{osVersion}.{ubr}",
+            };
         }
+
+        string operatingSystem = RuntimeInformation.OSDescription;
+        string operatingSystemVersion = Environment.OSVersion.ToString();
         return new OsInfo
         {
             Name = operatingSystem,
@@ -115,7 +124,7 @@ public class OsDetector
 #if NET6_0_OR_GREATER
         OperatingSystem.IsWindows(); // prefer linker-friendly OperatingSystem APIs
 #else
-        IsOSPlatform(OSPlatform.Windows);
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 #endif
 
 
@@ -124,7 +133,7 @@ public class OsDetector
 #if NET6_0_OR_GREATER
         OperatingSystem.IsLinux();
 #else
-        IsOSPlatform(OSPlatform.Linux);
+        RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 #endif
 
     [SupportedOSPlatformGuard("macos")]
@@ -133,7 +142,7 @@ public class OsDetector
 #if NET6_0_OR_GREATER
         OperatingSystem.IsMacOS();
 #else
-        IsOSPlatform(OSPlatform.OSX);
+        RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 #endif
 
     [SupportedOSPlatformGuard("android")]
@@ -159,6 +168,6 @@ public class OsDetector
 #if NET6_0_OR_GREATER
         OperatingSystem.IsTvOS();
 #else
-        IsOSPlatform(OSPlatform.Create("TVOS"));
+        RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"));
 #endif
 }


### PR DESCRIPTION
This PR intended to fix issue that commented on https://github.com/dotnet/BenchmarkDotNet/pull/3190/changes#r3526354668 issue.

By this PR changes,
OS name is displayed same as previous build on Windows  (OS display name is formatted by Perfolizer at https://github.com/dotnet/BenchmarkDotNet/blob/40736e96f0c528a4f90423e925d63fd7dd3f1bad/src/BenchmarkDotNet/Environments/HostEnvironmentInfo.cs#L91-L96)

**On current master branch result**
> BenchmarkDotNet v0.16.0-develop (2026-07-09), Microsoft Windows 10.0.26200 Microsoft Windows NT 10.0.26200.0.8737

**On this PR branch result**
> BenchmarkDotNet v0.16.0-develop (2026-07-09), Windows 11 (10.0.26200.8737/25H2/2025Update/HudsonValley2)
