### PR TITLE
Handle null values in joined summary columns

### DIFF
--- a/src/BenchmarkDotNet/Reports/SummaryTable.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTable.cs
@@ -61,7 +61,7 @@ namespace BenchmarkDotNet.Reports
             ColumnCount = columns.Length;
             FullHeader = columns.Select(c => c.GetColumnTitle(style)).ToArray();
 
-            FullContent = summary.Reports.Select(r => columns.Select(c => c.GetValue(summary, r.BenchmarkCase, style) ?? string.Empty).ToArray()).ToArray();
+            FullContent = summary.Reports.Select(r => columns.Select(c => c.GetValue(summary, r.BenchmarkCase, style) ?? "-").ToArray()).ToArray();
             IsDefault = columns.Select(c => summary.Reports.All(r => c.IsDefault(summary, r.BenchmarkCase))).ToArray();
 
             var highlightGroupKeys = summary.BenchmarksCases.Select(b => b.Config.Orderer.GetHighlightGroupKey(b)).ToArray();

--- a/src/BenchmarkDotNet/Reports/SummaryTable.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTable.cs
@@ -61,7 +61,7 @@ namespace BenchmarkDotNet.Reports
             ColumnCount = columns.Length;
             FullHeader = columns.Select(c => c.GetColumnTitle(style)).ToArray();
 
-            FullContent = summary.Reports.Select(r => columns.Select(c => c.GetValue(summary, r.BenchmarkCase, style)).ToArray()).ToArray();
+            FullContent = summary.Reports.Select(r => columns.Select(c => c.GetValue(summary, r.BenchmarkCase, style) ?? string.Empty).ToArray()).ToArray();
             IsDefault = columns.Select(c => summary.Reports.All(r => c.IsDefault(summary, r.BenchmarkCase))).ToArray();
 
             var highlightGroupKeys = summary.BenchmarksCases.Select(b => b.Config.Orderer.GetHighlightGroupKey(b)).ToArray();

--- a/src/BenchmarkDotNet/Reports/SummaryTable.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTable.cs
@@ -61,7 +61,7 @@ namespace BenchmarkDotNet.Reports
             ColumnCount = columns.Length;
             FullHeader = columns.Select(c => c.GetColumnTitle(style)).ToArray();
 
-            FullContent = summary.Reports.Select(r => columns.Select(c => c.GetValue(summary, r.BenchmarkCase, style) ?? "-").ToArray()).ToArray();
+            FullContent = summary.Reports.Select(r => columns.Select(c => c.GetValue(summary, r.BenchmarkCase, style) ?? "NA").ToArray()).ToArray();
             IsDefault = columns.Select(c => summary.Reports.All(r => c.IsDefault(summary, r.BenchmarkCase))).ToArray();
 
             var highlightGroupKeys = summary.BenchmarksCases.Select(b => b.Config.Orderer.GetHighlightGroupKey(b)).ToArray();

--- a/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
@@ -95,7 +95,7 @@ namespace BenchmarkDotNet.Tests.Reports
 
             var joinedSummary = Summary.Join([taggedSummary, otherSummary], default);
 
-            Assert.Equal(["", "tagged"], joinedSummary.Table.Columns.Single(c => c.Header == "Tag").Content);
+            Assert.Equal(["-", "tagged"], joinedSummary.Table.Columns.Single(c => c.Header == "Tag").Content);
         }
 
         [Fact] // Issue #1070

--- a/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
@@ -87,6 +87,17 @@ namespace BenchmarkDotNet.Tests.Reports
             Assert.Equal(SummaryTable.SummaryTableColumn.TextJustification.Right, table.Columns.First(c => c.Header == "Param").Justify);
         }
 
+        [Fact] // Issue #2656
+        public void JoinedSummaryHandlesMissingColumnValues()
+        {
+            var taggedSummary = MockFactory.CreateSummary(typeof(TaggedBenchmark));
+            var otherSummary = MockFactory.CreateSummary(typeof(OtherBenchmark));
+
+            var joinedSummary = Summary.Join([taggedSummary, otherSummary], default);
+
+            Assert.Equal(["", "tagged"], joinedSummary.Table.Columns.Single(c => c.Header == "Tag").Content);
+        }
+
         [Fact] // Issue #1070
         public void CustomOrdererIsSupported()
         {
@@ -475,6 +486,27 @@ namespace BenchmarkDotNet.Tests.Reports
             // assert
             Assert.Equal(["-", "-"], lockContentionCount!);
             Assert.Equal(["-", "-"], completedWorkItemCount!);
+        }
+
+        [Config(typeof(TagColumnConfig))]
+        public class TaggedBenchmark
+        {
+            [Benchmark]
+            public void Tagged() { }
+        }
+
+        public class OtherBenchmark
+        {
+            [Benchmark]
+            public void Other() { }
+        }
+
+        public class TagColumnConfig : ManualConfig
+        {
+            public TagColumnConfig()
+            {
+                AddColumn(new TagColumn("Tag", methodName => methodName == nameof(TaggedBenchmark.Tagged) ? "tagged" : null!));
+            }
         }
         #endregion
     }

--- a/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/SummaryTableTests.cs
@@ -95,7 +95,7 @@ namespace BenchmarkDotNet.Tests.Reports
 
             var joinedSummary = Summary.Join([taggedSummary, otherSummary], default);
 
-            Assert.Equal(["-", "tagged"], joinedSummary.Table.Columns.Single(c => c.Header == "Tag").Content);
+            Assert.Equal(["NA", "tagged"], joinedSummary.Table.Columns.Single(c => c.Header == "Tag").Content);
         }
 
         [Fact] // Issue #1070


### PR DESCRIPTION
Fixes #2656.

When summaries with different column providers are joined, a column may not have a value for benchmarks originating from another summary. `SummaryTable` stored that `null` value and later dereferenced it while calculating the column width, which caused the reported `NullReferenceException`.

This change renders missing column values as `NA` and adds a regression test that joins two summaries where a custom column only applies to one of them.

Tests:

- `dotnet test tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj -c Release -f net10.0 --no-restore --filter FullyQualifiedName~JoinedSummaryHandlesMissingColumnValues` (1 passed)
- `dotnet test tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj -c Release -f net10.0 --no-restore --no-build --filter FullyQualifiedName~BenchmarkDotNet.Tests.Reports.SummaryTableTests` (23 passed)
- Full `BenchmarkDotNet.Tests` run: 1022 passed, 4 skipped, 2 failed. The two Linux CPU parser fixture failures reproduce unchanged on a clean `upstream/master` worktree.
