### PR TITLE
Remove ImportDirectoryBuildProps/Targets properties

### DIFF
--- a/src/BenchmarkDotNet/Templates/CsProj.txt
+++ b/src/BenchmarkDotNet/Templates/CsProj.txt
@@ -1,8 +1,6 @@
 <Project Sdk="$SDKNAME$">
 
   <PropertyGroup>
-    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
-    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
     <AssemblyTitle>$PROGRAMNAME$</AssemblyTitle>
     <TargetFrameworks>$TFM$</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/BenchmarkDotNet/Templates/R2RCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/R2RCsProj.txt
@@ -2,8 +2,6 @@
 
    <!-- Properties same as standard CsProj.txt template -->
    <PropertyGroup>
-    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
-    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
     <AssemblyTitle>$PROGRAMNAME$</AssemblyTitle>
     <TargetFrameworks>$TFM$</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/NativeAot/Generator.cs
@@ -138,8 +138,6 @@ namespace BenchmarkDotNet.Toolchains.NativeAot
         private string GenerateProjectForNuGetBuild(string projectFilePath, BuildPartition buildPartition, ArtifactsPaths artifactsPaths, ILogger logger) => $"""
             <Project Sdk="Microsoft.NET.Sdk">
               <PropertyGroup>
-                <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
-                <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
                 <OutputType>Exe</OutputType>
                 <TargetFrameworks>{TargetFrameworkMoniker}</TargetFrameworks>
                 <RuntimeIdentifier>{runtimeIdentifier}</RuntimeIdentifier>


### PR DESCRIPTION
These haven't actually worked as intended since #1066, and became unnecessary since we started passing output paths to the cli.