### PR TITLE
chore: Modify powercfg output parse logics

### DIFF
--- a/tests/BenchmarkDotNet.IntegrationTests/PowerRequestsParser.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/PowerRequestsParser.cs
@@ -106,29 +106,36 @@ internal class PowerRequestsParser
         // return an empty string when CR is followed by LF.
         StringReader reader = new StringReader(input);
         string? line;
+        TokenType previousTokenType = TokenType.None;
         while ((line = reader.ReadLine()) != null)
         {
             if (line.Length == 0)
             {
                 yield return new Token(TokenType.EmptyLine, "");
+                previousTokenType = TokenType.EmptyLine;
             }
             else if (line[line.Length - 1] == ':')
             {
                 yield return new Token(TokenType.RequestType, line.Substring(0, line.Length - 1).ToString());
-            }
-            else if (IsNoneToken(line))
-            {
-                yield return new Token(TokenType.None, line);
+                previousTokenType = TokenType.RequestType;
             }
             else if (line[0] == '[')
             {
                 int pos = line.IndexOf(']');
                 yield return new Token(TokenType.RequesterType, line.Substring(1, pos - 1));
                 yield return new Token(TokenType.RequesterName, line.Substring(pos + 2));
+                previousTokenType = TokenType.RequesterName;
+            }
+            else if (previousTokenType == TokenType.RequestType)
+            {
+                // Any single line directly after a request type header is the localized "None."
+                yield return new Token(TokenType.None, line);
+                previousTokenType = TokenType.None;
             }
             else
             {
                 yield return new Token(TokenType.Reason, line);
+                previousTokenType = TokenType.Reason;
             }
         }
     }
@@ -162,27 +169,6 @@ internal class PowerRequestsParser
         }
 
         public void Dispose() => tokens.Dispose();
-    }
-
-    private static bool IsNoneToken(string line)
-    {
-        // Note: This mapping don't cover all available Windows UI Language.
-        switch (line)
-        {
-            case "None.":    // English
-            case "Keine.":   // German
-            case "Aucune.":  // French
-            case "Ninguna.": // Spanish
-            case "Nessuna.": // Italian
-            case "Geen.":    // Dutch
-            case "Brak.":    // Polish
-            case "なし。":    // Japanese
-            case "无。":      // Simplified Chinese
-            case "無。":      // Traditional Chinese
-                return true;
-            default:
-                return false;
-        }
     }
 
     private enum TokenType

--- a/tests/BenchmarkDotNet.IntegrationTests/PowerRequestsParser.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/PowerRequestsParser.cs
@@ -116,7 +116,7 @@ internal class PowerRequestsParser
             {
                 yield return new Token(TokenType.RequestType, line.Substring(0, line.Length - 1).ToString());
             }
-            else if (string.Equals(line, "None.", StringComparison.InvariantCulture))
+            else if (IsNoneToken(line))
             {
                 yield return new Token(TokenType.None, line);
             }
@@ -162,6 +162,27 @@ internal class PowerRequestsParser
         }
 
         public void Dispose() => tokens.Dispose();
+    }
+
+    private static bool IsNoneToken(string line)
+    {
+        // Note: This mapping don't cover all available Windows UI Language.
+        switch (line)
+        {
+            case "None.":    // English
+            case "Keine.":   // German
+            case "Aucune.":  // French
+            case "Ninguna.": // Spanish
+            case "Nessuna.": // Italian
+            case "Geen.":    // Dutch
+            case "Brak.":    // Polish
+            case "なし。":    // Japanese
+            case "无。":      // Simplified Chinese
+            case "無。":      // Traditional Chinese
+                return true;
+            default:
+                return false;
+        }
     }
 
     private enum TokenType

--- a/tests/BenchmarkDotNet.IntegrationTests/WakeLockTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/WakeLockTests.cs
@@ -99,8 +99,14 @@ public class WakeLockTests : BenchmarkTestExecutor
         async Task WaitForBenchmarkRunningAndGetPowerRequests()
         {
             await AsTask(ping, testTimeout);
-            pwrRequests = GetPowerRequests("BenchmarkDotNet Running Benchmarks");
-            pong.Set();
+            try
+            {
+                pwrRequests = GetPowerRequests("BenchmarkDotNet Running Benchmarks");
+            }
+            finally
+            {
+                pong.Set();
+            }
         }
     }
 

--- a/tests/BenchmarkDotNet.IntegrationTests/WakeLockTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/WakeLockTests.cs
@@ -98,9 +98,9 @@ public class WakeLockTests : BenchmarkTestExecutor
 
         async Task WaitForBenchmarkRunningAndGetPowerRequests()
         {
-            await AsTask(ping, testTimeout);
             try
             {
+                await AsTask(ping, testTimeout);
                 pwrRequests = GetPowerRequests("BenchmarkDotNet Running Benchmarks");
             }
             finally


### PR DESCRIPTION
This PR intended to fix `BenchmarkRunnerAcquiresWakeLock` tests are failed with timeout error when running on non-english Windows environment.

`powercfg /requests` command output is localized based on UI language setting of Windows.
So it need to handle localized message.

So I've added `IsNoneToken` helper method to check `None.` equivalent string.

---
The added language mapping are generated by LLM.
And it's confirmed `powercfg /requests` output message data source per language.

There are some languages that can't find reliable message sources.
So test still failed on these language environment.