### PR TITLE
chore: Reduce messages that reported by analyzers

### DIFF
--- a/samples/BenchmarkDotNet.Samples/IntroFilters.cs
+++ b/samples/BenchmarkDotNet.Samples/IntroFilters.cs
@@ -16,8 +16,8 @@ namespace BenchmarkDotNet.Samples
             {
                 // benchmark with names which contains "A" OR "1"
                 AddFilter(new DisjunctionFilter(
-                    new NameFilter(name => name.Contains("A")),
-                    new NameFilter(name => name.Contains("1"))
+                    new NameFilter(name => name.Contains('A')),
+                    new NameFilter(name => name.Contains('1'))
                 ));
 
                 // benchmark with names with length < 3

--- a/src/BenchmarkDotNet.Diagnostics.Windows/ConcurrencyVisualizerProfiler.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/ConcurrencyVisualizerProfiler.cs
@@ -48,7 +48,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
 
         public void DisplayResults(ILogger logger)
         {
-            if (!benchmarkToCvTraceFile.Any())
+            if (benchmarkToCvTraceFile.Count == 0)
                 return;
 
             logger.WriteLineInfo($"Exported {benchmarkToCvTraceFile.Count} CV trace file(s). Example:");

--- a/src/BenchmarkDotNet.Diagnostics.Windows/EtwProfiler.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/EtwProfiler.cs
@@ -81,7 +81,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
 
         public void DisplayResults(ILogger logger)
         {
-            if (!benchmarkToEtlFile.Any())
+            if (benchmarkToEtlFile.Count == 0)
                 return;
 
             logger.WriteLineInfo($"Exported {benchmarkToEtlFile.Count} trace file(s). Example:");
@@ -95,7 +95,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows
                 .Select(counter => HardwareCounters.FromCounter(counter, config.IntervalSelectors.TryGetValue(counter, out var selector) ? selector : GetInterval))
                 .ToArray();
 
-            if (counters.Any()) // we need to enable the counters before starting the kernel session
+            if (counters.Length != 0) // we need to enable the counters before starting the kernel session
                 HardwareCounters.Enable(counters);
 
             try

--- a/src/BenchmarkDotNet.Diagnostics.Windows/Tracing/TraceLogParser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/Tracing/TraceLogParser.cs
@@ -96,7 +96,7 @@ namespace BenchmarkDotNet.Diagnostics.Windows.Tracing
 
         private readonly List<(double timeStamp, ulong instructionPointer, int profileSource)> samples = [];
 
-        public bool HasBenchmarkEvents => overheadTimestamps.Any() || workloadTimestamps.Any();
+        public bool HasBenchmarkEvents => overheadTimestamps.Count != 0 || workloadTimestamps.Count != 0;
 
         public void HandleIterationEvent(double timeStamp, IterationMode iterationMode, long totalOperations)
         {

--- a/src/BenchmarkDotNet.Diagnostics.Windows/Tracing/TraceLogParser.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/Tracing/TraceLogParser.cs
@@ -81,10 +81,10 @@ namespace BenchmarkDotNet.Diagnostics.Windows.Tracing
         private void OnPmcEvent(PMCCounterProfTraceData data)
         {
             // if given process did not emit Benchmarking events before, we don't care about it
-            if (!processIdToData.ContainsKey(data.ProcessID))
+            if (!processIdToData.TryGetValue(data.ProcessID, out ProcessMetrics? value))
                 return;
 
-            processIdToData[data.ProcessID].HandleNewSample(data.TimeStampRelativeMSec, data.InstructionPointer, data.ProfileSource);
+            value.HandleNewSample(data.TimeStampRelativeMSec, data.InstructionPointer, data.ProfileSource);
         }
     }
 

--- a/src/BenchmarkDotNet/Analysers/ConclusionHelper.cs
+++ b/src/BenchmarkDotNet/Analysers/ConclusionHelper.cs
@@ -14,7 +14,7 @@ namespace BenchmarkDotNet.Analysers
         private static void PrintFiltered(IEnumerable<Conclusion> conclusions, ConclusionKind kind, string title, Action<string> printLine)
         {
             var filtered = conclusions.Where(c => c.Kind == kind).ToArray();
-            if (filtered.Any())
+            if (filtered.Length != 0)
             {
                 printLine("");
                 printLine($"// * {title} *");

--- a/src/BenchmarkDotNet/Analysers/EnvironmentAnalyser.cs
+++ b/src/BenchmarkDotNet/Analysers/EnvironmentAnalyser.cs
@@ -32,7 +32,7 @@ namespace BenchmarkDotNet.Analysers
             if (unexpectedExit)
             {
                 var avProducts = summary.HostEnvironmentInfo.AntivirusProducts.Value;
-                if (avProducts.Any())
+                if (avProducts.Count != 0)
                     yield return CreateWarning(CreateWarningAboutAntivirus(avProducts));
             }
 

--- a/src/BenchmarkDotNet/Analysers/OutliersAnalyser.cs
+++ b/src/BenchmarkDotNet/Analysers/OutliersAnalyser.cs
@@ -27,7 +27,7 @@ namespace BenchmarkDotNet.Analysers
             var actualOutliers = statistics.GetActualOutliers(outlierMode);
 
             var cultureInfo = summary.GetCultureInfo();
-            if (allOutliers.Any())
+            if (allOutliers.Length != 0)
                 yield return CreateHint(GetMessage(actualOutliers, allOutliers, statistics.LowerOutliers, statistics.UpperOutliers, cultureInfo), report);
         }
 
@@ -54,7 +54,7 @@ namespace BenchmarkDotNet.Analysers
 
             var rangeMessages = new List<string?> { GetRangeMessage(lowerOutliers), GetRangeMessage(upperOutliers) };
             rangeMessages.RemoveAll(string.IsNullOrEmpty);
-            string rangeMessage = rangeMessages.Any()
+            string rangeMessage = rangeMessages.Count != 0
                 ? " (" + string.Join(", ", rangeMessages) + ")"
                 : string.Empty;
 

--- a/src/BenchmarkDotNet/Analysers/ZeroMeasurementAnalyser.cs
+++ b/src/BenchmarkDotNet/Analysers/ZeroMeasurementAnalyser.cs
@@ -30,7 +30,7 @@ namespace BenchmarkDotNet.Analysers
             var workloadSample = workloadMeasurements.GetStatistics().Sample;
             var threshold = currentFrequency.Value.ToResolution().Nanoseconds / 2;
 
-            var zeroMeasurement = overheadMeasurements.Any()
+            var zeroMeasurement = overheadMeasurements.Length != 0
                 ? ZeroMeasurementHelper.AreIndistinguishable(workloadSample, overheadMeasurements.GetStatistics().Sample)
                 : ZeroMeasurementHelper.IsNegligible(workloadSample, threshold);
 

--- a/src/BenchmarkDotNet/Code/CodeGenerator.cs
+++ b/src/BenchmarkDotNet/Code/CodeGenerator.cs
@@ -239,7 +239,7 @@ namespace BenchmarkDotNet.Code
             var factory = benchmarkCase.Job.ResolveValue(InfrastructureMode.EngineFactoryCharacteristic, InfrastructureResolver.Instance)!;
             var factoryType = factory.GetType();
 
-            if (!factoryType.GetTypeInfo().DeclaredConstructors.Any(ctor => ctor.IsPublic && !ctor.GetParameters().Any()))
+            if (!factoryType.GetTypeInfo().DeclaredConstructors.Any(ctor => ctor.IsPublic && ctor.GetParameters().Length == 0))
             {
                 throw new NotSupportedException("Custom factory must have a public parameterless constructor");
             }

--- a/src/BenchmarkDotNet/Code/CodeGenerator.cs
+++ b/src/BenchmarkDotNet/Code/CodeGenerator.cs
@@ -69,7 +69,7 @@ namespace BenchmarkDotNet.Code
         {
             string benchmarkDotNetLocation = Path.GetDirectoryName(typeof(CodeGenerator).GetTypeInfo().Assembly.Location)!;
 
-            if (benchmarkDotNetLocation != null && benchmarkDotNetLocation.IndexOf("LINQPAD", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (benchmarkDotNetLocation != null && benchmarkDotNetLocation.Contains("LINQPAD", StringComparison.OrdinalIgnoreCase))
             {
                 /* "LINQPad normally puts the compiled query into a different folder than the referenced assemblies
                  * - this allows for optimizations to reduce file I/O, which is important in the scratchpad scenario"

--- a/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfig.cs
@@ -122,7 +122,7 @@ namespace BenchmarkDotNet.Configs
         {
             var diagnosersForGivenMode = diagnosers.Where(diagnoser => runModeComparer(diagnoser.GetRunMode(benchmarkCase))).ToImmutableHashSet();
 
-            return diagnosersForGivenMode.Any() ? new CompositeDiagnoser(diagnosersForGivenMode) : null;
+            return !diagnosersForGivenMode.IsEmpty ? new CompositeDiagnoser(diagnosersForGivenMode) : null;
         }
 
         public IReadOnlyList<Conclusion> ConfigAnalysisConclusion { get; private set; }

--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -88,8 +88,7 @@ namespace BenchmarkDotNet.Configs
             var builder = ImmutableHashSet.CreateBuilder(new TypeComparer<IDiagnoser>());
 
             foreach (var diagnoser in diagnosers)
-                if (!builder.Contains(diagnoser))
-                    builder.Add(diagnoser);
+                builder.Add(diagnoser);
 
             if (!uniqueHardwareCounters.IsEmpty && !diagnosers.OfType<IHardwareCountersDiagnoser>().Any())
             {
@@ -187,13 +186,11 @@ namespace BenchmarkDotNet.Configs
             var builder = ImmutableHashSet.CreateBuilder<IAnalyser>();
 
             foreach (var analyser in analysers)
-                if (!builder.Contains(analyser))
-                    builder.Add(analyser);
+                builder.Add(analyser);
 
             foreach (var diagnoser in uniqueDiagnosers)
                 foreach (var analyser in diagnoser.Analysers)
-                    if (!builder.Contains(analyser))
-                        builder.Add(analyser);
+                    builder.Add(analyser);
 
             return builder.ToImmutable();
         }

--- a/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
+++ b/src/BenchmarkDotNet/Configs/ImmutableConfigBuilder.cs
@@ -229,7 +229,7 @@ namespace BenchmarkDotNet.Configs
             var customDefaultJob = unique.SingleOrDefault(job => job.Meta.IsDefault);
             var defaultJob = customDefaultJob ?? Job.Default;
 
-            if (!result.Any())
+            if (result.Count == 0)
                 result.Add(defaultJob);
 
             foreach (var mutatorJob in unique.Where(job => job.Meta.IsMutator))

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -287,7 +287,7 @@ namespace BenchmarkDotNet.ConsoleArguments
             {
                 if (!TryParse(runtime, out RuntimeMoniker runtimeMoniker))
                 {
-                    logger.WriteLineError($"The provided runtime \"{runtime}\" is invalid. Available options are: {string.Join(", ", Enum.GetNames(typeof(RuntimeMoniker)).Select(name => name.ToLower()))}.");
+                    logger.WriteLineError($"The provided runtime \"{runtime}\" is invalid. Available options are: {string.Join(", ", Enum.GetNames<RuntimeMoniker>().Select(name => name.ToLower()))}.");
                     return false;
                 }
                 else if (runtimeMoniker == RuntimeMoniker.MonoAOTLLVM && (options.AOTCompilerPath == null || options.AOTCompilerPath.IsNotNullButDoesNotExist()))
@@ -353,7 +353,7 @@ namespace BenchmarkDotNet.ConsoleArguments
             foreach (var counterName in options.HardwareCounters)
                 if (!Enum.TryParse(counterName, ignoreCase: true, out HardwareCounter _))
                 {
-                    logger.WriteLineError($"The provided hardware counter \"{counterName}\" is invalid. Available options are: {string.Join("+", Enum.GetNames(typeof(HardwareCounter)))}.");
+                    logger.WriteLineError($"The provided hardware counter \"{counterName}\" is invalid. Available options are: {string.Join("+", Enum.GetNames<HardwareCounter>())}.");
                     return false;
                 }
 

--- a/src/BenchmarkDotNet/Diagnosers/EventPipeProfiler.cs
+++ b/src/BenchmarkDotNet/Diagnosers/EventPipeProfiler.cs
@@ -119,7 +119,7 @@ namespace BenchmarkDotNet.Diagnosers
 
         public void DisplayResults(ILogger resultLogger)
         {
-            if (!benchmarkToTraceFile.Any())
+            if (benchmarkToTraceFile.Count == 0)
                 return;
 
             resultLogger.WriteLineInfo($"Exported {benchmarkToTraceFile.Count} trace file(s). Example:");

--- a/src/BenchmarkDotNet/Diagnosers/PerfCollectProfiler.cs
+++ b/src/BenchmarkDotNet/Diagnosers/PerfCollectProfiler.cs
@@ -73,7 +73,7 @@ namespace BenchmarkDotNet.Diagnosers
 
         public void DisplayResults(ILogger logger)
         {
-            if (!benchmarkToTraceFile.Any())
+            if (benchmarkToTraceFile.Count == 0)
                 return;
 
             logger.WriteLineInfo($"Exported {benchmarkToTraceFile.Count} trace file(s). Example:");
@@ -227,7 +227,7 @@ namespace BenchmarkDotNet.Diagnosers
                 .Distinct()
                 .ToArray();
 
-            if (!missingSymbols.Any())
+            if (missingSymbols.Length == 0)
             {
                 return; // the symbol files are already where we need them!
             }

--- a/src/BenchmarkDotNet/Disassemblers/DataContracts.cs
+++ b/src/BenchmarkDotNet/Disassemblers/DataContracts.cs
@@ -252,7 +252,7 @@ internal sealed class State
         }
 
         string versionToParse = targetFrameworkMoniker.Substring(firstDigit, lastDigit - firstDigit + 1);
-        if (!versionToParse.Contains(".")) // Full .NET Framework (net48 etc)
+        if (!versionToParse.Contains('.')) // Full .NET Framework (net48 etc)
             versionToParse = string.Join(".", versionToParse.ToCharArray());
 
         return Version.Parse(versionToParse);

--- a/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
+++ b/src/BenchmarkDotNet/Disassemblers/DisassemblyDiagnoser.cs
@@ -217,7 +217,22 @@ namespace BenchmarkDotNet.Diagnosers
         }
 
         private static long SumNativeCodeSize(DisassemblyResult disassembly)
-            => disassembly.Methods.Sum(method => method.Maps.Sum(map => map.SourceCodes.OfType<Asm>().Sum(asm => asm.InstructionLength)));
+        {
+            long total = 0;
+
+            foreach (var method in disassembly.Methods)
+            {
+                foreach (var map in method.Maps)
+                {
+                    foreach (var asm in map.SourceCodes.OfType<Asm>())
+                    {
+                        total += asm.InstructionLength;
+                    }
+                }
+            }
+
+            return total;
+        }
 
         InProcessDiagnoserHandlerData IInProcessDiagnoser.GetHandlerData(BenchmarkCase benchmarkCase)
         {

--- a/src/BenchmarkDotNet/Disassemblers/MonoDisassembler.cs
+++ b/src/BenchmarkDotNet/Disassemblers/MonoDisassembler.cs
@@ -78,7 +78,7 @@ namespace BenchmarkDotNet.Disassemblers
                     if (TryParseInstruction(line, out var instruction))
                         instructions.Add(instruction);
 
-                while (instructions.Any() && instructions.Last().Text == "nop")
+                while (instructions.Count != 0 && instructions.Last().Text == "nop")
                     instructions.RemoveAt(instructions.Count - 1);
 
                 return new DisassemblyResult

--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
@@ -180,7 +180,7 @@ namespace BenchmarkDotNet.Environments
         {
             if (productVersion.IsNotBlank() && productName.IsNotBlank())
             {
-                if (productName.IndexOf(".NET Core", StringComparison.OrdinalIgnoreCase) >= 0)
+                if (productName.Contains(".NET Core", StringComparison.OrdinalIgnoreCase))
                 {
                     string parsableVersion = GetParsableVersionPart(productVersion);
                     if (Version.TryParse(productVersion, out version) || Version.TryParse(parsableVersion, out version))
@@ -190,7 +190,7 @@ namespace BenchmarkDotNet.Environments
                 }
 
                 // yes, .NET Core 2.X has a product name == .NET Framework...
-                if (productName.IndexOf(".NET Framework", StringComparison.OrdinalIgnoreCase) >= 0)
+                if (productName.Contains(".NET Framework", StringComparison.OrdinalIgnoreCase))
                 {
                     const string releaseVersionPrefix = "release/";
                     int releaseVersionIndex = productVersion.IndexOf(releaseVersionPrefix, StringComparison.Ordinal);

--- a/src/BenchmarkDotNet/Extensions/ReflectionExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ReflectionExtensions.cs
@@ -201,7 +201,7 @@ namespace BenchmarkDotNet.Extensions
             if (typeInfo.IsAbstract || typeInfo.IsGenericType && !IsRunnableGenericType(typeInfo))
                 return false;
 
-            return typeInfo.GetBenchmarks().Any();
+            return typeInfo.GetBenchmarks().Length != 0;
         }
 
         private static MethodInfo[] GetBenchmarks(this TypeInfo typeInfo)
@@ -254,11 +254,11 @@ namespace BenchmarkDotNet.Extensions
 
             var instanceType = argumentInstance.GetType();
 
-            var implicitCastsDefinedInArgumentInstance = instanceType.GetMethods().Where(method => method.Name == "op_Implicit" && method.GetParameters().Any()).ToArray();
+            var implicitCastsDefinedInArgumentInstance = instanceType.GetMethods().Where(method => method.Name == "op_Implicit" && method.GetParameters().Length != 0).ToArray();
             if (implicitCastsDefinedInArgumentInstance.Any(implicitCast => implicitCast.ReturnType == argumentType && implicitCast.GetParameters().All(p => p.ParameterType == instanceType)))
                 return true;
 
-            var implicitCastsDefinedInArgumentType = argumentType.GetMethods().Where(method => method.Name == "op_Implicit" && method.GetParameters().Any()).ToArray();
+            var implicitCastsDefinedInArgumentType = argumentType.GetMethods().Where(method => method.Name == "op_Implicit" && method.GetParameters().Length != 0).ToArray();
             if (implicitCastsDefinedInArgumentType.Any(implicitCast => implicitCast.ReturnType == argumentType && implicitCast.GetParameters().All(p => p.ParameterType == instanceType)))
                 return true;
 
@@ -267,7 +267,7 @@ namespace BenchmarkDotNet.Extensions
 
         private static bool IsRunnableGenericType(TypeInfo typeInfo)
             => // if it is an open generic - there must be GenericBenchmark attributes
-                (!typeInfo.IsGenericTypeDefinition || typeInfo.GenericTypeArguments.Any() || typeInfo.GetCustomAttributes(true).OfType<GenericTypeArgumentsAttribute>().Any())
+                (!typeInfo.IsGenericTypeDefinition || typeInfo.GenericTypeArguments.Length != 0 || typeInfo.GetCustomAttributes(true).OfType<GenericTypeArgumentsAttribute>().Any())
                     && typeInfo.DeclaredConstructors.Any(ctor => ctor.IsPublic && ctor.GetParameters().Length == 0); // we need public parameterless ctor to create it
 
         internal static bool IsLinqPad(this Assembly assembly) => assembly.FullName!.Contains("LINQPAD", StringComparison.OrdinalIgnoreCase);

--- a/src/BenchmarkDotNet/Extensions/ReflectionExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/ReflectionExtensions.cs
@@ -270,7 +270,7 @@ namespace BenchmarkDotNet.Extensions
                 (!typeInfo.IsGenericTypeDefinition || typeInfo.GenericTypeArguments.Any() || typeInfo.GetCustomAttributes(true).OfType<GenericTypeArgumentsAttribute>().Any())
                     && typeInfo.DeclaredConstructors.Any(ctor => ctor.IsPublic && ctor.GetParameters().Length == 0); // we need public parameterless ctor to create it
 
-        internal static bool IsLinqPad(this Assembly assembly) => assembly.FullName!.IndexOf("LINQPAD", StringComparison.OrdinalIgnoreCase) >= 0;
+        internal static bool IsLinqPad(this Assembly assembly) => assembly.FullName!.Contains("LINQPAD", StringComparison.OrdinalIgnoreCase);
 
         internal static bool IsByRefLike(this Type type)
 #if NETSTANDARD2_0

--- a/src/BenchmarkDotNet/Helpers/GenericBenchmarksBuilder.cs
+++ b/src/BenchmarkDotNet/Helpers/GenericBenchmarksBuilder.cs
@@ -18,7 +18,7 @@ namespace BenchmarkDotNet.Helpers
                                                               .Select(x => x.GenericTypeArguments)
                                                               .ToArray();
 
-            if (typeArguments.Any())
+            if (typeArguments.Length != 0)
                 return BuildGenericTypes(type, typeArguments);
 
             return [(true, type)];

--- a/src/BenchmarkDotNet/Helpers/SectionsHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/SectionsHelper.cs
@@ -10,7 +10,7 @@ namespace BenchmarkDotNet.Helpers
             var list = content?.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
             if (list != null)
                 foreach (string line in list)
-                    if (line.IndexOf(separator) != -1)
+                    if (line.Contains(separator))
                     {
                         var lineParts = line.Split(separator);
                         if (lineParts.Length >= 2)

--- a/src/BenchmarkDotNet/Helpers/UserInteractionHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/UserInteractionHelper.cs
@@ -19,7 +19,7 @@ namespace BenchmarkDotNet.Helpers
         /// </remarks>
         public static string EscapeCommandExample(string input)
         {
-            return !OsDetector.IsWindows() && input.IndexOf('*') >= 0 ? $"'{input}'" : input;
+            return !OsDetector.IsWindows() && input.Contains('*') ? $"'{input}'" : input;
         }
     }
 }

--- a/src/BenchmarkDotNet/Loggers/ConsoleLogger.cs
+++ b/src/BenchmarkDotNet/Loggers/ConsoleLogger.cs
@@ -71,7 +71,7 @@ namespace BenchmarkDotNet.Loggers
         }
 
         private ConsoleColor GetColor(LogKind logKind) =>
-            colorScheme.ContainsKey(logKind) ? colorScheme[logKind] : DefaultColor;
+            colorScheme.TryGetValue(logKind, out ConsoleColor value) ? value : DefaultColor;
 
         private static Dictionary<LogKind, ConsoleColor> CreateColorfulScheme() =>
             new Dictionary<LogKind, ConsoleColor>

--- a/src/BenchmarkDotNet/Mathematics/LegacyConfidenceInterval.cs
+++ b/src/BenchmarkDotNet/Mathematics/LegacyConfidenceInterval.cs
@@ -157,7 +157,7 @@ public struct LegacyConfidenceInterval
         builder.Append(formatter(Lower));
         builder.Append("; ");
         builder.Append(formatter(Upper));
-        builder.Append("]");
+        builder.Append(']');
         builder.Append(GetLevelHint(showLevel));
         return builder.ToString();
     }

--- a/src/BenchmarkDotNet/Mathematics/PercentileValues.cs
+++ b/src/BenchmarkDotNet/Mathematics/PercentileValues.cs
@@ -52,7 +52,7 @@ namespace BenchmarkDotNet.Mathematics
             builder.Append(formatter(P50));
             builder.Append("]; [P100: ");
             builder.Append(formatter(P100));
-            builder.Append("]");
+            builder.Append(']');
             return builder.ToString();
         }
 

--- a/src/BenchmarkDotNet/Portability/StringExtensions.cs
+++ b/src/BenchmarkDotNet/Portability/StringExtensions.cs
@@ -4,6 +4,6 @@ namespace BenchmarkDotNet.Portability
     {
         internal static bool EqualsWithIgnoreCase(this string left, string right) => left != null && left.Equals(right, StringComparison.InvariantCultureIgnoreCase);
 
-        internal static bool ContainsWithIgnoreCase(this string text, string word) => text != null && text.IndexOf(word, StringComparison.InvariantCultureIgnoreCase) >= 0;
+        internal static bool ContainsWithIgnoreCase(this string text, string word) => text != null && text.Contains(word, StringComparison.InvariantCultureIgnoreCase);
     }
 }

--- a/src/BenchmarkDotNet/Reports/DisplayPrecisionManager.cs
+++ b/src/BenchmarkDotNet/Reports/DisplayPrecisionManager.cs
@@ -19,15 +19,16 @@ namespace BenchmarkDotNet.Reports
         /// </summary>
         public int GetPrecision(SummaryStyle summaryStyle, IStatisticColumn column, IStatisticColumn? parentColumn = null)
         {
-            if (!precision.ContainsKey(column.Id))
-            {
-                var values = column.GetAllValues(summary, summaryStyle);
-                precision[column.Id] = parentColumn != null
-                    ? CalcPrecision(values, GetPrecision(summaryStyle, parentColumn))
-                    : CalcPrecision(values);
-            }
+            if (precision.TryGetValue(column.Id, out int value))
+                return value;
 
-            return precision[column.Id];
+            var values = column.GetAllValues(summary, summaryStyle);
+            value = parentColumn != null
+                ? CalcPrecision(values, GetPrecision(summaryStyle, parentColumn))
+                : CalcPrecision(values);
+            precision[column.Id] = value;
+
+            return value;
         }
 
         internal static int CalcPrecision(IList<double> values)

--- a/src/BenchmarkDotNet/Reports/SummaryTable.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTable.cs
@@ -118,7 +118,7 @@ namespace BenchmarkDotNet.Reports
                 Index = index;
                 Header = table.FullHeader[index];
                 Content = table.FullContent.Select(line => line[index]).ToArray();
-                Width = Math.Max(Header.Length, Content.Any() ? Content.Max(line => line.Length) : 0) + 1;
+                Width = Math.Max(Header.Length, Content.Length != 0 ? Content.Max(line => line.Length) : 0) + 1;
                 IsDefault = table.IsDefault[index];
                 OriginalColumn = column;
 

--- a/src/BenchmarkDotNet/Reports/SummaryTableExtensions.cs
+++ b/src/BenchmarkDotNet/Reports/SummaryTableExtensions.cs
@@ -14,7 +14,7 @@ namespace BenchmarkDotNet.Reports
         public static async ValueTask PrintCommonColumnsAsync(this SummaryTable table, StreamOrLoggerWriter writer, CancellationToken cancellationToken)
         {
             var commonColumns = table.Columns.Where(c => c.IsCommon).ToArray();
-            if (commonColumns.Any())
+            if (commonColumns.Length != 0)
             {
                 int paramsOnLine = 0;
                 foreach (var column in commonColumns)

--- a/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkConverter.cs
@@ -260,7 +260,7 @@ namespace BenchmarkDotNet.Running
 
         private static void AssertMethodHasCorrectSignature(string methodType, MethodInfo methodInfo)
         {
-            if (methodInfo.GetParameters().Any() && !methodInfo.HasAttribute<ArgumentsAttribute>() && !methodInfo.HasAttribute<ArgumentsSourceAttribute>())
+            if (methodInfo.GetParameters().Length != 0 && !methodInfo.HasAttribute<ArgumentsAttribute>() && !methodInfo.HasAttribute<ArgumentsSourceAttribute>())
                 throw new InvalidBenchmarkDeclarationException($"{methodType} method {methodInfo.Name} has incorrect signature.\nMethod shouldn't have any arguments.");
         }
 

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -793,7 +793,7 @@ namespace BenchmarkDotNet.Running
 
             void AddLogger(ILogger logger)
             {
-                if (!loggers.ContainsKey(logger.Id) || loggers[logger.Id].Priority < logger.Priority)
+                if (!loggers.TryGetValue(logger.Id, out ILogger? value) || value.Priority < logger.Priority)
                     loggers[logger.Id] = logger;
             }
 

--- a/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
+++ b/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs
@@ -374,12 +374,12 @@ namespace BenchmarkDotNet.Running
             bool needToShowTimeLegend = summary.Table.Columns.Any(c => c.NeedToShow && c.OriginalColumn.UnitType == UnitType.Time);
             var effectiveTimeUnit = needToShowTimeLegend ? summary.Table.EffectiveSummaryStyle.TimeUnit : null;
 
-            if (columnWithLegends.Any() || effectiveTimeUnit != null)
+            if (columnWithLegends.Length != 0 || effectiveTimeUnit != null)
             {
                 logger.WriteLine();
                 logger.WriteLineHeader("// * Legends *");
                 int maxNameWidth = 0;
-                if (columnWithLegends.Any())
+                if (columnWithLegends.Length != 0)
                     maxNameWidth = Math.Max(maxNameWidth, columnWithLegends.Select(c => c.ColumnName.Length).Max());
                 if (effectiveTimeUnit != null)
                     maxNameWidth = Math.Max(maxNameWidth, effectiveTimeUnit.GetAbbreviation().ToString(cultureInfo).Length + 2);

--- a/src/BenchmarkDotNet/Running/TypeFilter.cs
+++ b/src/BenchmarkDotNet/Running/TypeFilter.cs
@@ -63,7 +63,7 @@ namespace BenchmarkDotNet.Running
         public static BenchmarkRunInfo[] Filter(IConfig effectiveConfig, IEnumerable<Type> types)
             => types
                 .Select(type => BenchmarkConverter.TypeToBenchmarks(type, effectiveConfig))
-                .Where(info => info.BenchmarksCases.Any())
+                .Where(info => info.BenchmarksCases.Length != 0)
                 .ToArray();
     }
 }

--- a/src/BenchmarkDotNet/Toolchains/Roslyn/Builder.cs
+++ b/src/BenchmarkDotNet/Toolchains/Roslyn/Builder.cs
@@ -67,7 +67,7 @@ namespace BenchmarkDotNet.Toolchains.Roslyn
 
             var (result, missingReferences) = Build(generateResult, buildPartition, syntaxTree, compilationOptions, references, cancellationToken);
 
-            if (result.IsBuildSuccess || !missingReferences.Any())
+            if (result.IsBuildSuccess || missingReferences.Length == 0)
                 return result;
 
             var withMissingReferences = references.Union(missingReferences.Select(assemblyMetadata => assemblyMetadata.GetReference()));

--- a/src/BenchmarkDotNet/Validators/DotNetSdkValidator.cs
+++ b/src/BenchmarkDotNet/Validators/DotNetSdkValidator.cs
@@ -92,7 +92,7 @@ namespace BenchmarkDotNet.Validators
                     {
                         var lines = output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
 
-                        var versions = new List<Version>(lines.Count());
+                        var versions = new List<Version>(lines.Length);
                         foreach (var line in lines)
                         {
                             // Version.TryParse does not handle things like 3.0.0-WORD, so this will get just the 3.0.0 part

--- a/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/DisassemblyDiagnoserTests.cs
@@ -190,7 +190,7 @@ namespace BenchmarkDotNet.IntegrationTests
         private void AssertDisassemblyResult(DisassemblyResult result, string methodSignature)
         {
             Assert.Contains(methodSignature, result.Methods.Select(m => m.Name.Split('.').Last()).ToArray());
-            Assert.Contains(result.Methods.Single(m => m.Name.EndsWith(methodSignature)).Maps, map => map.SourceCodes.Any());
+            Assert.Contains(result.Methods.Single(m => m.Name.EndsWith(methodSignature)).Maps, map => map.SourceCodes.Length != 0);
         }
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/InProcessDiagnoserTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/InProcessDiagnoserTests.cs
@@ -23,7 +23,7 @@ public class InProcessDiagnoserTests(ITestOutputHelper output) : BenchmarkTestEx
 
     private static IEnumerable<RunMode[]> GetRunModeCombinations(int count)
     {
-        var runModes = (RunMode[])Enum.GetValues(typeof(RunMode));
+        var runModes = Enum.GetValues<RunMode>();
 
         if (count == 1)
         {
@@ -49,7 +49,7 @@ public class InProcessDiagnoserTests(ITestOutputHelper output) : BenchmarkTestEx
 
     public static IEnumerable<object[]> GetTestCombinations()
     {
-        var toolchains = (ToolchainType[])Enum.GetValues(typeof(ToolchainType));
+        var toolchains = Enum.GetValues<ToolchainType>();
         var counts = new[] { 1, 3 };
 
         foreach (var toolchain in toolchains)

--- a/tests/BenchmarkDotNet.IntegrationTests/JitListenerTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/JitListenerTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Helpers;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Reports;
@@ -410,9 +411,9 @@ public class JitListenerTests
         var measurements = stage.GetMeasurementList();
         while (stage.GetShouldRunIteration(measurements, out var data))
         {
-            data.setupAction().WaitValueTaskCompletion();
-            data.workloadAction(data.invokeCount / data.unrollFactor, null!).WaitValueTaskCompletion();
-            data.cleanupAction().WaitValueTaskCompletion();
+            data.setupAction().GetResult();
+            data.workloadAction(data.invokeCount / data.unrollFactor, null!).GetResult();
+            data.cleanupAction().GetResult();
             // A zero-time measurement keeps the stage out of its "long-running benchmark" early-exit
             // (iterationTime / 0 == Infinity, and Infinity < 1.5 is false).
             measurements.Add(new Measurement(1, data.mode, data.stage, data.index, data.invokeCount, 0d));
@@ -532,32 +533,5 @@ public class JitListenerTests
         public void ReportResults(RunResults runResults) { }
         public ValueTask SendSignalAsync(HostSignal hostSignal) => new();
         public ValueTask Yield() => new();
-    }
-}
-
-file static class ExtensionMethods
-{
-    // Helper method to suppress CA2012 analyzer message.
-    // ValueTask is not guaranteed to block until the operation completed when using GetAwaiter().GetResult().
-    public static void WaitValueTaskCompletion(this ValueTask valueTask)
-    {
-        var awaiter = valueTask.GetAwaiter();
-
-        if (awaiter.IsCompleted)
-        {
-            awaiter.GetResult();
-            return;
-        }
-
-        valueTask.AsTask().GetAwaiter().GetResult();
-    }
-
-    public static T WaitValueTaskCompletion<T>(this ValueTask<T> valueTask)
-    {
-        var awaiter = valueTask.GetAwaiter();
-
-        return awaiter.IsCompleted
-            ? awaiter.GetResult()
-            : valueTask.AsTask().GetAwaiter().GetResult();
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/JitListenerTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/JitListenerTests.cs
@@ -410,9 +410,9 @@ public class JitListenerTests
         var measurements = stage.GetMeasurementList();
         while (stage.GetShouldRunIteration(measurements, out var data))
         {
-            data.setupAction().GetAwaiter().GetResult();
-            data.workloadAction(data.invokeCount / data.unrollFactor, null!).GetAwaiter().GetResult();
-            data.cleanupAction().GetAwaiter().GetResult();
+            data.setupAction().WaitValueTaskCompletion();
+            data.workloadAction(data.invokeCount / data.unrollFactor, null!).WaitValueTaskCompletion();
+            data.cleanupAction().WaitValueTaskCompletion();
             // A zero-time measurement keeps the stage out of its "long-running benchmark" early-exit
             // (iterationTime / 0 == Infinity, and Infinity < 1.5 is false).
             measurements.Add(new Measurement(1, data.mode, data.stage, data.index, data.invokeCount, 0d));
@@ -532,5 +532,32 @@ public class JitListenerTests
         public void ReportResults(RunResults runResults) { }
         public ValueTask SendSignalAsync(HostSignal hostSignal) => new();
         public ValueTask Yield() => new();
+    }
+}
+
+file static class ExtensionMethods
+{
+    // Helper method to suppress CA2012 analyzer message.
+    // ValueTask is not guaranteed to block until the operation completed when using GetAwaiter().GetResult().
+    public static void WaitValueTaskCompletion(this ValueTask valueTask)
+    {
+        var awaiter = valueTask.GetAwaiter();
+
+        if (awaiter.IsCompleted)
+        {
+            awaiter.GetResult();
+            return;
+        }
+
+        valueTask.AsTask().GetAwaiter().GetResult();
+    }
+
+    public static T WaitValueTaskCompletion<T>(this ValueTask<T> valueTask)
+    {
+        var awaiter = valueTask.GetAwaiter();
+
+        return awaiter.IsCompleted
+            ? awaiter.GetResult()
+            : valueTask.AsTask().GetAwaiter().GetResult();
     }
 }

--- a/tests/BenchmarkDotNet.IntegrationTests/JitOptimizationsTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/JitOptimizationsTests.cs
@@ -33,7 +33,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
             var warnings = await JitOptimizationsValidator.DontFailOnError.ValidateAsync(benchmarksWithOptimizedDll).ToArrayAsync();
 
-            if (warnings.Any())
+            if (warnings.Length != 0)
             {
                 output.WriteLine("*** Warnings ***");
                 foreach (var warning in warnings)

--- a/tests/BenchmarkDotNet.IntegrationTests/RunStrategyTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/RunStrategyTests.cs
@@ -24,7 +24,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
             var results = CanExecute<ModeBenchmarks>(config);
 
-            Assert.Equal(6, results.BenchmarksCases.Count());
+            Assert.Equal(6, results.BenchmarksCases.Length);
 
             Assert.Equal(1, results.BenchmarksCases.Count(b => b.Job.Run.RunStrategy == RunStrategy.ColdStart && b.Descriptor.WorkloadMethod.Name == "BenchmarkWithVoid"));
             Assert.Equal(1, results.BenchmarksCases.Count(b => b.Job.Run.RunStrategy == RunStrategy.ColdStart && b.Descriptor.WorkloadMethod.Name == "BenchmarkWithReturnValue"));

--- a/tests/BenchmarkDotNet.IntegrationTests/RunningEmptyBenchmarkTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/RunningEmptyBenchmarkTests.cs
@@ -90,7 +90,7 @@ namespace BenchmarkDotNet.IntegrationTests
         {
             GetConfigWithLogger(out var logger, out var config);
 
-            var summary = BenchmarkRunner.Run(typeof(EmptyBenchmark), config, args);
+            var summary = BenchmarkRunner.Run<EmptyBenchmark>(config, args);
 
             if (args == null)
             {
@@ -115,7 +115,7 @@ namespace BenchmarkDotNet.IntegrationTests
         {
             GetConfigWithLogger(out var logger, out var config);
 
-            var summaries = BenchmarkRunner.Run(typeof(NotEmptyBenchmark), config, args);
+            var summaries = BenchmarkRunner.Run<NotEmptyBenchmark>(config, args);
             Assert.False(summaries.HasCriticalValidationErrors);
             Assert.DoesNotContain(summaries.ValidationErrors, validationError => validationError.Message == GetValidationErrorForType(typeof(NotEmptyBenchmark)));
             Assert.DoesNotContain(GetValidationErrorForType(typeof(NotEmptyBenchmark)), logger.GetLog());

--- a/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/CsProjGeneratorTests.cs
@@ -218,7 +218,7 @@ namespace BenchmarkDotNet.Tests
             var projectGenerator = new SteamLoadedBuildPartition("netcoreapp3.1", "", "", "", true);
             string binariesPath = projectGenerator.ResolvePathForBinaries(new BuildPartition(benchmarks, new Resolver()), programName);
 
-            string expectedPath = Path.Combine(Path.Combine(Directory.GetCurrentDirectory(), "BenchmarkDotNet.Bin"), programName);
+            string expectedPath = Path.Combine(Directory.GetCurrentDirectory(), "BenchmarkDotNet.Bin", programName);
             Assert.Equal(expectedPath, binariesPath);
         }
 

--- a/tests/BenchmarkDotNet.Tests/Exporters/XmlSerializerTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Exporters/XmlSerializerTests.cs
@@ -241,11 +241,11 @@ namespace BenchmarkDotNet.Tests.Exporters
             public void WriteElementString(string localName, string value)
             {
                 writer.Append(localName);
-                writer.Append(" ");
+                writer.Append(' ');
                 writer.Append(value);
-                writer.Append(" ");
+                writer.Append(' ');
                 writer.Append(localName);
-                writer.Append(" ");
+                writer.Append(' ');
             }
 
             public void WriteEndDocument()
@@ -257,14 +257,14 @@ namespace BenchmarkDotNet.Tests.Exporters
             {
                 var endElement = openElements.Pop();
                 writer.Append(endElement);
-                writer.Append(" ");
+                writer.Append(' ');
             }
 
             public void WriteStartElement(string localName)
             {
                 openElements.Push(localName);
                 writer.Append(localName);
-                writer.Append(" ");
+                writer.Append(' ');
             }
 
             public override string ToString() => writer.ToString();

--- a/tests/BenchmarkDotNet.Tests/Reports/DisplayPrecisionManagerTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Reports/DisplayPrecisionManagerTests.cs
@@ -66,7 +66,7 @@ namespace BenchmarkDotNet.Tests.Reports
 
                 string strParent = parentPrecision.HasValue ? 1234.5678.ToString("N" + parentPrecision, TestCultureInfo.Instance) : "NA";
                 var strValues = testData.Values.Select(v => v.ToString("N" + actualPrecision, TestCultureInfo.Instance)).ToList();
-                int maxWidth = strValues.Any() ? Math.Max(strValues.Max(s => s.Length), strParent.Length) + 6 : 0;
+                int maxWidth = strValues.Count != 0 ? Math.Max(strValues.Max(s => s.Length), strParent.Length) + 6 : 0;
                 int parentWidth = maxWidth - (actualPrecision - parentPrecision) ?? 0;
 
                 output.WriteLine("******************************");

--- a/tests/BenchmarkDotNet.Tests/Validators/CompilationValidatorTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Validators/CompilationValidatorTests.cs
@@ -75,7 +75,7 @@ namespace BenchmarkDotNet.Tests.Validators
         {
             var validationErrors = await CompilationValidator.FailOnError.ValidateAsync(BenchmarkConverter.TypeToBenchmarks(type)).ToArrayAsync();
 
-            Assert.Equal(hasErrors, validationErrors.Any());
+            Assert.Equal(hasErrors, validationErrors.Length != 0);
         }
 
         [Theory]
@@ -85,7 +85,7 @@ namespace BenchmarkDotNet.Tests.Validators
         {
             var validationErrors = await CompilationValidator.FailOnError.ValidateAsync(BenchmarkConverter.TypeToBenchmarks(type)).ToArrayAsync();
 
-            Assert.Equal(hasErrors, validationErrors.Any());
+            Assert.Equal(hasErrors, validationErrors.Length != 0);
         }
 
         [Theory]
@@ -108,7 +108,7 @@ namespace BenchmarkDotNet.Tests.Validators
             var validationErrors = await CompilationValidator.FailOnError.ValidateAsync(BenchmarkConverter.TypeToBenchmarks(constructed)).ToArrayAsync();
 
             // Assert
-            Assert.Equal(hasErrors, validationErrors.Any());
+            Assert.Equal(hasErrors, validationErrors.Length != 0);
         }
 
         private static Delegate BuildDummyMethod<T>(string name)

--- a/tests/BenchmarkDotNet.Tests/XUnit/EnvRequirementCheckerTests.cs
+++ b/tests/BenchmarkDotNet.Tests/XUnit/EnvRequirementCheckerTests.cs
@@ -6,7 +6,7 @@ public class EnvRequirementCheckerTests
     [Fact]
     public void AllEnvRequirementsAreSupported()
     {
-        foreach (var envRequirement in Enum.GetValues(typeof(EnvRequirement)).Cast<EnvRequirement>())
+        foreach (var envRequirement in Enum.GetValues<EnvRequirement>().Cast<EnvRequirement>())
             EnvRequirementChecker.GetSkip(envRequirement);
     }
 }


### PR DESCRIPTION
This PR intended to reduce messages that are reported by analyzers.
(Currently 2313 messages are reported)

Almost of changes are based on analyzer's code fixer.

And following changes are manually edited.

#### 1. [chore: fix ca2012 messages](https://github.com/dotnet/BenchmarkDotNet/commit/dcb8d0b42ac3c315e038b7533ded1390293ea1a6)

Add helper methods to wait value task.
Because `GetAwaiter().GetResult()` is not guaranteed to  wait ValueTask completion.

#### 2. [chore: fix cs9236 messages](https://github.com/dotnet/BenchmarkDotNet/commit/964e44f9e9f54874b32fee5f7e3644330ff462f9)

Unroll LINQ query to loops. to avoid following messages.
> CS9236: Compiling requires binding the lambda expression at least 1000 times. Consider declaring the lambda expression with explicit parameter types, or if the containing method call is generic, consider using explicit type arguments.



