### PR TITLE
Add CancellationToken support to synchronous benchmark runner APIs

### DIFF
--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs
@@ -15,54 +15,81 @@ namespace BenchmarkDotNet.Running
     public static class BenchmarkRunner
     {
         [PublicAPI]
-        public static Summary Run<T>(IConfig? config = null, string[]? args = null)
+        public static Summary Run<T>(
+     IConfig? config = null,
+     string[]? args = null,
+     CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync<T>(config, args));
+            return context.ExecuteUntilComplete(
+                RunAsync<T>(config, args, cancellationToken));
         }
 
         [PublicAPI]
-        public static Summary Run(Type type, IConfig? config = null, string[]? args = null)
+        public static Summary Run(
+    Type type,
+    IConfig? config = null,
+    string[]? args = null,
+    CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(type, config, args));
+            return context.ExecuteUntilComplete(
+                RunAsync(type, config, args, cancellationToken));
         }
 
         [PublicAPI]
-        public static Summary[] Run(Type[] types, IConfig? config = null, string[]? args = null)
+        public static Summary[] Run(
+    Type[] types,
+    IConfig? config = null,
+    string[]? args = null,
+    CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(types, config, args));
+            return context.ExecuteUntilComplete(
+                RunAsync(types, config, args, cancellationToken));
         }
 
         [PublicAPI]
-        public static Summary Run(Type type, MethodInfo[] methods, IConfig? config = null)
+        public static Summary Run(
+    Type type,
+    MethodInfo[] methods,
+    IConfig? config = null,
+    CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(type, methods, config));
+            return context.ExecuteUntilComplete(
+                RunAsync(type, methods, config, cancellationToken));
         }
 
         [PublicAPI]
-        public static Summary[] Run(Assembly assembly, IConfig? config = null, string[]? args = null)
+        public static Summary[] Run(
+    Assembly assembly,
+    IConfig? config = null,
+    string[]? args = null,
+    CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(assembly, config, args));
+            return context.ExecuteUntilComplete(
+                RunAsync(assembly, config, args, cancellationToken));
         }
 
         [PublicAPI]
-        public static Summary Run(BenchmarkRunInfo benchmarkRunInfo)
+        public static Summary Run(BenchmarkRunInfo benchmarkRunInfo, CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(benchmarkRunInfo));
+            return context.ExecuteUntilComplete(
+     RunAsync(benchmarkRunInfo, cancellationToken));
         }
 
         [PublicAPI]
-        public static Summary[] Run(BenchmarkRunInfo[] benchmarkRunInfos)
+        public static Summary[] Run(
+    BenchmarkRunInfo[] benchmarkRunInfos,
+    CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(benchmarkRunInfos));
+            return context.ExecuteUntilComplete(
+                RunAsync(benchmarkRunInfos, cancellationToken));
         }
-
         [PublicAPI]
         public static ValueTask<Summary> RunAsync<T>(IConfig? config = null, string[]? args = null, CancellationToken cancellationToken = default)
             => RunAsync(typeof(T), config, args, cancellationToken);
@@ -102,10 +129,13 @@ namespace BenchmarkDotNet.Running
                 return await RunWithExceptionHandling(() => RunWithDirtyAssemblyResolveHelper(assembly, config, args, cancellationToken)).ConfigureAwait(false);
             }
         }
-
         [PublicAPI]
-        public static async ValueTask<Summary> RunAsync(BenchmarkRunInfo benchmarkRunInfo)
-            => (await RunAsync([benchmarkRunInfo]).ConfigureAwait(false)).Single();
+        public static async ValueTask<Summary> RunAsync(
+            BenchmarkRunInfo benchmarkRunInfo,
+            CancellationToken cancellationToken = default)
+            => (await RunAsync([benchmarkRunInfo], cancellationToken)
+                .ConfigureAwait(false))
+                .Single();
 
         [PublicAPI]
         public static async ValueTask<Summary[]> RunAsync(BenchmarkRunInfo[] benchmarkRunInfos, CancellationToken cancellationToken = default)

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerDirty.cs
@@ -16,9 +16,9 @@ namespace BenchmarkDotNet.Running
     {
         [PublicAPI]
         public static Summary Run<T>(
-     IConfig? config = null,
-     string[]? args = null,
-     CancellationToken cancellationToken = default)
+            IConfig? config = null,
+            string[]? args = null,
+            CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
             return context.ExecuteUntilComplete(
@@ -27,10 +27,10 @@ namespace BenchmarkDotNet.Running
 
         [PublicAPI]
         public static Summary Run(
-    Type type,
-    IConfig? config = null,
-    string[]? args = null,
-    CancellationToken cancellationToken = default)
+            Type type,
+            IConfig? config = null,
+            string[]? args = null,
+            CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
             return context.ExecuteUntilComplete(
@@ -39,10 +39,10 @@ namespace BenchmarkDotNet.Running
 
         [PublicAPI]
         public static Summary[] Run(
-    Type[] types,
-    IConfig? config = null,
-    string[]? args = null,
-    CancellationToken cancellationToken = default)
+            Type[] types,
+            IConfig? config = null,
+            string[]? args = null,
+            CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
             return context.ExecuteUntilComplete(
@@ -51,10 +51,10 @@ namespace BenchmarkDotNet.Running
 
         [PublicAPI]
         public static Summary Run(
-    Type type,
-    MethodInfo[] methods,
-    IConfig? config = null,
-    CancellationToken cancellationToken = default)
+            Type type,
+            MethodInfo[] methods,
+            IConfig? config = null,
+            CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
             return context.ExecuteUntilComplete(
@@ -63,10 +63,10 @@ namespace BenchmarkDotNet.Running
 
         [PublicAPI]
         public static Summary[] Run(
-    Assembly assembly,
-    IConfig? config = null,
-    string[]? args = null,
-    CancellationToken cancellationToken = default)
+            Assembly assembly,
+            IConfig? config = null,
+            string[]? args = null,
+            CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
             return context.ExecuteUntilComplete(
@@ -78,13 +78,13 @@ namespace BenchmarkDotNet.Running
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
             return context.ExecuteUntilComplete(
-     RunAsync(benchmarkRunInfo, cancellationToken));
+                RunAsync(benchmarkRunInfo, cancellationToken));
         }
 
         [PublicAPI]
         public static Summary[] Run(
-    BenchmarkRunInfo[] benchmarkRunInfos,
-    CancellationToken cancellationToken = default)
+            BenchmarkRunInfo[] benchmarkRunInfos,
+            CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
             return context.ExecuteUntilComplete(

--- a/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkSwitcher.cs
@@ -52,27 +52,27 @@ namespace BenchmarkDotNet.Running
         /// Run all available benchmarks.
         /// </summary>
         [PublicAPI]
-        public IEnumerable<Summary> RunAll(IConfig? config = null, string[]? args = null)
+        public IEnumerable<Summary> RunAll(IConfig? config = null, string[]? args = null, CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAllAsync(config, args));
+            return context.ExecuteUntilComplete(RunAllAsync(config, args, cancellationToken));
         }
 
         /// <summary>
         /// Run all available benchmarks and join them to a single summary
         /// </summary>
         [PublicAPI]
-        public Summary RunAllJoined(IConfig? config = null, string[]? args = null)
+        public Summary RunAllJoined(IConfig? config = null, string[]? args = null, CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAllJoinedAsync(config, args));
+            return context.ExecuteUntilComplete(RunAllJoinedAsync(config, args, cancellationToken));
         }
 
         [PublicAPI]
-        public IEnumerable<Summary> Run(string[]? args = null, IConfig? config = null)
+        public IEnumerable<Summary> Run(string[]? args = null, IConfig? config = null, CancellationToken cancellationToken = default)
         {
             using var context = BenchmarkSynchronizationContext.CreateAndSetCurrent();
-            return context.ExecuteUntilComplete(RunAsync(args, config));
+            return context.ExecuteUntilComplete(RunAsync(args, config, cancellationToken));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Adds `CancellationToken` support to the synchronous `BenchmarkRunner` and `BenchmarkSwitcher` APIs.

### Changes
- Add `CancellationToken cancellationToken = default` to synchronous `Run` methods.
- Forward the token to the corresponding async implementations.
- Add the `RunAsync(BenchmarkRunInfo, CancellationToken)` overload.

### Validation
- Built successfully.
- Ran `dotnet test tests/BenchmarkDotNet.Tests/BenchmarkDotNet.Tests.csproj` successfully.