### PR TITLE
chore: Update Microsoft.NET.Test.Sdk version and modify IntroNuget sample

### DIFF
--- a/docs/articles/samples/IntroNuGet.md
+++ b/docs/articles/samples/IntroNuGet.md
@@ -13,11 +13,12 @@ It allows comparing different versions of the same package (if there are no brea
 
 ### Output
 
-| Method                    | Job    | Arguments           | Mean     | Error     | StdDev    |
-|-------------------------- |------- |-------------------- |---------:|----------:|----------:|
-| ToImmutableArrayBenchmark | v9.0.0 | /p:SciVersion=9.0.0 | 1.173 μs | 0.0057 μs | 0.0086 μs |
-| ToImmutableArrayBenchmark | v9.0.3 | /p:SciVersion=9.0.3 | 1.173 μs | 0.0038 μs | 0.0058 μs |
-| ToImmutableArrayBenchmark | v9.0.5 | /p:SciVersion=9.0.5 | 1.172 μs | 0.0107 μs | 0.0157 μs |
+| Method                   | Job     | Arguments                       | Mean     | Error    | StdDev   |
+|------------------------- |-------- |-------------------------------- |---------:|---------:|---------:|
+| SerializeAnonymousObject | v13.0.1 | /p:NewtonsoftJsonVersion=13.0.1 | 652.7 ns | 10.68 ns | 15.98 ns |
+| SerializeAnonymousObject | v13.0.2 | /p:NewtonsoftJsonVersion=13.0.2 | 654.0 ns |  8.62 ns | 12.89 ns |
+| SerializeAnonymousObject | v13.0.3 | /p:NewtonsoftJsonVersion=13.0.3 | 678.6 ns | 17.62 ns | 26.38 ns |
+| SerializeAnonymousObject | v13.0.4 | /p:NewtonsoftJsonVersion=13.0.4 | 637.2 ns | 16.95 ns | 24.84 ns |
 
 ### Links
 

--- a/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
+++ b/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="10.1.301" />
     <PackageReference Update="System.ValueTuple" Version="4.6.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
   </ItemGroup>
 
   <Import Project="..\..\build\common.targets" />

--- a/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -18,16 +18,16 @@
     <Reference Include="System.Reflection" />
   </ItemGroup>
   <PropertyGroup>
-    <!-- Use 10.0.0 as baseline package for IntroNuGet -->
-    <SihVersion Condition="'$(SihVersion)' == ''">10.0.0</SihVersion>
+    <!-- Use 13.0.1< as baseline package for IntroNuGet -->
+    <NewtonsoftJsonVersion Condition="'$(NewtonsoftJsonVersion)' == ''">13.0.1</NewtonsoftJsonVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Hashing" Version="[$(SihVersion)]" />
+    <PackageReference Include="Newtonsoft.Json" Version="[$(NewtonsoftJsonVersion)]" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
     <!-- The Test SDK is required only for the VSTest Adapter to work -->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.dotTrace\BenchmarkDotNet.Diagnostics.dotTrace.csproj" />

--- a/samples/BenchmarkDotNet.Samples/IntroNuGet.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroNuGet.cs
@@ -1,6 +1,7 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
+using Newtonsoft.Json;
 using System.IO.Hashing;
 
 namespace BenchmarkDotNet.Samples
@@ -17,11 +18,11 @@ namespace BenchmarkDotNet.Samples
         // Setup your csproj like this:
         /*
         <PropertyGroup>
-          <!-- Use 10.0.0 as default package version if not specified -->
-          <SihVersion Condition="'$(SihVersion)' == ''">10.0.0</SciVersion>
+          <!-- Use 13.0.1 as default package version if not specified -->
+          <NewtonsoftJsonVersion Condition="'$(NewtonsoftJsonVersion)' == ''">13.0.1</NewtonsoftJsonVersion>
         </PropertyGroup>
         <ItemGroup>
-          <PackageReference Include="System.IO.Hashing" Version="$(SihVersion)" />
+          <PackageReference Include="Newtonsoft.Json" Version="[$(NewtonsoftJsonVersion)]" />
         </ItemGroup>
         */
         // All versions of the package must be source-compatible with your benchmark code.
@@ -30,34 +31,27 @@ namespace BenchmarkDotNet.Samples
             public Config()
             {
                 string[] targetVersions = [
-                    "10.0.0",
-                    "10.0.5",
-                    "10.0.9",
+                    "13.0.1",
+                    "13.0.2",
+                    "13.0.3",
+                    "13.0.4",
                 ];
 
                 foreach (var version in targetVersions)
                 {
                     AddJob(Job.MediumRun
-                        .WithMsBuildArguments($"/p:SihVersion={version}")
+                        .WithMsBuildArguments($"/p:NewtonsoftJsonVersion={version}")
                         .WithId($"v{version}")
                     );
                 }
             }
         }
 
-        private static readonly byte[] values;
-
-        static IntroNuGet()
-        {
-            var rand = new Random(Seed: 0);
-            values = new byte[10_000];
-            rand.NextBytes(values);
-        }
-
         [Benchmark]
-        public void XxHash3Benchmark()
+        public void SerializeAnonymousObject()
         {
-            var results = XxHash3.Hash(values);
+            JsonConvert.SerializeObject(
+                new { hello = "world", price = 1.99, now = DateTime.UtcNow });
         }
     }
 }

--- a/tests/BenchmarkDotNet.Analyzers.Tests/BenchmarkDotNet.Analyzers.Tests.csproj
+++ b/tests/BenchmarkDotNet.Analyzers.Tests/BenchmarkDotNet.Analyzers.Tests.csproj
@@ -20,8 +20,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Xunit.Combinatorial" Version="[1.6.24]" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">

--- a/tests/BenchmarkDotNet.Exporters.Plotting.Tests/BenchmarkDotNet.Exporters.Plotting.Tests.csproj
+++ b/tests/BenchmarkDotNet.Exporters.Plotting.Tests/BenchmarkDotNet.Exporters.Plotting.Tests.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\BenchmarkDotNet.Tests\BenchmarkDotNet.Tests.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks/BenchmarkDotNet.IntegrationTests.ManualRunning.MultipleFrameworks.csproj
@@ -37,7 +37,7 @@
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/BenchmarkDotNet.IntegrationTests.ManualRunning.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/BenchmarkDotNet.IntegrationTests.ManualRunning.csproj
@@ -43,7 +43,7 @@
     <ProjectReference Include="..\..\src\BenchmarkDotNet.Diagnostics.dotMemory\BenchmarkDotNet.Diagnostics.dotMemory.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
@@ -37,7 +37,7 @@
     <Compile Include="..\BenchmarkDotNet.Tests\Shared\**\*.cs" Link="Shared\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />

--- a/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
+++ b/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Verify.Xunit" Version="31.12.5" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">


### PR DESCRIPTION
This PR update `Microsoft.NET.Test.Sdk`  package to latest version.

On latest version, `Newtonsoft.Json` package dependency is removed from TestSDK.
https://devblogs.microsoft.com/dotnet/vs-test-is-removing-its-newtonsoft-json-dependency

So I've reverted `IntroNuGet` sample to test Newtonsoft.Json versions.
(Previously it's tested with `System.Collections.Immutable` and `System.IO.Hashing` package, but it cause versioning issue after these package are integrated in BCL)
