### PR TITLE
Disable OSR by default

### DIFF
--- a/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ProcessExtensions.cs
@@ -134,9 +134,14 @@ namespace BenchmarkDotNet.Extensions
             // disable ReSharper's Dynamic Program Analysis (see https://github.com/dotnet/BenchmarkDotNet/issues/1871 for details)
             start.Environment["JETBRAINS_DPA_AGENT_ENABLE"] = "0";
 
-            if (benchmarkCase.Job.ResolveValueAsNullable(RunMode.RunStrategyCharacteristic) != RunStrategy.ColdStart)
+            var runStrategy = benchmarkCase.Job.ResolveValueAsNullable(RunMode.RunStrategyCharacteristic);
+            if (runStrategy != RunStrategy.ColdStart)
             {
                 SetClrEnvironmentVariables(start, JitInfo.EnvCallCountingDelayMs, "0");
+                if (runStrategy != RunStrategy.Monitoring)
+                {
+                    SetClrEnvironmentVariables(start, JitInfo.EnvOSR, "0");
+                }
             }
 
             if (!benchmarkCase.Job.HasValue(EnvironmentMode.EnvironmentVariablesCharacteristic))

--- a/src/BenchmarkDotNet/Portability/JitInfo.cs
+++ b/src/BenchmarkDotNet/Portability/JitInfo.cs
@@ -11,6 +11,7 @@ namespace BenchmarkDotNet.Portability;
 internal static class JitInfo
 {
     public const string EnvCallCountingDelayMs = "TC_CallCountingDelayMs";
+    public const string EnvOSR = "TC_OnStackReplacement";
 
     private const string EnvMinOpts = "JITMinOpts";
     private const string EnvTieredCompilation = "TieredCompilation";
@@ -20,7 +21,6 @@ internal static class JitInfo
     private const string EnvCallCountThreshold = "TC_CallCountThreshold";
     private const string EnvAggressiveTiering = "TC_AggressiveTiering";
     private const string EnvDelaySingleProcMultiplier = "TC_DelaySingleProcMultiplier";
-    private const string EnvOSR = "TC_OnStackReplacement";
 
     private const string KnobTieredCompilation = "System.Runtime.TieredCompilation";
     private const string KnobQuickJit = "System.Runtime.TieredCompilation.QuickJit";


### PR DESCRIPTION
Avoids the runtime bug of duplicated instrumented tiers when OSR is enabled to reduce time spent in the JIT stage with out-of-process CoreCLR toolchains with the default run strategy (https://github.com/dotnet/BenchmarkDotNet/pull/3143#issuecomment-4567849697). I think it should not affect the complete tier1 codegen. cc @AndyAyersMS @EgorBo