### PR TITLE
`GC.WaitForPendingFinalizers` again

### DIFF
--- a/src/BenchmarkDotNet/Engines/Engine.cs
+++ b/src/BenchmarkDotNet/Engines/Engine.cs
@@ -312,6 +312,7 @@ namespace BenchmarkDotNet.Engines
             GC.Collect();
             GC.WaitForPendingFinalizers();
             GC.Collect();
+            GC.WaitForPendingFinalizers();
         }
 
         [UsedImplicitly]


### PR DESCRIPTION
The engine calls `GC.Collect` a second time after `GC.WaitForPendingFinalizers`, presumably because a finalizer may allocate. But it doesn't wait for finalizers to complete the second time. Some types may revive themselves and allocate again every time the GC collects, like `Gen2GcCallback` (https://github.com/dotnet/runtime/issues/101536). This causes a race condition where our allocation measurement may capture those background allocations. Adding an extra `GC.WaitForPendingFinalizers` should fix that race (of course it doesn't help if the benchmark causes the GC to run naturally, but that's unavoidable).