### PR TITLE
Disambiguate type display names in benchmark selection

### DIFF
--- a/src/BenchmarkDotNet/Extensions/ReflectionExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ReflectionExtensions.cs
@@ -131,9 +131,9 @@ namespace BenchmarkDotNet.Extensions
             var displayNames = new string[types.Count];
             for (int i = 0; i < types.Count; i++)
             {
-                string? @namespace = types[i].Namespace;
-                displayNames[i] = ambiguousNames.Contains(simpleNames[i]) && !string.IsNullOrEmpty(@namespace)
-                    ? $"{@namespace}.{simpleNames[i]}"
+                string? fullName = types[i].FullName;
+                displayNames[i] = ambiguousNames.Contains(simpleNames[i]) && !string.IsNullOrEmpty(fullName)
+                    ? fullName
                     : simpleNames[i];
             }
 

--- a/src/BenchmarkDotNet/Extensions/ReflectionExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ReflectionExtensions.cs
@@ -113,6 +113,34 @@ namespace BenchmarkDotNet.Extensions
         internal static string GetDisplayName(this Type type) => GetDisplayName(type.GetTypeInfo());
 
         /// <summary>
+        /// Returns a display name per type, aligned with <paramref name="types"/>. When more than one
+        /// type shares the same simple <see cref="GetDisplayName(Type)"/> (e.g. same class name in
+        /// different namespaces), the colliding names are qualified with their namespace so they can be
+        /// told apart; unambiguous names are left as-is.
+        /// </summary>
+        internal static string[] GetDisambiguatedDisplayNames(this IReadOnlyList<Type> types)
+        {
+            var simpleNames = new string[types.Count];
+            for (int i = 0; i < types.Count; i++)
+                simpleNames[i] = types[i].GetDisplayName();
+
+            var ambiguousNames = new HashSet<string>(
+                simpleNames.GroupBy(name => name).Where(group => group.Count() > 1).Select(group => group.Key),
+                StringComparer.Ordinal);
+
+            var displayNames = new string[types.Count];
+            for (int i = 0; i < types.Count; i++)
+            {
+                string? @namespace = types[i].Namespace;
+                displayNames[i] = ambiguousNames.Contains(simpleNames[i]) && !string.IsNullOrEmpty(@namespace)
+                    ? $"{@namespace}.{simpleNames[i]}"
+                    : simpleNames[i];
+            }
+
+            return displayNames;
+        }
+
+        /// <summary>
         /// returns simple, human friendly display name
         /// </summary>
         private static string GetDisplayName(this TypeInfo typeInfo)

--- a/src/BenchmarkDotNet/Running/UserInteraction.cs
+++ b/src/BenchmarkDotNet/Running/UserInteraction.cs
@@ -21,11 +21,12 @@ namespace BenchmarkDotNet.Running
         public IReadOnlyList<Type> AskUser(IReadOnlyList<Type> allTypes, ILogger logger)
         {
             var selectedTypes = new List<Type>();
-            string benchmarkCaptionExample = allTypes.First().GetDisplayName();
+            var displayNames = allTypes.GetDisambiguatedDisplayNames();
+            string benchmarkCaptionExample = displayNames[0];
 
             while (selectedTypes.Count == 0 && !consoleCancelKeyPressed)
             {
-                PrintAvailable(allTypes, logger);
+                PrintAvailable(allTypes, displayNames, logger);
 
                 if (consoleCancelKeyPressed)
                     break;
@@ -42,7 +43,7 @@ namespace BenchmarkDotNet.Running
                     break;
                 }
 
-                selectedTypes.AddRange(GetMatching(allTypes, userInput.Split([' '], StringSplitOptions.RemoveEmptyEntries)));
+                selectedTypes.AddRange(GetMatching(allTypes, displayNames, userInput.Split([' '], StringSplitOptions.RemoveEmptyEntries)));
                 logger.WriteLine();
             }
 
@@ -81,7 +82,7 @@ namespace BenchmarkDotNet.Running
             logger.WriteLineInfo("To learn more about filtering use `--help`.");
         }
 
-        private static IEnumerable<Type> GetMatching(IReadOnlyList<Type> allTypes, string[] userInput)
+        private static IEnumerable<Type> GetMatching(IReadOnlyList<Type> allTypes, string[] displayNames, string[] userInput)
         {
             if (userInput.IsEmpty())
                 yield break;
@@ -93,7 +94,7 @@ namespace BenchmarkDotNet.Running
             {
                 var type = allTypes[i];
 
-                if (stringInput.Any(arg => type.GetDisplayName().ContainsWithIgnoreCase(arg))
+                if (stringInput.Any(arg => displayNames[i].ContainsWithIgnoreCase(arg))
                     || stringInput.Contains($"#{i}")
                     || integerInput.Contains($"{i}")
                     || stringInput.Contains("*"))
@@ -105,13 +106,13 @@ namespace BenchmarkDotNet.Running
             static bool IsInteger(string str) => int.TryParse(str, out _);
         }
 
-        private static void PrintAvailable(IReadOnlyList<Type> allTypes, ILogger logger)
+        private static void PrintAvailable(IReadOnlyList<Type> allTypes, string[] displayNames, ILogger logger)
         {
             logger.WriteLineHelp($"Available Benchmark{(allTypes.Count > 1 ? "s" : "")}:");
 
             int numberWidth = allTypes.Count.ToString().Length;
             for (int i = 0; i < allTypes.Count && !consoleCancelKeyPressed; i++)
-                logger.WriteLineHelp(string.Format(CultureInfo.InvariantCulture, "  #{0} {1}", i.ToString().PadRight(numberWidth), allTypes[i].GetDisplayName()));
+                logger.WriteLineHelp(string.Format(CultureInfo.InvariantCulture, "  #{0} {1}", i.ToString().PadRight(numberWidth), displayNames[i]));
 
             if (!consoleCancelKeyPressed)
             {

--- a/tests/BenchmarkDotNet.Tests/ReflectionTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ReflectionTests.cs
@@ -126,6 +126,34 @@ namespace BenchmarkDotNet.Tests
         }
 
         [Fact]
+        public void GetDisambiguatedDisplayNamesQualifiesCollidingNamesWithNamespace()
+        {
+            var types = new[]
+            {
+                typeof(Foo.Fixture),
+                typeof(Bar.Fixture),
+                typeof(ReflectionTests),
+            };
+
+            var displayNames = types.GetDisambiguatedDisplayNames();
+
+            Assert.Equal("BenchmarkDotNet.Tests.Foo.Fixture", displayNames[0]);
+            Assert.Equal("BenchmarkDotNet.Tests.Bar.Fixture", displayNames[1]);
+            Assert.Equal("ReflectionTests", displayNames[2]);
+        }
+
+        [Fact]
+        public void GetDisambiguatedDisplayNamesLeavesUniqueNamesUnqualified()
+        {
+            var types = new[] { typeof(Foo.Fixture), typeof(ReflectionTests) };
+
+            var displayNames = types.GetDisambiguatedDisplayNames();
+
+            Assert.Equal("Fixture", displayNames[0]);
+            Assert.Equal("ReflectionTests", displayNames[1]);
+        }
+
+        [Fact]
         public void OnlyClosedGenericsWithPublicParameterlessCtorsAreSupported()
         {
             Assert.False(typeof(Generic<>).ContainsRunnableBenchmarks());
@@ -175,4 +203,14 @@ namespace BenchmarkDotNet.Tests
                 => new StackOnlyStruct<T> { Span = instance.Array };
         }
     }
+}
+
+namespace BenchmarkDotNet.Tests.Foo
+{
+    public class Fixture { }
+}
+
+namespace BenchmarkDotNet.Tests.Bar
+{
+    public class Fixture { }
 }


### PR DESCRIPTION
#3202
Disambiguate type display names in benchmark selection

Added GetDisambiguatedDisplayNames to qualify ambiguous type names with namespaces. Updated UserInteraction to use these names for clearer benchmark selection and filtering. Added unit tests and supporting fixture classes to verify correct behavior.

<img width="1371" height="217" alt="image" src="https://github.com/user-attachments/assets/be42f48b-b91c-4acd-9e10-28aa0465c399" />
