### PR TITLE
chore: Modify ClrMD related code to use interface

### DIFF
--- a/src/BenchmarkDotNet/Disassemblers/Arm64Disassembler.cs
+++ b/src/BenchmarkDotNet/Disassemblers/Arm64Disassembler.cs
@@ -2,6 +2,7 @@ using BenchmarkDotNet.Diagnosers;
 using Gee.External.Capstone;
 using Gee.External.Capstone.Arm64;
 using Microsoft.Diagnostics.Runtime;
+using Microsoft.Diagnostics.Runtime.Interfaces;
 
 namespace BenchmarkDotNet.Disassemblers
 {
@@ -19,9 +20,9 @@ namespace BenchmarkDotNet.Disassemblers
         private long _value;
         private int _expectedMovkShift;
         private Arm64RegisterId _registerId;
-        private ClrRuntime _runtime;
+        private IClrRuntime _runtime;
 
-        public void Init(ClrRuntime runtime)
+        public void Init(IClrRuntime runtime)
         {
             _state = State.LookingForPattern;
             _expectedMovkShift = 0;
@@ -138,7 +139,7 @@ namespace BenchmarkDotNet.Disassemblers
 
     internal class Arm64Disassembler : ClrMdDisassembler
     {
-        protected override IEnumerable<Asm> Decode(byte[] code, ulong startAddress, State state, int depth, ClrMethod currentMethod, DisassemblySyntax syntax)
+        protected override IEnumerable<Asm> Decode(byte[] code, ulong startAddress, State state, int depth, IClrMethod currentMethod, DisassemblySyntax syntax)
         {
             const Arm64DisassembleMode disassembleMode = Arm64DisassembleMode.Arm;
             using (CapstoneArm64Disassembler disassembler = CapstoneDisassembler.CreateArm64Disassembler(disassembleMode))

--- a/src/BenchmarkDotNet/Disassemblers/ClrMdDisassembler.cs
+++ b/src/BenchmarkDotNet/Disassemblers/ClrMdDisassembler.cs
@@ -4,6 +4,7 @@ using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Portability;
 using Microsoft.Diagnostics.Runtime;
+using Microsoft.Diagnostics.Runtime.Interfaces;
 using System.Text.RegularExpressions;
 
 namespace BenchmarkDotNet.Disassemblers
@@ -157,7 +158,7 @@ namespace BenchmarkDotNet.Disassemblers
             return result.ToArray();
         }
 
-        private static bool CanBeDisassembled(ClrMethod method) => method.ILOffsetMap.Length > 0 && method.NativeCode > 0;
+        private static bool CanBeDisassembled(IClrMethod method) => method.ILOffsetMap.Length > 0 && method.NativeCode > 0;
 
         private DisassembledMethod DisassembleMethod(MethodInfo methodInfo, State state, ClrMdArgs args, DisassemblySyntax syntax, SourceCodeProvider sourceCodeProvider)
         {
@@ -206,7 +207,7 @@ namespace BenchmarkDotNet.Disassemblers
             };
         }
 
-        private IEnumerable<Asm> Decode(ILToNativeMap map, State state, int depth, ClrMethod currentMethod, DisassemblySyntax syntax)
+        private IEnumerable<Asm> Decode(ILToNativeMap map, State state, int depth, IClrMethod currentMethod, DisassemblySyntax syntax)
         {
             ulong startAddress = map.StartAddress;
             uint size = (uint)(map.EndAddress - map.StartAddress);
@@ -227,9 +228,9 @@ namespace BenchmarkDotNet.Disassemblers
             return Decode(code, startAddress, state, depth, currentMethod, syntax);
         }
 
-        protected abstract IEnumerable<Asm> Decode(byte[] code, ulong startAddress, State state, int depth, ClrMethod currentMethod, DisassemblySyntax syntax);
+        protected abstract IEnumerable<Asm> Decode(byte[] code, ulong startAddress, State state, int depth, IClrMethod currentMethod, DisassemblySyntax syntax);
 
-        private static ILToNativeMap[] GetCompleteNativeMap(ClrMethod method, ClrRuntime runtime)
+        private static ILToNativeMap[] GetCompleteNativeMap(IClrMethod method, IClrRuntime runtime)
         {
             // it's better to use one single map rather than few small ones
             // it's simply easier to get next instruction when decoding ;)
@@ -251,10 +252,10 @@ namespace BenchmarkDotNet.Disassemblers
                 .ToArray();
         }
 
-        private static DisassembledMethod CreateEmpty(ClrMethod method, string reason)
+        private static DisassembledMethod CreateEmpty(IClrMethod method, string reason)
             => DisassembledMethod.Empty(method.Signature ?? "", method.NativeCode, reason);
 
-        protected void TryTranslateAddressToName(ulong address, bool isAddressPrecodeMD, State state, int depth, ClrMethod currentMethod)
+        protected void TryTranslateAddressToName(ulong address, bool isAddressPrecodeMD, State state, int depth, IClrMethod currentMethod)
         {
             if (!IsValidAddress(address) || state.AddressToNameMapping.ContainsKey(address))
                 return;

--- a/src/BenchmarkDotNet/Disassemblers/DataContracts.cs
+++ b/src/BenchmarkDotNet/Disassemblers/DataContracts.cs
@@ -1,7 +1,7 @@
 using Gee.External.Capstone;
 using Gee.External.Capstone.Arm64;
 using Iced.Intel;
-using Microsoft.Diagnostics.Runtime;
+using Microsoft.Diagnostics.Runtime.Interfaces;
 using System.ComponentModel;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -218,18 +218,18 @@ public static class DisassemblerConstants
 
 internal sealed class State
 {
-    internal State(ClrRuntime runtime, string targetFrameworkMoniker)
+    internal State(IClrRuntime runtime, string targetFrameworkMoniker)
     {
         Runtime = runtime;
         Todo = new Queue<MethodInfo>();
-        HandledMethods = new HashSet<ClrMethod>(new ClrMethodComparer());
+        HandledMethods = new HashSet<IClrMethod>(new IClrMethodComparer());
         AddressToNameMapping = [];
         RuntimeVersion = ParseVersion(targetFrameworkMoniker);
     }
 
-    internal ClrRuntime Runtime { get; }
+    internal IClrRuntime Runtime { get; }
     internal Queue<MethodInfo> Todo { get; }
-    internal HashSet<ClrMethod> HandledMethods { get; }
+    internal HashSet<IClrMethod> HandledMethods { get; }
     internal Dictionary<ulong, string> AddressToNameMapping { get; }
     internal Version RuntimeVersion { get; }
 
@@ -258,9 +258,9 @@ internal sealed class State
         return Version.Parse(versionToParse);
     }
 
-    private sealed class ClrMethodComparer : IEqualityComparer<ClrMethod>
+    private sealed class IClrMethodComparer : IEqualityComparer<IClrMethod>
     {
-        public bool Equals(ClrMethod? x, ClrMethod? y)
+        public bool Equals(IClrMethod? x, IClrMethod? y)
         {
             if (ReferenceEquals(x, y))
                 return true;
@@ -271,16 +271,16 @@ internal sealed class State
             return x.NativeCode == y.NativeCode;
         }
 
-        public int GetHashCode(ClrMethod obj) => (int)obj.NativeCode;
+        public int GetHashCode(IClrMethod obj) => (int)obj.NativeCode;
     }
 }
 
 internal readonly struct MethodInfo // I am not using ValueTuple here (would be perfect) to keep the number of dependencies as low as possible
 {
-    internal ClrMethod Method { get; }
+    internal IClrMethod Method { get; }
     internal int Depth { get; }
 
-    internal MethodInfo(ClrMethod method, int depth)
+    internal MethodInfo(IClrMethod method, int depth)
     {
         Method = method;
         Depth = depth;

--- a/src/BenchmarkDotNet/Disassemblers/IntelDisassembler.cs
+++ b/src/BenchmarkDotNet/Disassemblers/IntelDisassembler.cs
@@ -1,12 +1,13 @@
 using BenchmarkDotNet.Diagnosers;
 using Iced.Intel;
 using Microsoft.Diagnostics.Runtime;
+using Microsoft.Diagnostics.Runtime.Interfaces;
 
 namespace BenchmarkDotNet.Disassemblers
 {
     internal class IntelDisassembler : ClrMdDisassembler
     {
-        protected override IEnumerable<Asm> Decode(byte[] code, ulong startAddress, State state, int depth, ClrMethod currentMethod, DisassemblySyntax syntax)
+        protected override IEnumerable<Asm> Decode(byte[] code, ulong startAddress, State state, int depth, IClrMethod currentMethod, DisassemblySyntax syntax)
         {
             var reader = new ByteArrayCodeReader(code);
             var decoder = Decoder.Create(state.Runtime.DataTarget.DataReader.PointerSize * 8, reader);

--- a/src/BenchmarkDotNet/Disassemblers/SourceCodeProvider.cs
+++ b/src/BenchmarkDotNet/Disassemblers/SourceCodeProvider.cs
@@ -1,5 +1,6 @@
 using BenchmarkDotNet.Extensions;
 using Microsoft.Diagnostics.Runtime;
+using Microsoft.Diagnostics.Runtime.Interfaces;
 using Microsoft.Diagnostics.Symbols;
 using System.Diagnostics;
 
@@ -17,7 +18,7 @@ namespace BenchmarkDotNet.Disassemblers
             symbolReader.Dispose();
         }
 
-        internal IEnumerable<Sharp> GetSource(ClrMethod method, ILToNativeMap map)
+        internal IEnumerable<Sharp> GetSource(IClrMethod method, ILToNativeMap map)
         {
             var sourceLocation = GetSourceLocation(method, map.ILOffset);
             if (sourceLocation is not { LineNumber: > 0 })
@@ -105,7 +106,7 @@ namespace BenchmarkDotNet.Disassemblers
             return new string(prefix);
         }
 
-        internal SourceLocation? GetSourceLocation(ClrMethod method, int ilOffset)
+        internal SourceLocation? GetSourceLocation(IClrMethod method, int ilOffset)
         {
             var reader = GetReaderForMethod(method);
             if (reader == null)
@@ -114,9 +115,9 @@ namespace BenchmarkDotNet.Disassemblers
             return reader.SourceLocationForManagedCode((uint)method.MetadataToken, ilOffset);
         }
 
-        private ManagedSymbolModule? GetReaderForMethod(ClrMethod? method)
+        private ManagedSymbolModule? GetReaderForMethod(IClrMethod? method)
         {
-            ClrModule? module = method?.Type?.Module;
+            IClrModule? module = method?.Type?.Module;
             PdbInfo? info = module?.Pdb;
 
             ManagedSymbolModule? reader = null;


### PR DESCRIPTION
This PR modify ClrMD related code to use interface instead of sealed classes (`ClrRuntime`/`ClrMethod`)

These changes are required to write unit tests for `Arm64Disassembler::Decode`.
