### PR TITLE
feat: Add filter by UID feature by using existing --filter syntax

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -792,11 +792,24 @@ namespace BenchmarkDotNet.ConsoleArguments
         private static IEnumerable<IFilter> GetFilters(CommandLineOptions options)
         {
             if (options.Filters.Any())
-                yield return new GlobFilter(options.Filters.ToArray());
+            {
+                // Filter by UID when specified filter can be parsed as GUID.
+                var uids = options.Filters.Where(x => Guid.TryParse(x, out _)).ToArray();
+                if (uids.Length > 0)
+                    yield return new UidFilter(uids);
+
+                // Use GlobFilter for remaining filters.
+                var globFilters = options.Filters.Except(uids).ToArray();
+                if (globFilters.Length > 0)
+                    yield return new GlobFilter(globFilters);
+            }
+
             if (options.AllCategories.Any())
                 yield return new AllCategoriesFilter(options.AllCategories.ToArray());
+
             if (options.AnyCategories.Any())
                 yield return new AnyCategoriesFilter(options.AnyCategories.ToArray());
+
             if (options.AttributeNames.Any())
                 yield return new AttributesFilter(options.AttributeNames.ToArray());
         }

--- a/src/BenchmarkDotNet/Filters/UidFilter.cs
+++ b/src/BenchmarkDotNet/Filters/UidFilter.cs
@@ -1,0 +1,25 @@
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Running;
+
+namespace BenchmarkDotNet.Filters
+{
+    /// <summary>
+    /// filters benchmarks by unique id.
+    /// </summary>
+    public class UidFilter : IFilter
+    {
+        private readonly string[] uids;
+
+        public UidFilter(string[] uids)
+        {
+            this.uids = uids;
+        }
+
+        public bool Predicate(BenchmarkCase benchmarkCase)
+        {
+            var uid = benchmarkCase.GetUniqueId();
+            return uids.Any(x => x.Equals(uid, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.Tests/Filters/GlobFilterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Filters/GlobFilterTests.cs
@@ -2,7 +2,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Running;
 
-namespace BenchmarkDotNet.Tests
+namespace BenchmarkDotNet.Tests.Filters
 {
     public class GlobFilterTests
     {
@@ -35,8 +35,8 @@ namespace BenchmarkDotNet.Tests
         [InlineData("*", 2)]
         [InlineData("WRONG", 0)]
         [InlineData("*stillWRONG*", 0)]
-        [InlineData("BenchmarkDotNet.Tests.TypeWithBenchmarksAndParams.TheBenchmark", 2)]
-        [InlineData("BenchmarkDotNet.Tests.TypeWithBenchmarksAndParams.TheBenchmark(A: 100)", 1)]
+        [InlineData("BenchmarkDotNet.Tests.Filters.TypeWithBenchmarksAndParams.TheBenchmark", 2)]
+        [InlineData("BenchmarkDotNet.Tests.Filters.TypeWithBenchmarksAndParams.TheBenchmark(A: 100)", 1)]
         public void TheFilterWorksWithParams(string pattern, int expectedBenchmarks)
         {
             var benchmarkCases = BenchmarkConverter.TypeToBenchmarks(typeof(TypeWithBenchmarksAndParams)).BenchmarksCases;

--- a/tests/BenchmarkDotNet.Tests/Filters/TypeFilterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Filters/TypeFilterTests.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Tests.Loggers;
 using JetBrains.Annotations;
 using TypeFilter = BenchmarkDotNet.Running.TypeFilter;
 
-namespace BenchmarkDotNet.Tests
+namespace BenchmarkDotNet.Tests.Filters
 {
     public class TypeFilterTests
     {

--- a/tests/BenchmarkDotNet.Tests/Filters/UidFilterTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Filters/UidFilterTests.cs
@@ -1,0 +1,40 @@
+using AwesomeAssertions;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Filters;
+using BenchmarkDotNet.Running;
+
+namespace BenchmarkDotNet.Tests.Filters;
+
+public class UidFilterTests
+{
+    [Fact]
+    public void FilterByUid()
+    {
+        // Arrange
+        var benchmarkCase = BenchmarkConverter.TypeToBenchmarks(typeof(TypeWithBenchmarks)).BenchmarksCases.Single();
+        var uid = benchmarkCase.GetUniqueId();
+        var filter = new UidFilter([uid]);
+
+        // Assert
+        bool result = filter.Predicate(benchmarkCase);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FilterByUid_UpperCase()
+    {
+        // Arrange
+        var benchmarkCase = BenchmarkConverter.TypeToBenchmarks(typeof(TypeWithBenchmarks)).BenchmarksCases.Single();
+        var uid = benchmarkCase.GetUniqueId().ToUpperInvariant();
+        var filter = new UidFilter([uid]);
+
+        // Assert
+        bool result = filter.Predicate(benchmarkCase);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
This PR extend existing `--filter` syntax to support filter by UID of BenchmarkCase.
By modyfing existing filter logics to use `UidFilter` when filter text can be parsed as GUID format.

#### Other changes
- Move filter related test under `Filters` directory/namespace.