### PR TITLE
allow affinity mask wider than 32 processors

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -64,7 +64,7 @@ namespace BenchmarkDotNet.ConsoleArguments
         public OutlierMode Outliers { get; set; }
 
         [Option("affinity", Required = false, HelpText = "Affinity mask to set for the benchmark process")]
-        public int? Affinity { get; set; }
+        public long? Affinity { get; set; }
 
         [Option("allStats", Required = false, Default = false, HelpText = "Displays all statistics (min, max & more)")]
         public bool DisplayAllStatistics { get; set; }

--- a/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs
@@ -64,7 +64,7 @@ namespace BenchmarkDotNet.ConsoleArguments
         public OutlierMode Outliers { get; set; }
 
         [Option("affinity", Required = false, HelpText = "Affinity mask to set for the benchmark process")]
-        public long? Affinity { get; set; }
+        public ulong? Affinity { get; set; }
 
         [Option("allStats", Required = false, Default = false, HelpText = "Displays all statistics (min, max & more)")]
         public bool DisplayAllStatistics { get; set; }

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -470,7 +470,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 baseJob = baseJob.WithOutlierMode(options.Outliers);
 
             if (options.Affinity.HasValue)
-                baseJob = baseJob.WithAffinity((IntPtr)options.Affinity.Value);
+                baseJob = baseJob.WithAffinity(new IntPtr(unchecked((long)options.Affinity.Value)));
 
             if (options.LaunchCount.HasValue)
                 baseJob = baseJob.WithLaunchCount(options.LaunchCount.Value);

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -380,7 +380,26 @@ namespace BenchmarkDotNet.ConsoleArguments
                 return false;
             }
 
+            if (options.Affinity.HasValue && !TryConvertAffinity(options.Affinity.Value, IntPtr.Size, out _))
+            {
+                logger.WriteLineError($"The provided affinity mask 0x{options.Affinity.Value:X} does not fit into the {IntPtr.Size * 8} bit process that hosts the benchmarks. Use a mask of at most 32 bits or run in a 64 bit process.");
+                return false;
+            }
+
             return true;
+        }
+
+        // a 32 bit process only reaches the first 32 processors and new IntPtr(long) throws there instead of truncating
+        internal static bool TryConvertAffinity(ulong mask, int pointerSize, out IntPtr affinity)
+        {
+            if (pointerSize >= 8)
+            {
+                affinity = new IntPtr(unchecked((long)mask));
+                return true;
+            }
+
+            affinity = new IntPtr(unchecked((int)mask));
+            return mask <= uint.MaxValue;
         }
 
         private static IConfig CreateConfig(CommandLineOptions options, IConfig? globalConfig, string[] args)
@@ -469,8 +488,8 @@ namespace BenchmarkDotNet.ConsoleArguments
             if (baseJob != Job.Dry && options.Outliers != OutlierMode.RemoveUpper)
                 baseJob = baseJob.WithOutlierMode(options.Outliers);
 
-            if (options.Affinity.HasValue)
-                baseJob = baseJob.WithAffinity(new IntPtr(unchecked((long)options.Affinity.Value)));
+            if (options.Affinity.HasValue && TryConvertAffinity(options.Affinity.Value, IntPtr.Size, out var affinity))
+                baseJob = baseJob.WithAffinity(affinity);
 
             if (options.LaunchCount.HasValue)
                 baseJob = baseJob.WithLaunchCount(options.LaunchCount.Value);

--- a/src/BenchmarkDotNet/Jobs/EnvironmentMode.cs
+++ b/src/BenchmarkDotNet/Jobs/EnvironmentMode.cs
@@ -148,7 +148,7 @@ namespace BenchmarkDotNet.Jobs
         {
             Jit = HasValue(JitCharacteristic) ? Jit : null,
             Runtime = HasValue(RuntimeCharacteristic) ? Runtime?.RuntimeMoniker : null,
-            Affinity = HasValue(AffinityCharacteristic) ? (int)Affinity : null
+            Affinity = HasValue(AffinityCharacteristic) ? (long)Affinity : null
         };
     }
 }

--- a/src/BenchmarkDotNet/Models/BdnEnvironment.cs
+++ b/src/BenchmarkDotNet/Models/BdnEnvironment.cs
@@ -8,5 +8,5 @@ internal class BdnEnvironment : EnvironmentInfo
 {
     public RuntimeMoniker? Runtime { get; set; }
     public Jit? Jit { get; set; }
-    public int? Affinity { get; set; }
+    public long? Affinity { get; set; }
 }

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -498,33 +498,33 @@ namespace BenchmarkDotNet.Tests
         [Fact]
         public void UserCanSpecifyAffinity()
         {
-            const long affinity = 0b1010;
+            const ulong affinity = 0b1010;
             var config = ConfigParser.Parse(["--affinity", affinity.ToString()], new OutputLogger(Output)).config;
 
             Assert.NotNull(config);
-            Assert.Equal(new IntPtr(affinity), config.GetJobs().Single().Environment.Affinity);
+            Assert.Equal(new IntPtr((long)affinity), config.GetJobs().Single().Environment.Affinity);
         }
 
         [FactEnvSpecific("A mask with a bit above 32 does not fit in IntPtr on a 32 bit runtime", EnvRequirement.Platform64BitOnly)]
         public void UserCanSpecifyAffinityBeyondThirtyTwoProcessors()
         {
-            const long affinity = 1L << 40;
+            const ulong affinity = 1UL << 40;
             var config = ConfigParser.Parse(["--affinity", affinity.ToString()], new OutputLogger(Output)).config;
 
             Assert.NotNull(config);
-            Assert.Equal(new IntPtr(affinity), config.GetJobs().Single().Environment.Affinity);
+            Assert.Equal(new IntPtr((long)affinity), config.GetJobs().Single().Environment.Affinity);
         }
 
         [FactEnvSpecific("A mask with the top bit set does not fit in IntPtr on a 32 bit runtime", EnvRequirement.Platform64BitOnly)]
         public void UserCanSpecifyAffinityForTheSixtyFourthProcessor()
         {
-            // the top bit is the 64th cpu, which is the last one FixAffinity supports without
-            // cpu groups. as a mask it reads 0x8000000000000000, which only fits in a signed
-            // long as the negative value, so this is the spelling that reaches that processor
-            var config = ConfigParser.Parse(["--affinity", long.MinValue.ToString()], new OutputLogger(Output)).config;
+            // the top bit is the 64th cpu, the last one FixAffinity supports without cpu groups.
+            // as an unsigned option it is written the way the mask reads
+            const ulong affinity = 1UL << 63;
+            var config = ConfigParser.Parse(["--affinity", affinity.ToString()], new OutputLogger(Output)).config;
 
             Assert.NotNull(config);
-            Assert.Equal(unchecked((IntPtr)long.MinValue), config.GetJobs().Single().Environment.Affinity);
+            Assert.Equal(new IntPtr(unchecked((long)affinity)), config.GetJobs().Single().Environment.Affinity);
         }
 
         [Fact]

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -505,7 +505,7 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(new IntPtr(affinity), config.GetJobs().Single().Environment.Affinity);
         }
 
-        [Fact]
+        [FactEnvSpecific("A mask with a bit above 32 does not fit in IntPtr on a 32 bit runtime", EnvRequirement.Platform64BitOnly)]
         public void UserCanSpecifyAffinityBeyondThirtyTwoProcessors()
         {
             const long affinity = 1L << 40;
@@ -513,6 +513,18 @@ namespace BenchmarkDotNet.Tests
 
             Assert.NotNull(config);
             Assert.Equal(new IntPtr(affinity), config.GetJobs().Single().Environment.Affinity);
+        }
+
+        [FactEnvSpecific("A mask with the top bit set does not fit in IntPtr on a 32 bit runtime", EnvRequirement.Platform64BitOnly)]
+        public void UserCanSpecifyAffinityForTheSixtyFourthProcessor()
+        {
+            // the top bit is the 64th cpu, which is the last one FixAffinity supports without
+            // cpu groups. as a mask it reads 0x8000000000000000, which only fits in a signed
+            // long as the negative value, so this is the spelling that reaches that processor
+            var config = ConfigParser.Parse(["--affinity", long.MinValue.ToString()], new OutputLogger(Output)).config;
+
+            Assert.NotNull(config);
+            Assert.Equal(unchecked((IntPtr)long.MinValue), config.GetJobs().Single().Environment.Affinity);
         }
 
         [Fact]

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -496,6 +496,26 @@ namespace BenchmarkDotNet.Tests
         }
 
         [Fact]
+        public void UserCanSpecifyAffinity()
+        {
+            const long affinity = 0b1010;
+            var config = ConfigParser.Parse(["--affinity", affinity.ToString()], new OutputLogger(Output)).config;
+
+            Assert.NotNull(config);
+            Assert.Equal(new IntPtr(affinity), config.GetJobs().Single().Environment.Affinity);
+        }
+
+        [Fact]
+        public void UserCanSpecifyAffinityBeyondThirtyTwoProcessors()
+        {
+            const long affinity = 1L << 40;
+            var config = ConfigParser.Parse(["--affinity", affinity.ToString()], new OutputLogger(Output)).config;
+
+            Assert.NotNull(config);
+            Assert.Equal(new IntPtr(affinity), config.GetJobs().Single().Environment.Affinity);
+        }
+
+        [Fact]
         public void UserCanSpecifyBuildTimeout()
         {
             const int timeoutInSeconds = 10;

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -527,6 +527,35 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(new IntPtr(unchecked((long)affinity)), config.GetJobs().Single().Environment.Affinity);
         }
 
+        [Theory]
+        [InlineData(0b1010UL)]
+        [InlineData(1UL << 31)]
+        [InlineData(uint.MaxValue)]
+        public void AffinityThatFitsThirtyTwoBitsIsAcceptedByAThirtyTwoBitProcess(ulong affinity)
+        {
+            Assert.True(ConfigParser.TryConvertAffinity(affinity, pointerSize: 4, out var converted));
+            Assert.Equal(new IntPtr(unchecked((int)affinity)), converted);
+        }
+
+        [Theory]
+        [InlineData(1UL << 32)]
+        [InlineData(1UL << 40)]
+        [InlineData(1UL << 63)]
+        public void AffinityWiderThanThirtyTwoBitsIsRejectedByAThirtyTwoBitProcess(ulong affinity)
+        {
+            Assert.False(ConfigParser.TryConvertAffinity(affinity, pointerSize: 4, out _));
+        }
+
+        [Theory]
+        [InlineData(0b1010UL)]
+        [InlineData(1UL << 40)]
+        [InlineData(1UL << 63)]
+        public void AffinityOfAnyWidthIsAcceptedByASixtyFourBitProcess(ulong affinity)
+        {
+            Assert.True(ConfigParser.TryConvertAffinity(affinity, pointerSize: 8, out var converted));
+            Assert.Equal(new IntPtr(unchecked((long)affinity)), converted);
+        }
+
         [Fact]
         public void UserCanSpecifyBuildTimeout()
         {

--- a/tests/BenchmarkDotNet.Tests/Perfonar/PerfonarTests.cs
+++ b/tests/BenchmarkDotNet.Tests/Perfonar/PerfonarTests.cs
@@ -145,7 +145,7 @@ public class PerfonarTests(ITestOutputHelper output)
         ]
     };
 
-    private static EntryInfo Job(RuntimeMoniker? runtime = null, Jit? jit = null, int? affinity = null) => new EntryInfo
+    private static EntryInfo Job(RuntimeMoniker? runtime = null, Jit? jit = null, long? affinity = null) => new EntryInfo
     {
         Job = new JobInfo
         {

--- a/tests/BenchmarkDotNet.Tests/Shared/XUnit/EnvRequirement.cs
+++ b/tests/BenchmarkDotNet.Tests/Shared/XUnit/EnvRequirement.cs
@@ -10,6 +10,7 @@ public enum EnvRequirement
     FullFrameworkOnly,
     NonFullFramework,
     DotNetCoreOnly,
+    Platform64BitOnly,
     NeedsPrivilegedProcess,
     NonGitHubDraftPR,
 }

--- a/tests/BenchmarkDotNet.Tests/Shared/XUnit/EnvRequirementChecker.cs
+++ b/tests/BenchmarkDotNet.Tests/Shared/XUnit/EnvRequirementChecker.cs
@@ -20,6 +20,7 @@ public static class EnvRequirementChecker
         EnvRequirement.FullFrameworkOnly => BdnRuntimeInformation.IsFullFramework ? null : "Full .NET Framework-only test",
         EnvRequirement.NonFullFramework => !BdnRuntimeInformation.IsFullFramework ? null : "Non-Full .NET Framework test",
         EnvRequirement.DotNetCoreOnly => BdnRuntimeInformation.IsNetCore ? null : ".NET/.NET Core-only test",
+        EnvRequirement.Platform64BitOnly => BdnRuntimeInformation.Is64BitPlatform() ? null : "64 bit platform-only test",
         EnvRequirement.NeedsPrivilegedProcess => IsPrivilegedProcess() ? null : "Needs authorization to perform security-relevant functions",
         EnvRequirement.NonGitHubDraftPR => !IsGitHubDraftPR() ? null : "GitHub draft PR",
         _ => throw new ArgumentOutOfRangeException(nameof(requirement), requirement, "Unknown value")


### PR DESCRIPTION
## problem

`--affinity` is parsed as `int` so any mask with a bit above 32 can not be passed at all.

```csharp
[Option("affinity", Required = false, HelpText = "Affinity mask to set for the benchmark process")]
public int? Affinity { get; set; }
```

everything under it is already wider. the job stores affinity as `IntPtr` and `FixAffinity` in `ProcessExtensions` already masks against a 64 bit `cpuMask` and comments that the max supported affinity without cpu groups is 64. only the cli entry point was narrow.

## fix

`int?` becomes `ulong?` on the option. unsigned so the 64th cpu is written as `9223372036854775808` the way the mask reads rather than as `-9223372036854775808`. thanks @timcassell for pushing for that.

three things had to move with it.

**the perfonar projection.** `EnvironmentMode.ToPerfonar()` did

```csharp
Affinity = HasValue(AffinityCharacteristic) ? (int)Affinity : null
```

once a wider mask can actually reach that line the cast is a problem. on net10 `IntPtr` is `nint` so it truncates silently and on net472 the explicit operator goes through `ToInt32()` which throws `OverflowException`. so `BdnEnvironment.Affinity` becomes `long?` and the cast becomes `(long)`. `BdnEnvironment` is internal so this is not a public api change.

it stays signed rather than unsigned on purpose. perfolizer 0.7.5 `LightJsonSerializer` has `AppendInt(Int32)` and `AppendLong(Int64)` and `AppendDouble(Double)` and no `UInt64` case so a `ulong` there throws `NotSupportedException: Unsupported type: System.UInt64`. same bits either way.

**the conversion to IntPtr.** `new IntPtr(long)` is `checked((int)value)` on a 32 bit process so it throws instead of truncating. that would have made `ConfigParser.Parse` fail with an unhandled `OverflowException` on x86 rather than a normal option error. a full 32 processor mask of `0xFFFFFFFF` does not fit in `int` either even though it is legal there. so the conversion goes through a helper that takes the pointer size

```csharp
internal static bool TryConvertAffinity(ulong mask, int pointerSize, out IntPtr affinity)
```

which keeps the whole 64 bit mask on 8 bytes and takes the low 32 bits on 4 bytes and reports failure for anything wider so `Validate` can print an error. on a 64 bit process it is bit for bit the same as before.

**a new env requirement.** `EnvRequirement.Platform64BitOnly` so the wide mask parse tests skip rather than fail on a 32 bit runtime.

## tests

in `ConfigParserTests`

- `UserCanSpecifyAffinity` for a normal small mask
- `UserCanSpecifyAffinityBeyondThirtyTwoProcessors` for `1UL << 40`
- `UserCanSpecifyAffinityForTheSixtyFourthProcessor` for `1UL << 63`
- `AffinityThatFitsThirtyTwoBitsIsAcceptedByAThirtyTwoBitProcess`
- `AffinityWiderThanThirtyTwoBitsIsRejectedByAThirtyTwoBitProcess`
- `AffinityOfAnyWidthIsAcceptedByASixtyFourBitProcess`

the last three take the pointer size as an argument so the 32 bit behaviour is checked on any machine.

they are real regression tests. with the option reverted to `int?` the wide mask test fails and the small one still passes. with the pointer size guard removed five of the nine theory cases fail.

## verification

`./build.cmd build` and `./build.cmd unit-tests -e` and `./build.cmd analyzer-tests -e` which is what `run-tests.yaml` runs.

| check | result |
|---|---|
| build | succeeded |
| unit tests | 1073 total 1065 passed 0 failed 8 skipped |
| exporter tests | 51 of 51 |
| analyzer tests | 20234 of 20234 |

net10.0 on macos arm64.

## note

i did not touch cpu groups. this only widens what the cli can express up to the 64 that `FixAffinity` already supports.

closes #3231
