### PR TITLE
Update dotMemory/dotTrace TFMs

### DIFF
--- a/src/BenchmarkDotNet.Diagnostics.dotMemory/BenchmarkDotNet.Diagnostics.dotMemory.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.dotMemory/BenchmarkDotNet.Diagnostics.dotMemory.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\build\common.props" />
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net462</TargetFrameworks>
+        <TargetFrameworks>net462;netcoreapp3.1;net10.0</TargetFrameworks>
         <NoWarn>$(NoWarn);1591</NoWarn>
         <AssemblyTitle>BenchmarkDotNet.Diagnostics.dotMemory</AssemblyTitle>
         <AssemblyName>BenchmarkDotNet.Diagnostics.dotMemory</AssemblyName>

--- a/src/BenchmarkDotNet.Diagnostics.dotTrace/BenchmarkDotNet.Diagnostics.dotTrace.csproj
+++ b/src/BenchmarkDotNet.Diagnostics.dotTrace/BenchmarkDotNet.Diagnostics.dotTrace.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\build\common.props" />
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net462</TargetFrameworks>
+        <TargetFrameworks>net462;netcoreapp3.1;net10.0</TargetFrameworks>
         <NoWarn>$(NoWarn);1591</NoWarn>
         <AssemblyTitle>BenchmarkDotNet.Diagnostics.dotTrace</AssemblyTitle>
         <AssemblyName>BenchmarkDotNet.Diagnostics.dotTrace</AssemblyName>


### PR DESCRIPTION
Restores `netcoreapp3.1` target (partially reverts #3123, see comments in #2947).
Updates `net8.0` to `net10.0` (technically it's not required, `netcoreapp3.1` is forward-compatible).