### PR TITLE
Add references to in-process diagnoser handlers in Roslyn toolchain.

### DIFF
--- a/src/BenchmarkDotNet/Toolchains/Roslyn/Generator.cs
+++ b/src/BenchmarkDotNet/Toolchains/Roslyn/Generator.cs
@@ -1,4 +1,5 @@
 using BenchmarkDotNet.Detectors;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Running;
 using JetBrains.Annotations;
@@ -54,9 +55,14 @@ namespace BenchmarkDotNet.Toolchains.Roslyn
                 [
                     benchmarkCase.Descriptor.Type.GetTypeInfo().Assembly, // this assembly does not has to have a reference to BenchmarkDotNet (e.g. custom framework for benchmarking that internally uses BenchmarkDotNet
                     typeof(BenchmarkCase).Assembly, // BenchmarkDotNet
-                    typeof(System.Threading.Tasks.ValueTask).Assembly, // TaskExtensions
+                    typeof(ValueTask).Assembly, // TaskExtensions
                     typeof(Perfolizer.Horology.IClock).Assembly // Perfolizer
                 ])
+                // In-process diagnoser handlers
+                .Concat(benchmarkCase.Config.GetDiagnosers()
+                    .OfType<IInProcessDiagnoser>()
+                    .Select(diagnoser => diagnoser.GetHandlerData(benchmarkCase).HandlerType?.GetTypeInfo().Assembly)
+                    .WhereNotNull())
                 .Distinct();
     }
 }


### PR DESCRIPTION
#3218 only for the Roslyn toolchain. CsProj toolchains are the same issue as #2214, I will add a validator for that separately.