### PR TITLE
chore: Drop net9.0 from target frameworks

### DIFF
--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>BenchmarkDotNet</AssemblyTitle>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);1701;1702;1705;1591;3005;NU1510;NU1702;CS3001;CS3003</NoWarn>
     <AssemblyName>BenchmarkDotNet</AssemblyName>


### PR DESCRIPTION
This PR remove `net9.0` from TargetFrameworks.
By dropping `net9.0` tfm, **build solution** time is reduced.

Currently `net9.0` tfm is only used on preview/nightly versions.
So dropping support for net9.0 will have little impact.

### What's affected when `net9.0` tfm is dropped.
When running benchmarks on .NET 9.0. `net8.0` version of BenchmarkDotnet Dlls are referenced.
So it might affects benchmark results slightly because ` `allows ref struct` support is dropped.

---
Close this PR if this PR changes are not desirable.