### PR TITLE
chore: Update test projects to use net10.0

### DIFF
--- a/.github/workflows/generate-coverage-report.yaml
+++ b/.github/workflows/generate-coverage-report.yaml
@@ -28,10 +28,10 @@ jobs:
       - uses: actions/checkout@v7
 
       # Ensure DOTNET_ROOT environment variable set on macOS
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
-            8.x
+            10.x
 
       # Setup additional tools
       - name: Setup additional tools for Wasm/NativeAot tests
@@ -49,13 +49,13 @@ jobs:
 
       - name: Collect Code Coverage
         run: |
-          dotnet coverage connect bdn_coverage "dotnet test tests/BenchmarkDotNet.Tests -c Release --no-build --framework net8.0"
-          dotnet coverage connect bdn_coverage "dotnet test tests/BenchmarkDotNet.Analyzers.Tests  -c Release --no-build --framework net8.0"
+          dotnet coverage connect bdn_coverage "dotnet test tests/BenchmarkDotNet.Tests -c Release --no-build --framework net10.0"
+          dotnet coverage connect bdn_coverage "dotnet test tests/BenchmarkDotNet.Analyzers.Tests  -c Release --no-build --framework net10.0"
 
       - name: Collect Code Coverage for BenchmarkDotNet.IntegrationTests
         if: ${{ github.event.inputs.skip_integration_tests == 'false'}}
         run: |
-          dotnet coverage connect bdn_coverage "dotnet test tests/BenchmarkDotNet.IntegrationTests -c Release --no-build --framework net8.0"
+          dotnet coverage connect bdn_coverage "dotnet test tests/BenchmarkDotNet.IntegrationTests -c Release --no-build --framework net10.0"
 
       - name: Shutdown dotnet-coverage server.
         run: dotnet coverage shutdown bdn_coverage --timeout 60000

--- a/.github/workflows/run-tests-selected.yaml
+++ b/.github/workflows/run-tests-selected.yaml
@@ -32,10 +32,10 @@ on:
         description: Specify target framework
         required: true
         options:
-          - net8.0
+          - net10.0
           - net472
           # Following target framework is used for `MultipleFrameworks` tests
-          - net10.0
+          - net8.0
           - net462
           - net48
       filter:

--- a/build/BenchmarkDotNet.Build/Helpers/Utils.cs
+++ b/build/BenchmarkDotNet.Build/Helpers/Utils.cs
@@ -67,19 +67,19 @@ public static class Utils
         switch (jobName)
         {
             case "test-windows-core":
-                return ["net8.0"];
+                return ["net10.0"];
 
             case "test-windows-full":
                 return ["net472"];
 
             case "test-linux":
             case "test-macos":
-                return ["net8.0"];
+                return ["net10.0"];
 
             default:
                 return context.IsRunningOnWindows()
-                    ? ["net472", "net8.0"]
-                    : ["net8.0"];
+                    ? ["net472", "net10.0"]
+                    : ["net10.0"];
         }
     }
 }

--- a/build/BenchmarkDotNet.Build/Program.cs
+++ b/build/BenchmarkDotNet.Build/Program.cs
@@ -85,7 +85,7 @@ public class InstallWasmToolsWorkload : FrostingTask<BuildContext>, IHelpProvide
 
     public override void Run(BuildContext context)
     {
-        context.BuildRunner.InstallWorkload("wasm-tools-net8");
+        context.BuildRunner.InstallWorkload("wasm-tools"); // It need to specify `wasm-tools-net10` when using newer version of .NET SDK.
     }
 
     public HelpInfo GetHelp()
@@ -164,7 +164,7 @@ public class InTestsFullTask : FrostingTask<BuildContext>, IHelpProvider
 public class InTestsCoreTask : FrostingTask<BuildContext>, IHelpProvider
 {
     private const string Name = "in-tests-core";
-    public override void Run(BuildContext context) => context.UnitTestRunner.RunInTests("net8.0");
+    public override void Run(BuildContext context) => context.UnitTestRunner.RunInTests("net10.0");
     public HelpInfo GetHelp() => new();
 }
 

--- a/build/sdk/global.json
+++ b/build/sdk/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.300",
+    "version": "10.0.302",
     "rollForward": "disable"
   }
 }

--- a/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
+++ b/samples/BenchmarkDotNet.Samples.FSharp/BenchmarkDotNet.Samples.FSharp.fsproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <GenerateProgramFile>false</GenerateProgramFile>
     <!-- Disable parallel tests between TargetFrameworks -->
     <TestTfmsInParallel>false</TestTfmsInParallel>

--- a/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/samples/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.Samples</AssemblyTitle>
-    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <TargetFrameworks>net10.0;net472</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.Samples</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/samples/BenchmarkDotNet.Samples/IntroWasm.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroWasm.cs
@@ -12,7 +12,7 @@ namespace BenchmarkDotNet.Samples
     public class IntroWasmCmdConfig
     {
         // Example:
-        // --runtimes wasmnet8.0
+        // --runtimes wasmnet10.0
         // --cli /path/to/dotnet (optional)
         // --wasmEngine v8 (optional)
         // --wasmArgs "--expose_wasm" (optional)
@@ -34,9 +34,9 @@ namespace BenchmarkDotNet.Samples
             // Optional: set this to use a custom `dotnet` (for example, a local dotnet/runtime build).
             const string cliPath = "";
 
-            WasmRuntime runtime = new WasmRuntime(msBuildMoniker: "net8.0", RuntimeMoniker.WasmNet80, "Wasm .net8.0", false, "v8");
+            WasmRuntime runtime = new WasmRuntime(msBuildMoniker: "net10.0", RuntimeMoniker.WasmNet10_0, "Wasm .net10.0", false, "v8");
             NetCoreAppSettings netCoreAppSettings = new NetCoreAppSettings(
-                targetFrameworkMoniker: "net8.0", runtimeFrameworkVersion: "", name: "Wasm",
+                targetFrameworkMoniker: "net10.0", runtimeFrameworkVersion: "", name: "Wasm",
                 customDotNetCliPath: cliPath);
             var toolChain = WasmToolchain.From(netCoreAppSettings);
 

--- a/src/BenchmarkDotNet/Toolchains/CoreRun/CoreRunToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRun/CoreRunToolchain.cs
@@ -12,12 +12,12 @@ namespace BenchmarkDotNet.Toolchains.CoreRun
         /// </summary>
         /// <param name="coreRun">the path to CoreRun</param>
         /// /<param name="createCopy">should a copy of CoreRun be performed? True by default. <remarks>The toolchain replaces old dependencies in CoreRun folder with newer versions if used by the benchmarks.</remarks></param>
-        /// <param name="targetFrameworkMoniker">TFM, net8.0 is the default</param>
+        /// <param name="targetFrameworkMoniker">TFM, net10.0 is the default</param>
         /// <param name="customDotNetCliPath">path to dotnet cli, if not provided the one from PATH will be used</param>
         /// <param name="displayName">display name, CoreRun is the default value</param>
         /// <param name="restorePath">the directory to restore packages to</param>
         public CoreRunToolchain(FileInfo coreRun, bool createCopy = true,
-            string targetFrameworkMoniker = "net8.0",
+            string targetFrameworkMoniker = "net10.0",
             FileInfo? customDotNetCliPath = null,
             DirectoryInfo? restorePath = null,
             string displayName = "CoreRun")

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
@@ -35,6 +35,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
             "RuntimeHostConfigurationOption",
             "WarningsAsErrors",
             "Features",
+            "GarbageCollectionAdaptationMode" // TODO: Remove this setting after https://github.com/dotnet/runtime/pull/131069 issue is resolved, and backported to .NET 10.
         }.ToImmutableArray();
 
         public string RuntimeFrameworkVersion { get; }

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/CustomDotNetCliToolchainBuilder.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/CustomDotNetCliToolchainBuilder.cs
@@ -47,7 +47,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             return this;
         }
 
-        /// <param name="targetFrameworkMoniker">TFM, example: net8.0</param>
+        /// <param name="targetFrameworkMoniker">TFM, example: net10.0</param>
         [PublicAPI]
         [SuppressMessage("ReSharper", "ParameterHidesMember")]
         public CustomDotNetCliToolchainBuilder TargetFrameworkMoniker(string targetFrameworkMoniker)

--- a/tests/BenchmarkDotNet.Analyzers.Tests/BenchmarkDotNet.Analyzers.Tests.csproj
+++ b/tests/BenchmarkDotNet.Analyzers.Tests/BenchmarkDotNet.Analyzers.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyName>BenchmarkDotNet.Analyzers.Tests</AssemblyName>
-    <TargetFrameworks>net472;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/tests/BenchmarkDotNet.Exporters.Plotting.Tests/BenchmarkDotNet.Exporters.Plotting.Tests.csproj
+++ b/tests/BenchmarkDotNet.Exporters.Plotting.Tests/BenchmarkDotNet.Exporters.Plotting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <TargetFrameworks>net10.0;net472</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/tests/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly/BenchmarkDotNet.IntegrationTests.ConfigPerAssembly.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests.ConfigPerAssembly</AssemblyTitle>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.ConfigPerAssembly</AssemblyName>
     <PackageId>BenchmarkDotNet.IntegrationTests.ConfigPerAssembly</PackageId>

--- a/tests/BenchmarkDotNet.IntegrationTests.DisabledOptimizations/BenchmarkDotNet.IntegrationTests.DisabledOptimizations.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.DisabledOptimizations/BenchmarkDotNet.IntegrationTests.DisabledOptimizations.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests.DisabledOptimizations</AssemblyTitle>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.DisabledOptimizations</AssemblyName>
     <PackageId>BenchmarkDotNet.IntegrationTests.DisabledOptimizations</PackageId>

--- a/tests/BenchmarkDotNet.IntegrationTests.EnabledOptimizations/BenchmarkDotNet.IntegrationTests.EnabledOptimizations.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.EnabledOptimizations/BenchmarkDotNet.IntegrationTests.EnabledOptimizations.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests.EnabledOptimizations</AssemblyTitle>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.EnabledOptimizations</AssemblyName>
     <PackageId>BenchmarkDotNet.IntegrationTests.EnabledOptimizations</PackageId>

--- a/tests/BenchmarkDotNet.IntegrationTests.FSharp/BenchmarkDotNet.IntegrationTests.FSharp.fsproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.FSharp/BenchmarkDotNet.IntegrationTests.FSharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <PublicSign>false</PublicSign>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/BenchmarkDotNet.IntegrationTests.ManualRunning.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.ManualRunning/BenchmarkDotNet.IntegrationTests.ManualRunning.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests.ManualRunning</AssemblyTitle>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.ManualRunning</AssemblyName>
     <PackageId>BenchmarkDotNet.IntegrationTests.ManualRunning</PackageId>

--- a/tests/BenchmarkDotNet.IntegrationTests.Static/BenchmarkDotNet.IntegrationTests.Static.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.Static/BenchmarkDotNet.IntegrationTests.Static.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests.Static</AssemblyTitle>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests.Static</AssemblyName>
     <PackageId>BenchmarkDotNet.IntegrationTests.Static</PackageId>

--- a/tests/BenchmarkDotNet.IntegrationTests.VisualBasic/BenchmarkDotNet.IntegrationTests.VisualBasic.vbproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.VisualBasic/BenchmarkDotNet.IntegrationTests.VisualBasic.vbproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BenchmarkDotNet\BenchmarkDotNet.csproj" />

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
@@ -2,8 +2,9 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.IntegrationTests</AssemblyTitle>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net472;net8.0</TargetFrameworks>
-    <TargetFramework Condition="'$(OS)' != 'Windows_NT'">net8.0</TargetFramework>
+    <!-- net8.0 is required for Mono80IsSupported test-->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net472;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net8.0;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkDotNet.IntegrationTests</AssemblyName>
     <PackageId>BenchmarkDotNet.IntegrationTests</PackageId>

--- a/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
+++ b/tests/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
@@ -14,6 +14,10 @@
     <DebugSymbols>true</DebugSymbols>
     <NoWarn>$(NoWarn);CA2007;CA1825</NoWarn>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+
+    <!-- TODO: Remove this setting after https://github.com/dotnet/runtime/pull/131069 issue is resolved, and backported to .NET 10. -->
+    <!-- Disable Dynamic adaptation to application sizes (DATAS) -->
+    <GarbageCollectionAdaptationMode>0</GarbageCollectionAdaptationMode>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/tests/BenchmarkDotNet.IntegrationTests/BuildTimeoutTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/BuildTimeoutTests.cs
@@ -27,10 +27,10 @@ namespace BenchmarkDotNet.IntegrationTests
             var config = ManualConfig.CreateEmpty()
                 .WithBuildTimeout(timeout)
                 .AddJob(Job.Dry
-                    .WithRuntime(NativeAotRuntime.Net80)
+                    .WithRuntime(NativeAotRuntime.Net10_0)
                     .WithToolchain(NativeAotToolchain.CreateBuilder()
-                        .UseNuGet("8.0.0", "https://api.nuget.org/v3/index.json")
-                        .TargetFrameworkMoniker("net8.0")
+                        .UseNuGet("10.0.0", "https://api.nuget.org/v3/index.json")
+                        .TargetFrameworkMoniker("net10.0")
                         .ToToolchain()));
 
             var summary = CanExecute<NativeAotBenchmark>(config, fullValidation: false);

--- a/tests/BenchmarkDotNet.IntegrationTests/CancellationTokenTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/CancellationTokenTests.cs
@@ -57,14 +57,14 @@ public class CancellationTokenTests(ITestOutputHelper output) : BenchmarkTestExe
     [InlineData("node")]
     public void BenchmarkWithCancellationTokenProperty_ReceivesToken_Wasm(string javaScriptEngine)
     {
-        var dotnetVersion = "net8.0";
+        var dotnetVersion = "net10.0";
         var logger = new OutputLogger(Output);
         var netCoreAppSettings = new NetCoreAppSettings(dotnetVersion, runtimeFrameworkVersion: null!, "Wasm", aotCompilerMode: MonoAotCompilerMode.mini);
 
         var config = ManualConfig.CreateEmpty()
             .AddLogger(logger)
             .AddJob(Job.Dry
-                .WithRuntime(new WasmRuntime(dotnetVersion, RuntimeMoniker.WasmNet80, "wasm", false, javaScriptEngine))
+                .WithRuntime(new WasmRuntime(dotnetVersion, RuntimeMoniker.WasmNet10_0, "wasm", false, javaScriptEngine))
                 .WithToolchain(WasmToolchain.From(netCoreAppSettings)))
             .WithBuildTimeout(TimeSpan.FromSeconds(240))
             .WithOption(ConfigOptions.LogBuildOutput, true)
@@ -123,14 +123,14 @@ public class CancellationTokenTests(ITestOutputHelper output) : BenchmarkTestExe
         var cts = new CancellationTokenSource();
         var diagnoser = new CancelAfterFirstIterationDiagnoser(cts);
 
-        var dotnetVersion = "net8.0";
+        var dotnetVersion = "net10.0";
         var logger = new OutputLogger(Output);
         var netCoreAppSettings = new NetCoreAppSettings(dotnetVersion, runtimeFrameworkVersion: null!, "Wasm", aotCompilerMode: MonoAotCompilerMode.mini);
 
         var config = ManualConfig.CreateEmpty()
             .AddLogger(logger)
             .AddJob(Job.Dry
-                .WithRuntime(new WasmRuntime(dotnetVersion, RuntimeMoniker.WasmNet80, "wasm", false, javaScriptEngine))
+                .WithRuntime(new WasmRuntime(dotnetVersion, RuntimeMoniker.WasmNet10_0, "wasm", false, javaScriptEngine))
                 .WithToolchain(WasmToolchain.From(netCoreAppSettings)))
             .AddDiagnoser(diagnoser)
             .WithBuildTimeout(TimeSpan.FromSeconds(240))

--- a/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
@@ -41,12 +41,12 @@ namespace BenchmarkDotNet.IntegrationTests
                 // See: https://github.com/dotnet/BenchmarkDotNet/issues/3086
                 if (RuntimeInformation.GetCurrentPlatform() is Platform.X86 or Platform.X64 && !OsDetector.IsMacOS())
                 {
-                    yield return [Jit.RyuJit, Platform.X64, CsProjCoreToolchain.NetCoreApp80]; // .NET Core x64
+                    yield return [Jit.RyuJit, Platform.X64, CsProjCoreToolchain.NetCoreApp10_0]; // .NET Core x64
                     // We could add Platform.X86 here, but it would make our CI more complicated.
                 }
                 else if (RuntimeInformation.GetCurrentPlatform() is Platform.Arm64)
                 {
-                    yield return [Jit.RyuJit, Platform.Arm64, CsProjCoreToolchain.NetCoreApp80]; // .NET Core arm64
+                    yield return [Jit.RyuJit, Platform.Arm64, CsProjCoreToolchain.NetCoreApp10_0]; // .NET Core arm64
                 }
             }
 

--- a/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
@@ -163,10 +163,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
             CanExecute<WithInlineable>(CreateConfig(jit, platform, toolchain, disassemblyDiagnoser, RunStrategy.Monitoring));
 
-            var disassemblyResult = disassemblyDiagnoser.Results.Values.SingleOrDefault(result => result.Methods.Count(method => method.Name.Contains(nameof(WithInlineable.JustReturn))) == 1);
-
-            if (disassemblyResult == null)
-                disassemblyResult = disassemblyDiagnoser.Results.Values.Single(); // Benchmark method is got inlined.
+            var disassemblyResult = disassemblyDiagnoser.Results.Values.Single(result => result.Methods.Count(method => method.Name.Contains(nameof(WithInlineable.JustReturn))) == 1);
 
             Assert.Empty(disassemblyResult.Errors);
             Assert.Contains(disassemblyResult.Methods, method => method.Maps.Any(map => map.SourceCodes.OfType<Asm>().All(asm => asm.ToString()!.Contains("ret"))));

--- a/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
@@ -163,7 +163,10 @@ namespace BenchmarkDotNet.IntegrationTests
 
             CanExecute<WithInlineable>(CreateConfig(jit, platform, toolchain, disassemblyDiagnoser, RunStrategy.Monitoring));
 
-            var disassemblyResult = disassemblyDiagnoser.Results.Values.Single(result => result.Methods.Count(method => method.Name.Contains(nameof(WithInlineable.JustReturn))) == 1);
+            var disassemblyResult = disassemblyDiagnoser.Results.Values.SingleOrDefault(result => result.Methods.Count(method => method.Name.Contains(nameof(WithInlineable.JustReturn))) == 1);
+
+            if (disassemblyResult == null)
+                disassemblyResult = disassemblyDiagnoser.Results.Values.Single(); // Benchmark method is got inlined.
 
             Assert.Empty(disassemblyResult.Errors);
             Assert.Contains(disassemblyResult.Methods, method => method.Maps.Any(map => map.SourceCodes.OfType<Asm>().All(asm => asm.ToString()!.Contains("ret"))));

--- a/tests/BenchmarkDotNet.IntegrationTests/JitRuntimeValidationTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/JitRuntimeValidationTest.cs
@@ -48,7 +48,7 @@ namespace BenchmarkDotNet.IntegrationTests
         [MemberData(nameof(CheckCore_Arguments))]
         public void CheckCore(Jit jit, Platform platform, string errorMessage)
         {
-            Verify(CoreRuntime.Core80, jit, platform, errorMessage);
+            Verify(CoreRuntime.Core10_0, jit, platform, errorMessage);
         }
 
         private void Verify(Runtime runtime, Jit jit, Platform platform, string? errorMessage)

--- a/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -81,7 +81,7 @@ namespace BenchmarkDotNet.IntegrationTests
             if (OsDetector.IsMacOS())
                 return; // currently not supported
 
-            MemoryDiagnoserIsAccurate(NativeAotToolchain.Net80);
+            MemoryDiagnoserIsAccurate(NativeAotToolchain.Net10_0);
         }
 
         [FactEnvSpecific("We don't want to test MonoVM twice (.NET Framework and .NET Core), and it's not supported on Windows+Arm",
@@ -103,10 +103,10 @@ namespace BenchmarkDotNet.IntegrationTests
             var arraySizeOverhead = ptrSize * 2; // bounds + max_length
             var intTaskSize = 40; // We can't use CalculateRequiredSpace for AllocateTask since it calculates the size with IntPtr.Size.
 
-            var netCoreAppSettings = new NetCoreAppSettings("net8.0", runtimeFrameworkVersion: null!, "Wasm", aotCompilerMode: aotCompilerMode);
+            var netCoreAppSettings = new NetCoreAppSettings("net10.0", runtimeFrameworkVersion: null!, "Wasm", aotCompilerMode: aotCompilerMode);
 
             var runtime = new WasmRuntime(
-                netCoreAppSettings.TargetFrameworkMoniker, RuntimeMoniker.WasmNet80,
+                netCoreAppSettings.TargetFrameworkMoniker, RuntimeMoniker.WasmNet10_0,
                 "Wasm", aotCompilerMode == MonoAotCompilerMode.wasm, "v8");
 
             AssertAllocations(WasmToolchain.From(netCoreAppSettings), typeof(AccurateAllocations), new Dictionary<string, long>

--- a/tests/BenchmarkDotNet.IntegrationTests/WasmTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/WasmTests.cs
@@ -72,14 +72,14 @@ namespace BenchmarkDotNet.IntegrationTests
 
         private ManualConfig GetConfig(MonoAotCompilerMode aotCompilerMode, string javaScriptEngine, FileInfo? mainJsTemplate = null, WasmIpcType ipcType = WasmIpcType.Auto)
         {
-            var dotnetVersion = "net8.0";
+            var dotnetVersion = "net10.0";
             var logger = new OutputLogger(Output);
             var netCoreAppSettings = new NetCoreAppSettings(dotnetVersion, runtimeFrameworkVersion: null!, "Wasm", aotCompilerMode: aotCompilerMode);
 
             return ManualConfig.CreateEmpty()
                 .AddLogger(logger)
                 .AddJob(Job.Dry
-                    .WithRuntime(new WasmRuntime(dotnetVersion, RuntimeMoniker.WasmNet80, "wasm", aotCompilerMode == MonoAotCompilerMode.wasm, javaScriptEngine, mainJsTemplate: mainJsTemplate, ipcType: ipcType))
+                    .WithRuntime(new WasmRuntime(dotnetVersion, RuntimeMoniker.WasmNet10_0, "wasm", aotCompilerMode == MonoAotCompilerMode.wasm, javaScriptEngine, mainJsTemplate: mainJsTemplate, ipcType: ipcType))
                     .WithToolchain(WasmToolchain.From(netCoreAppSettings)))
                 .WithBuildTimeout(TimeSpan.FromSeconds(480)) // Increase timeout for `WasmSupportsInProcessDiagnosers` test on macos(x64)
                 .WithOption(ConfigOptions.LogBuildOutput, true)

--- a/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
+++ b/tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet.Tests</AssemblyTitle>
-    <TargetFrameworks>net8.0;net10.0;net472</TargetFrameworks>
+    <TargetFrameworks>net10.0;net472</TargetFrameworks>
     <AssemblyName>BenchmarkDotNet.Tests</AssemblyName>
     <PackageId>BenchmarkDotNet.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/tests/BenchmarkDotNet.Tests/Jobs/JobIdGeneratorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Jobs/JobIdGeneratorTests.cs
@@ -22,5 +22,6 @@ public class JobIdGeneratorTests
         {"Job-OOTPKI", Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp80) },
         {"Job-QAODSR", Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp90) },
         {"Job-KHMDUZ", Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp80).WithRuntime(CoreRuntime.Core80) },
+        {"Job-JMDAGQ", Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp10_0) },
     };
 }


### PR DESCRIPTION
This PR intended to update test baseline TFM from `net8.0` to `net10.0` (#3002)

### What's changed in this PR
**1. Update `build/sdk/global.json`**
Update .NET 10 SDK version to `10.0.302`

**2. Update `build/BenchmarkDotNet.Build/*`**
Modify code to use net10.0 and wasm-tools for .NET 10.

**3. Update CI workflows**
Modify workflows to use `net10.0`

**4. Update samples/tests project files**
Modify TFM to use net10.0 (`net8.0` TFM for integration tests is not removed, because it's required by `Mono80IsSupported` test)
Modify some tests to use net10.0 based toolchain/runtime.
