### PR TITLE
Support custom exporters via --exporters option

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -26,7 +26,7 @@ namespace BenchmarkDotNet.ConsoleArguments
         [Option('r', "runtimes", Required = false, HelpText = "Full target framework moniker for .NET Core and .NET. For Mono just 'Mono'. For NativeAOT please append target runtime version (example: 'nativeaot7.0'). First one will be marked as baseline!")]
         public IEnumerable<string> Runtimes { get; set; } = [];
 
-        [Option('e', "exporters", Required = false, HelpText = "GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML/CSVMeasurements/Markdown/Atlassian/Plain/BriefJSON/FullJSON/Asciidoc/BriefXML/FullXML/OpenMetrics")]
+        [Option('e', "exporters", Required = false, HelpText = "GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML/CSVMeasurements/Markdown/Atlassian/Plain/BriefJSON/FullJSON/Asciidoc/BriefXML/FullXML/OpenMetrics. A custom IExporter can also be selected by its assembly-qualified type name, e.g. \"My.Namespace.MyExporter, MyAssembly\".")]
         public IEnumerable<string> Exporters { get; set; } = [];
 
         [Option('m', "memory", Required = false, Default = false, HelpText = "Prints memory statistics")]

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -75,6 +75,47 @@ namespace BenchmarkDotNet.ConsoleArguments
                 { "openmetrics", new[] { Exporters.OpenMetrics.OpenMetricsExporter.Default } }
             };
 
+        /// <summary>
+        /// Resolves a single <c>--exporters</c> value. A built-in name (see <see cref="AvailableExporters"/>) maps to its
+        /// exporter(s); any other value is treated as an assembly-qualified type name of a custom <see cref="IExporter"/>
+        /// with a public parameterless constructor. Used by both validation and config creation so the two can't drift.
+        /// </summary>
+        private static bool TryResolveExporters(string name, [NotNullWhen(true)] out IExporter[]? exporters, [NotNullWhen(false)] out string? error)
+        {
+            if (AvailableExporters.TryGetValue(name, out var builtIn))
+            {
+                exporters = builtIn;
+                error = null;
+                return true;
+            }
+
+            exporters = null;
+
+            var type = Type.GetType(name, throwOnError: false, ignoreCase: false);
+            if (type == null)
+            {
+                error = $"The provided exporter \"{name}\" is invalid. Available options are: {string.Join(", ", AvailableExporters.Keys)}. "
+                    + "To use a custom exporter, pass its assembly-qualified type name (e.g. \"My.Namespace.MyExporter, MyAssembly\").";
+                return false;
+            }
+
+            if (!typeof(IExporter).IsAssignableFrom(type))
+            {
+                error = $"The provided exporter type \"{type.FullName}\" does not implement {nameof(IExporter)}.";
+                return false;
+            }
+
+            if (type.GetConstructor(Type.EmptyTypes) == null)
+            {
+                error = $"The provided exporter type \"{type.FullName}\" must have a public parameterless constructor to be used as an exporter.";
+                return false;
+            }
+
+            exporters = [(IExporter)Activator.CreateInstance(type)!];
+            error = null;
+            return true;
+        }
+
         public static (bool isSuccess, IConfig? config, CommandLineOptions? options) Parse(string[] args, ILogger logger, IConfig? globalConfig = null)
         {
             (bool isSuccess, IConfig? config, CommandLineOptions? options) result = default;
@@ -264,9 +305,9 @@ namespace BenchmarkDotNet.ConsoleArguments
             }
 
             foreach (string exporter in options.Exporters)
-                if (!AvailableExporters.ContainsKey(exporter))
+                if (!TryResolveExporters(exporter, out _, out string? exporterError))
                 {
-                    logger.WriteLineError($"The provided exporter \"{exporter}\" is invalid. Available options are: {string.Join(", ", AvailableExporters.Keys)}.");
+                    logger.WriteLineError(exporterError);
                     return false;
                 }
 
@@ -354,7 +395,8 @@ namespace BenchmarkDotNet.ConsoleArguments
             if (config.GetJobs().IsEmpty() && baseJob != Job.Default)
                 config.AddJob(baseJob);
 
-            config.AddExporter(options.Exporters.SelectMany(exporter => AvailableExporters[exporter]).ToArray());
+            // Validate() already gated every exporter through TryResolveExporters, so resolution here cannot fail.
+            config.AddExporter(options.Exporters.SelectMany(exporter => TryResolveExporters(exporter, out var resolved, out _) ? resolved : []).ToArray());
 
             config.AddHardwareCounters(options.HardwareCounters
                 .Select(counterName => (HardwareCounter)Enum.Parse(typeof(HardwareCounter), counterName, ignoreCase: true))

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -6,6 +6,8 @@ using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Helpers;
+using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Exporters.Csv;
 using BenchmarkDotNet.Exporters.Json;
 using BenchmarkDotNet.Exporters.OpenMetrics;
@@ -84,6 +86,69 @@ namespace BenchmarkDotNet.Tests
 
             Assert.NotNull(config);
             Assert.Equal(expectedExporters, config.GetExporters().ToArray());
+        }
+
+        [Fact]
+        public void CustomExporterIsResolvedFromAssemblyQualifiedTypeName()
+        {
+            var (isSuccess, config, _) = ConfigParser.Parse(["--exporters", typeof(CustomExporter).AssemblyQualifiedName!], new OutputLogger(Output));
+
+            Assert.True(isSuccess);
+            Assert.NotNull(config);
+            Assert.Single(config.GetExporters());
+            Assert.IsType<CustomExporter>(config.GetExporters().Single());
+        }
+
+        [Fact]
+        public void BuiltInAndCustomExportersCanBeCombined()
+        {
+            var (isSuccess, config, _) = ConfigParser.Parse(["--exporters", "json", typeof(CustomExporter).AssemblyQualifiedName!], new OutputLogger(Output));
+
+            Assert.True(isSuccess);
+            Assert.NotNull(config);
+            Assert.Contains(JsonExporter.Default, config.GetExporters());
+            Assert.Contains(config.GetExporters(), e => e is CustomExporter);
+        }
+
+        [Fact]
+        public void UnknownExporterNameFailsParsing()
+        {
+            var (isSuccess, config, _) = ConfigParser.Parse(["--exporters", "does-not-exist"], new OutputLogger(Output));
+
+            Assert.False(isSuccess);
+            Assert.Null(config);
+        }
+
+        [Fact]
+        public void CustomExporterThatDoesNotImplementIExporterFailsParsing()
+        {
+            var (isSuccess, config, _) = ConfigParser.Parse(["--exporters", typeof(NotAnExporter).AssemblyQualifiedName!], new OutputLogger(Output));
+
+            Assert.False(isSuccess);
+            Assert.Null(config);
+        }
+
+        [Fact]
+        public void CustomExporterWithoutParameterlessConstructorFailsParsing()
+        {
+            var (isSuccess, config, _) = ConfigParser.Parse(["--exporters", typeof(ExporterWithoutParameterlessCtor).AssemblyQualifiedName!], new OutputLogger(Output));
+
+            Assert.False(isSuccess);
+            Assert.Null(config);
+        }
+
+        public class CustomExporter : ExporterBase
+        {
+            public override ValueTask ExportAsync(Summary summary, CancelableStreamWriter writer, CancellationToken cancellationToken) => new();
+        }
+
+        public class NotAnExporter { }
+
+        public class ExporterWithoutParameterlessCtor : ExporterBase
+        {
+            public ExporterWithoutParameterlessCtor(int _) { }
+
+            public override ValueTask ExportAsync(Summary summary, CancelableStreamWriter writer, CancellationToken cancellationToken) => new();
         }
 
         [Fact]


### PR DESCRIPTION
#1967 

Support custom exporters via --exporters option

Allow specifying custom IExporter types by assembly-qualified name in the --exporters CLI option. Added TryResolveExporters for unified resolution and validation of exporters. Extended tests to cover custom exporters, combinations with built-ins, and error handling for invalid types.