### PR TITLE
chore: Fix error when running benchmark with file-based app

### DIFF
--- a/src/BenchmarkDotNet/Detectors/Cpu/Windows/MosCpuDetector.cs
+++ b/src/BenchmarkDotNet/Detectors/Cpu/Windows/MosCpuDetector.cs
@@ -10,7 +10,7 @@ namespace BenchmarkDotNet.Detectors.Cpu.Windows;
 internal class MosCpuDetector : ICpuDetector
 {
     [SupportedOSPlatform("windows")]
-    public bool IsApplicable() => OsDetector.IsWindows() && !RuntimeInformation.IsMono;
+    public bool IsApplicable() => OsDetector.IsWindows() && !RuntimeInformation.IsNativeAOT && !RuntimeInformation.IsMono;
 
     [SupportedOSPlatform("windows")]
     public CpuInfo? Detect()

--- a/src/BenchmarkDotNet/Detectors/Cpu/Windows/MosCpuDetector.cs
+++ b/src/BenchmarkDotNet/Detectors/Cpu/Windows/MosCpuDetector.cs
@@ -10,7 +10,7 @@ namespace BenchmarkDotNet.Detectors.Cpu.Windows;
 internal class MosCpuDetector : ICpuDetector
 {
     [SupportedOSPlatform("windows")]
-    public bool IsApplicable() => OsDetector.IsWindows() && !RuntimeInformation.IsNativeAOT && !RuntimeInformation.IsMono;
+    public bool IsApplicable() => OsDetector.IsWindows() && !RuntimeInformation.IsMono;
 
     [SupportedOSPlatform("windows")]
     public CpuInfo? Detect()
@@ -24,8 +24,9 @@ internal class MosCpuDetector : ICpuDetector
         double maxFrequency = 0;
         double nominalFrequency = 0;
 
-        using (var mosProcessor = new ManagementObjectSearcher("SELECT * FROM Win32_Processor"))
+        try
         {
+            using var mosProcessor = new ManagementObjectSearcher("SELECT * FROM Win32_Processor");
             foreach (var moProcessor in mosProcessor.Get().Cast<ManagementObject>())
             {
                 string? name = moProcessor[WmiCpuInfoKeyNames.Name]?.ToString();
@@ -44,6 +45,12 @@ internal class MosCpuDetector : ICpuDetector
                     maxFrequency = Math.Max(maxFrequency, tempMaxFrequency);
                 }
             }
+        }
+        catch
+        {
+            // System.TypeInitializationException: The type initializer for 'System.Management.ManagementPath' threw an exception.
+            // --->System.NotSupportedException: Built-in COM has been disabled via a feature switch.See https://aka.ms/dotnet-illink/com for more information.
+            return null;
         }
 
         string? processorName = processorModelNames.Count > 0 ? string.Join(", ", processorModelNames) : null;

--- a/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
+++ b/src/BenchmarkDotNet/Portability/RuntimeInformation.cs
@@ -76,6 +76,11 @@ namespace BenchmarkDotNet.Portability
                && IsAot
                && !IsWasm && !IsMono; // Wasm and MonoAOTLLVM are also AOT
 
+        // File-based apps contains specific RuntimeHostConfigurationOptions. 
+        // https://github.com/dotnet/dotnet/blob/v10.0.302/src/sdk/documentation/general/dotnet-run-file.md
+        public static bool IsFileBasedApp => AppContext.GetData("EntryPointFilePath") != null
+                                          && AppContext.GetData("EntryPointFileDirectoryPath") != null;
+
         public static readonly bool IsRunningInContainer = string.Equals(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), "true");
 
         internal static string GetArchitecture() => GetCurrentPlatform().ToString();

--- a/src/BenchmarkDotNet/Validators/ShadowCopyValidator.cs
+++ b/src/BenchmarkDotNet/Validators/ShadowCopyValidator.cs
@@ -1,3 +1,4 @@
+using BenchmarkDotNet.Portability;
 using System.Reflection;
 
 namespace BenchmarkDotNet.Validators
@@ -11,7 +12,12 @@ namespace BenchmarkDotNet.Validators
         public bool TreatsWarningsAsErrors => false;
 
         public IAsyncEnumerable<ValidationError> ValidateAsync(ValidationParameters validationParameters)
-            => validationParameters
+        {
+            // Skip validation when running on file-based app. because it's executed on temp directory.
+            if (RuntimeInformation.IsFileBasedApp)
+                return AsyncEnumerable.Empty<ValidationError>();
+
+            return validationParameters
                 .Benchmarks
                 .Select(benchmark => benchmark.Descriptor.Type.GetTypeInfo().Assembly)
                 .Distinct()
@@ -22,5 +28,6 @@ namespace BenchmarkDotNet.Validators
                         $"Assembly {assembly} is located in temp. If you are running benchmarks from xUnit you need to disable shadow copy. It's not supported by design.")
                 )
                 .ToAsyncEnumerable();
+        }
     }
 }


### PR DESCRIPTION
This PR intended following validation error when running benchmark with file-based apps.

> //    * Assembly run, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null is located in temp. If you are running benchmarks from xUnit you need to disable shadow copy. It's not supported by design.

#### What's changed in this PR

**1. `Portability/RuntimeInformation.cs`**
Add `IsFileBasedApp` API to detect benchmark is running on [File-based apps](https://learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps) or not.

**2. `ShadowCopyValidator.cs`**
Add logics to skip validatation when running file-based apps.

**3. `MosCpuDetector.cs`**
Add logics to avoid following errors when running file-based apps without `PublishAot=false` setting.  
(Note: As far as I knows, Currently **Benchmark Host** is not support NativeAot, Because it use reflections)

```
System.TypeInitializationException: The type initializer for 'System.Management.ManagementPath' threw an exception.
 ---> System.NotSupportedException: Built-in COM has been disabled via a feature switch. See https://aka.ms/dotnet-illink/com for more information.
   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
   at System.Management.MTAHelper.CreateInMTA(Type type)
   at System.Management.ManagementPath.CreateWbemPath(String path)
   at System.Management.ManagementPath..ctor(String path)
   at System.Management.ManagementPath..cctor()
   at System.Runtime.CompilerServices.InitHelpers.CallClassConstructor(Void* cctor, Void* instantiatingArg, Exception* pException)
```

#### TestCode

> dotnet main.cs -c Release

```csharp
#!/usr/bin/env dotnet

// Use latest preview version
#:package BenchmarkDotNet@*-preview*
#:property PublishAot=false

using System.Collections;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Jobs;
using BenchmarkDotNet.Running;
using BenchmarkDotNet.Toolchains;
using BenchmarkDotNet.Toolchains.InProcess.Emit;

var config = DefaultConfig.Instance
    .AddJob(Job.ShortRun.WithToolchain(InProcessEmitToolchain.Default));

if(args.Length == 0)
    args = ["--filter", "*"];
    
var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)
                                 .Run(args, config)
                                 .ToArray();

if (summaries.Any(x => x.Reports.Any(r => !r.Success)))
    return 1;
return 0;

namespace Benchmarks
{
    public class SampleBenchmarks
    {
        [Benchmark]
        public bool Execute() 
        {
            return true;
        }
    }
}

```

